### PR TITLE
Add annual leave entitlement AB test

### DIFF
--- a/app/assets/stylesheets/smart_answers.scss
+++ b/app/assets/stylesheets/smart_answers.scss
@@ -375,4 +375,19 @@ $is-ie: false !default;
     vertical-align: top;
   }
 
+  .ab-context {
+    padding: 0;
+    margin:  0;
+
+    h2 {
+      border: none;
+      @include bold-19;
+      margin: 0 0 1em;
+      position: relative;
+
+      @include ie-lte(8) {
+        line-height: 1.2em;
+      }
+    }
+  }
 }

--- a/app/controllers/concerns/benchmark_holiday_entitlement_ab_testable.rb
+++ b/app/controllers/concerns/benchmark_holiday_entitlement_ab_testable.rb
@@ -1,0 +1,36 @@
+module BenchmarkHolidayEntitlementABTestable
+  BENCHMARKING_PATHS = [
+    '/calculate-your-holiday-entitlement',
+    '/calculate-your-holiday-entitlement/y/days-worked-per-week',
+    '/calculate-your-holiday-entitlement/y/hours-worked-per-week',
+    '/calculate-your-holiday-entitlement/y/shift-worker'
+  ].freeze
+
+  def should_show_holiday_entitlement_variant?
+    # Use GOVUK-ABTest-BenchmarkALDescription1=B header in dev to test this
+    benchmark_holiday_entitlement_variant.variant_b? &&
+      is_holiday_entitlement_tested_path?
+  end
+
+  def is_holiday_entitlement_tested_path?
+    BENCHMARKING_PATHS.include? request.path
+  end
+
+  def benchmark_holiday_entitlement_variant
+    @benchmark_holiday_entitlement_variant ||= benchmarking_holiday_entitlement_ab_test.requested_variant request.headers
+  end
+
+  def set_benchmark_holiday_entitlement_response_header
+    benchmark_holiday_entitlement_variant.configure_response response
+  end
+
+  def self.included(base)
+    base.helper_method :benchmark_holiday_entitlement_variant
+  end
+
+private
+
+  def benchmarking_holiday_entitlement_ab_test
+    @description_ab_test ||= GovukAbTesting::AbTest.new("BenchmarkALDescription1", dimension: 63)
+  end
+end

--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -3,6 +3,7 @@ class SmartAnswersController < ApplicationController
   include Slimmer::Headers
   include EducationNavigationABTestable
   include BenchmarkChildMaintenanceButtonPositionABTestable
+  include BenchmarkHolidayEntitlementABTestable
 
   before_action :find_smart_answer, except: %w(index)
   before_action :redirect_response_to_canonical_url, only: %w{show}
@@ -18,6 +19,8 @@ class SmartAnswersController < ApplicationController
     :present_taxonomy_sidebar?,
     :is_button_position_tested_path?,
     :should_show_button_position_variant?,
+    :is_holiday_entitlement_tested_path?,
+    :should_show_holiday_entitlement_variant?
   )
 
   rescue_from SmartAnswer::FlowRegistry::NotFound, with: :error_404
@@ -40,6 +43,10 @@ class SmartAnswersController < ApplicationController
 
         if is_button_position_tested_path?
           set_benchmark_button_position_response_header
+        end
+
+        if is_holiday_entitlement_tested_path?
+          set_benchmark_holiday_entitlement_response_header
         end
 
         render page_type

--- a/app/views/layouts/smart_answers.html.erb
+++ b/app/views/layouts/smart_answers.html.erb
@@ -11,6 +11,10 @@
   <% if is_button_position_tested_path? %>
     <%= benchmark_button_position_variant.analytics_meta_tag.html_safe %>
   <% end %>
+
+  <% if is_holiday_entitlement_tested_path? %>
+    <%= benchmark_holiday_entitlement_variant.analytics_meta_tag.html_safe %>
+  <% end %>
 <% end %>
 
 <% if should_present_new_navigation_view?(@content_item) %>

--- a/app/views/smart_answers/landing.html.erb
+++ b/app/views/smart_answers/landing.html.erb
@@ -17,7 +17,7 @@
     <div class="inner">
       <div class="intro">
 
-      <% if should_show_button_position_variant? %>
+      <% if should_show_button_position_variant? || should_show_holiday_entitlement_variant? %>
         <%= start_node.ab_body %>
       <% else %>
         <%= start_node.body %>

--- a/app/views/smart_answers/question.html.erb
+++ b/app/views/smart_answers/question.html.erb
@@ -9,6 +9,22 @@
 <% question = @presenter.current_node %>
 
 <div class="step current">
+
+  <% if should_show_holiday_entitlement_variant? %>
+    <div class="ab-context">
+      <h2 id="leave-year-dates">
+        Leave year dates
+      </h2>
+      <p>
+       The leave year will usually be in an employee’s contract. If it isn’t, their leave year will start:
+      </p>
+      <ul>
+        <li>on their first day (if the job began after 1 October 1998)</li>
+        <li>on 1 October (if the job began on or before 1 October 1998)</li>
+      </ul>
+    </div>
+  <% end %>
+
   <%= form_tag calculate_current_question_path(@presenter), :method => :get %>
     <div class="current-question" id="current-question">
 

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/calculate_your_holiday_entitlement.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/calculate_your_holiday_entitlement.govspeak.erb
@@ -20,3 +20,11 @@
   - on 1 October (if the job began on or before 1 October 1998)
 
 <% end %>
+
+<% content_for :ab_body do %>
+  Use this tool to calculate holiday entitlement for:
+
+  - a full leave year
+  - part of a leave year, if the job started or finished part way through the year
+
+<% end %>

--- a/test/data/calculate-your-holiday-entitlement-files.yml
+++ b/test/data/calculate-your-holiday-entitlement-files.yml
@@ -1,6 +1,6 @@
 ---
 lib/smart_answer/calculators/holiday_entitlement.rb: dab915508991c038dcc0fd51935bcf82
-lib/smart_answer_flows/calculate-your-holiday-entitlement/calculate_your_holiday_entitlement.govspeak.erb: 448c48df1c04abbf03ded760e29a227f
+lib/smart_answer_flows/calculate-your-holiday-entitlement/calculate_your_holiday_entitlement.govspeak.erb: 2ef053da554acbe99f7fb8df8126f9a1
 lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/_your_employer_with_rounding.govspeak.erb: 968b6d15a99334328227528f3feea6ba
 lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/annualised_hours_done.govspeak.erb: 5be498f482bc4686f612cdca0dbbc2ab
 lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/casual_or_irregular_hours_done.govspeak.erb: f2b0964438fdb8b9ef4aaa4972bd7041

--- a/test/fixtures/smart_answer_flows/bridge-of-death/bridge_of_death.govspeak.erb
+++ b/test/fixtures/smart_answer_flows/bridge-of-death/bridge_of_death.govspeak.erb
@@ -15,3 +15,7 @@
   These questions three
   Ere the other side he see.
 <% end %>
+
+<% content_for :ab_body do %>
+  There are some who call me Tim!
+<% end %>


### PR DESCRIPTION
Our user research suggests that giving the context of when a leave year starts
closer to the place where a user needs that information could help completion.

The text we are testing is this:

 -----
 Leave year dates
  The leave year will usually be in an employee’s contract. If it isn’t, their leave year will start:

  - on their first day (if the job began after 1 October 1998)
  - on 1 October (if the job began on or before 1 October 1998)
-----

The A variant keeps this text on the [landing page](https://www.gov.uk/calculate-your-holiday-entitlement) where it is currently.

The B variant does not show this text on the landing page, but instead on:

- https://www.gov.uk/calculate-your-holiday-entitlement/y/days-worked-per-week
- https://www.gov.uk/calculate-your-holiday-entitlement/y/shift-worker
- https://www.gov.uk/calculate-your-holiday-entitlement/y/hours-worked-per-week

To minimise duplication and to make it more obvious where the text is displayed,
I've put this markup directly in the question view rather than using Govspeak
in the node body (which is the approach we've typically used for the landing
pages)

This test will run until at least 26th June 2017.

https://trello.com/c/GgnYfigi/161-annual-leave-description-develop-and-deploy-change-to-form-flow

##Screenshots of the A and B variants of the landing page
![screen shot 2017-06-16 at 14 30 32](https://user-images.githubusercontent.com/773037/27228664-7821ffe4-52a0-11e7-8596-7d564cf84497.png)
![screen shot 2017-06-16 at 14 30 12](https://user-images.githubusercontent.com/773037/27228663-781a6dd8-52a0-11e7-82bc-77299bac548d.png)

##Screenshots of A and B variants of a question page
![screen shot 2017-06-16 at 14 30 46](https://user-images.githubusercontent.com/773037/27228662-77ffadd6-52a0-11e7-8282-a0f55e57e981.png)
![screen shot 2017-06-16 at 14 31 01](https://user-images.githubusercontent.com/773037/27228661-77e31892-52a0-11e7-899e-59eb796c10a1.png)