### PR TITLE
Marriage abroad: Italy content update

### DIFF
--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/italy/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/italy/_opposite_sex.govspeak.erb
@@ -50,13 +50,13 @@ You’ll need to get a Nulla Osta if you’re in Italy.
 
 To get a Nulla Osta, [make an appointment at the British Embassy in Rome](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rome/notice-of-marriage-or-civil-partnership/slot_picker) to give notice of your marriage. Your partner doesn’t have to come with you.
 
-If you can’t get to the embassy, download the [Nulla Osta application pack](#), fill in the notice of marriage and affirmation or affidavit and sign them in front of an [Italian notary](http://www.notaries-directory.eu/). You’ll have to pay a fee. Send the signed documents and supporting documents to the embassy.
+If you can’t get to the embassy, download the [Nulla Osta application pack](/government/publications/nulla-osta-application-pack-for-marriages-in-italy), fill in the notice of marriage and affirmation or affidavit and sign them in front of an [Italian notary](http://www.notaries-directory.eu/). You’ll have to pay a fee. Send the signed documents and supporting documents to the embassy.
 
 $A
 British Embassy Rome
 Via XX Settembre 80/a
- 00187 Rome
- Italy
+00187 Rome
+Italy
 $A
 
 
@@ -68,7 +68,6 @@ You’ll need to bring:
 
 - your passport
 - a copy of your partner’s passport
-- your [full birth certificate](/order-copy-birth-death-marriage-certificate/) including your parents’ details
 - [notice of marriage](/government/publications/notice-of-marriage-form--2) and [affidavit for marriage](/government/publications/affirmationaffidavit-of-marital-status-form) - you can fill in (but not sign) these in advance
 - a residency certificate issued in the last 3 months (if you have one)
 - proof that you’ve been in Italy for at least 3 full days (if you don’t have a residency certificate) - for example a boarding pass or a bank statement

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/italy/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/italy/_opposite_sex.govspeak.erb
@@ -50,7 +50,7 @@ You’ll need to get a Nulla Osta if you’re in Italy.
 
 To get a Nulla Osta, [make an appointment at the British Embassy in Rome](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rome/notice-of-marriage-or-civil-partnership/slot_picker) to give notice of your marriage. Your partner doesn’t have to come with you.
 
-If you can’t get to the embassy, download the [Nulla Osta application pack](/government/publications/nulla-osta-application-pack-for-marriages-in-italy), fill in the notice of marriage and affirmation or affidavit and sign them in front of an [Italian notary](http://www.notaries-directory.eu/). You’ll have to pay a fee. Send the signed documents and supporting documents to the embassy.
+If you can’t get to the embassy, download the [Nulla Osta application pack](/government/publications/nulla-osta-application-pack-for-marriages-in-italy), fill in the affirmation and notice of marriage and sign them in front of an [Italian notary](http://www.notaries-directory.eu/). You’ll have to pay a fee. Send the signed documents and supporting documents to the embassy.
 
 $A
 British Embassy Rome
@@ -62,7 +62,7 @@ $A
 
 You need to be in Italy for 3 full days before you can give notice. This means if you arrive on Monday you can’t give notice until Friday.
 
-It costs <%= format_money calculator.consular_fee(:receiving_notice_of_marriage) %> to give notice and <%= format_money calculator.consular_fee(:issuing_cni_or_nulla_osta) %> for the Nulla Osta. You can pay by card. If you want to pay in cash you need to pay in the [local currency](/government/publications/italy-consular-fees). 
+It costs <%= format_money calculator.consular_fee(:receiving_notice_of_marriage) %> to give notice and <%= format_money calculator.consular_fee(:issuing_cni_or_nulla_osta) %> for the Nulla Osta. You can pay by card. If you want to pay in cash you need to pay in the [local currency](/government/publications/italy-consular-fees).
 
 You’ll need to bring:
 
@@ -80,7 +80,7 @@ If you’ve been married or in a civil partnership before, you’ll also need:
 - your annulment certificate - if your marriage or civil partnership was annulled
 - your civil partnership dissolution - if your civil partnership was dissolved
 - your partner’s [death certificate](/order-copy-birth-death-marriage-certificate/) and marriage certificate - if you’ve been widowed
-- evidence of name change (for example a deed poll) if the name on your current passport doesn’t match the name on your divorce or previous marriage certificate
+- evidence of name change (for example a deed poll or previous marriage certificate) if the name on your current passport doesn’t match the name on your divorce or previous marriage certificate
 
 You can provide copies of a divorce decree or death certificate instead of originals. They’ll need to be certified by a notary public or solicitor in the country where the divorce took place or the death was registered.
 
@@ -122,7 +122,6 @@ Your marriage will be recognised in the UK if:
 
 You won’t need to register your marriage in the UK.
 
-If you need extra copies of your marriage certificate, you can apply for them at the local comune. 
+If you need extra copies of your marriage certificate, you can apply for them at the local comune.
 
 If your partner isn’t a British citizen, they can apply for [British citizenship](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
-

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/italy/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/italy/_opposite_sex.govspeak.erb
@@ -68,7 +68,7 @@ You’ll need to bring:
 
 - your passport
 - a copy of your partner’s passport
-- [notice of marriage](/government/publications/notice-of-marriage-form--2) and [affidavit for marriage](/government/publications/affirmationaffidavit-of-marital-status-form) - you can fill in (but not sign) these in advance
+- [notice of marriage](/government/publications/italy-notice-of-marriage-form) and [affirmation or affidavit for marriage](/government/publications/italy-affirmationaffidavit-of-marital-status-forms) - you can fill in (but not sign) these in advance
 - a residency certificate issued in the last 3 months (if you have one)
 - proof that you’ve been in Italy for at least 3 full days (if you don’t have a residency certificate) - for example a boarding pass or a bank statement
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/italy/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/italy/_opposite_sex.govspeak.erb
@@ -50,6 +50,16 @@ You’ll need to get a Nulla Osta if you’re in Italy.
 
 To get a Nulla Osta, [make an appointment at the British Embassy in Rome](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rome/notice-of-marriage-or-civil-partnership/slot_picker) to give notice of your marriage. Your partner doesn’t have to come with you.
 
+If you can’t get to the embassy, download the [Nulla Osta application pack](#), fill in the notice of marriage and affirmation or affidavit and sign them in front of an [Italian notary](http://www.notaries-directory.eu/). You’ll have to pay a fee. Send the signed documents and supporting documents to the embassy.
+
+$A
+British Embassy Rome
+Via XX Settembre 80/a
+ 00187 Rome
+ Italy
+$A
+
+
 You need to be in Italy for 3 full days before you can give notice. This means if you arrive on Monday you can’t give notice until Friday.
 
 It costs <%= format_money calculator.consular_fee(:receiving_notice_of_marriage) %> to give notice and <%= format_money calculator.consular_fee(:issuing_cni_or_nulla_osta) %> for the Nulla Osta. You can pay by card. If you want to pay in cash you need to pay in the [local currency](/government/publications/italy-consular-fees). 
@@ -71,16 +81,19 @@ If you’ve been married or in a civil partnership before, you’ll also need:
 - your annulment certificate - if your marriage or civil partnership was annulled
 - your civil partnership dissolution - if your civil partnership was dissolved
 - your partner’s [death certificate](/order-copy-birth-death-marriage-certificate/) and marriage certificate - if you’ve been widowed
+- evidence of name change (for example a deed poll) if the name on your current passport doesn’t match the name on your divorce or previous marriage certificate
+
+You can provide copies of a divorce decree or death certificate instead of originals. They’ll need to be certified by a notary public or solicitor in the country where the divorce took place or the death was registered.
 
 ^If your divorce, civil partnership dissolution or annulment took place outside the UK, you’ll also need evidence that you or your former partner lived in or were a national of that country at the time of the divorce.^
 
-The British embassy will display your notice of marriage publicly for 7 full days. This means if you give notice on Monday, it will be displayed until the following Tuesday. If nobody registers an objection, your Nulla Osta should be ready within 2 weeks of giving your notice. You can collect it in person or have it delivered by post.
+The British embassy will display your notice of marriage publicly for 7 full days. This means if the embassy gets your notice on Monday (in person or by post), it will be displayed until the following Tuesday. If nobody registers an objection, your Nulla Osta should be ready within 2 weeks of giving your notice. You can collect it in person or have it delivered by post.
 
 You don’t need to stay in the country while your notice is displayed.
 
 ### If you’ve changed your name
 
-If your name on any of your documents doesn’t appear exactly as it does on your birth certificate, you’ll need to provide evidence of your name change (for example, a marriage certificate or deed poll). If you don’t, the authorities may refuse to allow the marriage to go ahead.
+If your name on any of your documents doesn’t appear exactly as it does on your birth certificate, you’ll need to give the local marriage authorities evidence of your name change (for example, a marriage certificate or deed poll). If you don’t, the authorities may refuse to allow the marriage to go ahead.
 
 ### Get your documents translated and legalised
 
@@ -113,3 +126,4 @@ You won’t need to register your marriage in the UK.
 If you need extra copies of your marriage certificate, you can apply for them at the local comune. 
 
 If your partner isn’t a British citizen, they can apply for [British citizenship](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
+

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/italy/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/italy/_same_sex.govspeak.erb
@@ -48,6 +48,15 @@ You’ll need to get a Nulla Osta if you’re in Italy.
 
 To get a Nulla Osta, [make an appointment at the British Embassy in Rome](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rome/notice-of-marriage-or-civil-partnership/slot_picker) to give notice of your civil partnership. Your partner doesn’t have to come with you.
 
+If you can’t get to the embassy, download the [Nulla Osta application pack](/government/publications/nulla-osta-application-pack-for-marriages-in-italy), fill in the notice of marriage and affirmation or affidavit and sign them in front of an [Italian notary](http://www.notaries-directory.eu/). You’ll have to pay a fee. Send the signed documents and supporting documents to the embassy.
+
+$A
+British Embassy Rome
+Via XX Settembre 80/a
+00187 Rome
+Italy
+$A
+
 You need to be in Italy for 3 full days before you can give notice. This means if you arrive on Monday you can’t give notice until Friday.
 
 It costs <%= format_money calculator.consular_fee(:receiving_notice_of_civil_partnership) %> to give notice and <%= format_money calculator.consular_fee(:issuing_cni_or_nulla_osta) %> for the Nulla Osta. If you want to pay in cash you need to pay in the [local currency](/government/publications/italy-consular-fees).
@@ -56,7 +65,6 @@ You’ll need to bring:
 
 - your passport
 - a copy of your partner’s passport
-- your [full birth certificate](/order-copy-birth-death-marriage-certificate/) including your parents’ details
 - [notice for civil partnership](/government/publications/notice-for-registration-of-civil-partnership-under-italian-law) and [civil partnership declaration](/government/publications/declaration-for-formation-of-civil-partnership-under-italian-law) - you can fill in (but not sign) these in advance
 - a residency certificate issued in the last 3 months (if you have one)
 - proof that you’ve been in Italy for at least 3 full days (if you don’t have a residency certificate) - for example a boarding pass or a bank statement
@@ -69,16 +77,19 @@ If you’ve been married or in a civil partnership before, you’ll also need:
 - your annulment certificate - if your marriage or civil partnership was annulled
 - your civil partnership dissolution - if your civil partnership was dissolved
 - your partner’s [death certificate](/order-copy-birth-death-marriage-certificate/) and marriage certificate - if you’ve been widowed
+- evidence of name change (for example a deed poll) if the name on your current passport doesn’t match the name on your divorce or previous marriage certificate
+
+You can provide copies of a divorce decree or death certificate instead of originals. They’ll need to be certified by a notary public or solicitor in the country where the divorce took place or the death was registered.
 
 ^If your divorce, civil partnership dissolution or annulment took place outside the UK, you’ll also need evidence that you or your former partner lived in or were a national of that country at the time of the divorce.^
 
-The British embassy will display your notice of civil partnership publicly for 7 full days. This means if you give notice on Monday, it will be displayed until the following Tuesday. If nobody registers an objection, your Nulla Osta should be ready within 2 weeks of giving your notice. You can collect it in person or have it delivered by post.
+The British embassy will display your notice of civil partnership publicly for 7 full days. This means if the embassy gets your notice on Monday (in person or by post), it will be displayed until the following Tuesday. If nobody registers an objection, your Nulla Osta should be ready within 2 weeks of giving your notice. You can collect it in person or have it delivered by post.
 
 You don’t need to stay in the country while your notice is displayed.
 
 ### If you’ve changed your name
 
-If your name on any of your documents doesn’t appear exactly as it does on your birth certificate, you’ll need to provide evidence of your name change (for example, a marriage certificate or deed poll). If you don’t, the authorities may refuse to allow the marriage to go ahead.
+If your name on any of your documents doesn’t appear exactly as it does on your birth certificate, you’ll need to give the local marriage authorities evidence of your name change (for example, a marriage certificate or deed poll). If you don’t, the authorities may refuse to allow the marriage to go ahead.
 
 ### Get your documents translated and legalised
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/italy/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/italy/_same_sex.govspeak.erb
@@ -48,7 +48,7 @@ You’ll need to get a Nulla Osta if you’re in Italy.
 
 To get a Nulla Osta, [make an appointment at the British Embassy in Rome](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rome/notice-of-marriage-or-civil-partnership/slot_picker) to give notice of your civil partnership. Your partner doesn’t have to come with you.
 
-If you can’t get to the embassy, download the [Nulla Osta application pack](/government/publications/nulla-osta-application-pack-for-marriages-in-italy), fill in the notice of marriage and affirmation or affidavit and sign them in front of an [Italian notary](http://www.notaries-directory.eu/). You’ll have to pay a fee. Send the signed documents and supporting documents to the embassy.
+If you can’t get to the embassy, download the [Nulla Osta application pack](/government/publications/nulla-osta-application-pack-for-marriages-in-italy), fill in the affirmation and notice of marriage and sign them in front of an [Italian notary](http://www.notaries-directory.eu/). You’ll have to pay a fee. Send the signed documents and supporting documents to the embassy.
 
 $A
 British Embassy Rome
@@ -77,7 +77,7 @@ If you’ve been married or in a civil partnership before, you’ll also need:
 - your annulment certificate - if your marriage or civil partnership was annulled
 - your civil partnership dissolution - if your civil partnership was dissolved
 - your partner’s [death certificate](/order-copy-birth-death-marriage-certificate/) and marriage certificate - if you’ve been widowed
-- evidence of name change (for example a deed poll) if the name on your current passport doesn’t match the name on your divorce or previous marriage certificate
+- evidence of name change (for example a deed poll or previous marriage certificate) if the name on your current passport doesn’t match the name on your divorce or previous marriage certificate
 
 You can provide copies of a divorce decree or death certificate instead of originals. They’ll need to be certified by a notary public or solicitor in the country where the divorce took place or the death was registered.
 
@@ -118,6 +118,6 @@ Your civil partnership will be recognised in the UK if:
 
 You won’t need to register your civil partnership in the UK.
 
-If you need extra copies of your civil partnership certificate, you can apply for them at the local comune. 
+If you need extra copies of your civil partnership certificate, you can apply for them at the local comune.
 
 If your partner isn’t a British citizen, they can apply for [British citizenship](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.

--- a/test/artefacts/marriage-abroad/italy/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/italy/opposite_sex.txt
@@ -69,7 +69,7 @@ You’ll need to bring:
 
 - your passport
 - a copy of your partner’s passport
-- [notice of marriage](/government/publications/notice-of-marriage-form--2) and [affidavit for marriage](/government/publications/affirmationaffidavit-of-marital-status-form) - you can fill in (but not sign) these in advance
+- [notice of marriage](/government/publications/italy-notice-of-marriage-form) and [affirmation or affidavit for marriage](/government/publications/italy-affirmationaffidavit-of-marital-status-forms) - you can fill in (but not sign) these in advance
 - a residency certificate issued in the last 3 months (if you have one)
 - proof that you’ve been in Italy for at least 3 full days (if you don’t have a residency certificate) - for example a boarding pass or a bank statement
 

--- a/test/artefacts/marriage-abroad/italy/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/italy/opposite_sex.txt
@@ -52,6 +52,15 @@ You’ll need to get a Nulla Osta if you’re in Italy.
 
 To get a Nulla Osta, [make an appointment at the British Embassy in Rome](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rome/notice-of-marriage-or-civil-partnership/slot_picker) to give notice of your marriage. Your partner doesn’t have to come with you.
 
+If you can’t get to the embassy, download the [Nulla Osta application pack](/government/publications/nulla-osta-application-pack-for-marriages-in-italy), fill in the notice of marriage and affirmation or affidavit and sign them in front of an [Italian notary](http://www.notaries-directory.eu/). You’ll have to pay a fee. Send the signed documents and supporting documents to the embassy.
+
+$A
+British Embassy Rome
+Via XX Settembre 80/a
+00187 Rome
+Italy
+$A
+
 You need to be in Italy for 3 full days before you can give notice. This means if you arrive on Monday you can’t give notice until Friday.
 
 It costs £50 to give notice and £50 for the Nulla Osta. You can pay by card. If you want to pay in cash you need to pay in the [local currency](/government/publications/italy-consular-fees). 
@@ -60,7 +69,6 @@ You’ll need to bring:
 
 - your passport
 - a copy of your partner’s passport
-- your [full birth certificate](/order-copy-birth-death-marriage-certificate/) including your parents’ details
 - [notice of marriage](/government/publications/notice-of-marriage-form--2) and [affidavit for marriage](/government/publications/affirmationaffidavit-of-marital-status-form) - you can fill in (but not sign) these in advance
 - a residency certificate issued in the last 3 months (if you have one)
 - proof that you’ve been in Italy for at least 3 full days (if you don’t have a residency certificate) - for example a boarding pass or a bank statement
@@ -73,16 +81,19 @@ If you’ve been married or in a civil partnership before, you’ll also need:
 - your annulment certificate - if your marriage or civil partnership was annulled
 - your civil partnership dissolution - if your civil partnership was dissolved
 - your partner’s [death certificate](/order-copy-birth-death-marriage-certificate/) and marriage certificate - if you’ve been widowed
+- evidence of name change (for example a deed poll) if the name on your current passport doesn’t match the name on your divorce or previous marriage certificate
+
+You can provide copies of a divorce decree or death certificate instead of originals. They’ll need to be certified by a notary public or solicitor in the country where the divorce took place or the death was registered.
 
 ^If your divorce, civil partnership dissolution or annulment took place outside the UK, you’ll also need evidence that you or your former partner lived in or were a national of that country at the time of the divorce.^
 
-The British embassy will display your notice of marriage publicly for 7 full days. This means if you give notice on Monday, it will be displayed until the following Tuesday. If nobody registers an objection, your Nulla Osta should be ready within 2 weeks of giving your notice. You can collect it in person or have it delivered by post.
+The British embassy will display your notice of marriage publicly for 7 full days. This means if the embassy gets your notice on Monday (in person or by post), it will be displayed until the following Tuesday. If nobody registers an objection, your Nulla Osta should be ready within 2 weeks of giving your notice. You can collect it in person or have it delivered by post.
 
 You don’t need to stay in the country while your notice is displayed.
 
 ### If you’ve changed your name
 
-If your name on any of your documents doesn’t appear exactly as it does on your birth certificate, you’ll need to provide evidence of your name change (for example, a marriage certificate or deed poll). If you don’t, the authorities may refuse to allow the marriage to go ahead.
+If your name on any of your documents doesn’t appear exactly as it does on your birth certificate, you’ll need to give the local marriage authorities evidence of your name change (for example, a marriage certificate or deed poll). If you don’t, the authorities may refuse to allow the marriage to go ahead.
 
 ### Get your documents translated and legalised
 

--- a/test/artefacts/marriage-abroad/italy/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/italy/opposite_sex.txt
@@ -52,7 +52,7 @@ You’ll need to get a Nulla Osta if you’re in Italy.
 
 To get a Nulla Osta, [make an appointment at the British Embassy in Rome](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rome/notice-of-marriage-or-civil-partnership/slot_picker) to give notice of your marriage. Your partner doesn’t have to come with you.
 
-If you can’t get to the embassy, download the [Nulla Osta application pack](/government/publications/nulla-osta-application-pack-for-marriages-in-italy), fill in the notice of marriage and affirmation or affidavit and sign them in front of an [Italian notary](http://www.notaries-directory.eu/). You’ll have to pay a fee. Send the signed documents and supporting documents to the embassy.
+If you can’t get to the embassy, download the [Nulla Osta application pack](/government/publications/nulla-osta-application-pack-for-marriages-in-italy), fill in the affirmation and notice of marriage and sign them in front of an [Italian notary](http://www.notaries-directory.eu/). You’ll have to pay a fee. Send the signed documents and supporting documents to the embassy.
 
 $A
 British Embassy Rome
@@ -63,7 +63,7 @@ $A
 
 You need to be in Italy for 3 full days before you can give notice. This means if you arrive on Monday you can’t give notice until Friday.
 
-It costs £50 to give notice and £50 for the Nulla Osta. You can pay by card. If you want to pay in cash you need to pay in the [local currency](/government/publications/italy-consular-fees). 
+It costs £50 to give notice and £50 for the Nulla Osta. You can pay by card. If you want to pay in cash you need to pay in the [local currency](/government/publications/italy-consular-fees).
 
 You’ll need to bring:
 
@@ -81,7 +81,7 @@ If you’ve been married or in a civil partnership before, you’ll also need:
 - your annulment certificate - if your marriage or civil partnership was annulled
 - your civil partnership dissolution - if your civil partnership was dissolved
 - your partner’s [death certificate](/order-copy-birth-death-marriage-certificate/) and marriage certificate - if you’ve been widowed
-- evidence of name change (for example a deed poll) if the name on your current passport doesn’t match the name on your divorce or previous marriage certificate
+- evidence of name change (for example a deed poll or previous marriage certificate) if the name on your current passport doesn’t match the name on your divorce or previous marriage certificate
 
 You can provide copies of a divorce decree or death certificate instead of originals. They’ll need to be certified by a notary public or solicitor in the country where the divorce took place or the death was registered.
 
@@ -123,7 +123,7 @@ Your marriage will be recognised in the UK if:
 
 You won’t need to register your marriage in the UK.
 
-If you need extra copies of your marriage certificate, you can apply for them at the local comune. 
+If you need extra copies of your marriage certificate, you can apply for them at the local comune.
 
 If your partner isn’t a British citizen, they can apply for [British citizenship](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
 

--- a/test/artefacts/marriage-abroad/italy/same_sex.txt
+++ b/test/artefacts/marriage-abroad/italy/same_sex.txt
@@ -50,6 +50,15 @@ You’ll need to get a Nulla Osta if you’re in Italy.
 
 To get a Nulla Osta, [make an appointment at the British Embassy in Rome](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rome/notice-of-marriage-or-civil-partnership/slot_picker) to give notice of your civil partnership. Your partner doesn’t have to come with you.
 
+If you can’t get to the embassy, download the [Nulla Osta application pack](/government/publications/nulla-osta-application-pack-for-marriages-in-italy), fill in the notice of marriage and affirmation or affidavit and sign them in front of an [Italian notary](http://www.notaries-directory.eu/). You’ll have to pay a fee. Send the signed documents and supporting documents to the embassy.
+
+$A
+British Embassy Rome
+Via XX Settembre 80/a
+00187 Rome
+Italy
+$A
+
 You need to be in Italy for 3 full days before you can give notice. This means if you arrive on Monday you can’t give notice until Friday.
 
 It costs £50 to give notice and £50 for the Nulla Osta. If you want to pay in cash you need to pay in the [local currency](/government/publications/italy-consular-fees).
@@ -58,7 +67,6 @@ You’ll need to bring:
 
 - your passport
 - a copy of your partner’s passport
-- your [full birth certificate](/order-copy-birth-death-marriage-certificate/) including your parents’ details
 - [notice for civil partnership](/government/publications/notice-for-registration-of-civil-partnership-under-italian-law) and [civil partnership declaration](/government/publications/declaration-for-formation-of-civil-partnership-under-italian-law) - you can fill in (but not sign) these in advance
 - a residency certificate issued in the last 3 months (if you have one)
 - proof that you’ve been in Italy for at least 3 full days (if you don’t have a residency certificate) - for example a boarding pass or a bank statement
@@ -71,16 +79,19 @@ If you’ve been married or in a civil partnership before, you’ll also need:
 - your annulment certificate - if your marriage or civil partnership was annulled
 - your civil partnership dissolution - if your civil partnership was dissolved
 - your partner’s [death certificate](/order-copy-birth-death-marriage-certificate/) and marriage certificate - if you’ve been widowed
+- evidence of name change (for example a deed poll) if the name on your current passport doesn’t match the name on your divorce or previous marriage certificate
+
+You can provide copies of a divorce decree or death certificate instead of originals. They’ll need to be certified by a notary public or solicitor in the country where the divorce took place or the death was registered.
 
 ^If your divorce, civil partnership dissolution or annulment took place outside the UK, you’ll also need evidence that you or your former partner lived in or were a national of that country at the time of the divorce.^
 
-The British embassy will display your notice of civil partnership publicly for 7 full days. This means if you give notice on Monday, it will be displayed until the following Tuesday. If nobody registers an objection, your Nulla Osta should be ready within 2 weeks of giving your notice. You can collect it in person or have it delivered by post.
+The British embassy will display your notice of civil partnership publicly for 7 full days. This means if the embassy gets your notice on Monday (in person or by post), it will be displayed until the following Tuesday. If nobody registers an objection, your Nulla Osta should be ready within 2 weeks of giving your notice. You can collect it in person or have it delivered by post.
 
 You don’t need to stay in the country while your notice is displayed.
 
 ### If you’ve changed your name
 
-If your name on any of your documents doesn’t appear exactly as it does on your birth certificate, you’ll need to provide evidence of your name change (for example, a marriage certificate or deed poll). If you don’t, the authorities may refuse to allow the marriage to go ahead.
+If your name on any of your documents doesn’t appear exactly as it does on your birth certificate, you’ll need to give the local marriage authorities evidence of your name change (for example, a marriage certificate or deed poll). If you don’t, the authorities may refuse to allow the marriage to go ahead.
 
 ### Get your documents translated and legalised
 

--- a/test/artefacts/marriage-abroad/italy/same_sex.txt
+++ b/test/artefacts/marriage-abroad/italy/same_sex.txt
@@ -50,7 +50,7 @@ You’ll need to get a Nulla Osta if you’re in Italy.
 
 To get a Nulla Osta, [make an appointment at the British Embassy in Rome](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rome/notice-of-marriage-or-civil-partnership/slot_picker) to give notice of your civil partnership. Your partner doesn’t have to come with you.
 
-If you can’t get to the embassy, download the [Nulla Osta application pack](/government/publications/nulla-osta-application-pack-for-marriages-in-italy), fill in the notice of marriage and affirmation or affidavit and sign them in front of an [Italian notary](http://www.notaries-directory.eu/). You’ll have to pay a fee. Send the signed documents and supporting documents to the embassy.
+If you can’t get to the embassy, download the [Nulla Osta application pack](/government/publications/nulla-osta-application-pack-for-marriages-in-italy), fill in the affirmation and notice of marriage and sign them in front of an [Italian notary](http://www.notaries-directory.eu/). You’ll have to pay a fee. Send the signed documents and supporting documents to the embassy.
 
 $A
 British Embassy Rome
@@ -79,7 +79,7 @@ If you’ve been married or in a civil partnership before, you’ll also need:
 - your annulment certificate - if your marriage or civil partnership was annulled
 - your civil partnership dissolution - if your civil partnership was dissolved
 - your partner’s [death certificate](/order-copy-birth-death-marriage-certificate/) and marriage certificate - if you’ve been widowed
-- evidence of name change (for example a deed poll) if the name on your current passport doesn’t match the name on your divorce or previous marriage certificate
+- evidence of name change (for example a deed poll or previous marriage certificate) if the name on your current passport doesn’t match the name on your divorce or previous marriage certificate
 
 You can provide copies of a divorce decree or death certificate instead of originals. They’ll need to be certified by a notary public or solicitor in the country where the divorce took place or the death was registered.
 
@@ -120,7 +120,7 @@ Your civil partnership will be recognised in the UK if:
 
 You won’t need to register your civil partnership in the UK.
 
-If you need extra copies of your civil partnership certificate, you can apply for them at the local comune. 
+If you need extra copies of your civil partnership certificate, you can apply for them at the local comune.
 
 If your partner isn’t a British citizen, they can apply for [British citizenship](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
 

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -161,8 +161,8 @@ lib/smart_answer_flows/marriage-abroad/outcomes/countries/iran/uk/partner_other/
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/ireland/_opposite_sex.govspeak.erb: f0abd764c71f1af9f3b0a625bfb7e185
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/ireland/_same_sex.govspeak.erb: 8b85a31d089af46889eb665136403ce0
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/ireland/_title.govspeak.erb: c7f3e2d5e41aa82806b1aedbe69b33b8
-lib/smart_answer_flows/marriage-abroad/outcomes/countries/italy/_opposite_sex.govspeak.erb: 5defb8b6a82caeb160036cb6e23d75a1
-lib/smart_answer_flows/marriage-abroad/outcomes/countries/italy/_same_sex.govspeak.erb: fdd943a79ee53b15d386e8184c13d92d
+lib/smart_answer_flows/marriage-abroad/outcomes/countries/italy/_opposite_sex.govspeak.erb: d2963814ff4d2e955875c687f3e03272
+lib/smart_answer_flows/marriage-abroad/outcomes/countries/italy/_same_sex.govspeak.erb: 5f0c04a679de229a21e80b215e74a50a
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/italy/_title.govspeak.erb: 9ed9b141d5d5418375ec81e96fe67ca7
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/_title.govspeak.erb: 244778b903869fce5ce20769b189ad23
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/ceremony_country/partner_british/_opposite_sex.govspeak.erb: f419c024409087f34a6facc650098c64

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -161,7 +161,7 @@ lib/smart_answer_flows/marriage-abroad/outcomes/countries/iran/uk/partner_other/
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/ireland/_opposite_sex.govspeak.erb: f0abd764c71f1af9f3b0a625bfb7e185
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/ireland/_same_sex.govspeak.erb: 8b85a31d089af46889eb665136403ce0
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/ireland/_title.govspeak.erb: c7f3e2d5e41aa82806b1aedbe69b33b8
-lib/smart_answer_flows/marriage-abroad/outcomes/countries/italy/_opposite_sex.govspeak.erb: d2963814ff4d2e955875c687f3e03272
+lib/smart_answer_flows/marriage-abroad/outcomes/countries/italy/_opposite_sex.govspeak.erb: aa8ceb9107db058e83f54e298abe24ff
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/italy/_same_sex.govspeak.erb: 5f0c04a679de229a21e80b215e74a50a
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/italy/_title.govspeak.erb: 9ed9b141d5d5418375ec81e96fe67ca7
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/_title.govspeak.erb: 244778b903869fce5ce20769b189ad23

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -161,8 +161,8 @@ lib/smart_answer_flows/marriage-abroad/outcomes/countries/iran/uk/partner_other/
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/ireland/_opposite_sex.govspeak.erb: f0abd764c71f1af9f3b0a625bfb7e185
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/ireland/_same_sex.govspeak.erb: 8b85a31d089af46889eb665136403ce0
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/ireland/_title.govspeak.erb: c7f3e2d5e41aa82806b1aedbe69b33b8
-lib/smart_answer_flows/marriage-abroad/outcomes/countries/italy/_opposite_sex.govspeak.erb: da21764e077cb1233ef10c29aa3b89f0
-lib/smart_answer_flows/marriage-abroad/outcomes/countries/italy/_same_sex.govspeak.erb: c0789e949180c7f053dde4a13ddfdbf3
+lib/smart_answer_flows/marriage-abroad/outcomes/countries/italy/_opposite_sex.govspeak.erb: 5defb8b6a82caeb160036cb6e23d75a1
+lib/smart_answer_flows/marriage-abroad/outcomes/countries/italy/_same_sex.govspeak.erb: fdd943a79ee53b15d386e8184c13d92d
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/italy/_title.govspeak.erb: 9ed9b141d5d5418375ec81e96fe67ca7
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/_title.govspeak.erb: 244778b903869fce5ce20769b189ad23
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/ceremony_country/partner_british/_opposite_sex.govspeak.erb: f419c024409087f34a6facc650098c64


### PR DESCRIPTION
Supersedes #3019 

### Trello card

* [Trello card](https://trello.com/c/b5MEMkVU/607-2-may-getting-married-in-italy-changes-to-same-and-opposite-sex-marriages-content-change-request) 

## Description

This is when the British embassy will offer the new process.
The British embassy in Rome is introducing a new process for the notice of marriage service in Italy: users will be able to make an appointment at the British embassy in Rome to apply for a Nulla Osta OR have the notice of marriage and affirmation witnessed by a local notary public. 

There is a new Nulla Osta/CNI application pack, which we/FCO will publish on Whitehall when the smart answers are ready to deploy.

The FCO has also changed its policy on evidence of divorce. We will raise a separate Zendesk request for updating other countries. 

The attached Word doc sets out all the requested changes for Italy, for both opposite and same sex marriages. 
 
The embassy is aiming to begin the new processes on 1 May, so this is our top priority married abroad request: https://trello.com/b/UD8fauOl/fco-content-priorities. David, the policy lead in London, is copied into this ticket, if you have any questions.

## Expected changes

* [URL on GOV.UK](https://www.gov.uk/marriage-abroad/y/italy/opposite_sex)
* [Fact check preview](https://smart-answers-pr-3020.herokuapp.com/marriage-abroad/y/italy/opposite_sex)

### Before

![image](https://cloud.githubusercontent.com/assets/227328/25578786/fc7aedc4-2e69-11e7-9c6f-a06a0d89608c.png)

### After
![image](https://cloud.githubusercontent.com/assets/424772/25609608/bed1c99e-2f17-11e7-9772-d7bee942456c.png)

