### PR TITLE
Divert Start/Continue link for Overseas Passports

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,4 +21,12 @@ module ApplicationHelper
       "Start now"
     end
   end
+
+  def start_button_href
+    if @name.to_s == "overseas-passports"
+      "https://www.passport.service.gov.uk/filter"
+    else
+      smart_answer_path(@name, started: 'y')
+    end
+  end
 end

--- a/app/views/smart_answers/_landing.html.erb
+++ b/app/views/smart_answers/_landing.html.erb
@@ -18,7 +18,7 @@
       <div class="intro">
         <%= start_node.body %>
         <p class="get-started">
-          <a rel="nofollow" href="<%= smart_answer_path(@name, started: 'y') %>" class="big button"><%= start_button %></a>
+          <a rel="nofollow" href="<%= start_button_href %>" class="big button"><%= start_button %></a>
         </p>
       </div>
       <%= start_node.post_body %>


### PR DESCRIPTION
[Trello card](https://trello.com/c/OPekh47b)

This is part of [retiring Overseas Passports](https://trello.com/c/KujjRCk9)

Add logic to send users to hardcoded link when using the Overseas
Passports Smart Answer. This is a temporary measure while we work to
retire the Smart Answer permanently. We’ve had to roll out this
workaround as a matter of urgency.

There are no tests for the helper, which follows on from previous
changes on the ApplicationHelper in:

https://github.com/alphagov/smart-answers/pull/2792/commits/272251a8d302dd434c062385aa5ccfed81f0a075

## Expected changes

The "Start button" (labelled "Continue" in this case) will point the user to https://www.passport.service.gov.uk/filter/overseas

## Before
![image](https://cloud.githubusercontent.com/assets/424772/24861773/c345824a-1df1-11e7-8717-a1ad5009cb04.png)


## After
![image](https://cloud.githubusercontent.com/assets/424772/24861779/c93176d2-1df1-11e7-965f-c4517a45860f.png)

