### PR TITLE
Add 2017-2018 rates to pay-leave-for-parents

### DIFF
--- a/lib/smart_answer/calculators/pay_leave_for_parents_calculator.rb
+++ b/lib/smart_answer/calculators/pay_leave_for_parents_calculator.rb
@@ -109,6 +109,10 @@ module SmartAnswer::Calculators
       date_in_39_week_range?(2016, 2017, due_date)
     end
 
+    def range_in_2017_2018_fin_year?
+      date_in_39_week_range?(2017, 2018, due_date)
+    end
+
     def start_of_maternity_allowance
       sunday_before(due_date - 11.weeks)
     end

--- a/lib/smart_answer/calculators/pay_leave_for_parents_calculator.rb
+++ b/lib/smart_answer/calculators/pay_leave_for_parents_calculator.rb
@@ -39,8 +39,10 @@ module SmartAnswer::Calculators
         SmartAnswer::Money.new(112)
       elsif in_2016_2017_fin_year?(start_date)
         SmartAnswer::Money.new(112)
+      elsif in_2017_2018_fin_year?(start_date)
+        SmartAnswer::Money.new(113)
       else
-        SmartAnswer::Money.new(112)
+        SmartAnswer::Money.new(113)
       end
     end
 
@@ -145,6 +147,10 @@ module SmartAnswer::Calculators
 
     def in_2016_2017_fin_year?(date)
       (Date.new(2016, 05, 06)..Date.new(2017, 05, 05)).cover?(date)
+    end
+
+    def in_2017_2018_fin_year?(date)
+      (Date.new(2017, 05, 06)..Date.new(2018, 05, 05)).cover?(date)
     end
 
   private

--- a/lib/smart_answer/calculators/pay_leave_for_parents_calculator.rb
+++ b/lib/smart_answer/calculators/pay_leave_for_parents_calculator.rb
@@ -37,6 +37,8 @@ module SmartAnswer::Calculators
         SmartAnswer::Money.new(111)
       elsif in_2015_2016_fin_year?(start_date)
         SmartAnswer::Money.new(112)
+      elsif in_2016_2017_fin_year?(start_date)
+        SmartAnswer::Money.new(112)
       else
         SmartAnswer::Money.new(112)
       end
@@ -139,6 +141,10 @@ module SmartAnswer::Calculators
 
     def in_2015_2016_fin_year?(date)
       (Date.new(2015, 05, 06)..Date.new(2016, 05, 05)).cover?(date)
+    end
+
+    def in_2016_2017_fin_year?(date)
+      (Date.new(2016, 05, 06)..Date.new(2017, 05, 05)).cover?(date)
     end
 
   private

--- a/lib/smart_answer/calculators/pay_leave_for_parents_calculator.rb
+++ b/lib/smart_answer/calculators/pay_leave_for_parents_calculator.rb
@@ -105,6 +105,10 @@ module SmartAnswer::Calculators
       date_in_39_week_range?(2015, 2016, due_date)
     end
 
+    def range_in_2016_2017_fin_year?
+      date_in_39_week_range?(2016, 2017, due_date)
+    end
+
     def start_of_maternity_allowance
       sunday_before(due_date - 11.weeks)
     end

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_additional_pat_pay.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_additional_pat_pay.govspeak.erb
@@ -27,3 +27,9 @@ Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of their average weekly earnings (whichever is lower).
 
 <% end %>
+
+<% if calculator.range_in_2017_2018_fin_year? %>
+
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of their average weekly earnings (whichever is lower).
+
+<% end %>

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_additional_pat_pay.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_additional_pat_pay.govspeak.erb
@@ -22,8 +22,8 @@ Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their 
 
 <% end %>
 
-<% if !calculator.range_in_2013_2014_fin_year? && !calculator.range_in_2014_2015_fin_year? && !calculator.range_in_2015_2016_fin_year? %>
+<% if calculator.range_in_2016_2017_fin_year? %>
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of their average weekly earnings (whichever is lower).
 
 <% end %>

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_both_shared_pay.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_both_shared_pay.govspeak.erb
@@ -22,6 +22,12 @@ Mother’s shared parental pay (between 6 April 2016 and 5 April 2017) | £139.5
 
 <% end %>
 
+<% if calculator.range_in_2017_2018_fin_year? %>
+
+Mother’s shared parental pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+<% end %>
+
 <% if calculator.range_in_2014_2015_fin_year? %>
 
 Partner's shared parental pay (between 6 April 2014 and 5 April 2015) | £138.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
@@ -37,5 +43,11 @@ Partner's shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58
 <% if calculator.range_in_2016_2017_fin_year? %>
 
 Partner's shared parental pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+<% end %>
+
+<% if calculator.range_in_2017_2018_fin_year? %>
+
+Partner's shared parental pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_both_shared_pay.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_both_shared_pay.govspeak.erb
@@ -16,9 +16,9 @@ Mother’s shared parental pay (between 6 April 2015 and 5 April 2016) | £139.5
 
 <% end %>
 
-<% if !calculator.range_in_2014_2015_fin_year? && !calculator.range_in_2015_2016_fin_year? %>
+<% if calculator.range_in_2016_2017_fin_year? %>
 
-Mother’s shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Mother’s shared parental pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
@@ -34,8 +34,8 @@ Partner's shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58
 
 <% end %>
 
-<% if !calculator.range_in_2014_2015_fin_year? && !calculator.range_in_2015_2016_fin_year? %>
+<% if calculator.range_in_2016_2017_fin_year? %>
 
-Partner's shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Partner's shared parental pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_allowance.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_allowance.govspeak.erb
@@ -26,9 +26,9 @@ Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her av
 
 <% end %>
 
-<% if !calculator.range_in_2013_2014_fin_year? && !calculator.range_in_2014_2015_fin_year? && !calculator.range_in_2015_2016_fin_year? %>
+<% if calculator.range_in_2016_2017_fin_year? %>
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 <% end %>
 

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_allowance.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_allowance.govspeak.erb
@@ -32,4 +32,10 @@ Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her av
 
 <% end %>
 
+<% if calculator.range_in_2017_2018_fin_year? %>
+
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
+<% end %>
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_pay.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_pay.govspeak.erb
@@ -30,6 +30,12 @@ Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 9
 
 <% end %>
 
+<% if calculator.range_in_2017_2018_fin_year? %>
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+<% end %>
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_pay.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_pay.govspeak.erb
@@ -24,9 +24,9 @@ Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 9
 
 <% end %>
 
-<% if !calculator.range_in_2013_2014_fin_year? && !calculator.range_in_2014_2015_fin_year? && !calculator.range_in_2015_2016_fin_year? %>
+<% if calculator.range_in_2016_2017_fin_year? %>
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 <% end %>
 

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_shared_pay.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_shared_pay.govspeak.erb
@@ -21,3 +21,9 @@ Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
+
+<% if calculator.range_in_2017_2018_fin_year? %>
+
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+<% end %>

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_shared_pay.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_shared_pay.govspeak.erb
@@ -16,8 +16,8 @@ Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week 
 
 <% end %>
 
-<% if !calculator.range_in_2014_2015_fin_year? && !calculator.range_in_2015_2016_fin_year? %>
+<% if calculator.range_in_2016_2017_fin_year? %>
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_pay.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_pay.govspeak.erb
@@ -28,6 +28,12 @@ Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% o
 
 <% end %>
 
+<% if calculator.range_in_2017_2018_fin_year? %>
+
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+<% end %>
+
 <% if calculator.range_in_2013_2014_fin_year? %>
 
 Tell the partner’s employer | 28 days before they want to start paternity pay

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_pay.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_pay.govspeak.erb
@@ -22,9 +22,9 @@ Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% o
 
 <% end %>
 
-<% if !calculator.range_in_2013_2014_fin_year? && !calculator.range_in_2014_2015_fin_year? && !calculator.range_in_2015_2016_fin_year? %>
+<% if calculator.range_in_2016_2017_fin_year? %>
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_shared_pay.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_shared_pay.govspeak.erb
@@ -21,3 +21,9 @@ Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
+
+<% if calculator.range_in_2017_2018_fin_year? %>
+
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+<% end %>

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_shared_pay.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_shared_pay.govspeak.erb
@@ -16,8 +16,8 @@ Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week 
 
 <% end %>
 
-<% if !calculator.range_in_2014_2015_fin_year? && !calculator.range_in_2015_2016_fin_year? %>
+<% if calculator.range_in_2016_2017_fin_year? %>
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/employee/yes/yes/10000.0-year/yes.txt
@@ -17,8 +17,6 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
-
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/self-employed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/self-employed/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/unemployed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/unemployed/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/worker/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/worker/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/worker/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/worker/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/worker/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/worker/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/worker/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/worker/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/worker/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/worker/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/worker/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/worker/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/worker/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/worker/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2012-02-01/worker/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2012-02-01/worker/yes/yes/10000.0-year/yes.txt
@@ -8,8 +8,6 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
-
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/employee/yes/yes/10000.0-year/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/self-employed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/self-employed/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/unemployed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/unemployed/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/worker/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/worker/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/worker/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/worker/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/worker/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/worker/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/worker/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/worker/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/worker/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/worker/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/worker/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/worker/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/worker/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/worker/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2016-02-01/worker/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2016-02-01/worker/yes/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/yes/yes/10000.0-year/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/employee/yes/yes/10000.0-year/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/self-employed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/self-employed/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/self-employed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/self-employed/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/unemployed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/unemployed/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/unemployed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/unemployed/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/yes/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2017-02-01/worker/yes/yes/10000.0-year/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/no/10000.0-year/no/no/no.txt
@@ -1,0 +1,13 @@
+
+
+The mother can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/no/10000.0-year/no/no/yes.txt
@@ -1,0 +1,13 @@
+
+
+The mother can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/no/10000.0-year/no/yes/no.txt
@@ -1,0 +1,13 @@
+
+
+The mother can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/no/10000.0-year/yes/no/no.txt
@@ -1,0 +1,13 @@
+
+
+The mother can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/no/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,13 @@
+
+
+The mother can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/no/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,13 @@
+
+
+The mother can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/yes/10000.0-year/no/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/yes/10000.0-year/no/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/yes/10000.0-year/no/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/yes/10000.0-year/yes/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/yes/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/yes/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/yes/no/10000.0-year/no/no/no.txt
@@ -1,0 +1,13 @@
+
+
+The mother can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/yes/no/10000.0-year/no/no/yes.txt
@@ -1,0 +1,13 @@
+
+
+The mother can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/yes/no/10000.0-year/no/yes/no.txt
@@ -1,0 +1,13 @@
+
+
+The mother can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/yes/no/10000.0-year/yes/no/no.txt
@@ -1,0 +1,13 @@
+
+
+The mother can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/yes/no/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,13 @@
+
+
+The mother can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/yes/no/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,13 @@
+
+
+The mother can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/yes/yes/10000.0-year/no/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/yes/yes/10000.0-year/no/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/yes/yes/10000.0-year/no/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/employee/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/self-employed/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/self-employed/no/no.txt
@@ -1,0 +1,13 @@
+
+
+The mother can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/self-employed/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/self-employed/no/yes.txt
@@ -1,0 +1,13 @@
+
+
+The mother can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/self-employed/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/self-employed/yes/no.txt
@@ -1,0 +1,13 @@
+
+
+The mother can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/self-employed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/self-employed/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/self-employed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/self-employed/yes/yes/10000-year.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/self-employed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/self-employed/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/unemployed/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/unemployed/no/no.txt
@@ -1,0 +1,13 @@
+
+
+The mother can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/unemployed/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/unemployed/no/yes.txt
@@ -1,0 +1,13 @@
+
+
+The mother can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/unemployed/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/unemployed/yes/no.txt
@@ -1,0 +1,13 @@
+
+
+The mother can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/unemployed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/unemployed/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/unemployed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/unemployed/yes/yes/10000-year.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/unemployed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/unemployed/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/no/10000.0-year/no/no/no.txt
@@ -1,0 +1,13 @@
+
+
+The mother can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/no/10000.0-year/no/no/yes.txt
@@ -1,0 +1,13 @@
+
+
+The mother can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/no/10000.0-year/no/yes/no.txt
@@ -1,0 +1,13 @@
+
+
+The mother can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/no/10000.0-year/yes/no/no.txt
@@ -1,0 +1,13 @@
+
+
+The mother can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/no/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,13 @@
+
+
+The mother can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/no/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,13 @@
+
+
+The mother can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/yes/10000.0-year/no/no/no.txt
@@ -1,0 +1,13 @@
+
+
+The mother can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/yes/10000.0-year/no/no/yes.txt
@@ -1,0 +1,13 @@
+
+
+The mother can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/yes/10000.0-year/no/yes/no.txt
@@ -1,0 +1,13 @@
+
+
+The mother can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/yes/10000.0-year/yes/no/no.txt
@@ -1,0 +1,13 @@
+
+
+The mother can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/yes/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,13 @@
+
+
+The mother can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/yes/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,13 @@
+
+
+The mother can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/yes/no/10000.0-year/no/no/no.txt
@@ -1,0 +1,13 @@
+
+
+The mother can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/yes/no/10000.0-year/no/no/yes.txt
@@ -1,0 +1,13 @@
+
+
+The mother can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/yes/no/10000.0-year/no/yes/no.txt
@@ -1,0 +1,13 @@
+
+
+The mother can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/yes/no/10000.0-year/yes/no/no.txt
@@ -1,0 +1,13 @@
+
+
+The mother can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/yes/no/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,13 @@
+
+
+The mother can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/yes/no/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,13 @@
+
+
+The mother can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/yes/yes/10000.0-year/no/no/no.txt
@@ -1,0 +1,13 @@
+
+
+The mother can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/yes/yes/10000.0-year/no/no/yes.txt
@@ -1,0 +1,13 @@
+
+
+The mother can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/yes/yes/10000.0-year/no/yes/no.txt
@@ -1,0 +1,13 @@
+
+
+The mother can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/no/2018-02-01/worker/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -47,8 +47,6 @@ The mother’s partner can get [additional paternity pay](/paternity-pay-leave/p
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -27,8 +27,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -47,8 +47,6 @@ The mother’s partner can get [additional paternity pay](/paternity-pay-leave/p
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -27,8 +27,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -24,8 +24,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -24,8 +24,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -24,8 +24,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -56,8 +56,6 @@ The mother’s partner can get [additional paternity pay](/paternity-pay-leave/p
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -36,8 +36,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -24,8 +24,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -24,8 +24,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -24,8 +24,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -56,8 +56,6 @@ The mother’s partner can get [additional paternity pay](/paternity-pay-leave/p
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -36,8 +36,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -47,8 +47,6 @@ The mother’s partner can get [additional paternity pay](/paternity-pay-leave/p
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -27,8 +27,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -47,8 +47,6 @@ The mother’s partner can get [additional paternity pay](/paternity-pay-leave/p
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -27,8 +27,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000-year.txt
@@ -1,4 +1,4 @@
-Has the mother earned (or will she have earned) more than £112 per week in this job between 27 August 2011 and 22 October 2011?
+Has the mother earned (or will she have earned) more than £113 per week in this job between 27 August 2011 and 22 October 2011?
 
 
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -24,8 +24,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -24,8 +24,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -24,8 +24,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -56,8 +56,6 @@ The mother’s partner can get [additional paternity pay](/paternity-pay-leave/p
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -36,8 +36,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no.txt
@@ -17,8 +17,6 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
-
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes.txt
@@ -17,8 +17,6 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
-
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no.txt
@@ -17,8 +17,6 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
-
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes.txt
@@ -17,8 +17,6 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
-
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no.txt
@@ -17,8 +17,6 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
-
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes.txt
@@ -17,8 +17,6 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
-
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -1,4 +1,4 @@
-Has the mother’s partner earned (or will they have earned) more than £112 per week in this job between 27 August 2011 and 22 October 2011?
+Has the mother’s partner earned (or will they have earned) more than £113 per week in this job between 27 August 2011 and 22 October 2011?
 
 
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no.txt
@@ -17,8 +17,6 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
-
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -17,8 +17,6 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
-
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -56,8 +56,6 @@ The mother’s partner can get [additional paternity pay](/paternity-pay-leave/p
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -36,8 +36,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/self-employed/yes/yes/10000.0-year/yes.txt
@@ -17,8 +17,6 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
-
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/unemployed/yes/yes/10000.0-year/yes.txt
@@ -17,8 +17,6 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
-
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -28,8 +28,6 @@ The mother’s partner can get [additional paternity pay](/paternity-pay-leave/p
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -28,8 +28,6 @@ The mother’s partner can get [additional paternity pay](/paternity-pay-leave/p
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -37,8 +37,6 @@ The mother’s partner can get [additional paternity pay](/paternity-pay-leave/p
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -27,8 +27,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -37,8 +37,6 @@ The mother’s partner can get [additional paternity pay](/paternity-pay-leave/p
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -27,8 +27,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -28,8 +28,6 @@ The mother’s partner can get [additional paternity pay](/paternity-pay-leave/p
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -28,8 +28,6 @@ The mother’s partner can get [additional paternity pay](/paternity-pay-leave/p
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -37,8 +37,6 @@ The mother’s partner can get [additional paternity pay](/paternity-pay-leave/p
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -27,8 +27,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no.txt
@@ -17,8 +17,6 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
-
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes.txt
@@ -17,8 +17,6 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
-
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no.txt
@@ -17,8 +17,6 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
-
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes.txt
@@ -17,8 +17,6 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
-
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no.txt
@@ -17,8 +17,6 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
-
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes.txt
@@ -17,8 +17,6 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
-
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no.txt
@@ -17,8 +17,6 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
-
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -37,8 +37,6 @@ The mother’s partner can get [additional paternity pay](/paternity-pay-leave/p
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -17,8 +17,6 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
-
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -27,8 +27,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -47,8 +47,6 @@ The mother’s partner can get [additional paternity pay](/paternity-pay-leave/p
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -27,8 +27,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/self-employed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/self-employed/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/unemployed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/unemployed/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -28,8 +28,6 @@ The mother’s partner can get [additional paternity pay](/paternity-pay-leave/p
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -47,8 +47,6 @@ The mother’s partner can get [additional paternity pay](/paternity-pay-leave/p
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -27,8 +27,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/self-employed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/self-employed/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/unemployed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/unemployed/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -28,8 +28,6 @@ The mother’s partner can get [additional paternity pay](/paternity-pay-leave/p
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -47,8 +47,6 @@ The mother’s partner can get [additional paternity pay](/paternity-pay-leave/p
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -27,8 +27,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -47,8 +47,6 @@ The mother’s partner can get [additional paternity pay](/paternity-pay-leave/p
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -27,8 +27,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -47,8 +47,6 @@ The mother’s partner can get [additional paternity pay](/paternity-pay-leave/p
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -27,8 +27,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -47,8 +47,6 @@ The mother’s partner can get [additional paternity pay](/paternity-pay-leave/p
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -27,8 +27,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -47,8 +47,6 @@ The mother’s partner can get [additional paternity pay](/paternity-pay-leave/p
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -27,8 +27,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -47,8 +47,6 @@ The mother’s partner can get [additional paternity pay](/paternity-pay-leave/p
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -27,8 +27,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -47,8 +47,6 @@ The mother’s partner can get [additional paternity pay](/paternity-pay-leave/p
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -27,8 +27,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no.txt
@@ -8,8 +8,6 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
-
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes.txt
@@ -8,8 +8,6 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
-
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no.txt
@@ -8,8 +8,6 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
-
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes.txt
@@ -8,8 +8,6 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
-
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no.txt
@@ -8,8 +8,6 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
-
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes.txt
@@ -8,8 +8,6 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
-
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no.txt
@@ -8,8 +8,6 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
-
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -47,8 +47,6 @@ The mother’s partner can get [additional paternity pay](/paternity-pay-leave/p
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -27,8 +27,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -8,8 +8,6 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
-
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/self-employed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/self-employed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/self-employed/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/self-employed/yes/yes/10000.0-year/yes.txt
@@ -8,8 +8,6 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
-
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/unemployed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/unemployed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/unemployed/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/unemployed/yes/yes/10000.0-year/yes.txt
@@ -8,8 +8,6 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
-
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -28,8 +28,6 @@ The mother’s partner can get [additional paternity pay](/paternity-pay-leave/p
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -28,8 +28,6 @@ The mother’s partner can get [additional paternity pay](/paternity-pay-leave/p
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -28,8 +28,6 @@ The mother’s partner can get [additional paternity pay](/paternity-pay-leave/p
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -28,8 +28,6 @@ The mother’s partner can get [additional paternity pay](/paternity-pay-leave/p
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -28,8 +28,6 @@ The mother’s partner can get [additional paternity pay](/paternity-pay-leave/p
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -28,8 +28,6 @@ The mother’s partner can get [additional paternity pay](/paternity-pay-leave/p
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2011
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -28,8 +28,6 @@ The mother’s partner can get [additional paternity pay](/paternity-pay-leave/p
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no.txt
@@ -8,8 +8,6 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
-
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes.txt
@@ -8,8 +8,6 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
-
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no.txt
@@ -8,8 +8,6 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
-
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes.txt
@@ -8,8 +8,6 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
-
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no.txt
@@ -8,8 +8,6 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
-
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes.txt
@@ -8,8 +8,6 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
-
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no.txt
@@ -8,8 +8,6 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
-
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no.txt
@@ -18,8 +18,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no.txt
@@ -28,8 +28,6 @@ The mother’s partner can get [additional paternity pay](/paternity-pay-leave/p
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -8,8 +8,6 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
-
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -18,8 +18,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 22 October 2011
 
 ##Additional paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -28,8 +28,6 @@ The mother’s partner can get [additional paternity pay](/paternity-pay-leave/p
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -58,6 +58,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -33,6 +33,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -58,6 +58,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -33,6 +33,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -26,6 +26,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -26,6 +26,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -26,6 +26,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -67,6 +67,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -42,6 +42,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -26,6 +26,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -26,6 +26,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -26,6 +26,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -67,6 +67,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -42,6 +42,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -58,6 +58,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -33,6 +33,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -58,6 +58,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -33,6 +33,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -26,6 +26,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental leave (mother only)

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -26,6 +26,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental leave (mother only)

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -26,6 +26,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental leave (mother only)

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -42,6 +42,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -65,6 +65,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -46,6 +46,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -46,6 +46,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -46,6 +46,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -46,6 +46,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -46,6 +46,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -46,6 +46,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -53,6 +53,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -65,7 +65,11 @@ The mother and her partner can both get [shared parental pay](/shared-parental-l
 
 Mother’s shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Mother’s shared parental pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Partner's shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Partner's shared parental pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -42,6 +42,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/yes/no/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/yes/no/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/yes/yes/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -46,6 +46,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/yes/no/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/yes/no/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/yes/yes/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -46,6 +46,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -36,6 +36,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -24,6 +24,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -36,6 +36,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -24,6 +24,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -33,6 +33,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -45,6 +45,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -33,6 +33,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -45,6 +45,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -36,6 +36,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -24,6 +24,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -36,6 +36,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -24,6 +24,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental leave (mother only)

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental leave (mother only)

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental leave (mother only)

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -58,6 +58,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -33,6 +33,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental leave (mother only)

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -46,6 +46,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -46,6 +46,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -46,6 +46,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -46,6 +46,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -46,6 +46,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -46,6 +46,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -46,6 +46,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -58,7 +58,11 @@ The mother and her partner can both get [shared parental pay](/shared-parental-l
 
 Mother’s shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Mother’s shared parental pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Partner's shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Partner's shared parental pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -33,6 +33,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental leave (mother only)

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/no/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/no/yes/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/yes/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -58,6 +58,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -33,6 +33,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/self-employed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/self-employed/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/unemployed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/unemployed/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/no/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/no/yes/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/yes/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -36,6 +36,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -24,6 +24,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/no/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/no/yes/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/yes/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -58,6 +58,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -33,6 +33,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/self-employed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/self-employed/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/unemployed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/unemployed/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/no/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/no/yes/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/yes/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -36,6 +36,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -24,6 +24,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -58,6 +58,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -33,6 +33,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -58,6 +58,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -33,6 +33,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -58,6 +58,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -33,6 +33,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -58,6 +58,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -33,6 +33,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -58,6 +58,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -33,6 +33,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -58,6 +58,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -33,6 +33,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -58,6 +58,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -33,6 +33,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -24,6 +24,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -24,6 +24,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -24,6 +24,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -24,6 +24,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -24,6 +24,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -24,6 +24,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -46,6 +46,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -58,7 +58,11 @@ The mother and her partner can both get [shared parental pay](/shared-parental-l
 
 Mother’s shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Mother’s shared parental pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Partner's shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Partner's shared parental pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -33,6 +33,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/self-employed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/self-employed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/self-employed/yes/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/self-employed/yes/yes/10000.0-year/yes/no/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/self-employed/yes/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/self-employed/yes/yes/10000.0-year/yes/no/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/self-employed/yes/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/self-employed/yes/yes/10000.0-year/yes/yes/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -24,6 +24,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/unemployed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/unemployed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/unemployed/yes/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/unemployed/yes/yes/10000.0-year/yes/no/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/unemployed/yes/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/unemployed/yes/yes/10000.0-year/yes/no/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/unemployed/yes/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/unemployed/yes/yes/10000.0-year/yes/yes/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -24,6 +24,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -36,6 +36,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -24,6 +24,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -36,6 +36,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -24,6 +24,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -36,6 +36,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -24,6 +24,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -36,6 +36,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -24,6 +24,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -36,6 +36,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -24,6 +24,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -36,6 +36,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -24,6 +24,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -36,6 +36,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -24,6 +24,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 15 November 2015
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -24,6 +24,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -24,6 +24,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -24,6 +24,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -24,6 +24,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -24,6 +24,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -24,6 +24,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -24,6 +24,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -36,7 +36,11 @@ The mother and her partner can both get [shared parental pay](/shared-parental-l
 
 Mother’s shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Mother’s shared parental pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Partner's shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Partner's shared parental pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -24,6 +24,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 24 October 2015
 
 ##Shared parental pay

--- a/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2016-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -58,6 +58,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -31,7 +31,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -33,6 +33,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -56,7 +56,7 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -58,6 +58,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -31,7 +31,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -33,6 +33,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -56,7 +56,7 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -26,6 +26,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -24,7 +24,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -26,6 +26,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -24,7 +24,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -26,6 +26,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -24,7 +24,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -65,7 +65,7 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -67,6 +67,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -42,6 +42,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -40,7 +40,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -26,6 +26,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -24,7 +24,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -26,6 +26,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -24,7 +24,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -26,6 +26,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -24,7 +24,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -65,7 +65,7 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -67,6 +67,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -42,6 +42,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -40,7 +40,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -58,6 +58,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -31,7 +31,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -33,6 +33,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -56,7 +56,7 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -58,6 +58,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -31,7 +31,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -33,6 +33,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -56,7 +56,7 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -26,6 +26,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental leave (mother only)

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -24,7 +24,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -26,6 +26,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental leave (mother only)

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -24,7 +24,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -26,6 +26,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental leave (mother only)

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -24,7 +24,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -65,6 +65,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -42,6 +42,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -40,7 +40,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -63,7 +63,7 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -46,6 +46,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -44,7 +44,7 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -46,6 +46,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -44,7 +44,7 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -46,6 +46,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -44,7 +44,7 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -46,6 +46,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -44,7 +44,7 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -46,6 +46,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -44,7 +44,7 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -46,6 +46,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -44,7 +44,7 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -51,7 +51,7 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -53,6 +53,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -65,7 +65,11 @@ The mother and her partner can both get [shared parental pay](/shared-parental-l
 
 Mother’s shared parental pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Mother’s shared parental pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Partner's shared parental pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Partner's shared parental pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -42,6 +42,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -40,7 +40,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -63,9 +63,9 @@ The mother and her partner can both get [shared parental pay](/shared-parental-l
 
 ###Amount
 
-Mother’s shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Mother’s shared parental pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
-Partner's shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Partner's shared parental pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/yes/no/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/yes/no/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/yes/no/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/yes/no/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/yes/yes/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/yes/yes/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -46,6 +46,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -44,7 +44,7 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/yes/no/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/yes/no/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/yes/no/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/yes/no/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/yes/yes/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/yes/yes/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -46,6 +46,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -44,7 +44,7 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,7 +6,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,7 +6,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,7 +6,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -22,7 +22,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -34,7 +34,7 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -36,6 +36,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -24,6 +24,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,7 +6,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,7 +6,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,7 +6,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -22,7 +22,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -34,7 +34,7 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -36,6 +36,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -24,6 +24,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -33,6 +33,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -45,6 +45,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -31,7 +31,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -43,7 +43,7 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -33,6 +33,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -45,6 +45,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -31,7 +31,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -43,7 +43,7 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,7 +6,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,7 +6,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,7 +6,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -22,7 +22,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -34,7 +34,7 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -36,6 +36,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -24,6 +24,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,7 +6,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,7 +6,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,7 +6,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -22,7 +22,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -34,7 +34,7 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -36,6 +36,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -24,6 +24,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental leave (mother only)

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental leave (mother only)

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental leave (mother only)

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -58,6 +58,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -33,6 +33,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental leave (mother only)

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -31,7 +31,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -56,7 +56,7 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -46,6 +46,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -44,7 +44,7 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -46,6 +46,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -44,7 +44,7 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -46,6 +46,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -44,7 +44,7 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -46,6 +46,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -44,7 +44,7 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -46,6 +46,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -44,7 +44,7 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -46,6 +46,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -44,7 +44,7 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -46,6 +46,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -44,7 +44,7 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -33,6 +33,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental leave (mother only)

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -56,9 +56,9 @@ The mother and her partner can both get [shared parental pay](/shared-parental-l
 
 ###Amount
 
-Mother’s shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Mother’s shared parental pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
-Partner's shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Partner's shared parental pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -58,7 +58,11 @@ The mother and her partner can both get [shared parental pay](/shared-parental-l
 
 Mother’s shared parental pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Mother’s shared parental pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Partner's shared parental pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Partner's shared parental pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -31,7 +31,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -19,6 +19,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -17,7 +17,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/no/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/no/yes/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -58,6 +58,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -31,7 +31,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -33,6 +33,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -56,7 +56,7 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/self-employed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/self-employed/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/self-employed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/self-employed/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/unemployed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/unemployed/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/unemployed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/unemployed/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,7 +6,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/no/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,7 +6,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/no/yes/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,7 +6,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -22,7 +22,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -34,7 +34,7 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -36,6 +36,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -24,6 +24,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/no/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/no/yes/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -58,6 +58,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -31,7 +31,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -33,6 +33,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -56,7 +56,7 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/self-employed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/self-employed/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/self-employed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/self-employed/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/unemployed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/unemployed/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/unemployed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/unemployed/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,7 +6,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/no/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,7 +6,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/no/yes/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,7 +6,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -22,7 +22,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -34,7 +34,7 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -36,6 +36,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -24,6 +24,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -58,6 +58,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -31,7 +31,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -33,6 +33,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -56,7 +56,7 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -58,6 +58,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -31,7 +31,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -33,6 +33,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -56,7 +56,7 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -58,6 +58,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -31,7 +31,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -33,6 +33,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -56,7 +56,7 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -58,6 +58,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -31,7 +31,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -33,6 +33,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -56,7 +56,7 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -58,6 +58,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -31,7 +31,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -33,6 +33,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -56,7 +56,7 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -58,6 +58,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -31,7 +31,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -33,6 +33,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -56,7 +56,7 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -17,6 +17,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,7 +15,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -58,6 +58,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -31,7 +31,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -33,6 +33,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -56,7 +56,7 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -22,7 +22,7 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -24,6 +24,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -22,7 +22,7 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -24,6 +24,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -22,7 +22,7 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -24,6 +24,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -22,7 +22,7 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -24,6 +24,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -22,7 +22,7 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -24,6 +24,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -22,7 +22,7 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -24,6 +24,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -46,6 +46,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -44,7 +44,7 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -56,9 +56,9 @@ The mother and her partner can both get [shared parental pay](/shared-parental-l
 
 ###Amount
 
-Mother’s shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Mother’s shared parental pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
-Partner's shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Partner's shared parental pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -58,7 +58,11 @@ The mother and her partner can both get [shared parental pay](/shared-parental-l
 
 Mother’s shared parental pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Mother’s shared parental pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Partner's shared parental pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Partner's shared parental pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -31,7 +31,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -33,6 +33,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/yes/10000.0-year/yes/no/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/yes/10000.0-year/yes/no/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/yes/10000.0-year/yes/no/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/yes/10000.0-year/yes/no/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/yes/10000.0-year/yes/yes/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/yes/10000.0-year/yes/yes/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -22,7 +22,7 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -24,6 +24,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/yes/10000.0-year/yes/no/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/yes/10000.0-year/yes/no/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/yes/10000.0-year/yes/no/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/yes/10000.0-year/yes/no/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/yes/10000.0-year/yes/yes/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/yes/10000.0-year/yes/yes/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -22,7 +22,7 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -24,6 +24,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,7 +6,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,7 +6,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,7 +6,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -22,7 +22,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -34,7 +34,7 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -36,6 +36,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -24,6 +24,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,7 +6,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,7 +6,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,7 +6,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -22,7 +22,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -34,7 +34,7 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -36,6 +36,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -24,6 +24,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,7 +6,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,7 +6,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,7 +6,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -22,7 +22,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -34,7 +34,7 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -36,6 +36,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -24,6 +24,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,7 +6,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,7 +6,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,7 +6,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -22,7 +22,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -34,7 +34,7 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -36,6 +36,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -24,6 +24,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,7 +6,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,7 +6,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,7 +6,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -22,7 +22,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -34,7 +34,7 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -36,6 +36,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -24,6 +24,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,7 +6,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,7 +6,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,7 +6,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -22,7 +22,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -34,7 +34,7 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -36,6 +36,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -24,6 +24,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,7 +6,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,7 +6,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,7 +6,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -8,6 +8,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -22,7 +22,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -12,6 +12,8 @@ Maternity allowance can start on | 13 November 2016
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -34,7 +34,7 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -36,6 +36,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,7 +10,7 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 13 November 2016
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -24,6 +24,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -22,7 +22,7 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -24,6 +24,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -22,7 +22,7 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -24,6 +24,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -22,7 +22,7 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -24,6 +24,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -22,7 +22,7 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -24,6 +24,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -22,7 +22,7 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -24,6 +24,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -22,7 +22,7 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -24,6 +24,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -22,7 +22,7 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -24,6 +24,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -34,9 +34,9 @@ The mother and her partner can both get [shared parental pay](/shared-parental-l
 
 ###Amount
 
-Mother’s shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Mother’s shared parental pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
-Partner's shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Partner's shared parental pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -36,7 +36,11 @@ The mother and her partner can both get [shared parental pay](/shared-parental-l
 
 Mother’s shared parental pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Mother’s shared parental pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Partner's shared parental pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Partner's shared parental pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 ##Extra help
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -22,7 +22,7 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 Tell the partner’s employer | 22 October 2016
 

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -24,6 +24,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 22 October 2016
 
 ##Shared parental pay

--- a/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2017-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -8,7 +8,7 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-Remaining weeks | £139.58 per week or 90% of her average weekly earnings (before tax) - whichever is lower (this figure is for the current tax year - it may change next April)
+Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,47 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Shared parental leave (partner only)
+
+The mother’s partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The partner can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the partner’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -29,8 +29,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -29,6 +29,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,65 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental leave (partner only)
+
+The mother’s partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The partner can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the partner’s employer | 8 weeks before the first block of SPL
+
+##Shared parental pay (partner only)
+
+The mother’s partner can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance the mother has received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -52,6 +52,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -52,8 +52,6 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,47 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Shared parental leave (partner only)
+
+The mother’s partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The partner can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the partner’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -29,8 +29,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -29,6 +29,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,65 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental leave (partner only)
+
+The mother’s partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The partner can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the partner’s employer | 8 weeks before the first block of SPL
+
+##Shared parental pay (partner only)
+
+The mother’s partner can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance the mother has received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -52,6 +52,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -52,8 +52,6 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,29 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -24,6 +24,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,39 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -24,8 +24,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,29 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -24,6 +24,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,39 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -24,8 +24,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,29 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -24,6 +24,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,39 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -24,8 +24,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,56 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Shared parental leave (partner only)
+
+The mother’s partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The partner can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the partner’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -61,6 +61,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,74 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental leave (partner only)
+
+The mother’s partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The partner can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the partner’s employer | 8 weeks before the first block of SPL
+
+##Shared parental pay (partner only)
+
+The mother’s partner can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance the mother has received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -38,8 +38,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -38,6 +38,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -61,8 +61,6 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,29 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -24,6 +24,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,39 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -24,8 +24,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,29 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -24,6 +24,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,39 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -24,8 +24,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,29 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -24,6 +24,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,39 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -24,8 +24,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,56 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Shared parental leave (partner only)
+
+The mother’s partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The partner can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the partner’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -61,6 +61,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,74 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental leave (partner only)
+
+The mother’s partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The partner can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the partner’s employer | 8 weeks before the first block of SPL
+
+##Shared parental pay (partner only)
+
+The mother’s partner can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance the mother has received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -38,8 +38,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -38,6 +38,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -61,8 +61,6 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,47 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Shared parental leave (partner only)
+
+The mother’s partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The partner can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the partner’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -29,8 +29,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -29,6 +29,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,65 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental leave (partner only)
+
+The mother’s partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The partner can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the partner’s employer | 8 weeks before the first block of SPL
+
+##Shared parental pay (partner only)
+
+The mother’s partner can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance the mother has received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -52,6 +52,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -52,8 +52,6 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,47 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Shared parental leave (partner only)
+
+The mother’s partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The partner can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the partner’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -29,8 +29,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -29,6 +29,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,65 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental leave (partner only)
+
+The mother’s partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The partner can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the partner’s employer | 8 weeks before the first block of SPL
+
+##Shared parental pay (partner only)
+
+The mother’s partner can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance the mother has received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -52,6 +52,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -52,8 +52,6 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/no/no.txt
@@ -1,0 +1,29 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/no/yes.txt
@@ -1,0 +1,29 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/yes/no.txt
@@ -1,0 +1,29 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,42 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -24,6 +24,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (mother only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -24,8 +24,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (mother only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,52 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/no/no.txt
@@ -1,0 +1,29 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/no/yes.txt
@@ -1,0 +1,29 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/yes/no.txt
@@ -1,0 +1,29 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,42 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -24,6 +24,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (mother only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -24,8 +24,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (mother only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,52 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/no/no.txt
@@ -1,0 +1,29 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/no/yes.txt
@@ -1,0 +1,29 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/yes/no.txt
@@ -1,0 +1,29 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,42 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -24,6 +24,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (mother only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -24,8 +24,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (mother only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,52 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,47 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
@@ -1,0 +1,47 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,47 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
@@ -1,0 +1,47 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,47 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
@@ -1,0 +1,47 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
@@ -1,0 +1,56 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Shared parental leave (partner only)
+
+The mother’s partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The partner can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the partner’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
@@ -1,0 +1,56 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Shared parental leave (partner only)
+
+The mother’s partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The partner can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the partner’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
@@ -1,0 +1,56 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Shared parental leave (partner only)
+
+The mother’s partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The partner can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the partner’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,54 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Shared parental leave
+
+The mother and her partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The parents can choose how to share this leave between them. They can each take SPL in up to 3 blocks, going back to work between the blocks.
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the parent’s employer | 8 weeks before their first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,72 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental leave
+
+The mother and her partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The parents can choose how to share this leave between them. They can each take SPL in up to 3 blocks, going back to work between the blocks.
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the parent’s employer | 8 weeks before their first block of SPL
+
+##Shared parental pay (partner only)
+
+The mother’s partner can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance the mother has received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -59,6 +59,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -38,8 +38,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -38,6 +38,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -59,8 +59,6 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,55 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Shared parental pay (mother only)
+
+The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance they’ve received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -42,8 +42,6 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -42,6 +42,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -1,0 +1,55 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Shared parental pay (mother only)
+
+The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance they’ve received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -42,8 +42,6 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -42,6 +42,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,55 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Shared parental pay (mother only)
+
+The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance they’ve received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -42,8 +42,6 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -42,6 +42,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -1,0 +1,55 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Shared parental pay (mother only)
+
+The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance they’ve received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -42,8 +42,6 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -42,6 +42,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,55 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Shared parental pay (mother only)
+
+The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance they’ve received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -42,8 +42,6 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -42,6 +42,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -1,0 +1,55 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Shared parental pay (mother only)
+
+The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance they’ve received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -42,8 +42,6 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -42,6 +42,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
@@ -1,0 +1,56 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Shared parental leave (partner only)
+
+The mother’s partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The partner can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the partner’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
@@ -1,0 +1,56 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Shared parental leave (partner only)
+
+The mother’s partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The partner can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the partner’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
@@ -1,0 +1,56 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Shared parental leave (partner only)
+
+The mother’s partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The partner can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the partner’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -49,8 +49,6 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -49,6 +49,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,62 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Shared parental leave
+
+The mother and her partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The parents can choose how to share this leave between them. They can each take SPL in up to 3 blocks, going back to work between the blocks.
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the parent’s employer | 8 weeks before their first block of SPL
+
+##Shared parental pay (mother only)
+
+The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance they’ve received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -59,6 +59,10 @@ The mother and her partner can both get [shared parental pay](/shared-parental-l
 
 ###Amount
 
+Mother’s shared parental pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Partner's shared parental pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -38,8 +38,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -38,6 +38,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,74 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental leave
+
+The mother and her partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The parents can choose how to share this leave between them. They can each take SPL in up to 3 blocks, going back to work between the blocks.
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the parent’s employer | 8 weeks before their first block of SPL
+
+##Shared parental pay
+
+The mother and her partner can both get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance the mother has received.
+
+###Amount
+
+Mother’s shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Partner's shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -59,10 +59,6 @@ The mother and her partner can both get [shared parental pay](/shared-parental-l
 
 ###Amount
 
-Mother’s shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
-Partner's shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/no/10000.0-year/no/no/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/no/10000.0-year/no/no/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/no/10000.0-year/no/yes/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/no/10000.0-year/yes/no/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/no/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/no/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/yes/10000.0-year/no/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/yes/10000.0-year/no/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/yes/10000.0-year/yes/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/yes/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/no/10000.0-year/no/no/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/no/10000.0-year/no/no/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/no/10000.0-year/no/yes/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/no/10000.0-year/yes/no/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/no/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/no/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/no/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/no/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/no/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/no/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/yes/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/yes/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/yes/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/no/yes/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/no/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/no/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/no/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/no/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
@@ -1,0 +1,47 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/yes/no/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -1,0 +1,55 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Shared parental pay (mother only)
+
+The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance they’ve received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -42,8 +42,6 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -42,6 +42,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/no/10000.0-year/no/no/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/no/10000.0-year/no/no/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/no/10000.0-year/no/yes/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/no/10000.0-year/yes/no/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/no/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/no/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/yes/10000.0-year/no/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/yes/10000.0-year/no/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/yes/10000.0-year/yes/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/yes/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/no/10000.0-year/no/no/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/no/10000.0-year/no/no/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/no/10000.0-year/no/yes/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/no/10000.0-year/yes/no/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/no/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/no/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/no/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/no/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/no/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/no/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/yes/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/yes/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/yes/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/no/yes/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/no/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/no/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/no/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/no/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes.txt
@@ -1,0 +1,47 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/yes/no/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -1,0 +1,55 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Shared parental pay (mother only)
+
+The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance they’ve received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -42,8 +42,6 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -42,6 +42,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,6 +6,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,21 @@
+
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,6 +6,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,21 @@
+
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,6 +6,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,21 @@
+
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,6 +20,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -30,8 +30,6 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,43 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental pay (partner only)
+
+The mother’s partner can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance the mother has received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -30,6 +30,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,6 +6,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,21 @@
+
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,6 +6,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,21 @@
+
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,6 +6,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,21 @@
+
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,6 +20,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -30,8 +30,6 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,43 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental pay (partner only)
+
+The mother’s partner can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance the mother has received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -30,6 +30,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,52 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental pay (partner only)
+
+The mother’s partner can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance the mother has received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -39,6 +39,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -29,8 +29,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -29,6 +29,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -39,8 +39,6 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,52 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental pay (partner only)
+
+The mother’s partner can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance the mother has received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -39,6 +39,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -29,8 +29,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -29,6 +29,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -39,8 +39,6 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,6 +6,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,21 @@
+
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,6 +6,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,21 @@
+
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,6 +6,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,21 @@
+
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,6 +20,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -30,8 +30,6 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,43 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental pay (partner only)
+
+The mother’s partner can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance the mother has received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -30,6 +30,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,6 +6,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,21 @@
+
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,6 +6,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,21 @@
+
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,6 +6,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,21 @@
+
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,6 +20,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -30,8 +30,6 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,43 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental pay (partner only)
+
+The mother’s partner can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance the mother has received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -30,6 +30,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,43 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (mother only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (mother only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,43 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (mother only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (mother only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/no/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/no/yes.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/yes/no.txt
@@ -1,0 +1,20 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,43 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (mother only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (mother only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/no/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,47 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes/yes/yes.txt
@@ -1,0 +1,47 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/no/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,47 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes/yes/yes.txt
@@ -1,0 +1,47 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/no/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,47 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes/yes/yes.txt
@@ -1,0 +1,47 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/no/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,47 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -29,8 +29,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (mother only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Maternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -52,6 +52,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,65 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Shared parental pay (partner only)
+
+The mother’s partner can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance the mother has received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -29,6 +29,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (mother only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -52,8 +52,6 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,55 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Shared parental pay (mother only)
+
+The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance they’ve received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -42,8 +42,6 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -42,6 +42,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -1,0 +1,55 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Shared parental pay (mother only)
+
+The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance they’ve received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -42,8 +42,6 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -42,6 +42,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,55 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Shared parental pay (mother only)
+
+The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance they’ve received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -42,8 +42,6 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -42,6 +42,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -1,0 +1,55 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Shared parental pay (mother only)
+
+The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance they’ve received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -42,8 +42,6 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -42,6 +42,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,55 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Shared parental pay (mother only)
+
+The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance they’ve received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -42,8 +42,6 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -42,6 +42,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -1,0 +1,55 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Shared parental pay (mother only)
+
+The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance they’ve received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -42,8 +42,6 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -42,6 +42,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,55 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Shared parental pay (mother only)
+
+The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance they’ve received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -42,8 +42,6 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -42,6 +42,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -29,8 +29,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (mother only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -52,6 +52,10 @@ The mother and her partner can both get [shared parental pay](/shared-parental-l
 
 ###Amount
 
+Mother’s shared parental pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Partner's shared parental pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -52,10 +52,6 @@ The mother and her partner can both get [shared parental pay](/shared-parental-l
 
 ###Amount
 
-Mother’s shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
-Partner's shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,67 @@
+
+
+##Maternity leave
+
+The mother can take up to 52 weeks of [maternity leave](/maternity-pay-leave/leave). The leave will end if the mother goes back to work.
+
+| Dates
+- | -
+Earliest leave can start | 12 November 2017
+Tell the mother’s employer | 21 October 2017
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental leave (mother only)
+
+The mother can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave she takes.
+
+She can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother’s partner can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the mother’s employer | 8 weeks before the first block of SPL
+
+##Shared parental pay
+
+The mother and her partner can both get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance the mother has received.
+
+###Amount
+
+Mother’s shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Partner's shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/employee/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -29,6 +29,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (mother only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/no/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/no/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/no/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/no/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/no/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/no/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/no/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/no/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/no/yes/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/no/yes/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/no/yes/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/no/yes/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/no/yes/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/no/yes/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/no/yes/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/no/yes/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,47 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Shared parental leave (partner only)
+
+The mother’s partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The partner can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the partner’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -29,8 +29,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -29,6 +29,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,65 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental leave (partner only)
+
+The mother’s partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The partner can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the partner’s employer | 8 weeks before the first block of SPL
+
+##Shared parental pay (partner only)
+
+The mother’s partner can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance the mother has received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -52,6 +52,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -52,8 +52,6 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/self-employed/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/self-employed/no/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/self-employed/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/self-employed/no/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/self-employed/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/self-employed/yes/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/self-employed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/self-employed/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/self-employed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/self-employed/yes/yes/10000-year.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/self-employed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/self-employed/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/unemployed/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/unemployed/no/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/unemployed/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/unemployed/no/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/unemployed/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/unemployed/yes/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/unemployed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/unemployed/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/unemployed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/unemployed/yes/yes/10000-year.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/unemployed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/unemployed/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/no/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/no/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/no/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/no/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/no/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/no/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/no/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,6 +6,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/no/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,21 @@
+
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/no/yes/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/no/yes/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/no/yes/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/no/yes/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/no/yes/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/no/yes/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/no/yes/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,6 +6,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/no/yes/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,21 @@
+
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,6 +6,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,21 @@
+
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,6 +20,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -30,8 +30,6 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,43 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental pay (partner only)
+
+The mother’s partner can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance the mother has received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -30,6 +30,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/self-employed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/no/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/no/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/no/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/no/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/no/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/no/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/no/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/no/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/no/yes/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/no/yes/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/no/yes/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/no/yes/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/no/yes/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/no/yes/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/no/yes/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/no/yes/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,47 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Shared parental leave (partner only)
+
+The mother’s partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The partner can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the partner’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -29,8 +29,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -29,6 +29,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,65 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental leave (partner only)
+
+The mother’s partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The partner can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the partner’s employer | 8 weeks before the first block of SPL
+
+##Shared parental pay (partner only)
+
+The mother’s partner can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance the mother has received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -52,6 +52,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/employee/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -52,8 +52,6 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/self-employed/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/self-employed/no/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 14 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+| Dates and amounts
+- | -
+Maternity allowance can start on | 12 November 2017
+Weekly rate | £27
+Total allowance | £378
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/self-employed/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/self-employed/no/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 14 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+| Dates and amounts
+- | -
+Maternity allowance can start on | 12 November 2017
+Weekly rate | £27
+Total allowance | £378
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/self-employed/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/self-employed/yes/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 14 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+| Dates and amounts
+- | -
+Maternity allowance can start on | 12 November 2017
+Weekly rate | £27
+Total allowance | £378
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/self-employed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/self-employed/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/self-employed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/self-employed/yes/yes/10000-year.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/self-employed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/self-employed/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/unemployed/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/unemployed/no/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/unemployed/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/unemployed/no/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/unemployed/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/unemployed/yes/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/unemployed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/unemployed/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/unemployed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/unemployed/yes/yes/10000-year.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/unemployed/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/unemployed/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/no/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/no/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/no/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/no/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/no/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/no/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/no/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,6 +6,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/no/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,21 @@
+
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/no/yes/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/no/yes/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/no/yes/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/no/yes/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/no/yes/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/no/yes/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/no/yes/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,6 +6,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/no/yes/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,21 @@
+
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,6 +6,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,21 @@
+
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,6 +20,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -30,8 +30,6 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,43 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental pay (partner only)
+
+The mother’s partner can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance the mother has received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -30,6 +30,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/unemployed/worker/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,47 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Shared parental leave (partner only)
+
+The mother’s partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The partner can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the partner’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -29,8 +29,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -29,6 +29,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,65 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental leave (partner only)
+
+The mother’s partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The partner can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the partner’s employer | 8 weeks before the first block of SPL
+
+##Shared parental pay (partner only)
+
+The mother’s partner can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance the mother has received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -52,6 +52,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -52,8 +52,6 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,47 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Shared parental leave (partner only)
+
+The mother’s partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The partner can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the partner’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -29,8 +29,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -29,6 +29,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,65 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental leave (partner only)
+
+The mother’s partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The partner can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the partner’s employer | 8 weeks before the first block of SPL
+
+##Shared parental pay (partner only)
+
+The mother’s partner can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance the mother has received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -52,6 +52,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -52,8 +52,6 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,47 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Shared parental leave (partner only)
+
+The mother’s partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The partner can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the partner’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -29,8 +29,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -29,6 +29,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,65 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental leave (partner only)
+
+The mother’s partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The partner can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the partner’s employer | 8 weeks before the first block of SPL
+
+##Shared parental pay (partner only)
+
+The mother’s partner can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance the mother has received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -52,6 +52,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -52,8 +52,6 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,47 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Shared parental leave (partner only)
+
+The mother’s partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The partner can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the partner’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -29,8 +29,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -29,6 +29,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,65 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental leave (partner only)
+
+The mother’s partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The partner can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the partner’s employer | 8 weeks before the first block of SPL
+
+##Shared parental pay (partner only)
+
+The mother’s partner can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance the mother has received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -52,6 +52,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -52,8 +52,6 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,47 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Shared parental leave (partner only)
+
+The mother’s partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The partner can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the partner’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -29,8 +29,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -29,6 +29,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,65 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental leave (partner only)
+
+The mother’s partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The partner can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the partner’s employer | 8 weeks before the first block of SPL
+
+##Shared parental pay (partner only)
+
+The mother’s partner can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance the mother has received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -52,6 +52,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -52,8 +52,6 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,47 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Shared parental leave (partner only)
+
+The mother’s partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The partner can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the partner’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -29,8 +29,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -29,6 +29,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,65 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental leave (partner only)
+
+The mother’s partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The partner can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the partner’s employer | 8 weeks before the first block of SPL
+
+##Shared parental pay (partner only)
+
+The mother’s partner can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance the mother has received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -52,6 +52,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -52,8 +52,6 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,20 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,6 +15,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -15,8 +15,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,30 @@
+
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,47 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Shared parental leave (partner only)
+
+The mother’s partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The partner can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the partner’s employer | 8 weeks before the first block of SPL
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -29,8 +29,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -29,6 +29,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,65 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental leave (partner only)
+
+The mother’s partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The partner can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the partner’s employer | 8 weeks before the first block of SPL
+
+##Shared parental pay (partner only)
+
+The mother’s partner can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance the mother has received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -52,6 +52,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity leave

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -52,8 +52,6 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Shared parental pay (mother only)
+
+The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance they’ve received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -20,6 +20,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -20,8 +20,6 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Shared parental pay (mother only)
+
+The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance they’ve received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -20,6 +20,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -20,8 +20,6 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Shared parental pay (mother only)
+
+The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance they’ve received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -20,6 +20,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -20,8 +20,6 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Shared parental pay (mother only)
+
+The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance they’ve received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -20,6 +20,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -20,8 +20,6 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Shared parental pay (mother only)
+
+The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance they’ve received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -20,6 +20,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -20,8 +20,6 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Shared parental pay (mother only)
+
+The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance they’ve received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -20,6 +20,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -20,8 +20,6 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
@@ -1,0 +1,34 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,55 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Shared parental leave (partner only)
+
+The mother’s partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The partner can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the partner’s employer | 8 weeks before the first block of SPL
+
+##Shared parental pay (mother only)
+
+The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance they’ve received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -42,8 +42,6 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -42,6 +42,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -29,8 +29,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -29,6 +29,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental leave (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -52,6 +52,10 @@ The mother and her partner can both get [shared parental pay](/shared-parental-l
 
 ###Amount
 
+Mother’s shared parental pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Partner's shared parental pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,67 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Paternity leave
+
+The mother’s partner can take up to 2 weeks of [paternity leave](/paternity-pay-leave/leave).
+
+| Dates
+- | -
+Paternity leave must be used | within 56 days of the birth.
+Tell the partner’s employer by | 21 October 2017
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental leave (partner only)
+
+The mother’s partner can take [shared parental leave](/shared-parental-leave-and-pay) (SPL). It lasts for up to 52 weeks, minus any weeks of maternity leave taken by the mother.
+
+The partner can take SPL in up to 3 blocks, going back to work between the blocks.
+
+^The mother can’t take SPL.^
+
+| Dates
+- | -
+Shared parental leave must be used | Within a year of the birth
+Tell the partner’s employer | 8 weeks before the first block of SPL
+
+##Shared parental pay
+
+The mother and her partner can both get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance the mother has received.
+
+###Amount
+
+Mother’s shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Partner's shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/employee/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -52,10 +52,6 @@ The mother and her partner can both get [shared parental pay](/shared-parental-l
 
 ###Amount
 
-Mother’s shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
-Partner's shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/no/10000.0-year/no/no/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/no/10000.0-year/no/no/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/no/10000.0-year/no/yes/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/no/10000.0-year/yes/no/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/no/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/no/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/yes/10000.0-year/no/no/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/yes/10000.0-year/no/no/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/yes/10000.0-year/no/yes/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/yes/10000.0-year/yes/no/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/yes/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/yes/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/no/10000.0-year/no/no/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/no/10000.0-year/no/no/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/no/10000.0-year/no/yes/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/no/10000.0-year/yes/no/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/no/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/no/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/yes/10000.0-year/no/no/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/yes/10000.0-year/no/no/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/yes/10000.0-year/no/yes/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/yes/10000.0-year/yes/no/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/yes/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/yes/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Shared parental pay (mother only)
+
+The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance they’ve received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -20,6 +20,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/self-employed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -20,8 +20,6 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/no/10000.0-year/no/no/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/no/10000.0-year/no/no/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/no/10000.0-year/no/yes/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/no/10000.0-year/yes/no/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/no/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/no/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/yes/10000.0-year/no/no/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/yes/10000.0-year/no/no/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/yes/10000.0-year/no/yes/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/yes/10000.0-year/yes/no/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/yes/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/yes/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/no/yes/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/no/10000.0-year/no/no/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/no/10000.0-year/no/no/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/no/10000.0-year/no/yes/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/no/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/no/10000.0-year/yes/no/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/no/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/no/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/no/10000.0-year/yes/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/yes/10000.0-year/no/no/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/yes/10000.0-year/no/no/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/yes/10000.0-year/no/yes/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/yes/10000.0-year/no/yes/yes/10000-year.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/yes/10000.0-year/yes/no/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/yes/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/yes/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Shared parental pay (mother only)
+
+The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance they’ve received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -20,6 +20,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/unemployed/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -20,8 +20,6 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,6 +6,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,21 @@
+
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,6 +6,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,21 @@
+
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,6 +6,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,21 @@
+
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,6 +20,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -30,8 +30,6 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,43 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental pay (partner only)
+
+The mother’s partner can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance the mother has received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -30,6 +30,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,6 +6,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,21 @@
+
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,6 +6,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,21 @@
+
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,6 +6,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,21 @@
+
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,6 +20,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -30,8 +30,6 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,43 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental pay (partner only)
+
+The mother’s partner can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance the mother has received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -30,6 +30,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,6 +6,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,21 @@
+
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,6 +6,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,21 @@
+
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,6 +6,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,21 @@
+
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,6 +20,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -30,8 +30,6 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,43 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental pay (partner only)
+
+The mother’s partner can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance the mother has received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -30,6 +30,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,6 +6,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,21 @@
+
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,6 +6,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,21 @@
+
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,6 +6,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,21 @@
+
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,6 +20,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -30,8 +30,6 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,43 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental pay (partner only)
+
+The mother’s partner can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance the mother has received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -30,6 +30,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/no/yes/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,6 +6,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,21 @@
+
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,6 +6,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,21 @@
+
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,6 +6,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,21 @@
+
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,6 +20,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -30,8 +30,6 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,43 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental pay (partner only)
+
+The mother’s partner can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance the mother has received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -30,6 +30,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/no/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/no/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/no/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/no/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/no/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/no/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,6 +6,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/no/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,21 @@
+
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/no/yes/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/no/yes/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/no/yes/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/no/yes/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/no/yes/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/no/yes/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,6 +6,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/no/yes/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,21 @@
+
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,6 +6,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,21 @@
+
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,6 +20,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -30,8 +30,6 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,43 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental pay (partner only)
+
+The mother’s partner can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance the mother has received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -30,6 +30,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/no/10000.0-year/yes/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/no/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/no/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/no/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -6,6 +6,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/no/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,21 @@
+
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/no/yes/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/no/yes/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/no/yes/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -6,6 +6,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/no/yes/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,21 @@
+
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/no/no/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/no/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/no/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,13 @@
+
+
+The parents can’t get maternity leave or pay, paternity leave or pay, or shared parental leave or pay. 
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,8 +6,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -6,6 +6,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/no/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,21 @@
+
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/no/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/no/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/no.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Extra help

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,6 +20,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -30,8 +30,6 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,43 @@
+
+
+##Maternity allowance
+
+The mother can get [maternity allowance](/maternity-allowance) from the government for up to 39 weeks.
+
+^The mother isn't eligible for maternity allowance if she gets Statutory Maternity Pay from another job.^
+
+###Dates and amounts
+
+Maternity allowance can start on | 12 November 2017
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+
+The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental pay (partner only)
+
+The mother’s partner can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance the mother has received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -30,6 +30,8 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,8 +10,6 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
-
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental pay (partner only)

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/no/yes/yes/10000.0-year/yes/yes/10000.0-year/yes.txt
@@ -10,6 +10,8 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | 12 November 2017
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.
 
 ##Paternity pay

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/no/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Shared parental pay (mother only)
+
+The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance they’ve received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -20,6 +20,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/no/yes/yes.txt
@@ -20,8 +20,6 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Shared parental pay (mother only)
+
+The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance they’ve received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -20,6 +20,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/no/10000.0-year/yes/yes/yes.txt
@@ -20,8 +20,6 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/no/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Shared parental pay (mother only)
+
+The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance they’ve received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -20,6 +20,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/no/yes/yes.txt
@@ -20,8 +20,6 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Shared parental pay (mother only)
+
+The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance they’ve received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -20,6 +20,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/no/yes/10000.0-year/yes/yes/yes.txt
@@ -20,8 +20,6 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/no/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Shared parental pay (mother only)
+
+The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance they’ve received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -20,6 +20,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/no/yes/yes.txt
@@ -20,8 +20,6 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/no/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Shared parental pay (mother only)
+
+The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance they’ve received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -20,6 +20,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/no/10000.0-year/yes/yes/yes.txt
@@ -20,8 +20,6 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/no/yes.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/no.txt
@@ -1,0 +1,25 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -1,0 +1,33 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Shared parental pay (mother only)
+
+The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance they’ve received.
+
+###Amount
+
+Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -20,6 +20,8 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
+Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/no/yes/yes.txt
@@ -20,8 +20,6 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -30,6 +30,10 @@ The mother and her partner can both get [shared parental pay](/shared-parental-l
 
 ###Amount
 
+Mother’s shared parental pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Partner's shared parental pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -20,8 +20,6 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental pay

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -1,0 +1,45 @@
+
+
+##Maternity pay
+
+The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
+
+###Dates and amounts
+
+First 6 weeks | 90% of her average weekly earnings (before tax)
+
+Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+Tell the mother’s employer | 28 days before she wants want to start maternity pay
+
+Tax and National Insurance will be deducted.
+
+##Paternity pay
+
+The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-leave/pay).
+
+###Dates and amounts
+
+Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Tell the partner’s employer | 21 October 2017
+
+##Shared parental pay
+
+The mother and her partner can both get [shared parental pay](/shared-parental-leave-and-pay/overview). It lasts for up to 39 weeks, minus any weeks of maternity pay or maternity allowance the mother has received.
+
+###Amount
+
+Mother’s shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+Partner's shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+##Extra help
+
+They could get:
+
+- a £500 [Sure Start maternity grant](/sure-start-maternity-grant)
+- [benefits and tax credits](/benefits-calculators)
+
+
+

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -30,10 +30,6 @@ The mother and her partner can both get [shared parental pay](/shared-parental-l
 
 ###Amount
 
-Mother’s shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
-Partner's shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
-
 ##Extra help
 
 They could get:

--- a/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2018-02-01/worker/worker/yes/yes/10000.0-year/yes/yes/yes/10000.0-year/yes.txt
@@ -20,6 +20,8 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
+Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
 Tell the partner’s employer | 21 October 2017
 
 ##Shared parental pay

--- a/test/data/pay-leave-for-parents-files.yml
+++ b/test/data/pay-leave-for-parents-files.yml
@@ -104,4 +104,4 @@ lib/smart_answer_flows/pay-leave-for-parents/questions/partner_still_working_on_
 lib/smart_answer_flows/pay-leave-for-parents/questions/partner_worked_at_least_26_weeks.govspeak.erb: d9f1d868bbc5d89545a6f56396a9dd83
 lib/smart_answer_flows/pay-leave-for-parents/questions/salary_1_66_weeks.govspeak.erb: 9e6d0e41472690daf354dbef9dee36b5
 lib/smart_answer_flows/pay-leave-for-parents/questions/two_carers.govspeak.erb: bb7640d6d75c7882c1bf1d7feb90a8ac
-lib/smart_answer/calculators/pay_leave_for_parents_calculator.rb: a530b695a6514c7338c2beb21e56dcca
+lib/smart_answer/calculators/pay_leave_for_parents_calculator.rb: 27edfab8efa0fbad6fbafb27033bdf02

--- a/test/data/pay-leave-for-parents-files.yml
+++ b/test/data/pay-leave-for-parents-files.yml
@@ -8,7 +8,7 @@ lib/smart_answer_flows/pay-leave-for-parents/outcomes/_birth_nothing.govspeak.er
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_both_shared_leave.govspeak.erb: 7a2fc4dabb4b81d04c600bfcdb5898fe
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_both_shared_pay.govspeak.erb: 621cb7f0550fe5d38d9dc6d60dfb1a27
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_extra_help.govspeak.erb: 120e37ea86f9fd5fb138144d085549a7
-lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_allowance.govspeak.erb: b7c6fae7fa98a36781bd1b197150c5f8
+lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_allowance.govspeak.erb: 3991d96482a47f41c385076fba2c2a2b
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_allowance_14_weeks.govspeak.erb: e1555fd4de46d55dfb5d36e04f6bc42d
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_leave.govspeak.erb: 11e728f05f4e684db9a204c1f0cd62b3
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_pay.govspeak.erb: b93e26edaa0abfa2406723adf3579675

--- a/test/data/pay-leave-for-parents-files.yml
+++ b/test/data/pay-leave-for-parents-files.yml
@@ -3,7 +3,7 @@ lib/smart_answer_flows/pay-leave-for-parents.rb: f37cedf805aa6484b2e42ebbe6d42d9
 test/data/pay-leave-for-parents-questions-and-responses.yml: f77407cfeb279922121a952b1b99772b
 test/data/pay-leave-for-parents-responses-and-expected-results.yml: 3635c2ae8aaf92652f7dbae3c9a0a699
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_additional_pat_leave.govspeak.erb: dcede84d936f876a3c91c1457c3afc01
-lib/smart_answer_flows/pay-leave-for-parents/outcomes/_additional_pat_pay.govspeak.erb: d7089d045d450f62f66beb4c305db6b6
+lib/smart_answer_flows/pay-leave-for-parents/outcomes/_additional_pat_pay.govspeak.erb: 18f4b226c1b495ad1ed327cb2729cc79
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_birth_nothing.govspeak.erb: b550c42385547ccb1eab92cb3b3bff0b
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_both_shared_leave.govspeak.erb: 7a2fc4dabb4b81d04c600bfcdb5898fe
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_both_shared_pay.govspeak.erb: 621cb7f0550fe5d38d9dc6d60dfb1a27

--- a/test/data/pay-leave-for-parents-files.yml
+++ b/test/data/pay-leave-for-parents-files.yml
@@ -8,7 +8,7 @@ lib/smart_answer_flows/pay-leave-for-parents/outcomes/_birth_nothing.govspeak.er
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_both_shared_leave.govspeak.erb: 7a2fc4dabb4b81d04c600bfcdb5898fe
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_both_shared_pay.govspeak.erb: 621cb7f0550fe5d38d9dc6d60dfb1a27
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_extra_help.govspeak.erb: 120e37ea86f9fd5fb138144d085549a7
-lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_allowance.govspeak.erb: 3991d96482a47f41c385076fba2c2a2b
+lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_allowance.govspeak.erb: c6849372fa38ad64fee36e384703683e
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_allowance_14_weeks.govspeak.erb: e1555fd4de46d55dfb5d36e04f6bc42d
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_leave.govspeak.erb: 11e728f05f4e684db9a204c1f0cd62b3
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_pay.govspeak.erb: b93e26edaa0abfa2406723adf3579675

--- a/test/data/pay-leave-for-parents-files.yml
+++ b/test/data/pay-leave-for-parents-files.yml
@@ -15,7 +15,7 @@ lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_pay.govspeak.erb: b93
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_shared_leave.govspeak.erb: 11930d6727f1a95f6aba571c6c0148b6
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_shared_pay.govspeak.erb: 8d551b6951cda592031be89058fd69f6
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_leave.govspeak.erb: 5ca354d4c9d9a879c0b5d6e9a8df8d47
-lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_pay.govspeak.erb: 0c84842f4e5f28d3ae8831b5c9b2ca64
+lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_pay.govspeak.erb: 974aa9d20192b89ab5ed43bc2e35d2cf
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_shared_leave.govspeak.erb: 8a866beb5a6fb6fd3301185dfa7c9098
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_shared_pay.govspeak.erb: dd8475f0eabbd08efdf625db5dc4cede
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_single_birth_nothing.govspeak.erb: a62e26a33835b11b26320bcb09b193d6

--- a/test/data/pay-leave-for-parents-files.yml
+++ b/test/data/pay-leave-for-parents-files.yml
@@ -6,7 +6,7 @@ lib/smart_answer_flows/pay-leave-for-parents/outcomes/_additional_pat_leave.govs
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_additional_pat_pay.govspeak.erb: 75e94d6a556f701da24c7471721cd4e5
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_birth_nothing.govspeak.erb: b550c42385547ccb1eab92cb3b3bff0b
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_both_shared_leave.govspeak.erb: 7a2fc4dabb4b81d04c600bfcdb5898fe
-lib/smart_answer_flows/pay-leave-for-parents/outcomes/_both_shared_pay.govspeak.erb: 621cb7f0550fe5d38d9dc6d60dfb1a27
+lib/smart_answer_flows/pay-leave-for-parents/outcomes/_both_shared_pay.govspeak.erb: 37bc0e9138fd85883cf27b5c4a685623
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_extra_help.govspeak.erb: 120e37ea86f9fd5fb138144d085549a7
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_allowance.govspeak.erb: c6849372fa38ad64fee36e384703683e
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_allowance_14_weeks.govspeak.erb: e1555fd4de46d55dfb5d36e04f6bc42d

--- a/test/data/pay-leave-for-parents-files.yml
+++ b/test/data/pay-leave-for-parents-files.yml
@@ -3,7 +3,7 @@ lib/smart_answer_flows/pay-leave-for-parents.rb: f37cedf805aa6484b2e42ebbe6d42d9
 test/data/pay-leave-for-parents-questions-and-responses.yml: f77407cfeb279922121a952b1b99772b
 test/data/pay-leave-for-parents-responses-and-expected-results.yml: 3635c2ae8aaf92652f7dbae3c9a0a699
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_additional_pat_leave.govspeak.erb: dcede84d936f876a3c91c1457c3afc01
-lib/smart_answer_flows/pay-leave-for-parents/outcomes/_additional_pat_pay.govspeak.erb: 18f4b226c1b495ad1ed327cb2729cc79
+lib/smart_answer_flows/pay-leave-for-parents/outcomes/_additional_pat_pay.govspeak.erb: 75e94d6a556f701da24c7471721cd4e5
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_birth_nothing.govspeak.erb: b550c42385547ccb1eab92cb3b3bff0b
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_both_shared_leave.govspeak.erb: 7a2fc4dabb4b81d04c600bfcdb5898fe
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_both_shared_pay.govspeak.erb: 621cb7f0550fe5d38d9dc6d60dfb1a27

--- a/test/data/pay-leave-for-parents-files.yml
+++ b/test/data/pay-leave-for-parents-files.yml
@@ -1,7 +1,7 @@
 ---
 lib/smart_answer_flows/pay-leave-for-parents.rb: f37cedf805aa6484b2e42ebbe6d42d94
-test/data/pay-leave-for-parents-questions-and-responses.yml: 6aae67d1b585e8445878fb2994bac8d1
-test/data/pay-leave-for-parents-responses-and-expected-results.yml: 2cdd65aad00267bdf9a534e22858f03d
+test/data/pay-leave-for-parents-questions-and-responses.yml: f77407cfeb279922121a952b1b99772b
+test/data/pay-leave-for-parents-responses-and-expected-results.yml: 3635c2ae8aaf92652f7dbae3c9a0a699
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_additional_pat_leave.govspeak.erb: dcede84d936f876a3c91c1457c3afc01
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_additional_pat_pay.govspeak.erb: d7089d045d450f62f66beb4c305db6b6
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_birth_nothing.govspeak.erb: b550c42385547ccb1eab92cb3b3bff0b
@@ -11,7 +11,7 @@ lib/smart_answer_flows/pay-leave-for-parents/outcomes/_extra_help.govspeak.erb: 
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_allowance.govspeak.erb: b7c6fae7fa98a36781bd1b197150c5f8
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_allowance_14_weeks.govspeak.erb: e1555fd4de46d55dfb5d36e04f6bc42d
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_leave.govspeak.erb: 11e728f05f4e684db9a204c1f0cd62b3
-lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_pay.govspeak.erb: f12aafd411f2a5b4151e70831f265ce9
+lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_pay.govspeak.erb: b93e26edaa0abfa2406723adf3579675
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_shared_leave.govspeak.erb: 11930d6727f1a95f6aba571c6c0148b6
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_shared_pay.govspeak.erb: 8d551b6951cda592031be89058fd69f6
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_leave.govspeak.erb: 5ca354d4c9d9a879c0b5d6e9a8df8d47
@@ -104,4 +104,4 @@ lib/smart_answer_flows/pay-leave-for-parents/questions/partner_still_working_on_
 lib/smart_answer_flows/pay-leave-for-parents/questions/partner_worked_at_least_26_weeks.govspeak.erb: d9f1d868bbc5d89545a6f56396a9dd83
 lib/smart_answer_flows/pay-leave-for-parents/questions/salary_1_66_weeks.govspeak.erb: 9e6d0e41472690daf354dbef9dee36b5
 lib/smart_answer_flows/pay-leave-for-parents/questions/two_carers.govspeak.erb: bb7640d6d75c7882c1bf1d7feb90a8ac
-lib/smart_answer/calculators/pay_leave_for_parents_calculator.rb: 41b48410a507cd7d3af7a18dfca8a16a
+lib/smart_answer/calculators/pay_leave_for_parents_calculator.rb: bc1a998f8866fd559159d5d6ddc5f440

--- a/test/data/pay-leave-for-parents-files.yml
+++ b/test/data/pay-leave-for-parents-files.yml
@@ -13,11 +13,11 @@ lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_allowance_14_weeks.go
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_leave.govspeak.erb: 11e728f05f4e684db9a204c1f0cd62b3
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_pay.govspeak.erb: b93e26edaa0abfa2406723adf3579675
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_shared_leave.govspeak.erb: 11930d6727f1a95f6aba571c6c0148b6
-lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_shared_pay.govspeak.erb: ec3e1a5a55065ef0aab87168a64d0c9a
+lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_shared_pay.govspeak.erb: a508f7d8b26cd5c64ab686ae71cfd455
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_leave.govspeak.erb: 5ca354d4c9d9a879c0b5d6e9a8df8d47
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_pay.govspeak.erb: 974aa9d20192b89ab5ed43bc2e35d2cf
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_shared_leave.govspeak.erb: 8a866beb5a6fb6fd3301185dfa7c9098
-lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_shared_pay.govspeak.erb: 6210496fc4584ac394409402bea4f172
+lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_shared_pay.govspeak.erb: 9856d3dbf48a64dafccfdf3d0a8e40f2
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_single_birth_nothing.govspeak.erb: a62e26a33835b11b26320bcb09b193d6
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_statutory_maternity_pay_warning.govspeak.erb: 6bf9329c9514981523707aa72105e430
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/outcome_birth_nothing.govspeak.erb: 15ae49e3011c3aa0bfcde091a48b8a56

--- a/test/data/pay-leave-for-parents-files.yml
+++ b/test/data/pay-leave-for-parents-files.yml
@@ -6,7 +6,7 @@ lib/smart_answer_flows/pay-leave-for-parents/outcomes/_additional_pat_leave.govs
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_additional_pat_pay.govspeak.erb: 75e94d6a556f701da24c7471721cd4e5
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_birth_nothing.govspeak.erb: b550c42385547ccb1eab92cb3b3bff0b
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_both_shared_leave.govspeak.erb: 7a2fc4dabb4b81d04c600bfcdb5898fe
-lib/smart_answer_flows/pay-leave-for-parents/outcomes/_both_shared_pay.govspeak.erb: 37bc0e9138fd85883cf27b5c4a685623
+lib/smart_answer_flows/pay-leave-for-parents/outcomes/_both_shared_pay.govspeak.erb: db9bfd1cfd2c1dacd1e9d4519b8b8eb0
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_extra_help.govspeak.erb: 120e37ea86f9fd5fb138144d085549a7
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_allowance.govspeak.erb: c6849372fa38ad64fee36e384703683e
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_allowance_14_weeks.govspeak.erb: e1555fd4de46d55dfb5d36e04f6bc42d

--- a/test/data/pay-leave-for-parents-files.yml
+++ b/test/data/pay-leave-for-parents-files.yml
@@ -15,7 +15,7 @@ lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_pay.govspeak.erb: b93
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_shared_leave.govspeak.erb: 11930d6727f1a95f6aba571c6c0148b6
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_shared_pay.govspeak.erb: 8d551b6951cda592031be89058fd69f6
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_leave.govspeak.erb: 5ca354d4c9d9a879c0b5d6e9a8df8d47
-lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_pay.govspeak.erb: 30dfc0e0c1011a650076a20c46094c06
+lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_pay.govspeak.erb: 0c84842f4e5f28d3ae8831b5c9b2ca64
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_shared_leave.govspeak.erb: 8a866beb5a6fb6fd3301185dfa7c9098
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_shared_pay.govspeak.erb: dd8475f0eabbd08efdf625db5dc4cede
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_single_birth_nothing.govspeak.erb: a62e26a33835b11b26320bcb09b193d6

--- a/test/data/pay-leave-for-parents-files.yml
+++ b/test/data/pay-leave-for-parents-files.yml
@@ -13,11 +13,11 @@ lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_allowance_14_weeks.go
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_leave.govspeak.erb: 11e728f05f4e684db9a204c1f0cd62b3
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_pay.govspeak.erb: b93e26edaa0abfa2406723adf3579675
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_shared_leave.govspeak.erb: 11930d6727f1a95f6aba571c6c0148b6
-lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_shared_pay.govspeak.erb: 8d551b6951cda592031be89058fd69f6
+lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_shared_pay.govspeak.erb: ec3e1a5a55065ef0aab87168a64d0c9a
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_leave.govspeak.erb: 5ca354d4c9d9a879c0b5d6e9a8df8d47
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_pay.govspeak.erb: 974aa9d20192b89ab5ed43bc2e35d2cf
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_shared_leave.govspeak.erb: 8a866beb5a6fb6fd3301185dfa7c9098
-lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_shared_pay.govspeak.erb: dd8475f0eabbd08efdf625db5dc4cede
+lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_shared_pay.govspeak.erb: 6210496fc4584ac394409402bea4f172
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_single_birth_nothing.govspeak.erb: a62e26a33835b11b26320bcb09b193d6
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_statutory_maternity_pay_warning.govspeak.erb: 6bf9329c9514981523707aa72105e430
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/outcome_birth_nothing.govspeak.erb: 15ae49e3011c3aa0bfcde091a48b8a56

--- a/test/data/pay-leave-for-parents-files.yml
+++ b/test/data/pay-leave-for-parents-files.yml
@@ -11,7 +11,7 @@ lib/smart_answer_flows/pay-leave-for-parents/outcomes/_extra_help.govspeak.erb: 
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_allowance.govspeak.erb: b7c6fae7fa98a36781bd1b197150c5f8
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_allowance_14_weeks.govspeak.erb: e1555fd4de46d55dfb5d36e04f6bc42d
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_leave.govspeak.erb: 11e728f05f4e684db9a204c1f0cd62b3
-lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_pay.govspeak.erb: ee77d0073e0fa5fe2d402cfd56f4e045
+lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_pay.govspeak.erb: f12aafd411f2a5b4151e70831f265ce9
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_shared_leave.govspeak.erb: 11930d6727f1a95f6aba571c6c0148b6
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_shared_pay.govspeak.erb: 8d551b6951cda592031be89058fd69f6
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_leave.govspeak.erb: 5ca354d4c9d9a879c0b5d6e9a8df8d47
@@ -104,4 +104,4 @@ lib/smart_answer_flows/pay-leave-for-parents/questions/partner_still_working_on_
 lib/smart_answer_flows/pay-leave-for-parents/questions/partner_worked_at_least_26_weeks.govspeak.erb: d9f1d868bbc5d89545a6f56396a9dd83
 lib/smart_answer_flows/pay-leave-for-parents/questions/salary_1_66_weeks.govspeak.erb: 9e6d0e41472690daf354dbef9dee36b5
 lib/smart_answer_flows/pay-leave-for-parents/questions/two_carers.govspeak.erb: bb7640d6d75c7882c1bf1d7feb90a8ac
-lib/smart_answer/calculators/pay_leave_for_parents_calculator.rb: 83aec654ae82b98c797ee4bc04e62abb
+lib/smart_answer/calculators/pay_leave_for_parents_calculator.rb: 41b48410a507cd7d3af7a18dfca8a16a

--- a/test/data/pay-leave-for-parents-files.yml
+++ b/test/data/pay-leave-for-parents-files.yml
@@ -104,4 +104,4 @@ lib/smart_answer_flows/pay-leave-for-parents/questions/partner_still_working_on_
 lib/smart_answer_flows/pay-leave-for-parents/questions/partner_worked_at_least_26_weeks.govspeak.erb: d9f1d868bbc5d89545a6f56396a9dd83
 lib/smart_answer_flows/pay-leave-for-parents/questions/salary_1_66_weeks.govspeak.erb: 9e6d0e41472690daf354dbef9dee36b5
 lib/smart_answer_flows/pay-leave-for-parents/questions/two_carers.govspeak.erb: bb7640d6d75c7882c1bf1d7feb90a8ac
-lib/smart_answer/calculators/pay_leave_for_parents_calculator.rb: bc1a998f8866fd559159d5d6ddc5f440
+lib/smart_answer/calculators/pay_leave_for_parents_calculator.rb: a530b695a6514c7338c2beb21e56dcca

--- a/test/data/pay-leave-for-parents-questions-and-responses.yml
+++ b/test/data/pay-leave-for-parents-questions-and-responses.yml
@@ -8,7 +8,8 @@
 - '2015-02-01' # in 14/15 financial year
 - '2015-04-05' # in 14/15 financial year but on or after 5 Apr 15
 - '2016-02-01' # in 15/16 financial year
-- '2017-02-01' # not in 13/14, 14/15, 15/16 financial years, but after 5 Apr 15
+- '2017-02-01' # in 16/17 financial year
+- '2018-02-01' # in 17/18 financial year
 :mother_started_working_before_continuity_start_date:
 - 'yes'
 - 'no'

--- a/test/unit/calculators/pay_leave_for_parents_calculator_test.rb
+++ b/test/unit/calculators/pay_leave_for_parents_calculator_test.rb
@@ -126,6 +126,34 @@ module SmartAnswer
           assert_equal 112, @calculator.lower_earnings_amount
         end
       end
+
+      context "due date in 2017-2018 range" do
+        setup do
+          @date = Date.parse("2018-01-01")
+          @calculator = PayLeaveForParentsCalculator.new
+          @calculator.due_date = @date
+        end
+
+        should "be in 2017-2018 financial year" do
+          assert_equal true, @calculator.in_2017_2018_fin_year?(@date)
+        end
+
+        should "return £113 for lower_earnings_amount" do
+          assert_equal 113, @calculator.lower_earnings_amount
+        end
+      end
+
+      context "due date outside all ranges" do
+        setup do
+          @date = Date.parse("2022-01-01")
+          @calculator = PayLeaveForParentsCalculator.new
+          @calculator.due_date = @date
+        end
+
+        should "return the latest_pay_leave known lower_earnings_amount" do
+          assert_equal 113, @calculator.lower_earnings_amount
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/pay_leave_for_parents_calculator_test.rb
+++ b/test/unit/calculators/pay_leave_for_parents_calculator_test.rb
@@ -111,14 +111,18 @@ module SmartAnswer
         end
       end
 
-      context "due date outside all ranges" do
+      context "due date in 2016-2017 range" do
         setup do
-          @date = Date.parse("2022-1-1")
+          @date = Date.parse("2017-01-01")
           @calculator = PayLeaveForParentsCalculator.new
           @calculator.due_date = @date
         end
 
-        should "return the latest_pat_leave known lower_earnings_amount" do
+        should "be in 2016-2017 financial year" do
+          assert_equal true, @calculator.in_2016_2017_fin_year?(@date)
+        end
+
+        should "return £112 for lower_earnings_amount" do
           assert_equal 112, @calculator.lower_earnings_amount
         end
       end


### PR DESCRIPTION
Trello card: https://trello.com/c/Fc1bzWu0

## Factcheck
[pay-leave-for-parents](https://smart-answers-pr-2966.herokuapp.com/pay-leave-for-parents/y/yes/2017-06-02/employee/employee/yes/yes/26000.0-year/yes/yes/yes/26000.0-year/yes)

## Expected changes
* [URL on GOV.UK](https://www.gov.uk/pay-leave-for-parents/y/yes/2017-06-02/employee/employee/yes/yes/26000.0-year/yes/yes/yes/26000.0-year/yes)

The requested changes are to update `pay-leave-for-parents` with the figures for 2017-18, however in order to do this, the rates and text for the 2016-2017 tax year had to be fixed first. 

Half of the commits add the correct text and logic for parental leave that falls in the 2016-2017 tax year and the other half add the text and logic to display the rates for the 2017-2018 tax year.

### Before
![screen shot 2017-03-17 at 17 03 07](https://cloud.githubusercontent.com/assets/5793815/24054300/a5dbfe08-0b33-11e7-9563-de8444d68d25.png)

### After
![screen shot 2017-03-17 at 17 03 45](https://cloud.githubusercontent.com/assets/5793815/24054315/b3ca8926-0b33-11e7-8f2d-f3bf7b80918c.png)
