### PR TITLE
Updates to bereavement benefit content

### DIFF
--- a/lib/smart_answer_flows/state-pension-through-partner/outcomes/current_rules_national_insurance_no_state_pension_outcome.govspeak.erb
+++ b/lib/smart_answer_flows/state-pension-through-partner/outcomes/current_rules_national_insurance_no_state_pension_outcome.govspeak.erb
@@ -20,8 +20,6 @@
 
   You may also inherit some of their [Additional State Pension](/additional-state-pension) based on their contributions up to 5 April 2016 and half their Graduated Retirement Benefit (the earnings-related State Pension between 1961 and 1975).
 
-^You may be eligible for a [Bereavement Payment](/bereavement-payment) if your late spouse or civil partner wasn’t getting State Pension when they died.^
-
   ##If you get divorced or your civil partnership is dissolved
 
   You may be able to increase your [basic State Pension](/state-pension) up to <%= format_money(calculator.higher_basic_state_pension_rate) %> a week if:

--- a/lib/smart_answer_flows/state-pension-through-partner/outcomes/current_rules_no_additional_pension_outcome.govspeak.erb
+++ b/lib/smart_answer_flows/state-pension-through-partner/outcomes/current_rules_no_additional_pension_outcome.govspeak.erb
@@ -20,9 +20,6 @@
 
   You may also inherit a portion of their [Additional State-Pension](/additional-state-pension) and a portion of any [State Pension top up](/voluntary-national-insurance-contributions/top-up-your-state-pension). If they had [put off claiming their State Pension](/deferring-state-pension/tax-and-inheritance) you may inherit a portion of their deferral payment. You may also inherit half their Graduated Retirement Benefit (the earnings-related State Pension people could build up between 1961 and 1975).
 
-You may be eligible for a [Bereavement Payment](/bereavement-payment) if your late spouse or civil partner was not getting State Pension when they died.
-
-
   ##If you get divorced or your civil partnership is dissolved
 
   You may be able to increase your basic State Pension up to <%= format_money(calculator.higher_basic_state_pension_rate) %> a week if:

--- a/lib/smart_answer_flows/state-pension-through-partner/outcomes/married_woman_and_state_pension_outcome.govspeak.erb
+++ b/lib/smart_answer_flows/state-pension-through-partner/outcomes/married_woman_and_state_pension_outcome.govspeak.erb
@@ -77,7 +77,7 @@
 
   ###Other benefits you might get
 
-You might be eligible for a [Bereavement payment](/bereavement-payment), [Widowed Parent’s Allowance](/widowed-parents-allowance), or [Bereavement Allowance](/bereavement-allowance) if you haven’t yet reached State Pension age. You might be eligible for a bereavement payment if you’re over State Pension age but your late spouse or civil partner wasn’t getting any State Pension when they died.
+You might be eligible for a [Bereavement Support Payment](/bereavement-support-payment) if you haven’t yet reached State Pension age. 
 
   ^You can contact the [Future Pension Centre](/future-pension-centre) for help and advice.^
 

--- a/lib/smart_answer_flows/state-pension-through-partner/outcomes/married_woman_no_state_pension_outcome.govspeak.erb
+++ b/lib/smart_answer_flows/state-pension-through-partner/outcomes/married_woman_no_state_pension_outcome.govspeak.erb
@@ -63,7 +63,7 @@
 
   ###Other benefits you might get
 
-You might be eligible for a [Bereavement Payment](/bereavement-payment), [Widowed Parent’s Allowance](/widowed-parents-allowance), or [Bereavement Allowance](/bereavement-allowance) if you haven’t yet reached State Pension age. You might be eligible for a bereavement payment if you’re over State Pension age but your late spouse or civil partner was not getting any State Pension when they died.
+You might be eligible for a [Bereavement Support Payment](/bereavement-support-payment) if you haven’t yet reached State Pension age. 
 
   You should contact the [Future Pension Centre](/future-pension-centre) if you become widowed.
 

--- a/lib/smart_answer_flows/state-pension-through-partner/outcomes/widow_and_old_pension_outcome.govspeak.erb
+++ b/lib/smart_answer_flows/state-pension-through-partner/outcomes/widow_and_old_pension_outcome.govspeak.erb
@@ -36,11 +36,6 @@
 
   ^You can’t inherit any of your late spouse or civil partner’s State Pension if you were widowed before State Pension age and you remarried or formed a new civil partnership before State Pension age.^
 
-##Other help if you’re widowed
- 
- You may be eligible for a [Bereavement Payment](/bereavement-payment) if your late spouse or civil partner wasn’t getting State Pension when they died.
-
-
   ##If you remarry or form a new civil partnership
 
   You’ll normally keep any State Pension you’re getting through your previous spouse or civil partner if you remarry or form a new civil partnership after you’ve reached State Pension age. But if you’d get more State Pension through your new spouse or civil partner, you’ll get that instead.


### PR DESCRIPTION
Users will no longer be eligible for certain benefits in April. Bereavement Support Payment is replacing Bereavement Payment for users whose partners die after 6/4. 

These changes need to go live 6/4.

Trello: https://trello.com/c/qpknCFll/590-content-and-links-update-for-state-pension-through-partner