### PR TITLE
Fix calculate statutory sick pay tests

### DIFF
--- a/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
@@ -518,8 +518,10 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
     end
 
     should "not allow dates next year" do
-      add_response(Date.today.end_of_year + 1.day).to_s
-      assert_current_node_is_error
+      Timecop.freeze("2017-01-01") do
+        add_response(Date.today.end_of_year + 1.day).to_s
+        assert_current_node_is_error
+      end
     end
   end
 
@@ -538,8 +540,10 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
     end
 
     should "not allow dates next year" do
-      add_response(Date.today.end_of_year + 1.day).to_s
-      assert_current_node_is_error
+      Timecop.freeze("2017-01-01") do
+        add_response(Date.today.end_of_year + 1.day).to_s
+        assert_current_node_is_error
+      end
     end
 
     should "not allow dates before start_date" do


### PR DESCRIPTION
We have found that 2 tests for selecting the first sick day and last sick day
were failing as they were expecting an error to be raised if the date selected
is after the end of the current year.  However as of 1st June 2017 users are
able to select dates for the following year (see
https://github.com/alphagov/smart-answers/pull/2878), hence the tests are now
failing.  This fixes these tests to freeze the dates so that this issue
shouldn't occur again in future.