### PR TITLE
Create retirement log and rename rake task 

### DIFF
--- a/doc/retirement-log.md
+++ b/doc/retirement-log.md
@@ -1,0 +1,15 @@
+## Retirement log
+
+- Overseas passports
+  - Date of retirement: [28/04/2017](https://github.com/alphagov/smart-answers/releases/tag/release_3562).
+  - Associated [pull request](https://github.com/alphagov/smart-answers/pull/3014)
+  - Start button text set to external link: https://www.passport.service.gov.uk/filter.
+  - Changed format of start page on `/overseas-passports` to an answer format.
+  - Redirects from `/overseas-passports/y` to `/overseas-passports`.
+  - Artefact on publisher has been archived and it's slug changed to `archived-overseas-passports`.
+
+- State pension top up
+  - Date of retirement:  [06/04/2017](https://github.com/alphagov/smart-answers/releases/tag/release_3549)
+  - Associated [pull request](https://github.com/alphagov/smart-answers/pull/2996)
+  - Redirects from `/state-pension-topup` (and all descendants i.e `/state-pension-topup/\*`) to `/state-pension-top-up`
+  - Artefact on publisher remain un-change and it's slug changed to `/state-pension-topup`.

--- a/doc/retiring-a-smart-answer.md
+++ b/doc/retiring-a-smart-answer.md
@@ -41,7 +41,7 @@ In this document is prescribed the steps that need to be taken:
   the retire smart answer rake task is available. It needs to be supplied a
   content-id, base_path and it's new destination.
 
-  (i.e `retire:smart_answer[content_id,base_path,destination]`)
+  (i.e `retire:unpublish_redirect_remove_from_search[content_id,base_path,destination]`)
 
   The content-id for a smart answer can be found in the flow class for the smart
   answer in question. Also it can be found via the content store using the

--- a/doc/retiring-a-smart-answer.md
+++ b/doc/retiring-a-smart-answer.md
@@ -1,6 +1,8 @@
 # How to retire a Smart Answer
 
-At some point a request might come in for the removal of a SmartAnswer, most likely this request will include redirecting paths belonging to the identified smart answer to a new destination.
+At some point a request might come in for the removal of a SmartAnswer, most likely this request will include redirecting paths belonging to the identified smart answer to a new destination or retain the start page of the smart answer.
+
+NB: It is very important, that after every retirement of a smart answer it is important that the steps and current state of the smart answer are recorded in [retirement log](retirement-log.md)
 
 In this document is prescribed the steps that need to be taken:
 

--- a/lib/tasks/retire.rake
+++ b/lib/tasks/retire.rake
@@ -1,6 +1,6 @@
 namespace :retire do
-  desc "Retire an identified smart answer"
-  task :smart_answer, [:content_id, :base_path, :destination] => :environment do |_, args|
+  desc "Unpublish, redirect and remove from the search index an identified smart answer"
+  task :unpublish_redirect_remove_from_search, [:content_id, :base_path, :destination] => :environment do |_, args|
     raise "Missing content_id parameter" unless args.content_id.present?
     raise "Missing base_path parameter" unless args.base_path.present?
     raise "Missing destination parameter" unless args.destination.present?

--- a/test/unit/tasks/retire_test.rb
+++ b/test/unit/tasks/retire_test.rb
@@ -1,14 +1,14 @@
 require 'test_helper'
 
 class RetireSmartAnswerRakeTest < ActiveSupport::TestCase
-  context "retire:smart_answer rake task" do
+  context "retire:unpublish_redirect_remove_from_search rake task" do
     setup do
-      Rake::Task["retire:smart_answer"].reenable
+      Rake::Task["retire:unpublish_redirect_remove_from_search"].reenable
     end
 
     should "raise exception when content_id isn't supplied" do
       exception = assert_raises RuntimeError do
-        Rake::Task["retire:smart_answer"].invoke
+        Rake::Task["retire:unpublish_redirect_remove_from_search"].invoke
       end
 
       assert_equal "Missing content_id parameter", exception.message
@@ -16,7 +16,7 @@ class RetireSmartAnswerRakeTest < ActiveSupport::TestCase
 
     should "raise exception when base_path isn't supplied" do
       exception = assert_raises RuntimeError do
-        Rake::Task["retire:smart_answer"].invoke("content-id", nil)
+        Rake::Task["retire:unpublish_redirect_remove_from_search"].invoke("content-id", nil)
       end
 
       assert_equal "Missing base_path parameter", exception.message
@@ -24,7 +24,7 @@ class RetireSmartAnswerRakeTest < ActiveSupport::TestCase
 
     should "raise exception when destination isn't supplied" do
       exception = assert_raises RuntimeError do
-        Rake::Task["retire:smart_answer"].invoke(
+        Rake::Task["retire:unpublish_redirect_remove_from_search"].invoke(
           "content-id",
           "/base-path",
           nil
@@ -48,7 +48,7 @@ class RetireSmartAnswerRakeTest < ActiveSupport::TestCase
       content_item_publisher_mock.expects(:remove_smart_answer_from_search)
         .with("/base-path").once
 
-      Rake::Task["retire:smart_answer"].invoke(
+      Rake::Task["retire:unpublish_redirect_remove_from_search"].invoke(
         "content-id",
         "/base-path",
         "/new-destination"


### PR DESCRIPTION
This PR:
-  Creates a retirement log
   - This will provide information on the he steps and current state of the smart answer.
-  Renames a rake task
   - This has been done to properly describe what this rake task can achieve