### PR TITLE
Add rake task to retire a smart answer

### DIFF
--- a/app/services/content_item_publisher.rb
+++ b/app/services/content_item_publisher.rb
@@ -6,4 +6,16 @@ class ContentItemPublisher
       Services.publishing_api.publish(content_item.content_id, 'minor')
     end
   end
+
+  def unpublish(content_id)
+    if content_id.present?
+      Services.publishing_api.unpublish(
+        content_id,
+        type: "gone",
+        unpublished_at: Time.now
+      )
+    else
+      raise "Content id has not been supplied"
+    end
+  end
 end

--- a/app/services/content_item_publisher.rb
+++ b/app/services/content_item_publisher.rb
@@ -18,4 +18,36 @@ class ContentItemPublisher
       raise "Content id has not been supplied"
     end
   end
+
+  def redirect_smart_answer(path, destination)
+    if path.present? && destination.present?
+      content_id = SecureRandom.uuid
+      create_params = {
+        base_path: path,
+        document_type: :redirect,
+        publishing_app: :smartanswers,
+        schema_name: :redirect,
+        redirects: [
+          { path: path, type: :prefix, destination: destination }
+        ]
+      }
+
+      response = Services.publishing_api.put_content(content_id, create_params)
+
+      if response.code == 200
+        Services.publishing_api.publish(content_id, :major)
+        Services.router_api.add_redirect_route(
+          path,
+          :prefix,
+          destination,
+          :permanent,
+          segments_mode: :ignore
+        )
+      else
+        raise "This content item has not been created"
+      end
+    else
+      raise "The destination or path isn't defined"
+    end
+  end
 end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -4,6 +4,7 @@ require 'gds_api/content_store'
 require 'gds_api/imminence'
 require 'gds_api/worldwide'
 require 'gds_api/rummager'
+require 'gds_api/router'
 
 module Services
   def self.publishing_api
@@ -23,6 +24,12 @@ module Services
 
   def self.rummager
     @rummager ||= GdsApi::Rummager.new(Plek.find("rummager"))
+  end
+
+  def self.router_api
+    @router ||= GdsApi::Router.new(
+      Plek.new.find('router-api')
+    )
   end
 
   def self.content_store

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -11,4 +11,12 @@ namespace :publishing_api do
 
     ContentItemPublisher.new.unpublish(args.content_id)
   end
+
+  desc "Create redirect for a smart answer's paths on the content-store"
+  task :redirect_smart_answer, [:path, :destination] => :environment do |_, args|
+    raise "Missing path parameter" unless args.path
+    raise "Missing destination parameter" unless args.destination
+
+    ContentItemPublisher.new.redirect_smart_answer(args.path, args.destination)
+  end
 end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -4,4 +4,11 @@ namespace :publishing_api do
     flow_presenters = RegisterableSmartAnswers.new.flow_presenters
     ContentItemPublisher.new.publish(flow_presenters)
   end
+
+  desc "Unpublish a smart answer from content-store"
+  task :unpublish, [:content_id] => :environment do |_, args|
+    raise "Missing content-id parameter" unless args.content_id
+
+    ContentItemPublisher.new.unpublish(args.content_id)
+  end
 end

--- a/test/unit/services/content_item_publisher_test.rb
+++ b/test/unit/services/content_item_publisher_test.rb
@@ -17,4 +17,23 @@ class ContentItemPublisherTest < ActiveSupport::TestCase
     assert_requested draft_request
     assert_requested publishing_request
   end
+
+  context "#unpublish" do
+    should 'send unpublish request to content store' do
+      unpublish_url = 'https://publishing-api.test.gov.uk/v2/content/content-id/unpublish'
+      unpublish_request = stub_request(:post, unpublish_url)
+
+      ContentItemPublisher.new.unpublish('content-id')
+
+      assert_requested unpublish_request
+    end
+
+    should 'raises exception if smart answer does not exist' do
+      exception = assert_raises(RuntimeError) do
+        ContentItemPublisher.new.unpublish(nil)
+      end
+
+      assert_equal "Content id has not been supplied", exception.message
+    end
+  end
 end

--- a/test/unit/tasks/publishing_api_test.rb
+++ b/test/unit/tasks/publishing_api_test.rb
@@ -21,4 +21,33 @@ class PublishingApiRakeTest < ActiveSupport::TestCase
       Rake::Task["publishing_api:unpublish"].invoke("content-id")
     end
   end
+
+  context "publishing_api:redirect_smart_answer rake task" do
+    setup do
+      Rake::Task["publishing_api:redirect_smart_answer"].reenable
+      ContentItemPublisher.any_instance.stubs(:redirect_smart_answer).returns(nil)
+    end
+
+    should "raise exception when destination isn't defined" do
+      exception = assert_raises RuntimeError do
+        Rake::Task["publishing_api:redirect_smart_answer"].invoke("base-path", nil)
+      end
+
+      assert_equal "Missing destination parameter", exception.message
+    end
+
+    should "raise exception when path isn't defined" do
+      exception = assert_raises RuntimeError do
+        Rake::Task["publishing_api:redirect_smart_answer"].invoke(nil, "/destination-path")
+      end
+
+      assert_equal "Missing path parameter", exception.message
+    end
+
+    should "invoke the redirect_smart_answer method from ContentItemPublisher" do
+      ContentItemPublisher.any_instance.expects(:redirect_smart_answer).with("/base-path", "/destination-path").once
+
+      Rake::Task["publishing_api:redirect_smart_answer"].invoke("/base-path", "/destination-path")
+    end
+  end
 end

--- a/test/unit/tasks/publishing_api_test.rb
+++ b/test/unit/tasks/publishing_api_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class PublishingApiRakeTest < ActiveSupport::TestCase
+  context "publishing_api:unpublish rake task" do
+    setup do
+      Rake::Task["publishing_api:unpublish"].reenable
+      ContentItemPublisher.any_instance.stubs(:unpublish).returns(nil)
+    end
+
+    should "raise exception when slug isn't defined" do
+      exception = assert_raises RuntimeError do
+        Rake::Task["publishing_api:unpublish"].invoke
+      end
+
+      assert_equal "Missing content-id parameter", exception.message
+    end
+
+    should "invoke the unpublished method from ContentItemPublisher" do
+      ContentItemPublisher.any_instance.expects(:unpublish).with("content-id").once
+
+      Rake::Task["publishing_api:unpublish"].invoke("content-id")
+    end
+  end
+end


### PR DESCRIPTION
[Trello card](https://trello.com/c/TMIpJm8c/585-5-6-april-state-pension-top-up-delete-calculator)

## Description 
State pension topup has reached it's end. A request has been made to retire this smart answer.

This PR holds implementation for retiring a smart answer in a reusable way. So far the strategy can be categorised into two stages:

- Unpublishing a smart answer: 

   This uses the publishing-api to un-publish this the given smart answer.
   A smart answer's content-id  is required to be passed to the rake task.

   (i.e `rake publishing_api:unpublish[content-id]`)

   When this rake task is invoked a post request [1] is composed and made.
   This transitions an edition of a document into an unpublished state. The
   edition will be updated or removed from the live content store and sets
   it to type of gone with status 410.


-  Redirect smart answer paths to new destination

   This has become necessary as part of the process of retiring a smart answer.

    Once a smart answer has been unpublished it paths may need to point to a new
    destination.

    This implementation provides a rake task level interface that helps
    create a redirect format with a prefix type on the content store.

    This uses the publishing api to establish the redirect between
    the path and its new destination.

    (i.e `rake publishing_api:redirect_smart_answer[path,destination]`)

   When this rake task is invoked a put request [1] is composed and made.
   This request publishes the redirect with the supplied parameters.

- Update router API

## Expected changes

- A smart answer is retired
- Publishing app is switched from smart answers to another
- Paths under */y are redirected to a new destination of choice


## Testing in Integration

https://deploy.integration.publishing.service.gov.uk/job/Deploy_App/11942/
https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/1609/console