### PR TITLE
Remove references to the Content API

### DIFF
--- a/doc/common-errors.md
+++ b/doc/common-errors.md
@@ -19,11 +19,11 @@ undefined method `to_html' for nil:NilClass
 Visit a specific Smart Answer, e.g. /marriage-abroad.
 
 
-## "SocketError" when viewing a Smart Answer (relating to Content API)
+## "SocketError" when viewing a Smart Answer (relating to Content Store)
 
 __NOTE.__ This is specifically when the exception is raised in `SmartAnswerPresenter#artefact`.
 
-You'll see this error if the Smart Answers app can't connect to the Content API.
+You'll see this error if the Smart Answers app can't connect to the Content Store.
 
 ### Exception
 
@@ -36,9 +36,9 @@ Failed to open TCP connection to content_store.dev.gov.uk:80 (getaddrinfo: noden
 
 There are a couple of solutions to this problem:
 
-1. Set the `PLEK_SERVICE_CONTENT_STORE_URI` environment variable to a valid host. NOTE. This doesn't need to be hosting the Content API (although you can use "https://www.gov.uk/api" if that's what you want), it simply needs to be a host that responds to HTTP requests.
+1. Set the `PLEK_SERVICE_CONTENT_STORE_URI` environment variable to a valid host. NOTE. This doesn't need to be hosting the Content Store (although you can use "https://www.gov.uk/api" if that's what you want), it simply needs to be a host that responds to HTTP requests.
 
-2. Configure a web server (e.g. Apache) on your machine to respond to http://content_store.dev.gov.uk. This is the default location of the Content API in development so configuring this means that you won't have to set the `PLEK_SERVICE_CONTENT_STORE_URI` environment variable.
+2. Configure a web server (e.g. Apache) on your machine to respond to http://content_store.dev.gov.uk. This is the default location of the Content Store in development so configuring this means that you won't have to set the `PLEK_SERVICE_CONTENT_STORE_URI` environment variable.
 
 
 ## "SocketError" when viewing a Smart Answer (relating to Worldwide API)

--- a/doc/developing-without-vm.md
+++ b/doc/developing-without-vm.md
@@ -9,6 +9,6 @@ PLEK_SERVICE_STATIC_URI=assets-origin.integration.publishing.service.gov.uk \
 rails s
 ```
 
-This tells Smart Answers to use the production Content API & Worldwide API, and the asset server from the integration environment.
+This tells Smart Answers to use the production Content Store & Worldwide API, and the asset server from the integration environment.
 
-If you don't set either environment variable then the app will attempt to connect to the content API, worldwide API and asset server at http://contentapi.dev.gov.uk, http://whitehall-admin.dev.gov.uk and http://static.dev.gov.uk respectively. NOTE. These are available automatically if you're [developing using the VM](developing-using-vm.md). If the app can't connect to these hosts then you'll see [errors](common-errors.md).
+If you don't set either environment variable then the app will attempt to connect to the content store, worldwide API and asset server at http://content-store.dev.gov.uk, http://whitehall-admin.dev.gov.uk and http://static.dev.gov.uk respectively. NOTE. These are available automatically if you're [developing using the VM](developing-using-vm.md). If the app can't connect to these hosts then you'll see [errors](common-errors.md).


### PR DESCRIPTION
The [`content_api`](https://github.com/alphagov/govuk_content_api) has
been retired, and all content has been migrated to the
[`content_store`](https://github.com/alphagov/content-store).

Therefore, we can remove all references to the Content API, and rely
solely on the Content Store.

### Trello

https://trello.com/c/TsUsUwD7/153-remove-documentation-on-content-api