### PR TITLE
Marriage abroad: Chinese content change request

### DIFF
--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/china/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/china/_opposite_sex.govspeak.erb
@@ -2,7 +2,7 @@
 
 Contact the local civil affairs bureau (‘Min zheng ju’) where you or your partner are registered to find out about local marriage laws, including what documents you’ll need.
 
-If you’re a man you must be at least 20 and if you’re a woman you must be at least 22.
+If you’re a man you must be at least 22 and if you’re a woman you must be at least 20.
 
 %You or your partner must live in China to be allowed to get married there.%
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/china/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/china/_same_sex.govspeak.erb
@@ -21,7 +21,7 @@ Make an appointment to give notice of your marriage at:
 
 It costs <%= format_money calculator.consular_fee(:receiving_notice_of_marriage) %> to give notice. You can pay in the [local currency](/government/publications/china-consular-fees) with cash or credit card.
 
-You need to bring your and your partner’s passports.
+You need to bring your and your partner’s passports. Your passport must have an entry stamp showing that you've been in China for at least 7 full days.
 
 If your partner isn’t British, you’ll need to bring their ‘single certificate’. They can get this from:
 

--- a/test/artefacts/marriage-abroad/china/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/china/opposite_sex.txt
@@ -4,7 +4,7 @@ Marriage in China
 
 Contact the local civil affairs bureau (‘Min zheng ju’) where you or your partner are registered to find out about local marriage laws, including what documents you’ll need.
 
-If you’re a man you must be at least 20 and if you’re a woman you must be at least 22.
+If you’re a man you must be at least 22 and if you’re a woman you must be at least 20.
 
 %You or your partner must live in China to be allowed to get married there.%
 

--- a/test/artefacts/marriage-abroad/china/same_sex.txt
+++ b/test/artefacts/marriage-abroad/china/same_sex.txt
@@ -23,7 +23,7 @@ Make an appointment to give notice of your marriage at:
 
 It costs £50 to give notice. You can pay in the [local currency](/government/publications/china-consular-fees) with cash or credit card.
 
-You need to bring your and your partner’s passports.
+You need to bring your and your partner’s passports. Your passport must have an entry stamp showing that you've been in China for at least 7 full days.
 
 If your partner isn’t British, you’ll need to bring their ‘single certificate’. They can get this from:
 

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -95,8 +95,8 @@ lib/smart_answer_flows/marriage-abroad/outcomes/countries/chile/uk/partner_local
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/chile/uk/partner_local/_same_sex.govspeak.erb: 39c9884a91f921ae50f455c3232ff84d
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/chile/uk/partner_other/_opposite_sex.govspeak.erb: 402c5ef17562e5d85bd6fd4f9bfb0980
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/chile/uk/partner_other/_same_sex.govspeak.erb: d361b659b8865c033577a66022e61f6f
-lib/smart_answer_flows/marriage-abroad/outcomes/countries/china/_opposite_sex.govspeak.erb: b0439c1c2ad5c8ecc94767a5758236a4
-lib/smart_answer_flows/marriage-abroad/outcomes/countries/china/_same_sex.govspeak.erb: e340d6a3813ce12db74ebd60a89b95bd
+lib/smart_answer_flows/marriage-abroad/outcomes/countries/china/_opposite_sex.govspeak.erb: b7fcf64ad0f6c2222af07fe74c5ad27c
+lib/smart_answer_flows/marriage-abroad/outcomes/countries/china/_same_sex.govspeak.erb: 4dd6d096a63386e1cd3db8168262c6e8
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/china/_title.govspeak.erb: 475112c09ab99bdd0d610ab1e79cb0fd
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/denmark/_title.govspeak.erb: f3f69700147ffd739c4d3dc86f2ec22b
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/denmark/ceremony_country/partner_british/_opposite_sex.govspeak.erb: 7d0c5e38504d5db6d760347c84d23bbd


### PR DESCRIPTION
Supersedes #3025

[Trello card](https://trello.com/c/zQbyGlOC/610-china-marriages-same-sex-marriages-proof-of-residency-and-opposite-sex-marriage-minimum-age-correction-content-change-request)

## Description 

This PR holds content changes that correct the age requirement for opposite sex and adds the entry stamp requirement for same sex.

## Factcheck
[Preview link](https://smart-answers-pr-3034.herokuapp.com/marriage-abroad/y/china/opposite_sex)
[GOVUK](https://gov.uk/marriage-abroad/y/china/opposite_sex)

### Expected changes
- Content changes to Chinese opposite and same sex outcomes.

### Before
![screen shot 2017-05-05 at 13 27 07](https://cloud.githubusercontent.com/assets/84896/25745411/a09bbaa8-3196-11e7-97af-7049bf94efe1.png)

### After
![screen shot 2017-05-05 at 13 27 31](https://cloud.githubusercontent.com/assets/84896/25745416/a5fb2b82-3196-11e7-8081-37058c55083a.png)

### Affected outcomes

https://smart-answers-pr-3034.herokuapp.com/marriage-abroad/y/china/opposite_sex
https://smart-answers-pr-3034.herokuapp.com/marriage-abroad/y/china/same_sex