### PR TITLE
Mouse tracking

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'uk_postcode', '~> 1.0.1'
 gem 'unicorn', '4.8.3'
 gem 'rails_stdout_logging'
 gem 'govuk_navigation_helpers', '~> 4.0'
-gem 'govuk_ab_testing', '1.0.4'
+gem 'govuk_ab_testing', '~> 2.0'
 gem 'statsd-ruby', '1.3.0', require: 'statsd'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,7 @@ GEM
     govuk-lint (0.7.0)
       rubocop (~> 0.35.0)
       scss_lint
-    govuk_ab_testing (1.0.4)
+    govuk_ab_testing (2.0.0)
     govuk_frontend_toolkit (4.14.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
@@ -278,7 +278,7 @@ DEPENDENCIES
   govspeak (~> 3.3.0)
   govuk-content-schema-test-helpers (~> 1.3.0)
   govuk-lint
-  govuk_ab_testing (= 1.0.4)
+  govuk_ab_testing (~> 2.0)
   govuk_frontend_toolkit (= 4.14.0)
   govuk_navigation_helpers (~> 4.0)
   htmlentities (~> 4)

--- a/app/assets/javascripts/mouseflow.js
+++ b/app/assets/javascripts/mouseflow.js
@@ -1,0 +1,9 @@
+var _mfq = _mfq || [];
+
+(function() {
+  var mf = document.createElement("script");
+  mf.type = "text/javascript";
+  mf.async = true;
+  mf.src = "//cdn.mouseflow.com/projects/807ab5b2-3fe4-4b3b-b4d7-e83b8f6e71fe.js";
+  document.getElementsByTagName("head")[0].appendChild(mf);
+})();

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,21 @@ class ApplicationController < ActionController::Base
 
   slimmer_template 'wrapper'
 
+  helper_method :benchmarking_ab_test
+  helper_method :should_track_mouse_movements?
+
+  def benchmarking_ab_test
+    @benchmarking_ab_test ||= begin
+      benchmarking_test = BenchmarkingAbTestRequest.new(request)
+      benchmarking_test.set_response_vary_header(response)
+      benchmarking_test
+    end
+  end
+
+  def should_track_mouse_movements?
+    benchmarking_ab_test.in_benchmarking?
+  end
+
 protected
 
   def error_404; error(404); end

--- a/app/models/benchmarking_ab_test_request.rb
+++ b/app/models/benchmarking_ab_test_request.rb
@@ -1,0 +1,22 @@
+class BenchmarkingAbTestRequest
+  attr_accessor :requested_variant
+
+  delegate :analytics_meta_tag, to: :requested_variant
+
+  def initialize(request)
+    dimension = Rails.application.config.benchmarking_ab_test_dimension
+    ab_test = GovukAbTesting::AbTest.new(
+      "Benchmarking",
+      dimension: dimension
+    )
+    @requested_variant = ab_test.requested_variant(request.headers)
+  end
+
+  def in_benchmarking?
+    requested_variant.variant_b?
+  end
+
+  def set_response_vary_header(response)
+    requested_variant.configure_response(response)
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
     <title><%= yield :title %> - GOV.UK</title>
     <%= yield :head %>
 
+    <%= benchmarking_ab_test.requested_variant.analytics_meta_tag.html_safe %>
     <% if @content_item %>
       <%= render partial: 'govuk_component/analytics_meta_tags', locals: { content_item: @content_item } %>
     <% end %>
@@ -16,5 +17,9 @@
   <div id="wrapper" class="answer smart_answer">
     <%= yield %>
   </div>
+
+  <% if should_track_mouse_movements? %>
+    <%= javascript_include_tag 'mouseflow' %>
+  <% end %>
 </body>
 </html>

--- a/config/application.rb
+++ b/config/application.rb
@@ -51,6 +51,7 @@ module SmartAnswers
       dagre.js
       visualise.js
       visualise.css
+      mouseflow.js
     )
 
     # Version of your assets, change this if you want to expire all your assets
@@ -60,5 +61,8 @@ module SmartAnswers
     config.action_dispatch.rack_cache = nil
 
     config.action_dispatch.ignore_accept_header = true
+
+    # Google Analytics dimension assigned to the benchmarking A/B test
+    config.benchmarking_ab_test_dimension = 49
   end
 end

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -280,7 +280,7 @@ class SmartAnswersControllerTest < ActionController::TestCase
 
             get :show, id: 'smart-answers-controller-sample'
 
-            assert_response_not_modified_for_ab_test
+            assert_response_not_modified_for_ab_test('EducationNavigation')
           end
         end
       end

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -199,7 +199,7 @@ class SmartAnswersControllerTest < ActionController::TestCase
       end
     end
 
-    context "A/B testing" do
+    context "EducationNavigation A/B testing" do
       context "pages under A/B test" do
         setup do
           content_item = {
@@ -282,6 +282,24 @@ class SmartAnswersControllerTest < ActionController::TestCase
 
             assert_response_not_modified_for_ab_test('EducationNavigation')
           end
+        end
+      end
+    end
+
+    context "Benchmarking A/B test" do
+      should "show the mouseflow tag when in the benchmarking test" do
+        with_variant Benchmarking: "B" do
+          get :show, id: 'smart-answers-controller-sample'
+
+          assert_select("script[src*=mouseflow]", 1, "Expected to find one script tag with the mouseflow js code on the page")
+        end
+      end
+
+      should "not show the mouseflow tag when not in the benchmarking test" do
+        with_variant Benchmarking: "A" do
+          get :show, id: 'smart-answers-controller-sample'
+
+          assert_select("script[src*=mouseflow]", 0, "Did not expect to find a script tag with the mouseflow js code on the page")
         end
       end
     end


### PR DESCRIPTION
### Background

We are going to conduct a 2nd round of Benchmarking in GOV.UK. The idea is that we will try it with the new Education Navigation enabled across GOV.UK and see how it performs against the current navigation patterns (mainstream browse pages, topics, etc).

Besides checking if people actually complete the tasks, we would also like to know more details about how they use the new navigation pages and also about the new orientation in content pages. In order to do that, we will track mouse movements and gather the results in a heatmap. We are using a software called mouseflow to do this.

The tracking code will only be present for the people doing the benchmarking test (around 60 people). It will be behind a new A/B test so the tracking doesn't run for other GOV.UK users. These 60 users will be presented with a consent form where this will be explained.

### What this PR does

This PR adds the Mouseflow tracking code behind a new A/B test (`GOVUK-ABTest-Benchmarking`). With this new A/B test, we will be able to enable Mouseflow for all 60 users in the benchmarking round. This will allow us to collect data on how the navigation pages are used and generate a heatmap in the end in order to help us understand what areas of the site will be improved.

Trello: https://trello.com/c/NJ6O76BR/281-heatmap-tracking