### PR TITLE
A/B test the title and start button on calculate-your-child-maintenance

### DIFF
--- a/app/controllers/concerns/benchmark_child_maintenance_title_ab_testable.rb
+++ b/app/controllers/concerns/benchmark_child_maintenance_title_ab_testable.rb
@@ -1,0 +1,31 @@
+module BenchmarkChildMaintenanceTitleABTestable
+  BENCHMARKING_PATHS = ['/calculate-your-child-maintenance'].freeze
+
+  def should_show_benchmarking_variant?
+    # Use GOVUK-ABTest-BenchmarkCmTitle1=B header in dev to test this
+    benchmark_child_maintenance_title_variant.variant_b? &&
+      is_benchmarking_tested_path?
+  end
+
+  def is_benchmarking_tested_path?
+    BENCHMARKING_PATHS.include? request.path
+  end
+
+  def benchmark_child_maintenance_title_variant
+    @benchmark_child_maintenance_title_variant ||= benchmarking_ab_test.requested_variant request.headers
+  end
+
+  def set_benchmark_child_maintenance_title_response_header
+    benchmark_child_maintenance_title_variant.configure_response response
+  end
+
+  def self.included(base)
+    base.helper_method :benchmark_child_maintenance_title_variant
+  end
+
+private
+
+  def benchmarking_ab_test
+    @ab_test ||= GovukAbTesting::AbTest.new("BenchmarkCmTitle1", dimension: 44)
+  end
+end

--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -2,6 +2,7 @@ class SmartAnswersController < ApplicationController
   include Slimmer::GovukComponents
   include Slimmer::Headers
   include EducationNavigationABTestable
+  include BenchmarkChildMaintenanceTitleABTestable
 
   before_action :find_smart_answer, except: %w(index)
   before_action :redirect_response_to_canonical_url, only: %w{show}
@@ -14,7 +15,9 @@ class SmartAnswersController < ApplicationController
     :breadcrumbs,
     :should_present_new_navigation_view?,
     :page_is_under_ab_test?,
-    :present_taxonomy_sidebar?
+    :present_taxonomy_sidebar?,
+    :is_benchmarking_tested_path?,
+    :should_show_benchmarking_variant?
   )
 
   rescue_from SmartAnswer::FlowRegistry::NotFound, with: :error_404
@@ -34,6 +37,11 @@ class SmartAnswersController < ApplicationController
         if page_is_under_ab_test?(content_item)
           set_education_navigation_response_header(content_item)
         end
+
+        if is_benchmarking_tested_path?
+          set_benchmark_child_maintenance_title_response_header
+        end
+
         render page_type
       }
       if Rails.application.config.expose_govspeak

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,4 +10,8 @@ module ApplicationHelper
   def start_button_href
     SmartAnswer::StartButton.new(@name, self).href
   end
+
+  def ab_start_button
+    SmartAnswer::StartButton.new(@name, self).ab_text
+  end
 end

--- a/app/presenters/start_node_presenter.rb
+++ b/app/presenters/start_node_presenter.rb
@@ -11,6 +11,10 @@ class StartNodePresenter < NodePresenter
     @renderer.single_line_of_content_for(:title)
   end
 
+  def ab_title
+    @renderer.single_line_of_content_for(:ab_title)
+  end
+
   def meta_description
     @renderer.single_line_of_content_for(:meta_description)
   end

--- a/app/views/layouts/smart_answers.html.erb
+++ b/app/views/layouts/smart_answers.html.erb
@@ -7,6 +7,10 @@
   <% if page_is_under_ab_test?(@content_item) %>
     <%= education_navigation_variant.analytics_meta_tag.html_safe %>
   <% end %>
+
+  <% if is_benchmarking_tested_path? %>
+    <%= benchmark_child_maintenance_title_variant.analytics_meta_tag.html_safe %>
+  <% end %>
 <% end %>
 
 <% if should_present_new_navigation_view?(@content_item) %>

--- a/app/views/smart_answers/landing.html.erb
+++ b/app/views/smart_answers/landing.html.erb
@@ -10,17 +10,24 @@
   <% end %>
 <% end %>
 
-<%= render partial: 'page_title', locals: { title: start_node.title } %>
+<% if should_show_benchmarking_variant? %>
+  <%= render partial: 'page_title', locals: { title: start_node.ab_title } %>
+<% else %>
+  <%= render partial: 'page_title', locals: { title: start_node.title } %>
+<% end %>
 
 <div class="article-container group">
   <article role="article" class="group" data-debug-template-path="<%= start_node.relative_erb_template_path %>">
     <div class="inner">
       <div class="intro">
-
         <%= start_node.body %>
 
         <p class="get-started">
-          <a rel="nofollow" href="<%= start_button_href %>" class="big button"><%= start_button %></a>
+          <% if should_show_benchmarking_variant? %>
+            <a rel="nofollow" href="<%= start_button_href %>" class="big button"><%= ab_start_button %></a>
+          <% else %>
+            <a rel="nofollow" href="<%= start_button_href %>" class="big button"><%= start_button %></a>
+          <% end %>
         </p>
       </div>
 

--- a/lib/smart_answer/start_button.rb
+++ b/lib/smart_answer/start_button.rb
@@ -13,6 +13,10 @@ module SmartAnswer
       end
     end
 
+    def ab_text
+      "Estimate your child maintenance"
+    end
+
     def href
       if customized_start_button?
         custom_text_and_link[@smart_answer][:href]

--- a/lib/smart_answer_flows/calculate-your-child-maintenance/calculate_your_child_maintenance.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-child-maintenance/calculate_your_child_maintenance.govspeak.erb
@@ -2,6 +2,10 @@
   Child maintenance calculator
 <% end %>
 
+<% content_for :ab_title do %>
+  Estimate your child maintenance payments
+<% end %>
+
 <% content_for :meta_description do %>
   Work out the amount of child maintenance if you’re arranging it yourselves, or to get an idea of the statutory amounts from the Child Support Agency or Child Maintenance Service
 <% end %>

--- a/test/data/calculate-your-child-maintenance-files.yml
+++ b/test/data/calculate-your-child-maintenance-files.yml
@@ -2,7 +2,7 @@
 lib/data/child_maintenance_data.yml: a8cd91247e67f9f6bafdb93fb4ff8166
 lib/smart_answer/calculators/child_maintenance_calculator.rb: a0cd83a35856cf1c47ba12d711d3439d
 lib/smart_answer_flows/calculate-your-child-maintenance/_disclaimer.govspeak.erb: 4c59b8e3ac5f5071d11ee84e0d6a508b
-lib/smart_answer_flows/calculate-your-child-maintenance/calculate_your_child_maintenance.govspeak.erb: 07fd747ae23b05a8d267e5792ccdff0a
+lib/smart_answer_flows/calculate-your-child-maintenance/calculate_your_child_maintenance.govspeak.erb: f89bcc0a705211ca79cc3d07768b7239
 lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/flat_rate_result.govspeak.erb: b690c19299bfaadf511d35335487e3b1
 lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/nil_rate_result.govspeak.erb: cce0a8bd1df6f41baee3f2240ca56ad8
 lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/reduced_and_basic_rates_result.govspeak.erb: c32200392f1323ec6f0e406c3fe00347

--- a/test/fixtures/smart_answer_flows/benchmarking-sample.rb
+++ b/test/fixtures/smart_answer_flows/benchmarking-sample.rb
@@ -1,0 +1,7 @@
+module SmartAnswer
+  class BenchmarkingSampleFlow < Flow
+    def define
+      name 'benchmarking-sample'
+    end
+  end
+end

--- a/test/fixtures/smart_answer_flows/benchmarking-sample/benchmarking_sample.govspeak.erb
+++ b/test/fixtures/smart_answer_flows/benchmarking-sample/benchmarking_sample.govspeak.erb
@@ -1,0 +1,19 @@
+<% content_for :title do %>
+  Memorial bench cost calculator
+<% end %>
+
+<% content_for :ab_title do %>
+  Calculate the cost of a memorial bench
+<% end %>
+
+<% content_for :meta_description do %>
+  Sad stuff happens on bench descriptions
+<% end %>
+
+<% content_for :body do %>
+  Albert loved this view
+<% end %>
+
+<% content_for :ab_body do %>
+  Albert hated this view, the park and everyone in it.
+<% end %>


### PR DESCRIPTION
- This sets up the A/B test for the child maintenance page title and the
  start button text.
- We're not editing the `href` for the start button,
  so don't add `ab_start_button_href` anywhere - it's still going to the
  same place (`/calculate-your-child-maintenance/y`).

**Do not merge this until Tuesday - it deletes (most? some?) of the code for the ongoing BenchmarkInlineLink test, and will require a rebase when we revert the changes from #3046 and #3048 on Tuesday morning. 😱**