### PR TITLE
Fix header problem with A variant

### DIFF
--- a/app/controllers/concerns/benchmark_inline_link_ab_testable.rb
+++ b/app/controllers/concerns/benchmark_inline_link_ab_testable.rb
@@ -4,7 +4,11 @@ module BenchmarkInlineLinkABTestable
   def should_show_benchmarking_variant?
     # Use GOVUK-ABTest-BenchmarkInlineLink=B header in dev to test this
     benchmark_inline_link_variant.variant_b? &&
-      is_benchmarking_tested_path(request.path)
+      is_benchmarking_tested_path?
+  end
+
+  def is_benchmarking_tested_path?
+    BENCHMARKING_PATHS.include? request.path
   end
 
   def benchmark_inline_link_variant
@@ -20,10 +24,6 @@ module BenchmarkInlineLinkABTestable
   end
 
 private
-
-  def is_benchmarking_tested_path(path)
-    BENCHMARKING_PATHS.include? path
-  end
 
   def benchmarking_ab_test
     @ab_test ||= GovukAbTesting::AbTest.new("BenchmarkInlineLink", dimension: 43)

--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -16,6 +16,7 @@ class SmartAnswersController < ApplicationController
     :should_present_new_navigation_view?,
     :page_is_under_ab_test?,
     :present_taxonomy_sidebar?,
+    :is_benchmarking_tested_path?,
     :should_show_benchmarking_variant?
   )
 
@@ -37,7 +38,7 @@ class SmartAnswersController < ApplicationController
           set_education_navigation_response_header(content_item)
         end
 
-        if should_show_benchmarking_variant?
+        if is_benchmarking_tested_path?
           set_benchmark_inline_links_response_header
         end
 

--- a/app/views/layouts/smart_answers.html.erb
+++ b/app/views/layouts/smart_answers.html.erb
@@ -7,7 +7,7 @@
   <% if page_is_under_ab_test?(@content_item) %>
     <%= education_navigation_variant.analytics_meta_tag.html_safe %>
   <% end %>
-  <% if should_show_benchmarking_variant? %>
+  <% if is_benchmarking_tested_path? %>
     <%= benchmark_inline_link_variant.analytics_meta_tag.html_safe %>
   <% end %>
 <% end %>

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -276,7 +276,7 @@ class SmartAnswersControllerTest < ActionController::TestCase
     context "Benchmarking A/B testing" do
       context "pages in test" do
         setup do
-          @controller.stubs(:is_benchmarking_tested_path).returns(true)
+          @controller.stubs(:is_benchmarking_tested_path?).returns(true)
 
           content_item = {
             "base_path" => '/benchmarking-sample'
@@ -288,12 +288,12 @@ class SmartAnswersControllerTest < ActionController::TestCase
         end
 
         should "show the original body for the 'A' version" do
-          setup_ab_variant "BenchmarkInlineLink", "A"
+          with_variant BenchmarkInlineLink: "A" do
+            get :show, id: 'benchmarking-sample'
 
-          get :show, id: 'benchmarking-sample'
-
-          assert_match(/Albert loved/, response.body)
-          refute_match(/hated/, response.body)
+            assert_match(/Albert loved/, response.body)
+            refute_match(/hated/, response.body)
+          end
         end
 
 


### PR DESCRIPTION
This wasn't setting the meta tag or the Vary header correctly for the A variant which caused problems running the test.

The logic for whether the page is under test should not be the same as whether the B variant should be shown.  :man_facepalming: 

We live and learn