### PR TITLE
Maldives marriage abroad - all opposite sex outcomes

### DIFF
--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/maldives/ceremony_country/partner_british/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/maldives/ceremony_country/partner_british/_opposite_sex.govspeak.erb
@@ -3,6 +3,4 @@ Contact the relevant local authorities in the Maldives to find out about local m
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
 
-The UK doesn’t issue certificates of no impediment (CNI) for marriages in Commonwealth countries. You’ll need to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
-
 *[CNI]:certificate of no impediment

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/maldives/ceremony_country/partner_local/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/maldives/ceremony_country/partner_local/_opposite_sex.govspeak.erb
@@ -3,8 +3,6 @@ Contact the relevant local authorities in the Maldives to find out about local m
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
 
-The UK doesn’t issue certificates of no impediment (CNI) for marriages in Commonwealth countries. You’ll need to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
-
 ##Naturalisation of your partner if they move to the UK
 
 Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/maldives/ceremony_country/partner_other/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/maldives/ceremony_country/partner_other/_opposite_sex.govspeak.erb
@@ -3,8 +3,6 @@ Contact the relevant local authorities in the Maldives to find out about local m
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
 
-The UK doesn’t issue certificates of no impediment (CNI) for marriages in Commonwealth countries. You’ll need to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
-
 ##Naturalisation of your partner if they move to the UK
 
 Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/maldives/third_country/partner_british/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/maldives/third_country/partner_british/_opposite_sex.govspeak.erb
@@ -3,6 +3,4 @@ Contact the relevant local authorities in the Maldives to find out about local m
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for the Maldives](/foreign-travel-advice/maldives) before making any plans.
 
-The UK doesn’t issue certificates of no impediment (CNI) for marriages in Commonwealth countries. You’ll need to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
-
 *[CNI]:certificate of no impediment

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/maldives/third_country/partner_local/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/maldives/third_country/partner_local/_opposite_sex.govspeak.erb
@@ -3,8 +3,6 @@ Contact the relevant local authorities in the Maldives to find out about local m
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for the Maldives](/foreign-travel-advice/maldives) before making any plans.
 
-The UK doesn’t issue certificates of no impediment (CNI) for marriages in Commonwealth countries. You’ll need to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
-
 ##Naturalisation of your partner if they move to the UK
 
 Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/maldives/third_country/partner_other/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/maldives/third_country/partner_other/_opposite_sex.govspeak.erb
@@ -3,8 +3,6 @@ Contact the relevant local authorities in the Maldives to find out about local m
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for the Maldives](/foreign-travel-advice/maldives) before making any plans.
 
-The UK doesn’t issue certificates of no impediment (CNI) for marriages in Commonwealth countries. You’ll need to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
-
 ##Naturalisation of your partner if they move to the UK
 
 Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/maldives/uk/partner_british/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/maldives/uk/partner_british/_opposite_sex.govspeak.erb
@@ -3,6 +3,4 @@ Contact the [High Commission of the Maldives](/government/publications/foreign-e
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for the Maldives](/foreign-travel-advice/maldives) before making any plans.
 
-The UK doesn’t issue certificates of no impediment (CNI) for marriages in Commonwealth countries. You’ll need to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
-
 *[CNI]:certificate of no impediment

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/maldives/uk/partner_british/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/maldives/uk/partner_british/_opposite_sex.govspeak.erb
@@ -1,5 +1,5 @@
 
-Contact the [High Commission of the Maldives](/government/publications/foreign-embassies-in-the-uk) to find out about local marriage laws, including what documents you’ll need.
+Contact the [Embassy of the Maldives](/government/publications/foreign-embassies-in-the-uk) to find out about local marriage laws, including what documents you’ll need.
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for the Maldives](/foreign-travel-advice/maldives) before making any plans.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/maldives/uk/partner_local/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/maldives/uk/partner_local/_opposite_sex.govspeak.erb
@@ -3,8 +3,6 @@ Contact the [High Commission of the Maldives](/government/publications/foreign-e
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for the Maldives](/foreign-travel-advice/maldives) before making any plans.
 
-The UK doesn’t issue certificates of no impediment (CNI) for marriages in Commonwealth countries. You’ll need to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
-
 ##Naturalisation of your partner if they move to the UK
 
 Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/maldives/uk/partner_local/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/maldives/uk/partner_local/_opposite_sex.govspeak.erb
@@ -1,5 +1,5 @@
 
-Contact the [High Commission of the Maldives](/government/publications/foreign-embassies-in-the-uk) to find out about local marriage laws, including what documents you’ll need.
+Contact the [Embassy of the Maldives](/government/publications/foreign-embassies-in-the-uk) to find out about local marriage laws, including what documents you’ll need.
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for the Maldives](/foreign-travel-advice/maldives) before making any plans.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/maldives/uk/partner_other/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/maldives/uk/partner_other/_opposite_sex.govspeak.erb
@@ -3,8 +3,6 @@ Contact the [High Commission of the Maldives](/government/publications/foreign-e
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for the Maldives](/foreign-travel-advice/maldives) before making any plans.
 
-The UK doesn’t issue certificates of no impediment (CNI) for marriages in Commonwealth countries. You’ll need to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
-
 ##Naturalisation of your partner if they move to the UK
 
 Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/maldives/uk/partner_other/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/maldives/uk/partner_other/_opposite_sex.govspeak.erb
@@ -1,5 +1,5 @@
 
-Contact the [High Commission of the Maldives](/government/publications/foreign-embassies-in-the-uk) to find out about local marriage laws, including what documents you’ll need.
+Contact the [Embassy of the Maldives](/government/publications/foreign-embassies-in-the-uk) to find out about local marriage laws, including what documents you’ll need.
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for the Maldives](/foreign-travel-advice/maldives) before making any plans.
 


### PR DESCRIPTION
https://trello.com/c/WBVknQrr/502-maldives-marriage-tool-no-longer-a-commonwealth-country-content-change-request 

I’ve updated the 9 opposite sex outcomes to remove a paragraph about the Commonwealth as the Maldives are no longer in the Commonwealth.

I’ve additionally updated the 3 opposite sex outcomes where the user is in the UK to change the reference to the ‘High Commission of the Maldives’ to the ‘Embassy of the Maldives’. This is also related to the Maldives no longer being in the Commonwealth.

This doesn’t affect the logic.
