### PR TITLE
Student finance forms/updates june 2017

### DIFF
--- a/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_pt_1718_continuing.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_pt_1718_continuing.govspeak.erb
@@ -14,8 +14,8 @@
   If you started your course before 1 September 2012 you may be eligible for a Tuition Fee Grant.
 
   **Academic year** | **Form** |-
-  2017 to 2018 | [EUPTG1 - form (PDF, 57KB)](http://media.slc.co.uk/sfe/1718/eu/eu_ptg1_form_1718_d.pdf)
-  2017 to 2018 | [EUPTG1 - guidance notes (PDF, 57KB)](http://media.slc.co.uk/sfe/1718/eu/eu_ptg1_notes_1718_d.pdf)
+  2017 to 2018 | [EUPTG1 - form (PDF, 1034KB)](http://media.slc.co.uk/sfe/1718/eu/eu_ptg1_form_1718_d.pdf)
+  2017 to 2018 | [EUPTG1 - guidance notes (PDF, 505KB)](http://media.slc.co.uk/sfe/1718/eu/eu_ptg1_notes_1718_d.pdf)
 
   ##Additional information
   You may need to include additional information on the following forms.

--- a/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_pt_1718_continuing.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_pt_1718_continuing.govspeak.erb
@@ -14,8 +14,8 @@
   If you started your course before 1 September 2012 you may be eligible for a Tuition Fee Grant.
 
   **Academic year** | **Form** |-
-  2017 to 2018 | EUPTG1 - form (available in summer 2017)
-  2017 to 2018 | EUPTG1 - guidance notes (available in summer 2017)
+  2017 to 2018 | [EUPTG1 - form (PDF, 57KB)](http://media.slc.co.uk/sfe/1718/eu/eu_ptg1_form_1718_d.pdf)
+  2017 to 2018 | [EUPTG1 - guidance notes (PDF, 57KB)](http://media.slc.co.uk/sfe/1718/eu/eu_ptg1_notes_1718_d.pdf)
 
   ##Additional information
   You may need to include additional information on the following forms.

--- a/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1718_grant_continuing.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1718_grant_continuing.govspeak.erb
@@ -1,3 +1,39 @@
+<% content_for :title do %>
+  Student finance - application form
+<% end %>
+
 <% content_for :body do %>
-  You can't apply for the 2017 to 2018 academic year yet.
+  To apply for a fee grant and course grant download and fill in form PTGC.
+
+  | Academic year | Form
+  | 2017 to 2018 | [PTGC - form (PDF, 599KB)][PTGC-form]
+  | 2017 to 2018 | [PTGC - guidance notes (PDF, 622KB)][PTGC-guidance]
+
+  [PTGC-form]: http://media.slc.co.uk/sfe/1718/pt/sfe_ptgc_form_1718_d.pdf
+  [PTGC-guidance]: http://media.slc.co.uk/sfe/1718/pt/sfe_ptgc_notes_1718_d.pdf
+
+  You can apply up to 9 months after your course starts.
+
+  ##If you or your partner get benefits
+
+  You need to download and fill in [form CB1 (PDF, 82KB)][CB1-form] if you or your partner gets:
+
+  * Universal Credit
+  * Income Support
+  * Income-based Jobseeker’s Allowance (JSA)
+  * Income-related Employment Support Allowance (ESA)
+  * Housing Benefit
+  * Local Housing Allowance
+
+  [CB1-form]: http://media.slc.co.uk/sfe/1718/pt/sfe_part_time_cb1_form_1718_d.pdf
+
+  ##If your circumstances have changed
+
+  You need to download and fill in [form CO2 (PDF, 87KB)][CO2-form] if you’ve changed:
+
+  * your course, or left it
+  * university or college
+  * your name, address or contact details
+
+  [CO2-form]: http://media.slc.co.uk/sfe/1718/pt/sfe_part_time_co2_form_1718_d.pdf
 <% end %>

--- a/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1718_grant_continuing.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1718_grant_continuing.govspeak.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :body do %>
-  To apply for a fee grant and course grant download and fill in form PTGC.
+  To apply for a Fee Grant and Course Grant download and fill in form PTGC.
 
   | Academic year | Form
   | 2017 to 2018 | [PTGC - form (PDF, 599KB)][PTGC-form]

--- a/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1718_grant_new.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1718_grant_new.govspeak.erb
@@ -1,3 +1,41 @@
+<% content_for :title do %>
+  Student finance - application form
+<% end %>
+
 <% content_for :body do %>
-  You can't apply for the 2017 to 2018 academic year yet.
+  To apply for a fee grant and course grant download and fill in form PTGN.
+
+  | Academic year | Form
+  | 2017 to 2018 | [PTGN - form (PDF, 779KB)][PTGN-form]
+  | 2017 to 2018 | [PTGN - guidance notes (PDF, 615KB)][PTGN-guidance]
+
+  [PTGN-form]: http://media.slc.co.uk/sfe/1718/pt/sfe_ptgn_form_1718_d.pdf
+  [PTGN-guidance]: http://media.slc.co.uk/sfe/1718/pt/sfe_ptgn_notes_1718_d.pdf
+
+  You can apply up to 9 months after your course starts.
+
+  ##If you or your partner get benefits
+
+  You need to download and fill in [form CB1 (PDF, 82KB)][CB1-form] if
+  you or your partner gets:
+
+  * Universal Credit
+  * Income Support
+  * Income-based Jobseeker’s Allowance (JSA)
+  * Income-related Employment Support Allowance (ESA)
+  * Housing Benefit
+  * Local Housing Allowance
+
+  [CB1-form]: http://media.slc.co.uk/sfe/1718/pt/sfe_part_time_cb1_form_1718_d.pdf
+
+  ##If your circumstances have changed
+
+  You need to download and fill in [form CO2 (PDF, 87KB)][CO2-form] if
+  you’ve changed:
+
+  * your course, or left it
+  * university or college
+  * your name, address or contact details
+
+  [CO2-form]: http://media.slc.co.uk/sfe/1718/pt/sfe_part_time_co2_form_1718_d.pdf
 <% end %>

--- a/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1718_grant_new.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1718_grant_new.govspeak.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :body do %>
-  To apply for a fee grant and course grant download and fill in form PTGN.
+  To apply for a Fee Grant and Course Grant download and fill in form PTGN.
 
   | Academic year | Form
   | 2017 to 2018 | [PTGN - form (PDF, 779KB)][PTGN-form]

--- a/lib/smart_answer_flows/student-finance-forms/questions/type_of_student.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/questions/type_of_student.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :title do %>
-  What type of a student are you?
+  What type of student are you?
 <% end %>
 
 <% options(

--- a/test/artefacts/student-finance-forms/eu-part-time/year-1718/continuing-student.txt
+++ b/test/artefacts/student-finance-forms/eu-part-time/year-1718/continuing-student.txt
@@ -10,8 +10,8 @@ If you started your course on or after 1 September 2012 you may be eligible for 
 If you started your course before 1 September 2012 you may be eligible for a Tuition Fee Grant.
 
 **Academic year** | **Form** |-
-2017 to 2018 | [EUPTG1 - form (PDF, 57KB)](http://media.slc.co.uk/sfe/1718/eu/eu_ptg1_form_1718_d.pdf)
-2017 to 2018 | [EUPTG1 - guidance notes (PDF, 57KB)](http://media.slc.co.uk/sfe/1718/eu/eu_ptg1_notes_1718_d.pdf)
+2017 to 2018 | [EUPTG1 - form (PDF, 1034KB)](http://media.slc.co.uk/sfe/1718/eu/eu_ptg1_form_1718_d.pdf)
+2017 to 2018 | [EUPTG1 - guidance notes (PDF, 505KB)](http://media.slc.co.uk/sfe/1718/eu/eu_ptg1_notes_1718_d.pdf)
 
 ##Additional information
 You may need to include additional information on the following forms.

--- a/test/artefacts/student-finance-forms/eu-part-time/year-1718/continuing-student.txt
+++ b/test/artefacts/student-finance-forms/eu-part-time/year-1718/continuing-student.txt
@@ -10,8 +10,8 @@ If you started your course on or after 1 September 2012 you may be eligible for 
 If you started your course before 1 September 2012 you may be eligible for a Tuition Fee Grant.
 
 **Academic year** | **Form** |-
-2017 to 2018 | EUPTG1 - form (available in summer 2017)
-2017 to 2018 | EUPTG1 - guidance notes (available in summer 2017)
+2017 to 2018 | [EUPTG1 - form (PDF, 57KB)](http://media.slc.co.uk/sfe/1718/eu/eu_ptg1_form_1718_d.pdf)
+2017 to 2018 | [EUPTG1 - guidance notes (PDF, 57KB)](http://media.slc.co.uk/sfe/1718/eu/eu_ptg1_notes_1718_d.pdf)
 
 ##Additional information
 You may need to include additional information on the following forms.

--- a/test/artefacts/student-finance-forms/uk-part-time/apply-loans-grants/year-1718/continuing-student/course-start-before-01092012.txt
+++ b/test/artefacts/student-finance-forms/uk-part-time/apply-loans-grants/year-1718/continuing-student/course-start-before-01092012.txt
@@ -1,6 +1,6 @@
 Student finance - application form
 
-To apply for a fee grant and course grant download and fill in form PTGC.
+To apply for a Fee Grant and Course Grant download and fill in form PTGC.
 
 | Academic year | Form
 | 2017 to 2018 | [PTGC - form (PDF, 599KB)][PTGC-form]

--- a/test/artefacts/student-finance-forms/uk-part-time/apply-loans-grants/year-1718/continuing-student/course-start-before-01092012.txt
+++ b/test/artefacts/student-finance-forms/uk-part-time/apply-loans-grants/year-1718/continuing-student/course-start-before-01092012.txt
@@ -1,6 +1,38 @@
+Student finance - application form
 
+To apply for a fee grant and course grant download and fill in form PTGC.
 
-You can't apply for the 2017 to 2018 academic year yet.
+| Academic year | Form
+| 2017 to 2018 | [PTGC - form (PDF, 599KB)][PTGC-form]
+| 2017 to 2018 | [PTGC - guidance notes (PDF, 622KB)][PTGC-guidance]
+
+[PTGC-form]: http://media.slc.co.uk/sfe/1718/pt/sfe_ptgc_form_1718_d.pdf
+[PTGC-guidance]: http://media.slc.co.uk/sfe/1718/pt/sfe_ptgc_notes_1718_d.pdf
+
+You can apply up to 9 months after your course starts.
+
+##If you or your partner get benefits
+
+You need to download and fill in [form CB1 (PDF, 82KB)][CB1-form] if you or your partner gets:
+
+* Universal Credit
+* Income Support
+* Income-based Jobseeker’s Allowance (JSA)
+* Income-related Employment Support Allowance (ESA)
+* Housing Benefit
+* Local Housing Allowance
+
+[CB1-form]: http://media.slc.co.uk/sfe/1718/pt/sfe_part_time_cb1_form_1718_d.pdf
+
+##If your circumstances have changed
+
+You need to download and fill in [form CO2 (PDF, 87KB)][CO2-form] if you’ve changed:
+
+* your course, or left it
+* university or college
+* your name, address or contact details
+
+[CO2-form]: http://media.slc.co.uk/sfe/1718/pt/sfe_part_time_co2_form_1718_d.pdf
 
 
 

--- a/test/artefacts/student-finance-forms/uk-part-time/apply-loans-grants/year-1718/new-student/course-start-before-01092012.txt
+++ b/test/artefacts/student-finance-forms/uk-part-time/apply-loans-grants/year-1718/new-student/course-start-before-01092012.txt
@@ -1,6 +1,6 @@
 Student finance - application form
 
-To apply for a fee grant and course grant download and fill in form PTGN.
+To apply for a Fee Grant and Course Grant download and fill in form PTGN.
 
 | Academic year | Form
 | 2017 to 2018 | [PTGN - form (PDF, 779KB)][PTGN-form]

--- a/test/artefacts/student-finance-forms/uk-part-time/apply-loans-grants/year-1718/new-student/course-start-before-01092012.txt
+++ b/test/artefacts/student-finance-forms/uk-part-time/apply-loans-grants/year-1718/new-student/course-start-before-01092012.txt
@@ -1,6 +1,40 @@
+Student finance - application form
 
+To apply for a fee grant and course grant download and fill in form PTGN.
 
-You can't apply for the 2017 to 2018 academic year yet.
+| Academic year | Form
+| 2017 to 2018 | [PTGN - form (PDF, 779KB)][PTGN-form]
+| 2017 to 2018 | [PTGN - guidance notes (PDF, 615KB)][PTGN-guidance]
+
+[PTGN-form]: http://media.slc.co.uk/sfe/1718/pt/sfe_ptgn_form_1718_d.pdf
+[PTGN-guidance]: http://media.slc.co.uk/sfe/1718/pt/sfe_ptgn_notes_1718_d.pdf
+
+You can apply up to 9 months after your course starts.
+
+##If you or your partner get benefits
+
+You need to download and fill in [form CB1 (PDF, 82KB)][CB1-form] if
+you or your partner gets:
+
+* Universal Credit
+* Income Support
+* Income-based Jobseeker’s Allowance (JSA)
+* Income-related Employment Support Allowance (ESA)
+* Housing Benefit
+* Local Housing Allowance
+
+[CB1-form]: http://media.slc.co.uk/sfe/1718/pt/sfe_part_time_cb1_form_1718_d.pdf
+
+##If your circumstances have changed
+
+You need to download and fill in [form CO2 (PDF, 87KB)][CO2-form] if
+you’ve changed:
+
+* your course, or left it
+* university or college
+* your name, address or contact details
+
+[CO2-form]: http://media.slc.co.uk/sfe/1718/pt/sfe_part_time_co2_form_1718_d.pdf
 
 
 

--- a/test/artefacts/student-finance-forms/y.txt
+++ b/test/artefacts/student-finance-forms/y.txt
@@ -1,4 +1,4 @@
-What type of a student are you?
+What type of student are you?
 
 
 

--- a/test/data/student-finance-forms-files.yml
+++ b/test/data/student-finance-forms-files.yml
@@ -41,7 +41,7 @@ lib/smart_answer_flows/student-finance-forms/questions/continuing_student.govspe
 lib/smart_answer_flows/student-finance-forms/questions/form_needed_for_1.govspeak.erb: 5d02e8180eb5108e0b0cc9b5f083e758
 lib/smart_answer_flows/student-finance-forms/questions/form_needed_for_2.govspeak.erb: ec9515d39eae184fef90dd3455ea43bd
 lib/smart_answer_flows/student-finance-forms/questions/pt_course_start.govspeak.erb: e20ef6438ad8d25ecb72b679dfe5bd86
-lib/smart_answer_flows/student-finance-forms/questions/type_of_student.govspeak.erb: 7b236a9aae750540e95e476dace07a3f
+lib/smart_answer_flows/student-finance-forms/questions/type_of_student.govspeak.erb: 690ce1bda5da03f3259d5b6ce8d29d24
 lib/smart_answer_flows/student-finance-forms/questions/what_year_full_time.govspeak.erb: ba33987c1eee3ecd089045ca9e874b0e
 lib/smart_answer_flows/student-finance-forms/questions/what_year_part_time.govspeak.erb: 03d19fedbc8d455a39904b7833dcc955
 lib/smart_answer_flows/student-finance-forms/student_finance_forms.govspeak.erb: 41695473d757c255ec52ef041d662c86

--- a/test/data/student-finance-forms-files.yml
+++ b/test/data/student-finance-forms-files.yml
@@ -34,7 +34,7 @@ lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1617_grant_c
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1617_grant_new.govspeak.erb: 1794d81c3f1eb1ebf9ace499b6dd7228
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1617_new.govspeak.erb: 44392e71e2ffe85dbb0b9522c60cda47
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1718_continuing.govspeak.erb: d4d345b6bd748eddea51fa2e60033a79
-lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1718_grant_continuing.govspeak.erb: 8e3be820b8de7b8f09f28f3bd052fa4a
+lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1718_grant_continuing.govspeak.erb: cf1ed1619f0118af4cba94ae7a4046dc
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1718_grant_new.govspeak.erb: c939b609c0743915a147a91a713ed7c1
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1718_new.govspeak.erb: a17deb65ab2cd2932659e3d53b03043d
 lib/smart_answer_flows/student-finance-forms/questions/continuing_student.govspeak.erb: 105b036582d36928c82f7c47be78fd94

--- a/test/data/student-finance-forms-files.yml
+++ b/test/data/student-finance-forms-files.yml
@@ -35,7 +35,7 @@ lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1617_grant_n
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1617_new.govspeak.erb: 44392e71e2ffe85dbb0b9522c60cda47
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1718_continuing.govspeak.erb: d4d345b6bd748eddea51fa2e60033a79
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1718_grant_continuing.govspeak.erb: cf1ed1619f0118af4cba94ae7a4046dc
-lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1718_grant_new.govspeak.erb: c939b609c0743915a147a91a713ed7c1
+lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1718_grant_new.govspeak.erb: 7d2887d551a7946eb4da5364be3e6d26
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1718_new.govspeak.erb: a17deb65ab2cd2932659e3d53b03043d
 lib/smart_answer_flows/student-finance-forms/questions/continuing_student.govspeak.erb: 105b036582d36928c82f7c47be78fd94
 lib/smart_answer_flows/student-finance-forms/questions/form_needed_for_1.govspeak.erb: 5d02e8180eb5108e0b0cc9b5f083e758

--- a/test/data/student-finance-forms-files.yml
+++ b/test/data/student-finance-forms-files.yml
@@ -18,7 +18,7 @@ lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_ft_1718_continu
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_ft_1718_new.govspeak.erb: fb26ff222b50a6f25a094ffcfa5c8280
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_pt_1617_continuing.govspeak.erb: f2613a4435a7694756baad1b104d4f2e
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_pt_1617_new.govspeak.erb: 320fa759eec25e2330a0581e84b27c2c
-lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_pt_1718_continuing.govspeak.erb: d87c6e88d7543e10d9f903ea341712e3
+lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_pt_1718_continuing.govspeak.erb: c8c99e1765fd1204cbbbca6a2db1be0c
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_pt_1718_new.govspeak.erb: 25db3ff53e18d59e59620189a855e97f
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_parent_partner_1617.govspeak.erb: 41fea6bde7503488a9ee3e88fb3bbd90
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_parent_partner_1718.govspeak.erb: ccf49644f9266e50ec7a3e1dde7770e4
@@ -34,8 +34,8 @@ lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1617_grant_c
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1617_grant_new.govspeak.erb: 1794d81c3f1eb1ebf9ace499b6dd7228
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1617_new.govspeak.erb: 44392e71e2ffe85dbb0b9522c60cda47
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1718_continuing.govspeak.erb: d4d345b6bd748eddea51fa2e60033a79
-lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1718_grant_continuing.govspeak.erb: 58f2418d381541a68b9f0b65f596a1c3
-lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1718_grant_new.govspeak.erb: 58f2418d381541a68b9f0b65f596a1c3
+lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1718_grant_continuing.govspeak.erb: 8e3be820b8de7b8f09f28f3bd052fa4a
+lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1718_grant_new.govspeak.erb: c939b609c0743915a147a91a713ed7c1
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_uk_pt_1718_new.govspeak.erb: a17deb65ab2cd2932659e3d53b03043d
 lib/smart_answer_flows/student-finance-forms/questions/continuing_student.govspeak.erb: 105b036582d36928c82f7c47be78fd94
 lib/smart_answer_flows/student-finance-forms/questions/form_needed_for_1.govspeak.erb: 5d02e8180eb5108e0b0cc9b5f083e758

--- a/test/data/student-finance-forms-files.yml
+++ b/test/data/student-finance-forms-files.yml
@@ -18,7 +18,7 @@ lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_ft_1718_continu
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_ft_1718_new.govspeak.erb: fb26ff222b50a6f25a094ffcfa5c8280
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_pt_1617_continuing.govspeak.erb: f2613a4435a7694756baad1b104d4f2e
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_pt_1617_new.govspeak.erb: 320fa759eec25e2330a0581e84b27c2c
-lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_pt_1718_continuing.govspeak.erb: c8c99e1765fd1204cbbbca6a2db1be0c
+lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_pt_1718_continuing.govspeak.erb: fd4d502729ddc18b4c25ae4c86a70347
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_eu_pt_1718_new.govspeak.erb: 25db3ff53e18d59e59620189a855e97f
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_parent_partner_1617.govspeak.erb: 41fea6bde7503488a9ee3e88fb3bbd90
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_parent_partner_1718.govspeak.erb: ccf49644f9266e50ec7a3e1dde7770e4


### PR DESCRIPTION
Trello: https://trello.com/c/nBtA5GnP/652-3-student-loans-form-finder-updates

## Description 
This PR makes content updates affecting grants to EU and UK part time students.

### Factcheck

[Preview link](https://smart-answers-pr-3091.herokuapp.com/student-finance-forms/y/uk-part-time/apply-loans-grants/year-1718/continuing-student/course-start-before-01092012)
[GOV.UK](https://gov.uk/student-finance-forms/y/uk-part-time/apply-loans-grants/year-1718/continuing-student/course-start-before-01092012)

### Expected changes
- Content update to EU part time grant
    - Continuing students
- Content update to UK part-time grant 
    - Continuing students
    - New students

### Before
![screen shot 2017-06-21 at 10 43 09](https://user-images.githubusercontent.com/84896/27378062-9616371e-566e-11e7-9ef9-d28fce32fc0e.png)


### After


![screen shot 2017-06-21 at 10 53 36](https://user-images.githubusercontent.com/84896/27378482-ec9be240-566f-11e7-8fd6-eba60117fc90.png)

Marked as Don't merge as I'm waiting on feedback from the author of the content.
