### PR TITLE
Rails 5 Upgrade CNTD: Add SmartAnswer lib to eager load path

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -62,5 +62,7 @@ module SmartAnswers
     config.action_dispatch.rack_cache = nil
 
     config.action_dispatch.ignore_accept_header = true
+
+    config.eager_load_paths << Rails.root.join('lib')
   end
 end


### PR DESCRIPTION
## Description 

With Rails 5, autoloading is now completely disabled if
config.eager_load = true. What this means is that if file
paths outside of app/ are in your config.autoload_paths and
not in config.eager_load_paths (for example, lib/), these
files are no longer load in deployed environments.

In this repo production environment has been set to config.eager_load = true
and development to config.eager_load = false. This is why development
did not flag this problem

This PR fixes this by setting config.eager_load_paths << Rails.root.join('lib')

## Expected changes 
- SmartAnswer Classes and modules defined under lib are now loaded in production.

## Testing 
- https://www-origin.integration.publishing.service.gov.uk/marriage-abroad/y/sweden/uk/partner_other/same_sex?cachebust=0.5112451121156074
- https://deploy.integration.publishing.service.gov.uk/job/Deploy_App/718/console
- https://errbit.integration.publishing.service.gov.uk/apps/533c2ee40da115303f0129a5