### PR TITLE
Change description on holiday entitlement landing page

### DIFF
--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/calculate_your_holiday_entitlement.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/calculate_your_holiday_entitlement.govspeak.erb
@@ -7,5 +7,8 @@
 <% end %>
 
 <% content_for :body do %>
-  Calculate statutory holiday entitlement in days or hours for a full leave year or work out holiday someone is entitled to when they start or leave a job part way through a leave year.
+  Use this tool to calculate holiday entitlement for:
+
+  - a full leave year
+  - part of a leave year, if the job started or finished part way through the year
 <% end %>

--- a/test/artefacts/calculate-your-holiday-entitlement/calculate-your-holiday-entitlement.txt
+++ b/test/artefacts/calculate-your-holiday-entitlement/calculate-your-holiday-entitlement.txt
@@ -1,6 +1,9 @@
 Calculate holiday entitlement
 
-Calculate statutory holiday entitlement in days or hours for a full leave year or work out holiday someone is entitled to when they start or leave a job part way through a leave year.
+Use this tool to calculate holiday entitlement for:
+
+- a full leave year
+- part of a leave year, if the job started or finished part way through the year
 
 
 

--- a/test/data/calculate-your-holiday-entitlement-files.yml
+++ b/test/data/calculate-your-holiday-entitlement-files.yml
@@ -1,6 +1,6 @@
 ---
 lib/smart_answer/calculators/holiday_entitlement.rb: dab915508991c038dcc0fd51935bcf82
-lib/smart_answer_flows/calculate-your-holiday-entitlement/calculate_your_holiday_entitlement.govspeak.erb: 76f569916a2429d42e52afc658285f6a
+lib/smart_answer_flows/calculate-your-holiday-entitlement/calculate_your_holiday_entitlement.govspeak.erb: 7e3dc9481cf2f3a252ae2ae8dc9d5ae3
 lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/_your_employer_with_rounding.govspeak.erb: 968b6d15a99334328227528f3feea6ba
 lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/annualised_hours_done.govspeak.erb: c9174109c8f6d7c4e9eacefc288509d6
 lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/casual_or_irregular_hours_done.govspeak.erb: 414b678a5dd4ab8cde92f26c024ac267


### PR DESCRIPTION
The current description is unclear. The new text helps the user to understand what this service provides before deciding to start the process

https://trello.com/c/8Mkdr5V0/133-amend-the-description-text-for-the-calculate-holiday-entitlement-smart-answer