### PR TITLE
Add an AB test for calculate-your-child-maintenance

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,7 @@ GEM
     govuk-lint (0.7.0)
       rubocop (~> 0.35.0)
       scss_lint
-    govuk_ab_testing (2.0.0)
+    govuk_ab_testing (2.3.0)
     govuk_frontend_toolkit (4.14.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)

--- a/app/controllers/concerns/benchmark_inline_link_ab_testable.rb
+++ b/app/controllers/concerns/benchmark_inline_link_ab_testable.rb
@@ -1,0 +1,31 @@
+module BenchmarkInlineLinkABTestable
+  BENCHMARKING_PATHS = ['/calculate-your-child-maintenance'].freeze
+
+  def should_show_benchmarking_variant?
+    # Use GOVUK-ABTest-BenchmarkInlineLink=B header in dev to test this
+    benchmark_inline_link_variant.variant_b? &&
+      is_benchmarking_tested_path(request.path)
+  end
+
+  def benchmark_inline_link_variant
+    @benchmark_inline_link_variant ||= benchmarking_ab_test.requested_variant request.headers
+  end
+
+  def set_benchmark_inline_links_response_header
+    benchmark_inline_link_variant.configure_response response
+  end
+
+  def self.included(base)
+    base.helper_method :benchmark_inline_link_variant
+  end
+
+private
+
+  def is_benchmarking_tested_path(path)
+    BENCHMARKING_PATHS.include? path
+  end
+
+  def benchmarking_ab_test
+    @ab_test ||= GovukAbTesting::AbTest.new("BenchmarkInlineLink", dimension: 43)
+  end
+end

--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -2,6 +2,7 @@ class SmartAnswersController < ApplicationController
   include Slimmer::GovukComponents
   include Slimmer::Headers
   include EducationNavigationABTestable
+  include BenchmarkInlineLinkABTestable
 
   before_action :find_smart_answer, except: %w(index)
   before_action :redirect_response_to_canonical_url, only: %w{show}
@@ -14,7 +15,8 @@ class SmartAnswersController < ApplicationController
     :breadcrumbs,
     :should_present_new_navigation_view?,
     :page_is_under_ab_test?,
-    :present_taxonomy_sidebar?
+    :present_taxonomy_sidebar?,
+    :should_show_benchmarking_variant?
   )
 
   rescue_from SmartAnswer::FlowRegistry::NotFound, with: :error_404
@@ -34,6 +36,11 @@ class SmartAnswersController < ApplicationController
         if page_is_under_ab_test?(content_item)
           set_education_navigation_response_header(content_item)
         end
+
+        if should_show_benchmarking_variant?
+          set_benchmark_inline_links_response_header
+        end
+
         render page_type
       }
       if Rails.application.config.expose_govspeak

--- a/app/presenters/start_node_presenter.rb
+++ b/app/presenters/start_node_presenter.rb
@@ -19,6 +19,10 @@ class StartNodePresenter < NodePresenter
     @renderer.content_for(:body, html: html)
   end
 
+  def ab_body(html: true)
+    @renderer.content_for(:ab_body, html: html)
+  end
+
   def post_body(html: true)
     @renderer.content_for(:post_body, html: html)
   end

--- a/app/views/layouts/smart_answers.html.erb
+++ b/app/views/layouts/smart_answers.html.erb
@@ -7,6 +7,9 @@
   <% if page_is_under_ab_test?(@content_item) %>
     <%= education_navigation_variant.analytics_meta_tag.html_safe %>
   <% end %>
+  <% if should_show_benchmarking_variant? %>
+    <%= benchmark_inline_link_variant.analytics_meta_tag.html_safe %>
+  <% end %>
 <% end %>
 
 <% if should_present_new_navigation_view?(@content_item) %>

--- a/app/views/smart_answers/landing.html.erb
+++ b/app/views/smart_answers/landing.html.erb
@@ -17,7 +17,11 @@
     <div class="inner">
       <div class="intro">
 
+      <% if should_show_benchmarking_variant? %>
+        <%= start_node.ab_body %>
+      <% else %>
         <%= start_node.body %>
+      <% end %>
 
         <p class="get-started">
           <a rel="nofollow" href="<%= start_button_href %>" class="big button"><%= start_button %></a>

--- a/lib/smart_answer_flows/calculate-your-child-maintenance/calculate_your_child_maintenance.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-child-maintenance/calculate_your_child_maintenance.govspeak.erb
@@ -13,8 +13,8 @@
   * agree an amount with the other parent if [you’re arranging it yourselves](/arranging-child-maintenance-yourself)
   * get an idea of the amount the government would work out for you (including collection and application fees)
 
-  The calculator is based on the rules used by the Child Maintenance Service. 
-  
+  The calculator is based on the rules used by the Child Maintenance Service.
+
   Don't use the calculator if you have a ['1993 scheme' or '2003 scheme' case](/how-child-maintenance-is-worked-out/child-maintenance-before-march-2003). These are managed by the [Child Support Agency](/child-maintenance/contact) (CSA).
 
   ^<%= render partial: 'disclaimer.govspeak.erb' %>^
@@ -24,6 +24,29 @@
   You need information about the income of the parent who'll be paying.
 
   Check the [child maintenance rates](/how-child-maintenance-is-worked-out/how-the-child-maintenance-service-works-out-child-maintenance) before you use the calculator.
+
+  ##If your circumstances have changed
+
+  If you already have a case with the Child Support Agency (CSA) or the Child Maintenance Service and your circumstances have changed, [contact the office managing your case](/child-maintenance/contact). They’ll tell you if your child maintenance payments will change.
+
+  *[CSA]: Child Support Agency
+<% end %>
+
+<% content_for :ab_body do %>
+  You can use this calculator to estimate your child maintenance. It can help you to:
+
+  * agree an amount with the other parent if [you’re arranging it yourselves](/arranging-child-maintenance-yourself)
+  * get an idea of the amount the government would work out for you (including collection and application fees)
+
+  The calculator is based on the rules used by the Child Maintenance Service.
+
+  Don't use the calculator if you have a ['1993 scheme' or '2003 scheme' case](/how-child-maintenance-is-worked-out/child-maintenance-before-march-2003). These are managed by the [Child Support Agency](/child-maintenance/contact) (CSA).
+
+  ^<%= render partial: 'disclaimer.govspeak.erb' %>^
+
+  ##Before you start
+
+  You need information about the income of the parent who'll be paying.
 
   ##If your circumstances have changed
 

--- a/test/artefacts/calculate-your-child-maintenance/calculate-your-child-maintenance.txt
+++ b/test/artefacts/calculate-your-child-maintenance/calculate-your-child-maintenance.txt
@@ -6,7 +6,7 @@ You can use this calculator to estimate your child maintenance. It can help you 
 * agree an amount with the other parent if [you’re arranging it yourselves](/arranging-child-maintenance-yourself)
 * get an idea of the amount the government would work out for you (including collection and application fees)
 
-The calculator is based on the rules used by the Child Maintenance Service. 
+The calculator is based on the rules used by the Child Maintenance Service.
 
 Don't use the calculator if you have a ['1993 scheme' or '2003 scheme' case](/how-child-maintenance-is-worked-out/child-maintenance-before-march-2003). These are managed by the [Child Support Agency](/child-maintenance/contact) (CSA).
 

--- a/test/data/calculate-your-child-maintenance-files.yml
+++ b/test/data/calculate-your-child-maintenance-files.yml
@@ -2,7 +2,7 @@
 lib/data/child_maintenance_data.yml: a8cd91247e67f9f6bafdb93fb4ff8166
 lib/smart_answer/calculators/child_maintenance_calculator.rb: a0cd83a35856cf1c47ba12d711d3439d
 lib/smart_answer_flows/calculate-your-child-maintenance/_disclaimer.govspeak.erb: 4c59b8e3ac5f5071d11ee84e0d6a508b
-lib/smart_answer_flows/calculate-your-child-maintenance/calculate_your_child_maintenance.govspeak.erb: 07fd747ae23b05a8d267e5792ccdff0a
+lib/smart_answer_flows/calculate-your-child-maintenance/calculate_your_child_maintenance.govspeak.erb: 364dc1fdc9769b26e9042712babc2b71
 lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/flat_rate_result.govspeak.erb: b690c19299bfaadf511d35335487e3b1
 lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/nil_rate_result.govspeak.erb: cce0a8bd1df6f41baee3f2240ca56ad8
 lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/reduced_and_basic_rates_result.govspeak.erb: c32200392f1323ec6f0e406c3fe00347

--- a/test/fixtures/smart_answer_flows/benchmarking-sample.rb
+++ b/test/fixtures/smart_answer_flows/benchmarking-sample.rb
@@ -1,0 +1,7 @@
+module SmartAnswer
+  class BenchmarkingSampleFlow < Flow
+    def define
+      name 'benchmarking-sample'
+    end
+  end
+end

--- a/test/fixtures/smart_answer_flows/benchmarking-sample/benchmarking_sample.govspeak.erb
+++ b/test/fixtures/smart_answer_flows/benchmarking-sample/benchmarking_sample.govspeak.erb
@@ -1,0 +1,15 @@
+<% content_for :title do %>
+  Memorial bench cost calculator
+<% end %>
+
+<% content_for :meta_description do %>
+  Sad stuff happens on bench descriptions
+<% end %>
+
+<% content_for :body do %>
+  Albert loved this view
+<% end %>
+
+<% content_for :ab_body do %>
+  Albert hated this view, the park and everyone in it.
+<% end %>

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -272,6 +272,61 @@ class SmartAnswersControllerTest < ActionController::TestCase
         end
       end
     end
+
+    context "Benchmarking A/B testing" do
+      context "pages in test" do
+        setup do
+          @controller.stubs(:is_benchmarking_tested_path).returns(true)
+
+          content_item = {
+            "base_path" => '/benchmarking-sample'
+          }
+
+          Services.content_store.stubs(:content_item)
+            .with("/benchmarking-sample")
+            .returns(content_item)
+        end
+
+        should "show the original body for the 'A' version" do
+          setup_ab_variant "BenchmarkInlineLink", "A"
+
+          get :show, id: 'benchmarking-sample'
+
+          assert_match(/Albert loved/, response.body)
+          refute_match(/hated/, response.body)
+        end
+
+
+        should "show the alternate body for the 'B' version" do
+          with_variant BenchmarkInlineLink: "B" do
+            get :show, id: 'benchmarking-sample'
+
+            assert_match(/Albert hated/, response.body)
+            refute_match(/loved/, response.body)
+          end
+        end
+      end
+
+      context "pages not in test" do
+        setup do
+          content_item = {
+            "base_path" => '/bridge-of-death'
+          }
+
+          Services.content_store.stubs(:content_item)
+            .with("/bridge-of-death")
+            .returns(content_item)
+        end
+
+        should "show the normal body for the 'B' version" do
+          setup_ab_variant "BenchmarkInlineLink", "B"
+
+          get :show, id: 'bridge-of-death'
+
+          assert_match(/He who would cross the Bridge of Death/, response.body)
+        end
+      end
+    end
   end
 
   context "GET /<slug>/visualise" do


### PR DESCRIPTION
This sets up a test where we present alternate content to users in the B
variant.

We do this by configuring `ab_body` content for the pages that are affected.
At this point, we're only testing one page, but we expect to expand this to
encompass other content.

This test specifically removes an inline link from the "Before you start"
section, as we have noted that this distracts users from their ultimate goal,
which is probably starting the calculator.

This test is intended to run for between 1 and 2 weeks.

The corresponding Fastly configuration for this test was committed in
[this pull request](https://github.com/alphagov/fastly-configure/pull/21/files)

The ABTest-BenchmarkInlineLink cookie is listed on https://www.gov.uk/help/cookies

paired with @deborahchua 