### PR TITLE
Add appointment link for no CNI explanatory letter

### DIFF
--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/ceremony_country/partner_british/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/ceremony_country/partner_british/_opposite_sex.govspeak.erb
@@ -7,4 +7,4 @@ The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Com
 
 Book an appointment to collect a letter at the [British Consulate General in Cape Town](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-cape-town/providing-an-informative-note/slot_picker) or the [British High Commission in Pretoria](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-pretoria/providing-an-informative-note/slot_picker).
 
-The letter is free. If you can't go to an appointment, you can ask a friend or family member to make an appointment and collect the letter for you.
+The letter is free. If you can't go to an appointment, you can ask a friend or family member to make an appointment and collect it for you.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/ceremony_country/partner_british/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/ceremony_country/partner_british/_opposite_sex.govspeak.erb
@@ -3,12 +3,8 @@ Contact the [relevant local authorities](http://www.dha.gov.za/index.php/civic-s
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for South Africa](/foreign-travel-advice/south-africa) before making any plans.^
 
-The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Commonwealth countries. The British High Commission in Pretoria or the Consulate General in Cape Town can provide a letter to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
+The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Commonwealth countries. You can get a letter to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
 
-Contact the High Commission and Consulate General to arrange to collect a letter.
+Book an appointment to collect a letter at the [British Consulate General in Cape Town](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-cape-town/providing-an-informative-note/slot_picker) or the [British High Commission in Pretoria](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-pretoria/providing-an-informative-note/slot_picker).
 
-$C
-<southafrica.consulate@fco.gov.uk>
-$C
-
-The letter must be signed and stamped by a member of the consular staff.
+The letter is free. If you can't go to an appointment, you can ask a friend or family member to make an appointment and collect the letter for you.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/ceremony_country/partner_british/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/ceremony_country/partner_british/_same_sex.govspeak.erb
@@ -7,4 +7,4 @@ The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Com
 
 Book an appointment to collect a letter at the [British Consulate General in Cape Town](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-cape-town/providing-an-informative-note/slot_picker) or the [British High Commission in Pretoria](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-pretoria/providing-an-informative-note/slot_picker).
 
-The letter is free. If you can't go to an appointment, you can ask a friend or family member to make an appointment and collect the letter for you.
+The letter is free. If you can't go to an appointment, you can ask a friend or family member to make an appointment and collect it for you.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/ceremony_country/partner_british/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/ceremony_country/partner_british/_same_sex.govspeak.erb
@@ -3,12 +3,8 @@ Contact the [relevant local authorities](http://www.dha.gov.za/index.php/civic-s
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for South Africa](/foreign-travel-advice/south-africa) before making any plans.^
 
-The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Commonwealth countries. The British High Commission in Pretoria or the Consulate General in Cape Town can provide a letter to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
+The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Commonwealth countries. You can get a letter to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
 
-Contact the High Commission and Consulate General to arrange to collect a letter.
+Book an appointment to collect a letter at the [British Consulate General in Cape Town](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-cape-town/providing-an-informative-note/slot_picker) or the [British High Commission in Pretoria](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-pretoria/providing-an-informative-note/slot_picker).
 
-$C
-<southafrica.consulate@fco.gov.uk>
-$C
-
-The letter must be signed and stamped by a member of the consular staff.
+The letter is free. If you can't go to an appointment, you can ask a friend or family member to make an appointment and collect the letter for you.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/ceremony_country/partner_local/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/ceremony_country/partner_local/_opposite_sex.govspeak.erb
@@ -5,15 +5,11 @@ Contact the [relevant local authorities](http://www.dha.gov.za/index.php/civic-s
 
 %You’ll probably be asked for a CNI if you want to marry a South African citizen in South Africa. You’ll need to ask if there are any other documents the authorities will accept instead.%
 
-The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Commonwealth countries. The British High Commission in Pretoria or the Consulate General in Cape Town can provide a letter to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
+The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Commonwealth countries. You can get a letter to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
 
-Contact the High Commission and Consulate General to arrange to collect a letter.
+Book an appointment to collect a letter at the [British Consulate General in Cape Town](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-cape-town/providing-an-informative-note/slot_picker) or the [British High Commission in Pretoria](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-pretoria/providing-an-informative-note/slot_picker).
 
-$C
-<southafrica.consulate@fco.gov.uk>
-$C
-
-The letter must be signed and stamped by a member of the consular staff.
+The letter is free. If you can't go to an appointment, you can ask a friend or family member to make an appointment and collect the letter for you.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/ceremony_country/partner_local/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/ceremony_country/partner_local/_opposite_sex.govspeak.erb
@@ -9,7 +9,7 @@ The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Com
 
 Book an appointment to collect a letter at the [British Consulate General in Cape Town](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-cape-town/providing-an-informative-note/slot_picker) or the [British High Commission in Pretoria](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-pretoria/providing-an-informative-note/slot_picker).
 
-The letter is free. If you can't go to an appointment, you can ask a friend or family member to make an appointment and collect the letter for you.
+The letter is free. If you can't go to an appointment, you can ask a friend or family member to make an appointment and collect it for you.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/ceremony_country/partner_local/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/ceremony_country/partner_local/_same_sex.govspeak.erb
@@ -5,15 +5,11 @@ Contact the [relevant local authorities](http://www.dha.gov.za/index.php/civic-s
 
 %You’ll probably be asked for a CNI if you want to marry a South African citizen in South Africa. You’ll need to ask if there are any other documents the authorities will accept instead.%
 
-The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Commonwealth countries. The British High Commission in Pretoria or the Consulate General in Cape Town can provide a letter to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
+The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Commonwealth countries. You can get a letter to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
 
-Contact the High Commission and Consulate General to arrange to collect a letter.
+Book an appointment to collect a letter at the [British Consulate General in Cape Town](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-cape-town/providing-an-informative-note/slot_picker) or the [British High Commission in Pretoria](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-pretoria/providing-an-informative-note/slot_picker).
 
-$C
-<southafrica.consulate@fco.gov.uk>
-$C
-
-The letter must be signed and stamped by a member of the consular staff.
+The letter is free. If you can't go to an appointment, you can ask a friend or family member to make an appointment and collect the letter for you.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/ceremony_country/partner_local/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/ceremony_country/partner_local/_same_sex.govspeak.erb
@@ -9,7 +9,7 @@ The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Com
 
 Book an appointment to collect a letter at the [British Consulate General in Cape Town](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-cape-town/providing-an-informative-note/slot_picker) or the [British High Commission in Pretoria](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-pretoria/providing-an-informative-note/slot_picker).
 
-The letter is free. If you can't go to an appointment, you can ask a friend or family member to make an appointment and collect the letter for you.
+The letter is free. If you can't go to an appointment, you can ask a friend or family member to make an appointment and collect it for you.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/ceremony_country/partner_other/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/ceremony_country/partner_other/_opposite_sex.govspeak.erb
@@ -7,7 +7,7 @@ The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Com
 
 Book an appointment to collect a letter at the [British Consulate General in Cape Town](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-cape-town/providing-an-informative-note/slot_picker) or the [British High Commission in Pretoria](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-pretoria/providing-an-informative-note/slot_picker).
 
-The letter is free. If you can't go to an appointment, you can ask a friend or family member to make an appointment and collect the letter for you.
+The letter is free. If you can't go to an appointment, you can ask a friend or family member to make an appointment and collect it for you.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/ceremony_country/partner_other/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/ceremony_country/partner_other/_opposite_sex.govspeak.erb
@@ -3,15 +3,11 @@ Contact the [relevant local authorities](http://www.dha.gov.za/index.php/civic-s
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for South Africa](/foreign-travel-advice/south-africa) before making any plans.^
 
-The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Commonwealth countries. The British High Commission in Pretoria or the Consulate General in Cape Town can provide a letter to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
+The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Commonwealth countries. You can get a letter to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
 
-Contact the High Commission and Consulate General to arrange to collect a letter.
+Book an appointment to collect a letter at the [British Consulate General in Cape Town](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-cape-town/providing-an-informative-note/slot_picker) or the [British High Commission in Pretoria](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-pretoria/providing-an-informative-note/slot_picker).
 
-$C
-<southafrica.consulate@fco.gov.uk>
-$C
-
-The letter must be signed and stamped by a member of the consular staff.
+The letter is free. If you can't go to an appointment, you can ask a friend or family member to make an appointment and collect the letter for you.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/ceremony_country/partner_other/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/ceremony_country/partner_other/_same_sex.govspeak.erb
@@ -7,7 +7,7 @@ The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Com
 
 Book an appointment to collect a letter at the [British Consulate General in Cape Town](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-cape-town/providing-an-informative-note/slot_picker) or the [British High Commission in Pretoria](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-pretoria/providing-an-informative-note/slot_picker).
 
-The letter is free. If you can't go to an appointment, you can ask a friend or family member to make an appointment and collect the letter for you.
+The letter is free. If you can't go to an appointment, you can ask a friend or family member to make an appointment and collect it for you.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/ceremony_country/partner_other/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/ceremony_country/partner_other/_same_sex.govspeak.erb
@@ -3,15 +3,11 @@ Contact the [relevant local authorities](http://www.dha.gov.za/index.php/civic-s
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for South Africa](/foreign-travel-advice/south-africa) before making any plans.^
 
-The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Commonwealth countries. The British High Commission in Pretoria or the Consulate General in Cape Town can provide a letter to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
+The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Commonwealth countries. You can get a letter to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
 
-Contact the High Commission and Consulate General to arrange to collect a letter.
+Book an appointment to collect a letter at the [British Consulate General in Cape Town](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-cape-town/providing-an-informative-note/slot_picker) or the [British High Commission in Pretoria](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-pretoria/providing-an-informative-note/slot_picker).
 
-$C
-<southafrica.consulate@fco.gov.uk>
-$C
-
-The letter must be signed and stamped by a member of the consular staff.
+The letter is free. If you can't go to an appointment, you can ask a friend or family member to make an appointment and collect the letter for you.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/third_country/partner_british/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/third_country/partner_british/_opposite_sex.govspeak.erb
@@ -3,12 +3,8 @@ Contact the [relevant local authorities](http://www.dha.gov.za/index.php/civic-s
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for South Africa](/foreign-travel-advice/south-africa) before making any plans.^
 
-The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Commonwealth countries. The British High Commission in Pretoria or the Consulate General in Cape Town can provide a letter to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
+The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Commonwealth countries. You can get a letter to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
 
-Contact the High Commission and Consulate General to arrange to collect a letter.
+Book an appointment to collect a letter at the [British Consulate General in Cape Town](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-cape-town/providing-an-informative-note/slot_picker) or the [British High Commission in Pretoria](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-pretoria/providing-an-informative-note/slot_picker).
 
-$C
-<southafrica.consulate@fco.gov.uk>
-$C
-
-The letter must be signed and stamped by a member of the consular staff.
+The letter is free. If you can't go to an appointment, you can ask a friend or family member to make an appointment and collect it for you.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/third_country/partner_british/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/third_country/partner_british/_same_sex.govspeak.erb
@@ -3,12 +3,8 @@ Contact the [relevant local authorities](http://www.dha.gov.za/index.php/civic-s
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for South Africa](/foreign-travel-advice/south-africa) before making any plans.^
 
-The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Commonwealth countries. The British High Commission in Pretoria or the Consulate General in Cape Town can provide a letter to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
+The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Commonwealth countries. You can get a letter to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
 
-Contact the High Commission and Consulate General to arrange to collect a letter.
+Book an appointment to collect a letter at the [British Consulate General in Cape Town](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-cape-town/providing-an-informative-note/slot_picker) or the [British High Commission in Pretoria](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-pretoria/providing-an-informative-note/slot_picker).
 
-$C
-<southafrica.consulate@fco.gov.uk>
-$C
-
-The letter must be signed and stamped by a member of the consular staff.
+The letter is free. If you can't go to an appointment, you can ask a friend or family member to make an appointment and collect it for you.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/third_country/partner_local/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/third_country/partner_local/_opposite_sex.govspeak.erb
@@ -5,15 +5,11 @@ Contact the [relevant local authorities](http://www.dha.gov.za/index.php/civic-s
 
 %You’ll probably be asked for a CNI if you want to marry a South African citizen in South Africa. You’ll need to ask if there are any other documents the authorities will accept instead.%
 
-The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Commonwealth countries. The British High Commission in Pretoria or the Consulate General in Cape Town can provide a letter to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
+The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Commonwealth countries. You can get a letter to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
 
-Contact the High Commission and Consulate General to arrange to collect a letter.
+Book an appointment to collect a letter at the [British Consulate General in Cape Town](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-cape-town/providing-an-informative-note/slot_picker) or the [British High Commission in Pretoria](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-pretoria/providing-an-informative-note/slot_picker).
 
-$C
-<southafrica.consulate@fco.gov.uk>
-$C
-
-The letter must be signed and stamped by a member of the consular staff.
+The letter is free. If you can't go to an appointment, you can ask a friend or family member to make an appointment and collect it for you.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/third_country/partner_local/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/third_country/partner_local/_same_sex.govspeak.erb
@@ -5,15 +5,11 @@ Contact the [relevant local authorities](http://www.dha.gov.za/index.php/civic-s
 
 %You’ll probably be asked for a CNI if you want to marry a South African citizen in South Africa. You’ll need to ask if there are any other documents the authorities will accept instead.%
 
-The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Commonwealth countries. The British High Commission in Pretoria or the Consulate General in Cape Town can provide a letter to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
+The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Commonwealth countries. You can get a letter to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
 
-Contact the High Commission and Consulate General to arrange to collect a letter.
+Book an appointment to collect a letter at the [British Consulate General in Cape Town](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-cape-town/providing-an-informative-note/slot_picker) or the [British High Commission in Pretoria](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-pretoria/providing-an-informative-note/slot_picker).
 
-$C
-<southafrica.consulate@fco.gov.uk>
-$C
-
-The letter must be signed and stamped by a member of the consular staff.
+The letter is free. If you can't go to an appointment, you can ask a friend or family member to make an appointment and collect it for you.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/third_country/partner_other/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/third_country/partner_other/_opposite_sex.govspeak.erb
@@ -3,15 +3,11 @@ Contact the [relevant local authorities](http://www.dha.gov.za/index.php/civic-s
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for South Africa](/foreign-travel-advice/south-africa) before making any plans.^
 
-The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Commonwealth countries. The British High Commission in Pretoria or the Consulate General in Cape Town can provide a letter to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
+The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Commonwealth countries. You can get a letter to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
 
-Contact the High Commission and Consulate General to arrange to collect a letter.
+Book an appointment to collect a letter at the [British Consulate General in Cape Town](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-cape-town/providing-an-informative-note/slot_picker) or the [British High Commission in Pretoria](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-pretoria/providing-an-informative-note/slot_picker).
 
-$C
-<southafrica.consulate@fco.gov.uk>
-$C
-
-The letter must be signed and stamped by a member of the consular staff.
+The letter is free. If you can't go to an appointment, you can ask a friend or family member to make an appointment and collect it for you.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/third_country/partner_other/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/third_country/partner_other/_same_sex.govspeak.erb
@@ -3,15 +3,11 @@ Contact the [relevant local authorities](http://www.dha.gov.za/index.php/civic-s
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for South Africa](/foreign-travel-advice/south-africa) before making any plans.^
 
-The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Commonwealth countries. The British High Commission in Pretoria or the Consulate General in Cape Town can provide a letter to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
+The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Commonwealth countries. You can get a letter to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
 
-Contact the High Commission and Consulate General to arrange to collect a letter.
+Book an appointment to collect a letter at the [British Consulate General in Cape Town](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-cape-town/providing-an-informative-note/slot_picker) or the [British High Commission in Pretoria](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-pretoria/providing-an-informative-note/slot_picker).
 
-$C
-<southafrica.consulate@fco.gov.uk>
-$C
-
-The letter must be signed and stamped by a member of the consular staff.
+The letter is free. If you can't go to an appointment, you can ask a friend or family member to make an appointment and collect it for you.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/uk/partner_british/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/uk/partner_british/_opposite_sex.govspeak.erb
@@ -3,12 +3,8 @@ Contact the [relevant local authorities](http://www.dha.gov.za/index.php/civic-s
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for South Africa](/foreign-travel-advice/south-africa) before making any plans.^
 
-The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Commonwealth countries. The British High Commission in Pretoria or the Consulate General in Cape Town can provide a letter to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
+The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Commonwealth countries. You can get a letter to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
 
-Contact the High Commission and Consulate General to arrange to collect a letter.
+Book an appointment to collect a letter at the [British Consulate General in Cape Town](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-cape-town/providing-an-informative-note/slot_picker) or the [British High Commission in Pretoria](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-pretoria/providing-an-informative-note/slot_picker).
 
-$C
-<southafrica.consulate@fco.gov.uk>
-$C
-
-The letter must be signed and stamped by a member of the consular staff.
+The letter is free. If you can't go to an appointment, you can ask a friend or family member to make an appointment and collect it for you.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/uk/partner_british/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/uk/partner_british/_same_sex.govspeak.erb
@@ -3,12 +3,8 @@ Contact the [relevant local authorities](http://www.dha.gov.za/index.php/civic-s
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for South Africa](/foreign-travel-advice/south-africa) before making any plans.^
 
-The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Commonwealth countries. The British High Commission in Pretoria or the Consulate General in Cape Town can provide a letter to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
+The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Commonwealth countries. You can get a letter to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
 
-Contact the High Commission and Consulate General to arrange to collect a letter.
+Book an appointment to collect a letter at the [British Consulate General in Cape Town](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-cape-town/providing-an-informative-note/slot_picker) or the [British High Commission in Pretoria](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-pretoria/providing-an-informative-note/slot_picker).
 
-$C
-<southafrica.consulate@fco.gov.uk>
-$C
-
-The letter must be signed and stamped by a member of the consular staff.
+The letter is free. If you can't go to an appointment, you can ask a friend or family member to make an appointment and collect it for you.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/uk/partner_local/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/uk/partner_local/_opposite_sex.govspeak.erb
@@ -5,15 +5,11 @@ Contact the [relevant local authorities](http://www.dha.gov.za/index.php/civic-s
 
 %You’ll probably be asked for a CNI if you want to marry a South African citizen in South Africa. You’ll need to ask if there are any other documents the authorities will accept instead.%
 
-The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Commonwealth countries. The British High Commission in Pretoria or the Consulate General in Cape Town can provide a letter to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
+The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Commonwealth countries. You can get a letter to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
 
-Contact the High Commission and Consulate General to arrange to collect a letter.
+Book an appointment to collect a letter at the [British Consulate General in Cape Town](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-cape-town/providing-an-informative-note/slot_picker) or the [British High Commission in Pretoria](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-pretoria/providing-an-informative-note/slot_picker).
 
-$C
-<southafrica.consulate@fco.gov.uk>
-$C
-
-The letter must be signed and stamped by a member of the consular staff.
+The letter is free. If you can't go to an appointment, you can ask a friend or family member to make an appointment and collect it for you.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/uk/partner_local/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/uk/partner_local/_same_sex.govspeak.erb
@@ -5,15 +5,11 @@ Contact the [relevant local authorities](http://www.dha.gov.za/index.php/civic-s
 
 %You’ll probably be asked for a CNI if you want to marry a South African citizen in South Africa. You’ll need to ask if there are any other documents the authorities will accept instead.%
 
-The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Commonwealth countries. The British High Commission in Pretoria or the Consulate General in Cape Town can provide a letter to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
+The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Commonwealth countries. You can get a letter to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
 
-Contact the High Commission and Consulate General to arrange to collect a letter.
+Book an appointment to collect a letter at the [British Consulate General in Cape Town](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-cape-town/providing-an-informative-note/slot_picker) or the [British High Commission in Pretoria](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-pretoria/providing-an-informative-note/slot_picker).
 
-$C
-<southafrica.consulate@fco.gov.uk>
-$C
-
-The letter must be signed and stamped by a member of the consular staff.
+The letter is free. If you can't go to an appointment, you can ask a friend or family member to make an appointment and collect it for you.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/uk/partner_other/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/uk/partner_other/_opposite_sex.govspeak.erb
@@ -3,15 +3,11 @@ Contact the [relevant local authorities](http://www.dha.gov.za/index.php/civic-s
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for South Africa](/foreign-travel-advice/south-africa) before making any plans.^
 
-The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Commonwealth countries. The British High Commission in Pretoria or the Consulate General in Cape Town can provide a letter to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
+The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Commonwealth countries. You can get a letter to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
 
-Contact the High Commission and Consulate General to arrange to collect a letter.
+Book an appointment to collect a letter at the [British Consulate General in Cape Town](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-cape-town/providing-an-informative-note/slot_picker) or the [British High Commission in Pretoria](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-pretoria/providing-an-informative-note/slot_picker).
 
-$C
-<southafrica.consulate@fco.gov.uk>
-$C
-
-The letter must be signed and stamped by a member of the consular staff.
+The letter is free. If you can't go to an appointment, you can ask a friend or family member to make an appointment and collect it for you.
 
 ##Naturalisation of your partner if they move to the UK
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/uk/partner_other/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/uk/partner_other/_same_sex.govspeak.erb
@@ -3,15 +3,11 @@ Contact the [relevant local authorities](http://www.dha.gov.za/index.php/civic-s
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for South Africa](/foreign-travel-advice/south-africa) before making any plans.^
 
-The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Commonwealth countries. The British High Commission in Pretoria or the Consulate General in Cape Town can provide a letter to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
+The UK doesn’t issue certificates of no impediment (CNIs) for marriages in Commonwealth countries. You can get a letter to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
 
-Contact the High Commission and Consulate General to arrange to collect a letter.
+Book an appointment to collect a letter at the [British Consulate General in Cape Town](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-cape-town/providing-an-informative-note/slot_picker) or the [British High Commission in Pretoria](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-pretoria/providing-an-informative-note/slot_picker).
 
-$C
-<southafrica.consulate@fco.gov.uk>
-$C
-
-The letter must be signed and stamped by a member of the consular staff.
+The letter is free. If you can't go to an appointment, you can ask a friend or family member to make an appointment and collect it for you.
 
 ##Naturalisation of your partner if they move to the UK
 


### PR DESCRIPTION
Removing embassy contact details and adding link because users can now use the CABS appointment service instead.

## Trello

https://trello.com/c/4we62Wrb/789-getting-married-in-south-africa-new-appointments-service-content-change-request

## Zendesk

https://govuk.zendesk.com/agent/tickets/2097107