### PR TITLE
Remove redundant text

### DIFF
--- a/lib/smart_answer_flows/calculate-your-child-maintenance/calculate_your_child_maintenance.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-child-maintenance/calculate_your_child_maintenance.govspeak.erb
@@ -13,8 +13,6 @@
   * agree an amount with the other parent if [you’re arranging it yourselves](/arranging-child-maintenance-yourself)
   * get an idea of the amount the government would work out for you (including collection and application fees)
 
-  The calculator is based on the rules used by the Child Maintenance Service.
-
   ##Before you start
 
   You need information about the income of the parent who'll be paying.
@@ -32,7 +30,6 @@
   * agree an amount with the other parent if [you’re arranging it yourselves](/arranging-child-maintenance-yourself)
   * get an idea of the amount the government would work out for you (including collection and application fees)
 
-  The calculator is based on the rules used by the Child Maintenance Service.
 <% end %>
 
 <% content_for :ab_post_body do %>

--- a/test/artefacts/calculate-your-child-maintenance/calculate-your-child-maintenance.txt
+++ b/test/artefacts/calculate-your-child-maintenance/calculate-your-child-maintenance.txt
@@ -6,8 +6,6 @@ You can use this calculator to estimate your child maintenance. It can help you 
 * agree an amount with the other parent if [you’re arranging it yourselves](/arranging-child-maintenance-yourself)
 * get an idea of the amount the government would work out for you (including collection and application fees)
 
-The calculator is based on the rules used by the Child Maintenance Service.
-
 ##Before you start
 
 You need information about the income of the parent who'll be paying.

--- a/test/data/calculate-your-child-maintenance-files.yml
+++ b/test/data/calculate-your-child-maintenance-files.yml
@@ -2,7 +2,7 @@
 lib/data/child_maintenance_data.yml: a8cd91247e67f9f6bafdb93fb4ff8166
 lib/smart_answer/calculators/child_maintenance_calculator.rb: a0cd83a35856cf1c47ba12d711d3439d
 lib/smart_answer_flows/calculate-your-child-maintenance/_disclaimer.govspeak.erb: 28ee54c8d67310b832496139f9a978ee
-lib/smart_answer_flows/calculate-your-child-maintenance/calculate_your_child_maintenance.govspeak.erb: a1955443eb294afb8cff4b9a577fa070
+lib/smart_answer_flows/calculate-your-child-maintenance/calculate_your_child_maintenance.govspeak.erb: 9f8804b702bade8520c17af51fdf9b5c
 lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/flat_rate_result.govspeak.erb: b690c19299bfaadf511d35335487e3b1
 lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/nil_rate_result.govspeak.erb: cce0a8bd1df6f41baee3f2240ca56ad8
 lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/reduced_and_basic_rates_result.govspeak.erb: c32200392f1323ec6f0e406c3fe00347


### PR DESCRIPTION
In [this previous commit](https://github.com/alphagov/smart-answers/pull/3081/commits/f395a970921a85152d487ff84a4da29427f9451a) I neglected to remove a redundant line of text.  It has now been merged with the general disclaimer.