### PR TITLE
Add implementation and tests to render and validate start button text and link

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,21 +4,10 @@ module ApplicationHelper
   end
 
   def start_button
-    case @name.to_s
-    when "overseas-passports"
-      "Continue"
-    when "calculate-your-child-maintenance"
-      "Calculate your child maintenance"
-    else
-      "Start now"
-    end
+    SmartAnswer::StartButton.new(@name, self).text
   end
 
   def start_button_href
-    if @name.to_s == "overseas-passports"
-      "https://www.passport.service.gov.uk/filter"
-    else
-      smart_answer_path(@name, started: 'y')
-    end
+    SmartAnswer::StartButton.new(@name, self).href
   end
 end

--- a/app/views/smart_answers/landing.html.erb
+++ b/app/views/smart_answers/landing.html.erb
@@ -20,7 +20,7 @@
         <%= start_node.body %>
 
         <p class="get-started">
-          <a rel="nofollow" href="<%= smart_answer_path(@name, started: 'y') %>" class="big button"><%= start_button %></a>
+          <a rel="nofollow" href="<%= start_button_href %>" class="big button"><%= start_button %></a>
         </p>
       </div>
 

--- a/lib/smart_answer/start_button.rb
+++ b/lib/smart_answer/start_button.rb
@@ -31,7 +31,7 @@ module SmartAnswer
       {
         "overseas-passports": {
           text: "Continue",
-          href: "/overseas-passports/y"
+          href: "https://www.passport.service.gov.uk/filter"
         },
         "calculate-your-child-maintenance": {
           text: "Calculate your child maintenance",

--- a/lib/smart_answer/start_button.rb
+++ b/lib/smart_answer/start_button.rb
@@ -1,0 +1,43 @@
+module SmartAnswer
+  class StartButton
+    def initialize(smart_answer, view)
+      @smart_answer = smart_answer.to_sym
+      @view = view
+    end
+
+    def text
+      if customized_start_button?
+        custom_text_and_link[@smart_answer][:text]
+      else
+        "Start now"
+      end
+    end
+
+    def href
+      if customized_start_button?
+        custom_text_and_link[@smart_answer][:href]
+      else
+        @view.smart_answer_path(@smart_answer.to_s, started: "y")
+      end
+    end
+
+  private
+
+    def customized_start_button?
+      custom_text_and_link.has_key?(@smart_answer)
+    end
+
+    def custom_text_and_link
+      {
+        "overseas-passports": {
+          text: "Continue",
+          href: "/overseas-passports/y"
+        },
+        "calculate-your-child-maintenance": {
+          text: "Calculate your child maintenance",
+          href: "/calculate-your-child-maintenance/y"
+        }
+      }
+    end
+  end
+end

--- a/test/integration/start_page_test.rb
+++ b/test/integration/start_page_test.rb
@@ -1,0 +1,32 @@
+require_relative "../integration_test_helper"
+
+class StartPageTest < ActionDispatch::IntegrationTest
+  context "start page" do
+    RegisterableSmartAnswers.new.flow_presenters.each do |flow_presenter|
+      slug = flow_presenter.slug
+      context "when the smart answer is `#{slug}`" do
+        setup do
+          @view = mock("view")
+          @view.stubs(:smart_answer_path).returns("/#{slug}/y")
+        end
+
+        should "have button text and href belonging to this smart answer" do
+          start_button = SmartAnswer::StartButton.new(slug, @view)
+          Services.content_store.stubs(:content_item)
+            .with("/#{slug}")
+            .returns({})
+
+          visit "/#{slug}"
+
+          assert_current_url "/#{slug}"
+          within ".intro" do
+            assert page.has_link?(
+              start_button.text,
+              href: start_button.href
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/unit/start_button_test.rb
+++ b/test/unit/start_button_test.rb
@@ -1,0 +1,40 @@
+require_relative "../test_helper"
+
+module SmartAnswer
+  class StartButtonTest < ActiveSupport::TestCase
+    setup do
+      StartButton.any_instance.stubs(:custom_text_and_link).returns(
+        "customized-smart-answer": {
+          text: "Custom text",
+          href: "https://www.custom.service.gov.uk/path/to/external"
+        }
+      )
+      @view = mock("view")
+      @view.stubs(:smart_answer_path).returns("/another-smart-answer/y")
+    end
+
+    context "#text" do
+      should "return Start now when smart answer hasn't been customized" do
+        start_button = StartButton.new("another-smart-answer", @view)
+        assert_equal "Start now", start_button.text
+      end
+
+      should "return Custom text when smart answer has been customized" do
+        start_button = StartButton.new("customized-smart-answer", @view)
+        assert_equal "Custom text", start_button.text
+      end
+    end
+
+    context "#href" do
+      should "return /another-smart-answer/y when smart answer hasn't been customized" do
+        start_button = StartButton.new("another-smart-answer", @view)
+        assert_equal "/another-smart-answer/y", start_button.href
+      end
+
+      should "return the given link when smart answer has been customized" do
+        start_button = StartButton.new("customized-smart-answer", @view)
+        assert_equal "https://www.custom.service.gov.uk/path/to/external", start_button.href
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Trello card](https://trello.com/c/7AFqtTjE/598-important-overseas-passports-add-integration-test-to-validate-link-forwards-to-external-service)

## Description 

This PR includes implementation, unit and integration test for the stage page button text and link.

This ensures that the expected button text and link are rendered and validated each time the page is rendered or the tests are run against recent changes.

It also updates the start button link href with the start_button_href helper method.

The logic  in start_button_href helper has led to the update of the test to reflect the correct external link being used.

