### PR TITLE
[DO NOT MERGE] Publish "/part-year-profit-tax-credits" start page as a transaction

### DIFF
--- a/app/presenters/flow_content_item_without_start_page.rb
+++ b/app/presenters/flow_content_item_without_start_page.rb
@@ -1,4 +1,4 @@
-class StartPageLessFlowContentItem < FlowContentItem
+class FlowContentItemWithoutStartPage < FlowContentItem
   CONTENT_ID_FOR_BASE_PATH = {
     "/part-year-profit-tax-credits/y" => "22e523d6-a153-4f66-b0fa-53ec46bcd61f"
   }.freeze

--- a/app/presenters/start_page_less_flow_content_item.rb
+++ b/app/presenters/start_page_less_flow_content_item.rb
@@ -1,7 +1,7 @@
 class StartPageLessFlowContentItem < FlowContentItem
   CONTENT_ID_FOR_BASE_PATH = {
     "/part-year-profit-tax-credits/y" => "22e523d6-a153-4f66-b0fa-53ec46bcd61f"
-  }
+  }.freeze
 
   def payload
     {
@@ -22,5 +22,4 @@ class StartPageLessFlowContentItem < FlowContentItem
   def content_id
     CONTENT_ID_FOR_BASE_PATH[base_path]
   end
-
 end

--- a/app/presenters/start_page_less_flow_content_item.rb
+++ b/app/presenters/start_page_less_flow_content_item.rb
@@ -1,0 +1,26 @@
+class StartPageLessFlowContentItem < FlowContentItem
+  CONTENT_ID_FOR_BASE_PATH = {
+    "/part-year-profit-tax-credits/y" => "22e523d6-a153-4f66-b0fa-53ec46bcd61f"
+  }
+
+  def payload
+    {
+      base_path: base_path,
+      title: flow_presenter.title,
+      details: {
+          external_related_links: external_related_links
+      },
+      schema_name: 'generic_with_external_related_links',
+      document_type: 'smart_answer',
+      publishing_app: 'smartanswers',
+      rendering_app: 'smartanswers',
+      locale: 'en',
+      routes: routes
+    }
+  end
+
+  def content_id
+    CONTENT_ID_FOR_BASE_PATH[base_path]
+  end
+
+end

--- a/app/services/content_item_publisher.rb
+++ b/app/services/content_item_publisher.rb
@@ -1,6 +1,11 @@
 class ContentItemPublisher
   def publish(flow_presenters)
     flow_presenters.each do |smart_answer|
+      if smart_answer.slug == "part-year-profit-tax-credits"
+        content_item = StartPageLessFlowContentItem.new(smart_answer)
+      else
+        content_item = FlowContentItem.new(smart_answer)
+      end
       Services.publishing_api.put_content(content_item.content_id, content_item.payload)
       Services.publishing_api.publish(content_item.content_id, 'minor')
     end

--- a/app/services/content_item_publisher.rb
+++ b/app/services/content_item_publisher.rb
@@ -215,6 +215,7 @@ private
       schema_name: :transaction
     }
 
+    reserve_path_for_publishing_app(base_path, publishing_app)
     create_and_publish_via_publishing_api(payload, content_id)
   end
 

--- a/app/services/content_item_publisher.rb
+++ b/app/services/content_item_publisher.rb
@@ -1,7 +1,6 @@
 class ContentItemPublisher
   def publish(flow_presenters)
     flow_presenters.each do |smart_answer|
-      content_item = FlowContentItem.new(smart_answer)
       Services.publishing_api.put_content(content_item.content_id, content_item.payload)
       Services.publishing_api.publish(content_item.content_id, 'minor')
     end

--- a/app/services/content_item_publisher.rb
+++ b/app/services/content_item_publisher.rb
@@ -10,18 +10,26 @@ class ContentItemPublisher
       else
         content_item = FlowContentItem.new(smart_answer)
       end
-      Services.publishing_api.put_content(content_item.content_id, content_item.payload) unless smart_answer == start_page_smart_answer
-      Services.publishing_api.publish(content_item.content_id, 'minor') unless smart_answer == start_page_smart_answer
+      if content_item
+        Services.publishing_api.put_content(content_item.content_id, content_item.payload)
+        Services.publishing_api.publish(content_item.content_id, 'minor')
+      end
     end
-    self.unpublish("de6723a5-7256-4bfd-aad3-82b04b06b73e")
+    remove_start_page(self)
     self.publish_transaction_start_page(
       "de6723a5-7256-4bfd-aad3-82b04b06b73e",
       "/part-year-profit-tax-credits",
-      publishing_app: publisher,
+      publishing_app: "publisher",
       title: "Calculate your part-year profits to finalise your tax credits",
-      content:"  You need to report your part-year profits to end your Tax Credits claim because of a claim to Universal Credit and you’re self-employed.\n\nYou’ll need to know the following to use this calculator:\n\n- your Tax Credits award end date (you can find this on your award review)\n- your accounting dates for your business\n- your accounting year profit for the tax year in which your tax credits award ends\n\nYou can use this calculator to complete box 2.4 of your award review.",
+      content: "You need to report your part-year profits to end your Tax Credits claim because of a claim to Universal Credit and you’re self-employed.\n\nYou’ll need to know the following to use this calculator:\n\n- your Tax Credits award end date (you can find this on your award review)\n- your accounting dates for your business\n- your accounting year profit for the tax year in which your tax credits award ends\n\nYou can use this calculator to complete box 2.4 of your award review.",
       link: "https://www.gov.uk/part-year-profit-tax-credits/y"
     )
+  end
+
+  def remove_start_page(content_item_publisher)
+    self.unpublish("de6723a5-7256-4bfd-aad3-82b04b06b73e")
+    content_id_of_draft_to_discard = Services.publishing_api.lookup_content_ids(base_paths: "/part-year-profit-tax-credits").values.first
+    Services.publishing_api.discard_draft(content_id_of_draft_to_discard) if content_id_of_draft_to_discard
   end
 
   def unpublish(content_id)

--- a/app/services/content_item_publisher.rb
+++ b/app/services/content_item_publisher.rb
@@ -12,14 +12,14 @@ class ContentItemPublisher
   end
 
   def find_smart_answers_without_start_pages(flow_presenters)
-    @start_page_less_smart_answer = flow_presenters.select { |smart_answer| smart_answer.slug == "part-year-profit-tax-credits/y" }.first
+    @smart_answer_without_start_page = flow_presenters.select { |smart_answer| smart_answer.slug == "part-year-profit-tax-credits/y" }.first
     @start_page_smart_answer = flow_presenters.select { |smart_answer| smart_answer.slug == "part-year-profit-tax-credits" }.first
   end
 
   def assign_content_item(smart_answer)
     case smart_answer
-    when @start_page_less_smart_answer
-      StartPageLessFlowContentItem.new(smart_answer)
+    when @smart_answer_without_start_page
+      FlowContentItemWithoutStartPage.new(smart_answer)
     when @start_page_smart_answer
       nil
     else

--- a/app/services/content_item_publisher.rb
+++ b/app/services/content_item_publisher.rb
@@ -1,14 +1,27 @@
 class ContentItemPublisher
   def publish(flow_presenters)
+    start_page_less_smart_answer = flow_presenters.select { |smart_answer| smart_answer.slug == "part-year-profit-tax-credits/y" }.first
+    start_page_smart_answer = flow_presenters.select { |smart_answer| smart_answer.slug == "part-year-profit-tax-credits" }.first
     flow_presenters.each do |smart_answer|
-      if smart_answer.slug == "part-year-profit-tax-credits"
+      if smart_answer == start_page_less_smart_answer
         content_item = StartPageLessFlowContentItem.new(smart_answer)
+      elsif smart_answer == start_page_smart_answer
+        content_item = nil
       else
         content_item = FlowContentItem.new(smart_answer)
       end
-      Services.publishing_api.put_content(content_item.content_id, content_item.payload)
-      Services.publishing_api.publish(content_item.content_id, 'minor')
+      Services.publishing_api.put_content(content_item.content_id, content_item.payload) unless smart_answer == start_page_smart_answer
+      Services.publishing_api.publish(content_item.content_id, 'minor') unless smart_answer == start_page_smart_answer
     end
+    self.unpublish("de6723a5-7256-4bfd-aad3-82b04b06b73e")
+    self.publish_transaction_start_page(
+      "de6723a5-7256-4bfd-aad3-82b04b06b73e",
+      "/part-year-profit-tax-credits",
+      publishing_app: publisher,
+      title: "Calculate your part-year profits to finalise your tax credits",
+      content:"  You need to report your part-year profits to end your Tax Credits claim because of a claim to Universal Credit and you’re self-employed.\n\nYou’ll need to know the following to use this calculator:\n\n- your Tax Credits award end date (you can find this on your award review)\n- your accounting dates for your business\n- your accounting year profit for the tax year in which your tax credits award ends\n\nYou can use this calculator to complete box 2.4 of your award review.",
+      link: "https://www.gov.uk/part-year-profit-tax-credits/y"
+    )
   end
 
   def unpublish(content_id)

--- a/app/services/content_item_publisher.rb
+++ b/app/services/content_item_publisher.rb
@@ -55,6 +55,23 @@ class ContentItemPublisher
     )
   end
 
+  def publish_transaction_start_page(content_id, base_path, publishing_app:, title:, content:, link:)
+    raise "The base path isn't supplied" unless base_path.present?
+    raise "The publishing_app isn't supplied" unless publishing_app.present?
+    raise "The title isn't supplied" unless title.present?
+    raise "The content isn't supplied" unless content.present?
+    raise "The link isn't supplied" unless link.present?
+
+    publish_transaction_start_page_via_publishing_api(
+      content_id,
+      base_path,
+      publishing_app: publishing_app,
+      title: title,
+      content: content,
+      link: link
+    )
+  end
+
   def publish_answer(base_path, publishing_app:, title:, content:)
     raise "The base path isn't supplied" unless base_path.present?
     raise "The publishing_app isn't supplied" unless publishing_app.present?
@@ -146,8 +163,36 @@ private
     create_and_publish_via_publishing_api(payload)
   end
 
-  def create_and_publish_via_publishing_api(payload)
-    content_id = SecureRandom.uuid
+  def publish_transaction_start_page_via_publishing_api(content_id, base_path, publishing_app:, title:, content:, link:)
+    payload = {
+      base_path: base_path,
+      title: title,
+      document_type: :transaction,
+      publishing_app: publishing_app,
+      rendering_app: :frontend,
+      locale: :en,
+      details: {
+        introductory_paragraph: [
+          {
+            content: content,
+            content_type: "text/govspeak"
+          }
+        ],
+        transaction_start_link: link
+      },
+      routes: [
+        {
+          type: :exact,
+          path: base_path
+        }
+      ],
+      schema_name: :transaction
+    }
+
+    create_and_publish_via_publishing_api(payload, content_id)
+  end
+
+  def create_and_publish_via_publishing_api(payload, content_id=SecureRandom.uuid)
     response = Services.publishing_api.put_content(content_id, payload)
     raise "This content item has not been created" unless response.code == 200
     Services.publishing_api.publish(content_id, :major)

--- a/lib/smart_answer/erb_renderer.rb
+++ b/lib/smart_answer/erb_renderer.rb
@@ -45,6 +45,7 @@ module SmartAnswer
   private
 
     def erb_template_name
+      return "part_year_profit_tax_credits.govspeak.erb" if @template_name == "part_year_profit_tax_credits/y"
       "#{@template_name}.govspeak.erb"
     end
 

--- a/lib/smart_answer_flows/part-year-profit-tax-credits-start-page.rb
+++ b/lib/smart_answer_flows/part-year-profit-tax-credits-start-page.rb
@@ -1,0 +1,146 @@
+module SmartAnswer
+  class PartYearProfitTaxCreditsStartPageFlow < Flow
+    def define
+      name 'part-year-profit-tax-credits'
+
+      status :published
+      satisfies_need "103438"
+      content_id "de6723a5-7256-4bfd-aad3-82b04b06b73e"
+
+      date_question :when_did_your_tax_credits_award_end? do
+        from { Calculators::PartYearProfitTaxCreditsCalculator::TAX_CREDITS_AWARD_ENDS_EARLIEST_DATE }
+        to   { Calculators::PartYearProfitTaxCreditsCalculator::TAX_CREDITS_AWARD_ENDS_LATEST_DATE }
+
+        on_response do |response|
+          self.calculator = Calculators::PartYearProfitTaxCreditsCalculator.new
+          calculator.tax_credits_award_ends_on = response
+        end
+
+        next_node do
+          question :what_date_do_your_accounts_go_up_to?
+        end
+      end
+
+      date_question :what_date_do_your_accounts_go_up_to? do
+        default_year { 0 }
+
+        on_response do |response|
+          calculator.accounts_end_month_and_day = response
+        end
+
+        next_node do
+          question :have_you_stopped_trading?
+        end
+      end
+
+      multiple_choice :have_you_stopped_trading? do
+        option "yes"
+        option "no"
+
+        on_response do |response|
+          if response == 'yes'
+            calculator.stopped_trading = true
+          elsif response == 'no'
+            calculator.stopped_trading = false
+          end
+        end
+
+        next_node do
+          if calculator.stopped_trading
+            question :did_you_start_trading_before_the_relevant_accounting_year?
+          else
+            question :do_your_accounts_cover_a_12_month_period?
+          end
+        end
+      end
+
+      multiple_choice :did_you_start_trading_before_the_relevant_accounting_year? do
+        option "yes"
+        option "no"
+
+        precalculate(:accounting_year_begins_on) { calculator.accounting_year.begins_on }
+
+        next_node do |response|
+          if response == "yes"
+            question :when_did_you_stop_trading?
+          elsif response == "no"
+            question :when_did_you_start_trading?
+          end
+        end
+      end
+
+      date_question :when_did_you_stop_trading? do
+        from { Calculators::PartYearProfitTaxCreditsCalculator::START_OR_STOP_TRADING_EARLIEST_DATE }
+        to   { Calculators::PartYearProfitTaxCreditsCalculator::START_OR_STOP_TRADING_LATEST_DATE }
+
+        precalculate(:tax_year_begins_on) { calculator.tax_year.begins_on }
+        precalculate(:tax_year_ends_on)   { calculator.tax_year.ends_on }
+
+        on_response do |response|
+          calculator.stopped_trading_on = response
+        end
+
+        validate(:not_in_tax_year_error) do
+          calculator.valid_stopped_trading_date?
+        end
+
+        next_node do
+          question :what_is_your_taxable_profit?
+        end
+      end
+
+      multiple_choice :do_your_accounts_cover_a_12_month_period? do
+        option "yes"
+        option "no"
+
+        precalculate(:accounting_year_ends_on) { calculator.accounting_year.ends_on }
+
+        next_node do |response|
+          if response == "yes"
+            question :what_is_your_taxable_profit?
+          else
+            question :when_did_you_start_trading?
+          end
+        end
+      end
+
+      date_question :when_did_you_start_trading? do
+        from { Calculators::PartYearProfitTaxCreditsCalculator::START_OR_STOP_TRADING_EARLIEST_DATE }
+        to   { Calculators::PartYearProfitTaxCreditsCalculator::START_OR_STOP_TRADING_LATEST_DATE }
+
+        precalculate(:award_period_ends_on) { calculator.award_period.ends_on }
+
+        on_response do |response|
+          calculator.started_trading_on = response
+        end
+
+        validate(:invalid_start_trading_date) do
+          calculator.valid_start_trading_date?
+        end
+
+        next_node do
+          if calculator.stopped_trading
+            question :when_did_you_stop_trading?
+          else
+            question :what_is_your_taxable_profit?
+          end
+        end
+      end
+
+      money_question :what_is_your_taxable_profit? do
+        precalculate(:basis_period_begins_on) { calculator.basis_period.begins_on }
+        precalculate(:basis_period_ends_on)   { calculator.basis_period.ends_on }
+
+        on_response do |response|
+          calculator.taxable_profit = response
+        end
+
+        next_node do
+          outcome :result
+        end
+      end
+
+      outcome :result
+    end
+  end
+end

--- a/lib/smart_answer_flows/part-year-profit-tax-credits.rb
+++ b/lib/smart_answer_flows/part-year-profit-tax-credits.rb
@@ -1,11 +1,11 @@
 module SmartAnswer
   class PartYearProfitTaxCreditsFlow < Flow
     def define
-      name 'part-year-profit-tax-credits'
+      name 'part-year-profit-tax-credits/y'
 
       status :published
       satisfies_need "103438"
-      content_id "de6723a5-7256-4bfd-aad3-82b04b06b73e"
+      content_id "22e523d6-a153-4f66-b0fa-53ec46bcd61f"
 
       date_question :when_did_your_tax_credits_award_end? do
         from { Calculators::PartYearProfitTaxCreditsCalculator::TAX_CREDITS_AWARD_ENDS_EARLIEST_DATE }

--- a/lib/smart_answer_flows/part-year-profit-tax-credits/y/outcomes/result.govspeak.erb
+++ b/lib/smart_answer_flows/part-year-profit-tax-credits/y/outcomes/result.govspeak.erb
@@ -1,0 +1,28 @@
+<% content_for :body do %>
+  %Your part-year taxable profit is <%= format_money(calculator.award_period_taxable_profit) %>.%
+
+  Use this figure to complete box 2.4 on your award review. Enter £0 if you’ve made or expect to make a loss (your part-year profit is less than £0).
+
+  ^If you have more than one business, you need to calculate the part-year profits from all your businesses and add them together to complete box 2.4.^
+
+  You may be able to [make deductions from this amount](/end-tax-credits-claim/self-employed).
+
+  You’ll have to work out your part-year taxable profit [using the helpsheet](/government/publications/tax-credits-ending-your-award-when-you-claim-universal-credit) that came with your Award Review if:
+
+  - you changed your accounting period part way through the year
+  - your profits are based on a longer period or for example, you're a farmer, a foster carer or have foreign income
+
+  ## Your part-year taxable profit has been worked out from:
+
+  Your tax credits award ended on: <%= format_date(calculator.tax_credits_award_ends_on) %>
+
+  <% if calculator.stopped_trading_on %>
+    Your business stopped trading on: <%= format_date(calculator.basis_period.ends_on) %>
+  <% else %>
+    Your business accounts end on: <%= format_date(calculator.basis_period.ends_on) %>
+  <% end %>
+
+  Your estimated taxable profit between <%= format_date(calculator.basis_period.begins_on) %> and <%= format_date(calculator.basis_period.ends_on) %> was: <%= format_money(calculator.taxable_profit) %>
+
+  ^You must [keep the records](/self-employed-records/how-long-to-keep-your-records) of your calculation for at least 5 years.^
+<% end %>

--- a/lib/smart_answer_flows/part-year-profit-tax-credits/y/part_year_profit_tax_credits.govspeak.erb
+++ b/lib/smart_answer_flows/part-year-profit-tax-credits/y/part_year_profit_tax_credits.govspeak.erb
@@ -1,0 +1,19 @@
+<% content_for :title do %>
+  Calculate your part-year profits to finalise your tax credits
+<% end %>
+
+<% content_for :meta_description do %>
+  Calculate your part-year profits to end your Tax Credits award and claim Universal Credit if you’re self-employed
+<% end %>
+
+<% content_for :body do %>
+  You need to report your part-year profits to end your Tax Credits claim because of a claim to Universal Credit and you’re self-employed.
+
+  You’ll need to know the following to use this calculator:
+
+  - your Tax Credits award end date (you can find this on your award review)
+  - your accounting dates for your business
+  - your accounting year profit for the tax year in which your tax credits award ends
+
+  You can use this calculator to complete box 2.4 of your award review.
+<% end %>

--- a/lib/smart_answer_flows/part-year-profit-tax-credits/y/questions/did_you_start_trading_before_the_relevant_accounting_year.govspeak.erb
+++ b/lib/smart_answer_flows/part-year-profit-tax-credits/y/questions/did_you_start_trading_before_the_relevant_accounting_year.govspeak.erb
@@ -1,0 +1,12 @@
+<% content_for :title do %>
+  Did you start trading before <%= format_date(accounting_year_begins_on) %>?
+<% end %>
+
+<% options(
+  "yes": "Yes",
+  "no": "No"
+) %>
+
+<% content_for :error_message do %>
+  You need to select yes or no to continue.
+<% end %>

--- a/lib/smart_answer_flows/part-year-profit-tax-credits/y/questions/do_your_accounts_cover_a_12_month_period.govspeak.erb
+++ b/lib/smart_answer_flows/part-year-profit-tax-credits/y/questions/do_your_accounts_cover_a_12_month_period.govspeak.erb
@@ -1,0 +1,12 @@
+<% content_for :title do %>
+  Do your accounts cover the 12 month period up to <%= format_date(accounting_year_ends_on) %>?
+<% end %>
+
+<% options(
+  "yes": "Yes",
+  "no": "No"
+) %>
+
+<% content_for :error_message do %>
+  You need to select yes or no to continue.
+<% end %>

--- a/lib/smart_answer_flows/part-year-profit-tax-credits/y/questions/have_you_stopped_trading.govspeak.erb
+++ b/lib/smart_answer_flows/part-year-profit-tax-credits/y/questions/have_you_stopped_trading.govspeak.erb
@@ -1,0 +1,16 @@
+<% content_for :title do %>
+  Have you stopped trading?
+<% end %>
+
+<% options(
+  "yes": "Yes",
+  "no": "No"
+) %>
+
+<% content_for :hint do %>
+  This means you’re no longer running your business.
+<% end %>
+
+<% content_for :error_message do %>
+  You need to select yes or no to continue.
+<% end %>

--- a/lib/smart_answer_flows/part-year-profit-tax-credits/y/questions/what_date_do_your_accounts_go_up_to.govspeak.erb
+++ b/lib/smart_answer_flows/part-year-profit-tax-credits/y/questions/what_date_do_your_accounts_go_up_to.govspeak.erb
@@ -1,0 +1,11 @@
+<% content_for :title do %>
+  What date do your accounts go up to?
+<% end %>
+
+<% content_for :hint do %>
+  This is the last date of the accounting period for your business. For most people, this will be 5 April.
+<% end %>
+
+<% content_for :error_message do %>
+  You need to enter a date to continue.
+<% end %>

--- a/lib/smart_answer_flows/part-year-profit-tax-credits/y/questions/what_is_your_taxable_profit.govspeak.erb
+++ b/lib/smart_answer_flows/part-year-profit-tax-credits/y/questions/what_is_your_taxable_profit.govspeak.erb
@@ -1,0 +1,11 @@
+<% content_for :title do %>
+  What is your actual or estimated taxable profit between <%= format_date(basis_period_begins_on) %> and <%= format_date(basis_period_ends_on) %>?
+<% end %>
+
+<% content_for :hint do %>
+  This is the amount left over after you take all your earnings from self-employment and deduct any allowable expenses and losses. If this is over 2 years of accounts you need to add them together.
+<% end %>
+
+<% content_for :error_message do %>
+  Enter your taxable profit.
+<% end %>

--- a/lib/smart_answer_flows/part-year-profit-tax-credits/y/questions/when_did_you_start_trading.govspeak.erb
+++ b/lib/smart_answer_flows/part-year-profit-tax-credits/y/questions/when_did_you_start_trading.govspeak.erb
@@ -1,0 +1,14 @@
+<% content_for :title do %>
+  When did you start trading?
+<% end %>
+
+<% content_for :hint do %>
+  This date must be before <%= format_date(award_period_ends_on) %>.
+<% end %>
+
+<% content_for :error_message do %>
+  You need to enter a date to continue.
+<% end %>
+<% content_for :invalid_start_trading_date do %>
+  The start trading date must be before the date your Tax Credits award ends.
+<% end %>

--- a/lib/smart_answer_flows/part-year-profit-tax-credits/y/questions/when_did_you_stop_trading.govspeak.erb
+++ b/lib/smart_answer_flows/part-year-profit-tax-credits/y/questions/when_did_you_stop_trading.govspeak.erb
@@ -1,0 +1,14 @@
+<% content_for :title do %>
+  When did you stop trading?
+<% end %>
+
+<% content_for :hint do %>
+  This date must be between <%= format_date(tax_year_begins_on) %> and <%= format_date(tax_year_ends_on) %>, which is the start and end dates of the tax year that your tax credit award ends in.
+<% end %>
+
+<% content_for :not_in_tax_year_error do %>
+  The date must be between <%= format_date(tax_year_begins_on) %> and <%= format_date(tax_year_ends_on) %>.
+<% end %>
+<% content_for :error_message do %>
+  You need to enter a date to continue.
+<% end %>

--- a/lib/smart_answer_flows/part-year-profit-tax-credits/y/questions/when_did_your_tax_credits_award_end.govspeak.erb
+++ b/lib/smart_answer_flows/part-year-profit-tax-credits/y/questions/when_did_your_tax_credits_award_end.govspeak.erb
@@ -1,0 +1,11 @@
+<% content_for :title do %>
+  When did your Tax Credits award end?
+<% end %>
+
+<% content_for :hint do %>
+  You can find this on your award review.
+<% end %>
+
+<% content_for :error_message do %>
+  You need to enter a date to continue.
+<% end %>

--- a/lib/tasks/retire.rake
+++ b/lib/tasks/retire.rake
@@ -64,6 +64,29 @@ namespace :retire do
     )
   end
 
+  desc "Publish transaction start page via publishing api"
+  task :publish_start_page_as_transaction, [:content_id, :base_path, :publishing_app, :title, :content, :link] => :environment do |_, args|
+    raise "Missing base path parameter" unless args.base_path
+    raise "Missing publishing_app parameter" unless args.publishing_app
+    raise "Missing title parameter" unless args.title
+    raise "Missing content parameter" unless args.content
+    raise "Missing link parameter" unless args.link
+
+    ContentItemPublisher.new.reserve_path_for_publishing_app(
+      args.base_path,
+      args.publishing_app
+    )
+
+    ContentItemPublisher.new.publish_transaction_start_page_via_publishing_api(
+      content_id,
+      args.base_path,
+      publishing_app: args.publishing_app,
+      title: args.title,
+      content: args.content,
+      link: args.link
+    )
+  end
+
   desc "Publish answer via publishing api"
   task :publish_answer, [:base_path, :publishing_app, :title, :content] => :environment do |_, args|
     raise "Missing base path parameter" unless args.base_path

--- a/test/data/part-year-profit-tax-credits-files.yml
+++ b/test/data/part-year-profit-tax-credits-files.yml
@@ -10,4 +10,15 @@ lib/smart_answer_flows/part-year-profit-tax-credits/questions/what_is_your_taxab
 lib/smart_answer_flows/part-year-profit-tax-credits/questions/when_did_you_start_trading.govspeak.erb: cb3c008d06a0203a690d97171080e077
 lib/smart_answer_flows/part-year-profit-tax-credits/questions/when_did_you_stop_trading.govspeak.erb: 6891da3d443d97095bd1d1c4ec146b7e
 lib/smart_answer_flows/part-year-profit-tax-credits/questions/when_did_your_tax_credits_award_end.govspeak.erb: 2ffac48de292906f14ec748eba268f89
-lib/smart_answer_flows/part-year-profit-tax-credits.rb: 7d2f87a8862b1ea13c76ba1473d4ba22
+lib/smart_answer_flows/part-year-profit-tax-credits/y/outcomes/result.govspeak.erb: 57b230201210ac7e2e9691f0784a61a7
+lib/smart_answer_flows/part-year-profit-tax-credits/y/part_year_profit_tax_credits.govspeak.erb: 0b299d5a9ff62ad31f9ad74e2d343d84
+? lib/smart_answer_flows/part-year-profit-tax-credits/y/questions/did_you_start_trading_before_the_relevant_accounting_year.govspeak.erb
+: 140082ba51f5b4504d96e806cb2f2dc1
+lib/smart_answer_flows/part-year-profit-tax-credits/y/questions/do_your_accounts_cover_a_12_month_period.govspeak.erb: e71d5489dd988fcae7dc39e9f7ed92a0
+lib/smart_answer_flows/part-year-profit-tax-credits/y/questions/have_you_stopped_trading.govspeak.erb: 2e2bbba5570500708fd8f7e4cf56be1c
+lib/smart_answer_flows/part-year-profit-tax-credits/y/questions/what_date_do_your_accounts_go_up_to.govspeak.erb: 0577e3ca19a06aeb491012361ba97733
+lib/smart_answer_flows/part-year-profit-tax-credits/y/questions/what_is_your_taxable_profit.govspeak.erb: 2d7e81a69a3874c1872f1d250ff096f4
+lib/smart_answer_flows/part-year-profit-tax-credits/y/questions/when_did_you_start_trading.govspeak.erb: cb3c008d06a0203a690d97171080e077
+lib/smart_answer_flows/part-year-profit-tax-credits/y/questions/when_did_you_stop_trading.govspeak.erb: 6891da3d443d97095bd1d1c4ec146b7e
+lib/smart_answer_flows/part-year-profit-tax-credits/y/questions/when_did_your_tax_credits_award_end.govspeak.erb: 2ffac48de292906f14ec748eba268f89
+lib/smart_answer_flows/part-year-profit-tax-credits.rb: 8eb278844a4ea94ee33375edbb8ef9f0

--- a/test/data/part-year-profit-tax-credits-start-page-files.yml
+++ b/test/data/part-year-profit-tax-credits-start-page-files.yml
@@ -1,0 +1,2 @@
+---
+lib/smart_answer_flows/part-year-profit-tax-credits-start-page.rb: 98f37abdf39133508e65d8bc303684ab

--- a/test/integration/start_page_test.rb
+++ b/test/integration/start_page_test.rb
@@ -4,6 +4,7 @@ class StartPageTest < ActionDispatch::IntegrationTest
   context "start page" do
     RegisterableSmartAnswers.new.flow_presenters.each do |flow_presenter|
       slug = flow_presenter.slug
+      next if slug == "part-year-profit-tax-credits/y"
       context "when the smart answer is `#{slug}`" do
         setup do
           @view = mock("view")

--- a/test/unit/flow_content_item_without_start_page_test.rb
+++ b/test/unit/flow_content_item_without_start_page_test.rb
@@ -1,7 +1,7 @@
 require_relative '../test_helper'
 
 module SmartAnswer
-  class StartPageLessFlowContentItemTest < ActiveSupport::TestCase
+  class FlowContentItemWithoutStartPageTest < ActiveSupport::TestCase
     include GovukContentSchemaTestHelpers::TestUnit
 
     setup do
@@ -11,7 +11,7 @@ module SmartAnswer
 
     test '#payload returns a valid content-item' do
       presenter = FlowRegistrationPresenter.new(stub('flow', name: 'bridge-of-death', content_id: "22e523d6-a153-4f66-b0fa-53ec46bcd61f", external_related_links: nil))
-      content_item = StartPageLessFlowContentItem.new(presenter)
+      content_item = FlowContentItemWithoutStartPage.new(presenter)
 
       payload = content_item.payload
 
@@ -20,7 +20,7 @@ module SmartAnswer
 
     test '#payload returns a valid content-item with external related links' do
       presenter = FlowRegistrationPresenter.new(stub('flow', name: 'bridge-of-death', content_id: "22e523d6-a153-4f66-b0fa-53ec46bcd61f", external_related_links: [{ title: "hmrc", url: "https://hmrc.gov.uk" }]))
-      content_item = StartPageLessFlowContentItem.new(presenter)
+      content_item = FlowContentItemWithoutStartPage.new(presenter)
 
       payload = content_item.payload
 
@@ -29,7 +29,7 @@ module SmartAnswer
 
     test '#base_path is the name of the flow' do
       presenter = FlowRegistrationPresenter.new(stub('flow', name: 'bridge-of-death', content_id: "22e523d6-a153-4f66-b0fa-53ec46bcd61f", external_related_links: nil))
-      content_item = StartPageLessFlowContentItem.new(presenter)
+      content_item = FlowContentItemWithoutStartPage.new(presenter)
 
       base_path = content_item.payload[:base_path]
 

--- a/test/unit/services/content_item_publisher_test.rb
+++ b/test/unit/services/content_item_publisher_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
+require 'gds_api/test_helpers/publishing_api_v2'
 
 class ContentItemPublisherTest < ActiveSupport::TestCase
+  include GdsApi::TestHelpers::PublishingApiV2
   setup do
     load_path = fixture_file('smart_answer_flows')
     SmartAnswer::FlowRegistry.stubs(:instance).returns(stub("Flow registry", find: @flow, load_path: load_path))
@@ -9,6 +11,11 @@ class ContentItemPublisherTest < ActiveSupport::TestCase
   test 'sending item to content store' do
     draft_request = stub_request(:put, "https://publishing-api.test.gov.uk/v2/content/3e6f33b8-0723-4dd5-94a2-cab06f23a685")
     publishing_request = stub_request(:post, "https://publishing-api.test.gov.uk/v2/content/3e6f33b8-0723-4dd5-94a2-cab06f23a685/publish")
+    unpublishing_request = stub_request(:post, "https://publishing-api.test.gov.uk/v2/content/de6723a5-7256-4bfd-aad3-82b04b06b73e/unpublish")
+    publishing_api_has_lookups({"/part-year-profit-tax-credits" => "de6723a5-7256-4bfd-aad3-82b04b06b73e"})
+    stub_publishing_api_discard_draft("de6723a5-7256-4bfd-aad3-82b04b06b73e")
+    stub_any_publishing_api_put_content
+    stub_any_publishing_api_publish
 
     presenter = FlowRegistrationPresenter.new(stub('flow', name: 'bridge-of-death', content_id: '3e6f33b8-0723-4dd5-94a2-cab06f23a685', external_related_links: nil))
 
@@ -16,6 +23,7 @@ class ContentItemPublisherTest < ActiveSupport::TestCase
 
     assert_requested draft_request
     assert_requested publishing_request
+    assert_requested unpublishing_request
   end
 
   context "#unpublish" do

--- a/test/unit/services/content_item_publisher_test.rb
+++ b/test/unit/services/content_item_publisher_test.rb
@@ -12,6 +12,8 @@ class ContentItemPublisherTest < ActiveSupport::TestCase
     draft_request = stub_request(:put, "https://publishing-api.test.gov.uk/v2/content/3e6f33b8-0723-4dd5-94a2-cab06f23a685")
     publishing_request = stub_request(:post, "https://publishing-api.test.gov.uk/v2/content/3e6f33b8-0723-4dd5-94a2-cab06f23a685/publish")
     unpublishing_request = stub_request(:post, "https://publishing-api.test.gov.uk/v2/content/de6723a5-7256-4bfd-aad3-82b04b06b73e/unpublish")
+    reserve_path_request = stub_request(:put, "https://publishing-api.test.gov.uk/paths//part-year-profit-tax-credits")
+
     publishing_api_has_lookups({"/part-year-profit-tax-credits" => "de6723a5-7256-4bfd-aad3-82b04b06b73e"})
     stub_publishing_api_discard_draft("de6723a5-7256-4bfd-aad3-82b04b06b73e")
     stub_any_publishing_api_put_content
@@ -24,6 +26,7 @@ class ContentItemPublisherTest < ActiveSupport::TestCase
     assert_requested draft_request
     assert_requested publishing_request
     assert_requested unpublishing_request
+    assert_requested reserve_path_request
   end
 
   context "#unpublish" do

--- a/test/unit/start_page_less_flow_content_item_test.rb
+++ b/test/unit/start_page_less_flow_content_item_test.rb
@@ -1,0 +1,39 @@
+require_relative '../test_helper'
+
+module SmartAnswer
+  class StartPageLessFlowContentItemTest < ActiveSupport::TestCase
+    include GovukContentSchemaTestHelpers::TestUnit
+
+    setup do
+      load_path = fixture_file('smart_answer_flows')
+      SmartAnswer::FlowRegistry.stubs(:instance).returns(stub("Flow registry", find: @flow, load_path: load_path))
+    end
+
+    test '#payload returns a valid content-item' do
+      presenter = FlowRegistrationPresenter.new(stub('flow', name: 'bridge-of-death', content_id: "22e523d6-a153-4f66-b0fa-53ec46bcd61f", external_related_links: nil))
+      content_item = StartPageLessFlowContentItem.new(presenter)
+
+      payload = content_item.payload
+
+      assert_valid_against_schema(payload, 'generic_with_external_related_links')
+    end
+
+    test '#payload returns a valid content-item with external related links' do
+      presenter = FlowRegistrationPresenter.new(stub('flow', name: 'bridge-of-death', content_id: "22e523d6-a153-4f66-b0fa-53ec46bcd61f", external_related_links: [{ title: "hmrc", url: "https://hmrc.gov.uk" }]))
+      content_item = StartPageLessFlowContentItem.new(presenter)
+
+      payload = content_item.payload
+
+      assert_valid_against_schema(payload, 'generic_with_external_related_links')
+    end
+
+    test '#base_path is the name of the flow' do
+      presenter = FlowRegistrationPresenter.new(stub('flow', name: 'bridge-of-death', content_id: "22e523d6-a153-4f66-b0fa-53ec46bcd61f", external_related_links: nil))
+      content_item = StartPageLessFlowContentItem.new(presenter)
+
+      base_path = content_item.payload[:base_path]
+
+      assert_equal "/bridge-of-death", base_path
+    end
+  end
+end


### PR DESCRIPTION
This modifies the code that publishes smart-answers on deploy so it will publish the start page (aka "landing page") of "/part-year-profit-tax-credits" as a transaction that has the same content-id as the current "/part-year-profit-tax-credits" content item, and an exact route. Its "Start now" button will still point to the "/part-year-profit-tax-credits/y" path.

The pages of "/part-year-profit-tax-credits" other than the start page get republished as a StartPageLessContentItemFlow that have a new content-id and prefix routes. Their base path is "/part-year-profit-tax-credits/y".

Considerations:
- This is a proof of concept, all smart answers are meant to eventually get their start pages converted into transactions in the Publisher app.
- The code related to the publishing of the start page is meant to be ephemeral, and will be deleted once the transaction is managed in Publisher. 
- Marking this as [DO NOT MERGE] until other PRs are ready.
- I have not touched the StartNodePresenter, but once all the smart answer start pages have been converted to transactions, we should consider whether it is still useful.

cc @fofr and @pmanrubia if you/someone on your team gets a chance to have a look

This is part of the work to convert all start pages across GOV.UK publishers to transactions in the Publisher app, so they can be consolidated.

[Trello](https://trello.com/c/arlZczQO/423-2-republish-smart-answer-part-year-profits-to-finalise-your-tax-credits-start-page-as-a-transaction-page)