### PR TITLE
Implement new Child Maintenance A/B test

### DIFF
--- a/app/controllers/concerns/benchmark_child_maintenance_title_ab_testable.rb
+++ b/app/controllers/concerns/benchmark_child_maintenance_title_ab_testable.rb
@@ -26,6 +26,6 @@ module BenchmarkChildMaintenanceTitleABTestable
 private
 
   def benchmarking_ab_test
-    @ab_test ||= GovukAbTesting::AbTest.new("BenchmarkCmTitle1", dimension: 44)
+    @ab_test ||= GovukAbTesting::AbTest.new("BenchmarkCmTitle2", dimension: 46)
   end
 end

--- a/lib/smart_answer/start_button.rb
+++ b/lib/smart_answer/start_button.rb
@@ -14,7 +14,7 @@ module SmartAnswer
     end
 
     def ab_text
-      "Estimate your child maintenance"
+      "Calculate your child maintenance"
     end
 
     def href

--- a/lib/smart_answer_flows/calculate-your-child-maintenance/calculate_your_child_maintenance.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-child-maintenance/calculate_your_child_maintenance.govspeak.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :ab_title do %>
-  Estimate your child maintenance payments
+  Calculate your child maintenance payments
 <% end %>
 
 <% content_for :meta_description do %>
@@ -17,8 +17,8 @@
   * agree an amount with the other parent if [you’re arranging it yourselves](/arranging-child-maintenance-yourself)
   * get an idea of the amount the government would work out for you (including collection and application fees)
 
-  The calculator is based on the rules used by the Child Maintenance Service. 
-  
+  The calculator is based on the rules used by the Child Maintenance Service.
+
   Don't use the calculator if you have a ['1993 scheme' or '2003 scheme' case](/how-child-maintenance-is-worked-out/child-maintenance-before-march-2003). These are managed by the [Child Support Agency](/child-maintenance/contact) (CSA).
 
   ^<%= render partial: 'disclaimer.govspeak.erb' %>^

--- a/test/data/calculate-your-child-maintenance-files.yml
+++ b/test/data/calculate-your-child-maintenance-files.yml
@@ -2,7 +2,7 @@
 lib/data/child_maintenance_data.yml: a8cd91247e67f9f6bafdb93fb4ff8166
 lib/smart_answer/calculators/child_maintenance_calculator.rb: a0cd83a35856cf1c47ba12d711d3439d
 lib/smart_answer_flows/calculate-your-child-maintenance/_disclaimer.govspeak.erb: 4c59b8e3ac5f5071d11ee84e0d6a508b
-lib/smart_answer_flows/calculate-your-child-maintenance/calculate_your_child_maintenance.govspeak.erb: f89bcc0a705211ca79cc3d07768b7239
+lib/smart_answer_flows/calculate-your-child-maintenance/calculate_your_child_maintenance.govspeak.erb: 95597a6f8eaa063345308cc6d39fa3c6
 lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/flat_rate_result.govspeak.erb: b690c19299bfaadf511d35335487e3b1
 lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/nil_rate_result.govspeak.erb: cce0a8bd1df6f41baee3f2240ca56ad8
 lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/reduced_and_basic_rates_result.govspeak.erb: c32200392f1323ec6f0e406c3fe00347

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -288,7 +288,7 @@ class SmartAnswersControllerTest < ActionController::TestCase
         end
 
         should "show the original title and start button for the 'A' version" do
-          with_variant BenchmarkCmTitle1: "A" do
+          with_variant BenchmarkCmTitle2: "A" do
             get :show, id: 'benchmarking-sample'
 
             assert_select "h1", text: "Memorial bench cost calculator", count: 1
@@ -298,12 +298,12 @@ class SmartAnswersControllerTest < ActionController::TestCase
         end
 
         should "show the alternate title for the 'B' version" do
-          with_variant BenchmarkCmTitle1: "B" do
+          with_variant BenchmarkCmTitle2: "B" do
             get :show, id: 'benchmarking-sample'
 
             assert_select "h1", text: "Calculate the cost of a memorial bench", count: 1
 
-            assert_match(/Estimate/, response.body)
+            assert_match(/Calculate/, response.body)
           end
         end
       end
@@ -320,7 +320,7 @@ class SmartAnswersControllerTest < ActionController::TestCase
         end
 
         should "show the normal body for the 'B' version" do
-          setup_ab_variant "BenchmarkCmTitle1", "B"
+          setup_ab_variant "BenchmarkCmTitle2", "B"
 
           get :show, id: 'bridge-of-death'
 


### PR DESCRIPTION
This changes the title and the start button text for the B version from "Estimate your child maintenance payments" to "Calculate your child maintenance payments".

Will require [this fastly-configure PR](https://github.com/alphagov/fastly-configure/pull/27) and [that cdn-configs PR](https://github.digital.cabinet-office.gov.uk/gds/cdn-configs/pull/135) in order to work.

[Trello](https://trello.com/c/rcmqkFp3/120-%5Bcm-calculate-title%5D---develop-and-deploy-a%2Fb-test)