### PR TITLE
Register a death: Who should register

### DIFF
--- a/lib/smart_answer_flows/register-a-death/outcomes/uk_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-death/outcomes/uk_result.govspeak.erb
@@ -9,22 +9,24 @@
 
     ^Registering the death will take about 30 minutes - you might need to make an appointment.^
 
-    Who can register the death
+    Who should register the death
     --------
 
-    You can register the death if you’re:
+    A relative should register the death. 
+    
+    If a relative can’t register the death, you can do it if you:
+
 
     <% if calculator.died_at_home_or_in_hospital? %>
-      - a relative
-      - someone present at the death
-      - an administrator from the hospital
-      - the person making arrangements with the funeral directors
+      - were there at the time of death
+      - are an administrator from the hospital (if the person died in hospital)
+      - are in charge of making funeral arrangements
+
     <% else %>
-      - a relative
-      - someone present at the death
-      - the person who found the body
-      - the person in charge of the body
-      - the person making arrangements with the funeral directors
+      - were there at the time of death
+      - are the person who found the body
+      - are the person in charge of the body
+      - are in charge of making funeral arrangements
     <% end %>
 
     <% if calculator.death_expected? %>

--- a/test/artefacts/register-a-death/england_wales/at_home_hospital/no.txt
+++ b/test/artefacts/register-a-death/england_wales/at_home_hospital/no.txt
@@ -8,15 +8,16 @@ If you use a different register office the documents will be sent to the office 
 
 ^Registering the death will take about 30 minutes - you might need to make an appointment.^
 
-Who can register the death
+Who should register the death
 --------
 
-You can register the death if you’re:
+A relative should register the death. 
 
-- a relative
-- someone present at the death
-- an administrator from the hospital
-- the person making arrangements with the funeral directors
+If a relative can’t register the death, you can do it if you:
+
+- were there at the time of death
+- are an administrator from the hospital (if the person died in hospital)
+- are in charge of making funeral arrangements
 
 What you need to do
 --------

--- a/test/artefacts/register-a-death/england_wales/at_home_hospital/yes.txt
+++ b/test/artefacts/register-a-death/england_wales/at_home_hospital/yes.txt
@@ -8,15 +8,16 @@ If you use a different register office the documents will be sent to the office 
 
 ^Registering the death will take about 30 minutes - you might need to make an appointment.^
 
-Who can register the death
+Who should register the death
 --------
 
-You can register the death if you’re:
+A relative should register the death. 
 
-- a relative
-- someone present at the death
-- an administrator from the hospital
-- the person making arrangements with the funeral directors
+If a relative can’t register the death, you can do it if you:
+
+- were there at the time of death
+- are an administrator from the hospital (if the person died in hospital)
+- are in charge of making funeral arrangements
 
 What you need to do
 --------

--- a/test/artefacts/register-a-death/england_wales/elsewhere/no.txt
+++ b/test/artefacts/register-a-death/england_wales/elsewhere/no.txt
@@ -8,16 +8,17 @@ If you use a different register office the documents will be sent to the office 
 
 ^Registering the death will take about 30 minutes - you might need to make an appointment.^
 
-Who can register the death
+Who should register the death
 --------
 
-You can register the death if you’re:
+A relative should register the death. 
 
-- a relative
-- someone present at the death
-- the person who found the body
-- the person in charge of the body
-- the person making arrangements with the funeral directors
+If a relative can’t register the death, you can do it if you:
+
+- were there at the time of death
+- are the person who found the body
+- are the person in charge of the body
+- are in charge of making funeral arrangements
 
 What you need to do
 --------

--- a/test/artefacts/register-a-death/england_wales/elsewhere/yes.txt
+++ b/test/artefacts/register-a-death/england_wales/elsewhere/yes.txt
@@ -8,16 +8,17 @@ If you use a different register office the documents will be sent to the office 
 
 ^Registering the death will take about 30 minutes - you might need to make an appointment.^
 
-Who can register the death
+Who should register the death
 --------
 
-You can register the death if you’re:
+A relative should register the death. 
 
-- a relative
-- someone present at the death
-- the person who found the body
-- the person in charge of the body
-- the person making arrangements with the funeral directors
+If a relative can’t register the death, you can do it if you:
+
+- were there at the time of death
+- are the person who found the body
+- are the person in charge of the body
+- are in charge of making funeral arrangements
 
 What you need to do
 --------

--- a/test/data/register-a-death-files.yml
+++ b/test/data/register-a-death-files.yml
@@ -12,7 +12,7 @@ lib/smart_answer_flows/register-a-death/outcomes/commonwealth_result.govspeak.er
 lib/smart_answer_flows/register-a-death/outcomes/no_embassy_result.govspeak.erb: 5a7be7180708c2cc38fb612cee1c8a41
 lib/smart_answer_flows/register-a-death/outcomes/north_korea_result.govspeak.erb: 7d0d2ee70d18207f325e6999ca33b268
 lib/smart_answer_flows/register-a-death/outcomes/oru_result.govspeak.erb: 2ae8478485be4647a794d2b921360ce7
-lib/smart_answer_flows/register-a-death/outcomes/uk_result.govspeak.erb: aed4dc1d27dc52b74bdf182e62df8705
+lib/smart_answer_flows/register-a-death/outcomes/uk_result.govspeak.erb: 82b31690fb2254f19cb09069220f158e
 lib/smart_answer_flows/register-a-death/questions/did_the_person_die_at_home_hospital.govspeak.erb: 3405db8cb8b24782fc49981c2fce12e7
 lib/smart_answer_flows/register-a-death/questions/was_death_expected.govspeak.erb: 132d4a52801b619af05519a69f2767dd
 lib/smart_answer_flows/register-a-death/questions/where_are_you_now.govspeak.erb: b11b29b04cec875529be3714b5fba89e


### PR DESCRIPTION
[Trello card](https://trello.com/c/6BfDRV9k/655-1-register-a-death-tool)

## Description 

This PR make content updates to the following path to further explain who should actually be involved in the registeration of a said death:

This commit regenerates regression test artefacts for register-a-death
    for the following paths:

    - /register-a-death/y/england_wales/at_home_hospital/no
    - /register-a-death/y/england_wales/at_home_hospital/yes
    - /register-a-death/y/england_wales/elsewhere/no
    - /register-a-death/y/england_wales/elsewhere/yes

## Factcheck

[Preview link](https://smart-answers-pr-3099.herokuapp.com/register-a-death/y/england_wales/at_home_hospital/no)
[GOV.UK](https://gov.uk/register-a-death/y/england_wales/at_home_hospital/no)

## Expected changes
- Content update to explain should be registering a death.


## Before

![screen shot 2017-06-22 at 15 36 28](https://user-images.githubusercontent.com/84896/27439754-9deef104-5760-11e7-868b-ecbc30fcc9b9.png)

## After
![screen shot 2017-06-22 at 15 38 55](https://user-images.githubusercontent.com/84896/27439858-edbe1b88-5760-11e7-9a5b-2ba508e0d0aa.png)


