### PR TITLE
Revert from 13 week back to 12 week calculation

### DIFF
--- a/lib/smart_answer/calculators/maternity_paternity_calculator.rb
+++ b/lib/smart_answer/calculators/maternity_paternity_calculator.rb
@@ -126,7 +126,7 @@ module SmartAnswer::Calculators
       sprintf("%.5f", (
         case pay_pattern
         when "monthly"
-          earnings_for_pay_period.to_f / 2 * 13 / 52
+          earnings_for_pay_period.to_f / 2 * 12 / 52
         else
           earnings_for_pay_period.to_f / 8
         end

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/100.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/100.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is not entitled to Statutory Adoption Pay. To qualify:
 
-+ their average weekly earnings (£12.50) between Thursday, 02 November 2017 and Monday, 01 January 2018 must be at least £113.00
++ their average weekly earnings (£11.54) between Thursday, 02 November 2017 and Monday, 01 January 2018 must be at least £113.00
 
 Send them form SAP1 within 7 days of your decision. They must get this form within 28 days of their pay request or the date they were matched with the child (whichever is earlier).
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/first.txt
@@ -10,12 +10,12 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-6 May 2018|£1687.50
-3 June 2018|£872.74
+6 May 2018|£1557.70
+3 June 2018|£831.95
 1 July 2018|£563.92
 5 August 2018|£704.90
 2 September 2018|£563.92
@@ -23,7 +23,7 @@ Date | SAP amount
 4 November 2018|£563.92
 2 December 2018|£563.92
 6 January 2019|£644.48
-| **Total SAP: £6870.20**
+| **Total SAP: £6699.61**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/fourth.txt
@@ -10,12 +10,12 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-22 April 2018|£819.65
-27 May 2018|£1406.76
+22 April 2018|£756.60
+27 May 2018|£1314.05
 24 June 2018|£563.92
 22 July 2018|£563.92
 26 August 2018|£704.90
@@ -24,7 +24,7 @@ Date | SAP amount
 25 November 2018|£563.92
 23 December 2018|£563.92
 27 January 2019|£221.54
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/last.txt
@@ -10,12 +10,12 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-29 April 2018|£1157.15
-27 May 2018|£1069.26
+29 April 2018|£1068.14
+27 May 2018|£1002.51
 24 June 2018|£563.92
 29 July 2018|£704.90
 26 August 2018|£563.92
@@ -24,7 +24,7 @@ Date | SAP amount
 25 November 2018|£563.92
 30 December 2018|£704.90
 27 January 2019|£80.56
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/second.txt
@@ -10,13 +10,13 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-8 April 2018|£144.65
-13 May 2018|£1687.50
-10 June 2018|£676.22
+8 April 2018|£133.52
+13 May 2018|£1557.70
+10 June 2018|£661.39
 8 July 2018|£563.92
 12 August 2018|£704.90
 9 September 2018|£563.92
@@ -24,7 +24,7 @@ Date | SAP amount
 11 November 2018|£563.92
 9 December 2018|£563.92
 13 January 2019|£503.50
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/third.txt
@@ -10,12 +10,12 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-15 April 2018|£482.15
-20 May 2018|£1603.28
+15 April 2018|£445.06
+20 May 2018|£1484.61
 17 June 2018|£563.92
 15 July 2018|£563.92
 19 August 2018|£704.90
@@ -24,7 +24,7 @@ Date | SAP amount
 18 November 2018|£563.92
 16 December 2018|£563.92
 20 January 2019|£362.52
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/first.txt
@@ -10,12 +10,12 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-7 May 2018|£1687.50
-4 June 2018|£844.67
+7 May 2018|£1557.70
+4 June 2018|£807.58
 2 July 2018|£563.92
 6 August 2018|£704.90
 3 September 2018|£563.92
@@ -23,7 +23,7 @@ Date | SAP amount
 5 November 2018|£704.90
 3 December 2018|£563.92
 7 January 2019|£624.34
-| **Total SAP: £6821.99**
+| **Total SAP: £6655.10**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/fourth.txt
@@ -10,12 +10,12 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-23 April 2018|£867.86
-28 May 2018|£1378.69
+23 April 2018|£801.11
+28 May 2018|£1289.68
 25 June 2018|£563.92
 23 July 2018|£563.92
 27 August 2018|£704.90
@@ -24,7 +24,7 @@ Date | SAP amount
 26 November 2018|£704.90
 24 December 2018|£563.92
 28 January 2019|£201.40
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/last.txt
@@ -10,12 +10,12 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-30 April 2018|£1205.36
-28 May 2018|£1041.19
+30 April 2018|£1112.65
+28 May 2018|£978.14
 25 June 2018|£563.92
 30 July 2018|£704.90
 27 August 2018|£563.92
@@ -24,7 +24,7 @@ Date | SAP amount
 26 November 2018|£563.92
 31 December 2018|£704.90
 28 January 2019|£60.42
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/second.txt
@@ -10,13 +10,13 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-9 April 2018|£192.86
-14 May 2018|£1687.50
-11 June 2018|£648.15
+9 April 2018|£178.03
+14 May 2018|£1557.70
+11 June 2018|£637.02
 9 July 2018|£563.92
 13 August 2018|£704.90
 10 September 2018|£563.92
@@ -24,7 +24,7 @@ Date | SAP amount
 12 November 2018|£704.90
 10 December 2018|£563.92
 14 January 2019|£483.36
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/third.txt
@@ -10,12 +10,12 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-16 April 2018|£530.36
-21 May 2018|£1575.21
+16 April 2018|£489.57
+21 May 2018|£1460.24
 18 June 2018|£563.92
 16 July 2018|£563.92
 20 August 2018|£704.90
@@ -24,7 +24,7 @@ Date | SAP amount
 19 November 2018|£704.90
 17 December 2018|£563.92
 21 January 2019|£342.38
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/first.txt
@@ -10,12 +10,12 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-1 May 2018|£1350.00
-5 June 2018|£1154.09
+1 May 2018|£1246.16
+5 June 2018|£1094.76
 3 July 2018|£563.92
 7 August 2018|£704.90
 4 September 2018|£563.92
@@ -24,7 +24,7 @@ Date | SAP amount
 4 December 2018|£563.92
 1 January 2019|£563.92
 5 February 2019|£40.28
-| **Total SAP: £6773.77**
+| **Total SAP: £6610.60**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/fourth.txt
@@ -10,12 +10,12 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-24 April 2018|£916.08
-22 May 2018|£1209.63
+24 April 2018|£845.61
+22 May 2018|£1124.34
 26 June 2018|£704.90
 24 July 2018|£563.92
 28 August 2018|£704.90
@@ -24,7 +24,7 @@ Date | SAP amount
 27 November 2018|£704.90
 25 December 2018|£563.92
 22 January 2019|£181.26
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/last.txt
@@ -10,12 +10,12 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-24 April 2018|£916.08
-29 May 2018|£1350.61
+24 April 2018|£845.61
+29 May 2018|£1265.32
 26 June 2018|£563.92
 31 July 2018|£704.90
 28 August 2018|£563.92
@@ -24,7 +24,7 @@ Date | SAP amount
 27 November 2018|£563.92
 25 December 2018|£563.92
 29 January 2019|£181.26
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/second.txt
@@ -10,13 +10,13 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-10 April 2018|£241.08
-8 May 2018|£1350.00
-12 June 2018|£957.57
+10 April 2018|£222.53
+8 May 2018|£1246.16
+12 June 2018|£924.20
 10 July 2018|£563.92
 14 August 2018|£704.90
 11 September 2018|£563.92
@@ -24,7 +24,7 @@ Date | SAP amount
 13 November 2018|£704.90
 11 December 2018|£563.92
 8 January 2019|£463.22
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/third.txt
@@ -10,13 +10,13 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-17 April 2018|£578.58
-15 May 2018|£1350.00
-19 June 2018|£761.05
+17 April 2018|£534.07
+15 May 2018|£1246.16
+19 June 2018|£753.64
 17 July 2018|£563.92
 21 August 2018|£704.90
 18 September 2018|£563.92
@@ -24,7 +24,7 @@ Date | SAP amount
 20 November 2018|£704.90
 18 December 2018|£563.92
 15 January 2019|£322.24
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/first.txt
@@ -10,12 +10,12 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-2 May 2018|£1350.00
-6 June 2018|£1126.02
+2 May 2018|£1246.16
+6 June 2018|£1070.39
 4 July 2018|£563.92
 1 August 2018|£563.92
 5 September 2018|£704.90
@@ -24,7 +24,7 @@ Date | SAP amount
 5 December 2018|£563.92
 2 January 2019|£563.92
 6 February 2019|£20.14
-| **Total SAP: £6725.56**
+| **Total SAP: £6566.09**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/fourth.txt
@@ -10,12 +10,12 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-25 April 2018|£964.29
-23 May 2018|£1181.56
+25 April 2018|£890.12
+23 May 2018|£1099.97
 27 June 2018|£704.90
 25 July 2018|£563.92
 22 August 2018|£563.92
@@ -24,7 +24,7 @@ Date | SAP amount
 28 November 2018|£704.90
 26 December 2018|£563.92
 23 January 2019|£161.12
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/last.txt
@@ -10,12 +10,12 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-25 April 2018|£964.29
-30 May 2018|£1322.54
+25 April 2018|£890.12
+30 May 2018|£1240.95
 27 June 2018|£563.92
 25 July 2018|£563.92
 29 August 2018|£704.90
@@ -24,7 +24,7 @@ Date | SAP amount
 28 November 2018|£563.92
 26 December 2018|£563.92
 30 January 2019|£161.12
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/second.txt
@@ -10,13 +10,13 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-11 April 2018|£289.29
-9 May 2018|£1350.00
-13 June 2018|£929.50
+11 April 2018|£267.04
+9 May 2018|£1246.16
+13 June 2018|£899.83
 11 July 2018|£563.92
 8 August 2018|£563.92
 12 September 2018|£704.90
@@ -24,7 +24,7 @@ Date | SAP amount
 14 November 2018|£704.90
 12 December 2018|£563.92
 9 January 2019|£443.08
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/third.txt
@@ -10,13 +10,13 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-18 April 2018|£626.79
-16 May 2018|£1350.00
-20 June 2018|£732.98
+18 April 2018|£578.58
+16 May 2018|£1246.16
+20 June 2018|£729.27
 18 July 2018|£563.92
 15 August 2018|£563.92
 19 September 2018|£704.90
@@ -24,7 +24,7 @@ Date | SAP amount
 21 November 2018|£704.90
 19 December 2018|£563.92
 16 January 2019|£302.10
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/first.txt
@@ -10,12 +10,12 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-3 May 2018|£1350.00
-7 June 2018|£1097.94
+3 May 2018|£1246.16
+7 June 2018|£1046.02
 5 July 2018|£563.92
 2 August 2018|£563.92
 6 September 2018|£704.90
@@ -23,7 +23,7 @@ Date | SAP amount
 1 November 2018|£563.92
 6 December 2018|£704.90
 3 January 2019|£563.92
-| **Total SAP: £6677.34**
+| **Total SAP: £6521.58**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/fourth.txt
@@ -10,12 +10,12 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-26 April 2018|£1012.50
-24 May 2018|£1153.48
+26 April 2018|£934.63
+24 May 2018|£1075.61
 28 June 2018|£704.90
 26 July 2018|£563.92
 23 August 2018|£563.92
@@ -24,7 +24,7 @@ Date | SAP amount
 22 November 2018|£563.92
 27 December 2018|£704.90
 24 January 2019|£140.98
-| **Total SAP: £6677.34**
+| **Total SAP: £6521.60**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/last.txt
@@ -10,12 +10,12 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-26 April 2018|£1012.50
-31 May 2018|£1294.46
+26 April 2018|£934.63
+31 May 2018|£1216.59
 28 June 2018|£563.92
 26 July 2018|£563.92
 30 August 2018|£704.90
@@ -24,7 +24,7 @@ Date | SAP amount
 29 November 2018|£704.90
 27 December 2018|£563.92
 31 January 2019|£140.98
-| **Total SAP: £6677.34**
+| **Total SAP: £6521.60**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/second.txt
@@ -10,13 +10,13 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-12 April 2018|£337.50
-10 May 2018|£1350.00
-14 June 2018|£901.43
+12 April 2018|£311.54
+10 May 2018|£1246.16
+14 June 2018|£875.46
 12 July 2018|£563.92
 9 August 2018|£563.92
 13 September 2018|£704.90
@@ -24,7 +24,7 @@ Date | SAP amount
 8 November 2018|£563.92
 13 December 2018|£704.90
 10 January 2019|£422.94
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.58**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/third.txt
@@ -10,12 +10,12 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-19 April 2018|£675.00
-17 May 2018|£1350.00
+19 April 2018|£623.08
+17 May 2018|£1246.16
 21 June 2018|£704.90
 19 July 2018|£563.92
 16 August 2018|£563.92
@@ -24,7 +24,7 @@ Date | SAP amount
 15 November 2018|£563.92
 20 December 2018|£704.90
 17 January 2019|£281.96
-| **Total SAP: £6677.34**
+| **Total SAP: £6521.58**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/first.txt
@@ -10,13 +10,13 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-6 April 2018|£48.22
-4 May 2018|£1350.00
-1 June 2018|£928.89
+6 April 2018|£44.51
+4 May 2018|£1246.16
+1 June 2018|£880.68
 6 July 2018|£704.90
 3 August 2018|£563.92
 7 September 2018|£704.90
@@ -24,7 +24,7 @@ Date | SAP amount
 2 November 2018|£563.92
 7 December 2018|£704.90
 4 January 2019|£543.78
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/fourth.txt
@@ -10,12 +10,12 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-27 April 2018|£1060.72
-25 May 2018|£1125.41
+27 April 2018|£979.13
+25 May 2018|£1051.24
 22 June 2018|£563.92
 27 July 2018|£704.90
 24 August 2018|£563.92
@@ -24,7 +24,7 @@ Date | SAP amount
 23 November 2018|£563.92
 28 December 2018|£704.90
 25 January 2019|£120.84
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/last.txt
@@ -10,12 +10,12 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-27 April 2018|£1060.72
-25 May 2018|£1125.41
+27 April 2018|£979.13
+25 May 2018|£1051.24
 29 June 2018|£704.90
 27 July 2018|£563.92
 31 August 2018|£704.90
@@ -24,7 +24,7 @@ Date | SAP amount
 30 November 2018|£704.90
 28 December 2018|£563.92
 25 January 2019|£120.84
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/second.txt
@@ -10,13 +10,13 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-13 April 2018|£385.72
-11 May 2018|£1350.00
-8 June 2018|£732.37
+13 April 2018|£356.05
+11 May 2018|£1246.16
+8 June 2018|£710.12
 13 July 2018|£704.90
 10 August 2018|£563.92
 14 September 2018|£704.90
@@ -24,7 +24,7 @@ Date | SAP amount
 9 November 2018|£563.92
 14 December 2018|£704.90
 11 January 2019|£402.80
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/third.txt
@@ -10,12 +10,12 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-20 April 2018|£723.22
-18 May 2018|£1321.93
+20 April 2018|£667.59
+18 May 2018|£1221.80
 15 June 2018|£563.92
 20 July 2018|£704.90
 17 August 2018|£563.92
@@ -24,7 +24,7 @@ Date | SAP amount
 16 November 2018|£563.92
 21 December 2018|£704.90
 18 January 2019|£261.82
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/first.txt
@@ -10,13 +10,13 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-7 April 2018|£96.43
-5 May 2018|£1350.00
-2 June 2018|£900.82
+7 April 2018|£89.02
+5 May 2018|£1246.16
+2 June 2018|£856.31
 7 July 2018|£704.90
 4 August 2018|£563.92
 1 September 2018|£563.92
@@ -24,7 +24,7 @@ Date | SAP amount
 3 November 2018|£563.92
 1 December 2018|£563.92
 5 January 2019|£664.62
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/fourth.txt
@@ -10,12 +10,12 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-28 April 2018|£1108.93
-26 May 2018|£1097.34
+28 April 2018|£1023.64
+26 May 2018|£1026.87
 23 June 2018|£563.92
 28 July 2018|£704.90
 25 August 2018|£563.92
@@ -24,7 +24,7 @@ Date | SAP amount
 24 November 2018|£563.92
 22 December 2018|£563.92
 26 January 2019|£241.68
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/last.txt
@@ -10,12 +10,12 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-28 April 2018|£1108.93
-26 May 2018|£1097.34
+28 April 2018|£1023.64
+26 May 2018|£1026.87
 30 June 2018|£704.90
 28 July 2018|£563.92
 25 August 2018|£563.92
@@ -24,7 +24,7 @@ Date | SAP amount
 24 November 2018|£563.92
 29 December 2018|£704.90
 26 January 2019|£100.70
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/second.txt
@@ -10,13 +10,13 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-14 April 2018|£433.93
-12 May 2018|£1350.00
-9 June 2018|£704.30
+14 April 2018|£400.56
+12 May 2018|£1246.16
+9 June 2018|£685.75
 14 July 2018|£704.90
 11 August 2018|£563.92
 8 September 2018|£563.92
@@ -24,7 +24,7 @@ Date | SAP amount
 10 November 2018|£563.92
 8 December 2018|£563.92
 12 January 2019|£523.64
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/third.txt
@@ -10,12 +10,12 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-21 April 2018|£771.43
-19 May 2018|£1293.86
+21 April 2018|£712.10
+19 May 2018|£1197.43
 16 June 2018|£563.92
 21 July 2018|£704.90
 18 August 2018|£563.92
@@ -24,7 +24,7 @@ Date | SAP amount
 17 November 2018|£563.92
 15 December 2018|£563.92
 19 January 2019|£382.66
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/first_day_of_the_month.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/first_day_of_the_month.txt
@@ -10,12 +10,12 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-1 May 2018|£1253.58
-1 June 2018|£1073.53
+1 May 2018|£1157.15
+1 June 2018|£1014.20
 1 July 2018|£604.20
 1 August 2018|£624.34
 1 September 2018|£624.34
@@ -24,7 +24,7 @@ Date | SAP amount
 1 December 2018|£604.20
 1 January 2019|£624.34
 1 February 2019|£40.28
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_day_of_the_month.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_day_of_the_month.txt
@@ -10,12 +10,12 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-30 April 2018|£1205.36
-31 May 2018|£1101.61
+30 April 2018|£1112.65
+31 May 2018|£1038.56
 30 June 2018|£604.20
 31 July 2018|£624.34
 31 August 2018|£624.34
@@ -24,7 +24,7 @@ Date | SAP amount
 30 November 2018|£604.20
 31 December 2018|£624.34
 31 January 2019|£60.42
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/0.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/0.txt
@@ -10,12 +10,12 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-29 April 2018|£1157.15
-27 May 2018|£1069.26
+29 April 2018|£1068.14
+27 May 2018|£1002.51
 24 June 2018|£563.92
 29 July 2018|£704.90
 26 August 2018|£563.92
@@ -24,7 +24,7 @@ Date | SAP amount
 25 November 2018|£563.92
 30 December 2018|£704.90
 27 January 2019|£80.56
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/1.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/1.txt
@@ -10,12 +10,12 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-30 April 2018|£1205.36
-28 May 2018|£1041.19
+30 April 2018|£1112.65
+28 May 2018|£978.14
 25 June 2018|£563.92
 30 July 2018|£704.90
 27 August 2018|£563.92
@@ -24,7 +24,7 @@ Date | SAP amount
 26 November 2018|£563.92
 31 December 2018|£704.90
 28 January 2019|£60.42
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/2.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/2.txt
@@ -10,12 +10,12 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-24 April 2018|£916.08
-29 May 2018|£1350.61
+24 April 2018|£845.61
+29 May 2018|£1265.32
 26 June 2018|£563.92
 31 July 2018|£704.90
 28 August 2018|£563.92
@@ -24,7 +24,7 @@ Date | SAP amount
 27 November 2018|£563.92
 25 December 2018|£563.92
 29 January 2019|£181.26
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/3.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/3.txt
@@ -10,12 +10,12 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-25 April 2018|£964.29
-30 May 2018|£1322.54
+25 April 2018|£890.12
+30 May 2018|£1240.95
 27 June 2018|£563.92
 25 July 2018|£563.92
 29 August 2018|£704.90
@@ -24,7 +24,7 @@ Date | SAP amount
 28 November 2018|£563.92
 26 December 2018|£563.92
 30 January 2019|£161.12
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/4.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/4.txt
@@ -10,12 +10,12 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-26 April 2018|£1012.50
-31 May 2018|£1294.46
+26 April 2018|£934.63
+31 May 2018|£1216.59
 28 June 2018|£563.92
 26 July 2018|£563.92
 30 August 2018|£704.90
@@ -24,7 +24,7 @@ Date | SAP amount
 29 November 2018|£704.90
 27 December 2018|£563.92
 31 January 2019|£140.98
-| **Total SAP: £6677.34**
+| **Total SAP: £6521.60**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/5.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/5.txt
@@ -10,12 +10,12 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-27 April 2018|£1060.72
-25 May 2018|£1125.41
+27 April 2018|£979.13
+25 May 2018|£1051.24
 29 June 2018|£704.90
 27 July 2018|£563.92
 31 August 2018|£704.90
@@ -24,7 +24,7 @@ Date | SAP amount
 30 November 2018|£704.90
 28 December 2018|£563.92
 25 January 2019|£120.84
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/6.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/6.txt
@@ -10,12 +10,12 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-28 April 2018|£1108.93
-26 May 2018|£1097.34
+28 April 2018|£1023.64
+26 May 2018|£1026.87
 30 June 2018|£704.90
 28 July 2018|£563.92
 25 August 2018|£563.92
@@ -24,7 +24,7 @@ Date | SAP amount
 24 November 2018|£563.92
 29 December 2018|£704.90
 26 January 2019|£100.70
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/specific_date_each_month/14.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/specific_date_each_month/14.txt
@@ -10,13 +10,13 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-14 April 2018|£433.93
-14 May 2018|£1446.43
-14 June 2018|£708.57
+14 April 2018|£400.56
+14 May 2018|£1335.18
+14 June 2018|£697.44
 14 July 2018|£604.20
 14 August 2018|£624.34
 14 September 2018|£624.34
@@ -24,7 +24,7 @@ Date | SAP amount
 14 November 2018|£624.34
 14 December 2018|£604.20
 14 January 2019|£402.80
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.60**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/specific_date_each_month/29.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/specific_date_each_month/29.txt
@@ -10,12 +10,12 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-30 April 2018|£1205.36
-31 May 2018|£1101.61
+30 April 2018|£1112.65
+31 May 2018|£1038.56
 30 June 2018|£604.20
 31 July 2018|£624.34
 31 August 2018|£624.34
@@ -24,7 +24,7 @@ Date | SAP amount
 30 November 2018|£604.20
 31 December 2018|£624.34
 31 January 2019|£60.42
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/weekly_starting.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/no/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/weekly_starting.txt
@@ -10,16 +10,16 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-12 April 2018|£337.50
-19 April 2018|£337.50
-26 April 2018|£337.50
-3 May 2018|£337.50
-10 May 2018|£337.50
-17 May 2018|£337.50
+12 April 2018|£311.54
+19 April 2018|£311.54
+26 April 2018|£311.54
+3 May 2018|£311.54
+10 May 2018|£311.54
+17 May 2018|£311.54
 24 May 2018|£140.98
 31 May 2018|£140.98
 7 June 2018|£140.98
@@ -53,7 +53,7 @@ Date | SAP amount
 20 December 2018|£140.98
 27 December 2018|£140.98
 3 January 2019|£140.98
-| **Total SAP: £6677.34**
+| **Total SAP: £6521.58**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/100.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/100.txt
@@ -13,7 +13,7 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is not entitled to Statutory Adoption Pay. To qualify:
 
-+ their average weekly earnings (£12.50) between Thursday, 02 November 2017 and Monday, 01 January 2018 must be at least £113.00
++ their average weekly earnings (£11.54) between Thursday, 02 November 2017 and Monday, 01 January 2018 must be at least £113.00
 
 Send them form SAP1 within 7 days of your decision. They must get this form within 28 days of their pay request or the date they were matched with the child (whichever is earlier).
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/first.txt
@@ -13,12 +13,12 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-6 May 2018|£1687.50
-3 June 2018|£872.74
+6 May 2018|£1557.70
+3 June 2018|£831.95
 1 July 2018|£563.92
 5 August 2018|£704.90
 2 September 2018|£563.92
@@ -26,7 +26,7 @@ Date | SAP amount
 4 November 2018|£563.92
 2 December 2018|£563.92
 6 January 2019|£644.48
-| **Total SAP: £6870.20**
+| **Total SAP: £6699.61**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/fourth.txt
@@ -13,12 +13,12 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-22 April 2018|£819.65
-27 May 2018|£1406.76
+22 April 2018|£756.60
+27 May 2018|£1314.05
 24 June 2018|£563.92
 22 July 2018|£563.92
 26 August 2018|£704.90
@@ -27,7 +27,7 @@ Date | SAP amount
 25 November 2018|£563.92
 23 December 2018|£563.92
 27 January 2019|£221.54
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/last.txt
@@ -13,12 +13,12 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-29 April 2018|£1157.15
-27 May 2018|£1069.26
+29 April 2018|£1068.14
+27 May 2018|£1002.51
 24 June 2018|£563.92
 29 July 2018|£704.90
 26 August 2018|£563.92
@@ -27,7 +27,7 @@ Date | SAP amount
 25 November 2018|£563.92
 30 December 2018|£704.90
 27 January 2019|£80.56
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/second.txt
@@ -13,13 +13,13 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-8 April 2018|£144.65
-13 May 2018|£1687.50
-10 June 2018|£676.22
+8 April 2018|£133.52
+13 May 2018|£1557.70
+10 June 2018|£661.39
 8 July 2018|£563.92
 12 August 2018|£704.90
 9 September 2018|£563.92
@@ -27,7 +27,7 @@ Date | SAP amount
 11 November 2018|£563.92
 9 December 2018|£563.92
 13 January 2019|£503.50
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/third.txt
@@ -13,12 +13,12 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-15 April 2018|£482.15
-20 May 2018|£1603.28
+15 April 2018|£445.06
+20 May 2018|£1484.61
 17 June 2018|£563.92
 15 July 2018|£563.92
 19 August 2018|£704.90
@@ -27,7 +27,7 @@ Date | SAP amount
 18 November 2018|£563.92
 16 December 2018|£563.92
 20 January 2019|£362.52
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/first.txt
@@ -13,12 +13,12 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-7 May 2018|£1687.50
-4 June 2018|£844.67
+7 May 2018|£1557.70
+4 June 2018|£807.58
 2 July 2018|£563.92
 6 August 2018|£704.90
 3 September 2018|£563.92
@@ -26,7 +26,7 @@ Date | SAP amount
 5 November 2018|£704.90
 3 December 2018|£563.92
 7 January 2019|£624.34
-| **Total SAP: £6821.99**
+| **Total SAP: £6655.10**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/fourth.txt
@@ -13,12 +13,12 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-23 April 2018|£867.86
-28 May 2018|£1378.69
+23 April 2018|£801.11
+28 May 2018|£1289.68
 25 June 2018|£563.92
 23 July 2018|£563.92
 27 August 2018|£704.90
@@ -27,7 +27,7 @@ Date | SAP amount
 26 November 2018|£704.90
 24 December 2018|£563.92
 28 January 2019|£201.40
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/last.txt
@@ -13,12 +13,12 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-30 April 2018|£1205.36
-28 May 2018|£1041.19
+30 April 2018|£1112.65
+28 May 2018|£978.14
 25 June 2018|£563.92
 30 July 2018|£704.90
 27 August 2018|£563.92
@@ -27,7 +27,7 @@ Date | SAP amount
 26 November 2018|£563.92
 31 December 2018|£704.90
 28 January 2019|£60.42
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/second.txt
@@ -13,13 +13,13 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-9 April 2018|£192.86
-14 May 2018|£1687.50
-11 June 2018|£648.15
+9 April 2018|£178.03
+14 May 2018|£1557.70
+11 June 2018|£637.02
 9 July 2018|£563.92
 13 August 2018|£704.90
 10 September 2018|£563.92
@@ -27,7 +27,7 @@ Date | SAP amount
 12 November 2018|£704.90
 10 December 2018|£563.92
 14 January 2019|£483.36
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/third.txt
@@ -13,12 +13,12 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-16 April 2018|£530.36
-21 May 2018|£1575.21
+16 April 2018|£489.57
+21 May 2018|£1460.24
 18 June 2018|£563.92
 16 July 2018|£563.92
 20 August 2018|£704.90
@@ -27,7 +27,7 @@ Date | SAP amount
 19 November 2018|£704.90
 17 December 2018|£563.92
 21 January 2019|£342.38
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/first.txt
@@ -13,12 +13,12 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-1 May 2018|£1350.00
-5 June 2018|£1154.09
+1 May 2018|£1246.16
+5 June 2018|£1094.76
 3 July 2018|£563.92
 7 August 2018|£704.90
 4 September 2018|£563.92
@@ -27,7 +27,7 @@ Date | SAP amount
 4 December 2018|£563.92
 1 January 2019|£563.92
 5 February 2019|£40.28
-| **Total SAP: £6773.77**
+| **Total SAP: £6610.60**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/fourth.txt
@@ -13,12 +13,12 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-24 April 2018|£916.08
-22 May 2018|£1209.63
+24 April 2018|£845.61
+22 May 2018|£1124.34
 26 June 2018|£704.90
 24 July 2018|£563.92
 28 August 2018|£704.90
@@ -27,7 +27,7 @@ Date | SAP amount
 27 November 2018|£704.90
 25 December 2018|£563.92
 22 January 2019|£181.26
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/last.txt
@@ -13,12 +13,12 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-24 April 2018|£916.08
-29 May 2018|£1350.61
+24 April 2018|£845.61
+29 May 2018|£1265.32
 26 June 2018|£563.92
 31 July 2018|£704.90
 28 August 2018|£563.92
@@ -27,7 +27,7 @@ Date | SAP amount
 27 November 2018|£563.92
 25 December 2018|£563.92
 29 January 2019|£181.26
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/second.txt
@@ -13,13 +13,13 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-10 April 2018|£241.08
-8 May 2018|£1350.00
-12 June 2018|£957.57
+10 April 2018|£222.53
+8 May 2018|£1246.16
+12 June 2018|£924.20
 10 July 2018|£563.92
 14 August 2018|£704.90
 11 September 2018|£563.92
@@ -27,7 +27,7 @@ Date | SAP amount
 13 November 2018|£704.90
 11 December 2018|£563.92
 8 January 2019|£463.22
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/third.txt
@@ -13,13 +13,13 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-17 April 2018|£578.58
-15 May 2018|£1350.00
-19 June 2018|£761.05
+17 April 2018|£534.07
+15 May 2018|£1246.16
+19 June 2018|£753.64
 17 July 2018|£563.92
 21 August 2018|£704.90
 18 September 2018|£563.92
@@ -27,7 +27,7 @@ Date | SAP amount
 20 November 2018|£704.90
 18 December 2018|£563.92
 15 January 2019|£322.24
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/first.txt
@@ -13,12 +13,12 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-2 May 2018|£1350.00
-6 June 2018|£1126.02
+2 May 2018|£1246.16
+6 June 2018|£1070.39
 4 July 2018|£563.92
 1 August 2018|£563.92
 5 September 2018|£704.90
@@ -27,7 +27,7 @@ Date | SAP amount
 5 December 2018|£563.92
 2 January 2019|£563.92
 6 February 2019|£20.14
-| **Total SAP: £6725.56**
+| **Total SAP: £6566.09**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/fourth.txt
@@ -13,12 +13,12 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-25 April 2018|£964.29
-23 May 2018|£1181.56
+25 April 2018|£890.12
+23 May 2018|£1099.97
 27 June 2018|£704.90
 25 July 2018|£563.92
 22 August 2018|£563.92
@@ -27,7 +27,7 @@ Date | SAP amount
 28 November 2018|£704.90
 26 December 2018|£563.92
 23 January 2019|£161.12
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/last.txt
@@ -13,12 +13,12 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-25 April 2018|£964.29
-30 May 2018|£1322.54
+25 April 2018|£890.12
+30 May 2018|£1240.95
 27 June 2018|£563.92
 25 July 2018|£563.92
 29 August 2018|£704.90
@@ -27,7 +27,7 @@ Date | SAP amount
 28 November 2018|£563.92
 26 December 2018|£563.92
 30 January 2019|£161.12
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/second.txt
@@ -13,13 +13,13 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-11 April 2018|£289.29
-9 May 2018|£1350.00
-13 June 2018|£929.50
+11 April 2018|£267.04
+9 May 2018|£1246.16
+13 June 2018|£899.83
 11 July 2018|£563.92
 8 August 2018|£563.92
 12 September 2018|£704.90
@@ -27,7 +27,7 @@ Date | SAP amount
 14 November 2018|£704.90
 12 December 2018|£563.92
 9 January 2019|£443.08
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/third.txt
@@ -13,13 +13,13 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-18 April 2018|£626.79
-16 May 2018|£1350.00
-20 June 2018|£732.98
+18 April 2018|£578.58
+16 May 2018|£1246.16
+20 June 2018|£729.27
 18 July 2018|£563.92
 15 August 2018|£563.92
 19 September 2018|£704.90
@@ -27,7 +27,7 @@ Date | SAP amount
 21 November 2018|£704.90
 19 December 2018|£563.92
 16 January 2019|£302.10
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/first.txt
@@ -13,12 +13,12 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-3 May 2018|£1350.00
-7 June 2018|£1097.94
+3 May 2018|£1246.16
+7 June 2018|£1046.02
 5 July 2018|£563.92
 2 August 2018|£563.92
 6 September 2018|£704.90
@@ -26,7 +26,7 @@ Date | SAP amount
 1 November 2018|£563.92
 6 December 2018|£704.90
 3 January 2019|£563.92
-| **Total SAP: £6677.34**
+| **Total SAP: £6521.58**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/fourth.txt
@@ -13,12 +13,12 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-26 April 2018|£1012.50
-24 May 2018|£1153.48
+26 April 2018|£934.63
+24 May 2018|£1075.61
 28 June 2018|£704.90
 26 July 2018|£563.92
 23 August 2018|£563.92
@@ -27,7 +27,7 @@ Date | SAP amount
 22 November 2018|£563.92
 27 December 2018|£704.90
 24 January 2019|£140.98
-| **Total SAP: £6677.34**
+| **Total SAP: £6521.60**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/last.txt
@@ -13,12 +13,12 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-26 April 2018|£1012.50
-31 May 2018|£1294.46
+26 April 2018|£934.63
+31 May 2018|£1216.59
 28 June 2018|£563.92
 26 July 2018|£563.92
 30 August 2018|£704.90
@@ -27,7 +27,7 @@ Date | SAP amount
 29 November 2018|£704.90
 27 December 2018|£563.92
 31 January 2019|£140.98
-| **Total SAP: £6677.34**
+| **Total SAP: £6521.60**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/second.txt
@@ -13,13 +13,13 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-12 April 2018|£337.50
-10 May 2018|£1350.00
-14 June 2018|£901.43
+12 April 2018|£311.54
+10 May 2018|£1246.16
+14 June 2018|£875.46
 12 July 2018|£563.92
 9 August 2018|£563.92
 13 September 2018|£704.90
@@ -27,7 +27,7 @@ Date | SAP amount
 8 November 2018|£563.92
 13 December 2018|£704.90
 10 January 2019|£422.94
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.58**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/third.txt
@@ -13,12 +13,12 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-19 April 2018|£675.00
-17 May 2018|£1350.00
+19 April 2018|£623.08
+17 May 2018|£1246.16
 21 June 2018|£704.90
 19 July 2018|£563.92
 16 August 2018|£563.92
@@ -27,7 +27,7 @@ Date | SAP amount
 15 November 2018|£563.92
 20 December 2018|£704.90
 17 January 2019|£281.96
-| **Total SAP: £6677.34**
+| **Total SAP: £6521.58**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/first.txt
@@ -13,13 +13,13 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-6 April 2018|£48.22
-4 May 2018|£1350.00
-1 June 2018|£928.89
+6 April 2018|£44.51
+4 May 2018|£1246.16
+1 June 2018|£880.68
 6 July 2018|£704.90
 3 August 2018|£563.92
 7 September 2018|£704.90
@@ -27,7 +27,7 @@ Date | SAP amount
 2 November 2018|£563.92
 7 December 2018|£704.90
 4 January 2019|£543.78
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/fourth.txt
@@ -13,12 +13,12 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-27 April 2018|£1060.72
-25 May 2018|£1125.41
+27 April 2018|£979.13
+25 May 2018|£1051.24
 22 June 2018|£563.92
 27 July 2018|£704.90
 24 August 2018|£563.92
@@ -27,7 +27,7 @@ Date | SAP amount
 23 November 2018|£563.92
 28 December 2018|£704.90
 25 January 2019|£120.84
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/last.txt
@@ -13,12 +13,12 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-27 April 2018|£1060.72
-25 May 2018|£1125.41
+27 April 2018|£979.13
+25 May 2018|£1051.24
 29 June 2018|£704.90
 27 July 2018|£563.92
 31 August 2018|£704.90
@@ -27,7 +27,7 @@ Date | SAP amount
 30 November 2018|£704.90
 28 December 2018|£563.92
 25 January 2019|£120.84
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/second.txt
@@ -13,13 +13,13 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-13 April 2018|£385.72
-11 May 2018|£1350.00
-8 June 2018|£732.37
+13 April 2018|£356.05
+11 May 2018|£1246.16
+8 June 2018|£710.12
 13 July 2018|£704.90
 10 August 2018|£563.92
 14 September 2018|£704.90
@@ -27,7 +27,7 @@ Date | SAP amount
 9 November 2018|£563.92
 14 December 2018|£704.90
 11 January 2019|£402.80
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/third.txt
@@ -13,12 +13,12 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-20 April 2018|£723.22
-18 May 2018|£1321.93
+20 April 2018|£667.59
+18 May 2018|£1221.80
 15 June 2018|£563.92
 20 July 2018|£704.90
 17 August 2018|£563.92
@@ -27,7 +27,7 @@ Date | SAP amount
 16 November 2018|£563.92
 21 December 2018|£704.90
 18 January 2019|£261.82
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/first.txt
@@ -13,13 +13,13 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-7 April 2018|£96.43
-5 May 2018|£1350.00
-2 June 2018|£900.82
+7 April 2018|£89.02
+5 May 2018|£1246.16
+2 June 2018|£856.31
 7 July 2018|£704.90
 4 August 2018|£563.92
 1 September 2018|£563.92
@@ -27,7 +27,7 @@ Date | SAP amount
 3 November 2018|£563.92
 1 December 2018|£563.92
 5 January 2019|£664.62
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/fourth.txt
@@ -13,12 +13,12 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-28 April 2018|£1108.93
-26 May 2018|£1097.34
+28 April 2018|£1023.64
+26 May 2018|£1026.87
 23 June 2018|£563.92
 28 July 2018|£704.90
 25 August 2018|£563.92
@@ -27,7 +27,7 @@ Date | SAP amount
 24 November 2018|£563.92
 22 December 2018|£563.92
 26 January 2019|£241.68
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/last.txt
@@ -13,12 +13,12 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-28 April 2018|£1108.93
-26 May 2018|£1097.34
+28 April 2018|£1023.64
+26 May 2018|£1026.87
 30 June 2018|£704.90
 28 July 2018|£563.92
 25 August 2018|£563.92
@@ -27,7 +27,7 @@ Date | SAP amount
 24 November 2018|£563.92
 29 December 2018|£704.90
 26 January 2019|£100.70
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/second.txt
@@ -13,13 +13,13 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-14 April 2018|£433.93
-12 May 2018|£1350.00
-9 June 2018|£704.30
+14 April 2018|£400.56
+12 May 2018|£1246.16
+9 June 2018|£685.75
 14 July 2018|£704.90
 11 August 2018|£563.92
 8 September 2018|£563.92
@@ -27,7 +27,7 @@ Date | SAP amount
 10 November 2018|£563.92
 8 December 2018|£563.92
 12 January 2019|£523.64
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/third.txt
@@ -13,12 +13,12 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-21 April 2018|£771.43
-19 May 2018|£1293.86
+21 April 2018|£712.10
+19 May 2018|£1197.43
 16 June 2018|£563.92
 21 July 2018|£704.90
 18 August 2018|£563.92
@@ -27,7 +27,7 @@ Date | SAP amount
 17 November 2018|£563.92
 15 December 2018|£563.92
 19 January 2019|£382.66
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/first_day_of_the_month.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/first_day_of_the_month.txt
@@ -13,12 +13,12 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-1 May 2018|£1253.58
-1 June 2018|£1073.53
+1 May 2018|£1157.15
+1 June 2018|£1014.20
 1 July 2018|£604.20
 1 August 2018|£624.34
 1 September 2018|£624.34
@@ -27,7 +27,7 @@ Date | SAP amount
 1 December 2018|£604.20
 1 January 2019|£624.34
 1 February 2019|£40.28
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_day_of_the_month.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_day_of_the_month.txt
@@ -13,12 +13,12 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-30 April 2018|£1205.36
-31 May 2018|£1101.61
+30 April 2018|£1112.65
+31 May 2018|£1038.56
 30 June 2018|£604.20
 31 July 2018|£624.34
 31 August 2018|£624.34
@@ -27,7 +27,7 @@ Date | SAP amount
 30 November 2018|£604.20
 31 December 2018|£624.34
 31 January 2019|£60.42
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/0.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/0.txt
@@ -13,12 +13,12 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-29 April 2018|£1157.15
-27 May 2018|£1069.26
+29 April 2018|£1068.14
+27 May 2018|£1002.51
 24 June 2018|£563.92
 29 July 2018|£704.90
 26 August 2018|£563.92
@@ -27,7 +27,7 @@ Date | SAP amount
 25 November 2018|£563.92
 30 December 2018|£704.90
 27 January 2019|£80.56
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/1.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/1.txt
@@ -13,12 +13,12 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-30 April 2018|£1205.36
-28 May 2018|£1041.19
+30 April 2018|£1112.65
+28 May 2018|£978.14
 25 June 2018|£563.92
 30 July 2018|£704.90
 27 August 2018|£563.92
@@ -27,7 +27,7 @@ Date | SAP amount
 26 November 2018|£563.92
 31 December 2018|£704.90
 28 January 2019|£60.42
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/2.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/2.txt
@@ -13,12 +13,12 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-24 April 2018|£916.08
-29 May 2018|£1350.61
+24 April 2018|£845.61
+29 May 2018|£1265.32
 26 June 2018|£563.92
 31 July 2018|£704.90
 28 August 2018|£563.92
@@ -27,7 +27,7 @@ Date | SAP amount
 27 November 2018|£563.92
 25 December 2018|£563.92
 29 January 2019|£181.26
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/3.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/3.txt
@@ -13,12 +13,12 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-25 April 2018|£964.29
-30 May 2018|£1322.54
+25 April 2018|£890.12
+30 May 2018|£1240.95
 27 June 2018|£563.92
 25 July 2018|£563.92
 29 August 2018|£704.90
@@ -27,7 +27,7 @@ Date | SAP amount
 28 November 2018|£563.92
 26 December 2018|£563.92
 30 January 2019|£161.12
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/4.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/4.txt
@@ -13,12 +13,12 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-26 April 2018|£1012.50
-31 May 2018|£1294.46
+26 April 2018|£934.63
+31 May 2018|£1216.59
 28 June 2018|£563.92
 26 July 2018|£563.92
 30 August 2018|£704.90
@@ -27,7 +27,7 @@ Date | SAP amount
 29 November 2018|£704.90
 27 December 2018|£563.92
 31 January 2019|£140.98
-| **Total SAP: £6677.34**
+| **Total SAP: £6521.60**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/5.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/5.txt
@@ -13,12 +13,12 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-27 April 2018|£1060.72
-25 May 2018|£1125.41
+27 April 2018|£979.13
+25 May 2018|£1051.24
 29 June 2018|£704.90
 27 July 2018|£563.92
 31 August 2018|£704.90
@@ -27,7 +27,7 @@ Date | SAP amount
 30 November 2018|£704.90
 28 December 2018|£563.92
 25 January 2019|£120.84
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/6.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/6.txt
@@ -13,12 +13,12 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-28 April 2018|£1108.93
-26 May 2018|£1097.34
+28 April 2018|£1023.64
+26 May 2018|£1026.87
 30 June 2018|£704.90
 28 July 2018|£563.92
 25 August 2018|£563.92
@@ -27,7 +27,7 @@ Date | SAP amount
 24 November 2018|£563.92
 29 December 2018|£704.90
 26 January 2019|£100.70
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/specific_date_each_month/14.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/specific_date_each_month/14.txt
@@ -13,13 +13,13 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-14 April 2018|£433.93
-14 May 2018|£1446.43
-14 June 2018|£708.57
+14 April 2018|£400.56
+14 May 2018|£1335.18
+14 June 2018|£697.44
 14 July 2018|£604.20
 14 August 2018|£624.34
 14 September 2018|£624.34
@@ -27,7 +27,7 @@ Date | SAP amount
 14 November 2018|£624.34
 14 December 2018|£604.20
 14 January 2019|£402.80
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.60**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/specific_date_each_month/29.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/specific_date_each_month/29.txt
@@ -13,12 +13,12 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-30 April 2018|£1205.36
-31 May 2018|£1101.61
+30 April 2018|£1112.65
+31 May 2018|£1038.56
 30 June 2018|£604.20
 31 July 2018|£624.34
 31 August 2018|£624.34
@@ -27,7 +27,7 @@ Date | SAP amount
 30 November 2018|£604.20
 31 December 2018|£624.34
 31 January 2019|£60.42
-| **Total SAP: £6677.35**
+| **Total SAP: £6521.59**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/weekly_starting.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/maternity/2018-04-05/2018-04-06/yes/yes/yes/2018-04-06/2018-01-01/2017-11-01/monthly/3000.0/weekly_starting.txt
@@ -13,16 +13,16 @@ The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [cla
 
 The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-The employee’s average weekly earnings are: £375.00.
+The employee’s average weekly earnings are: £346.15.
 
 Date | SAP amount
 -|-
-12 April 2018|£337.50
-19 April 2018|£337.50
-26 April 2018|£337.50
-3 May 2018|£337.50
-10 May 2018|£337.50
-17 May 2018|£337.50
+12 April 2018|£311.54
+19 April 2018|£311.54
+26 April 2018|£311.54
+3 May 2018|£311.54
+10 May 2018|£311.54
+17 May 2018|£311.54
 24 May 2018|£140.98
 31 May 2018|£140.98
 7 June 2018|£140.98
@@ -56,7 +56,7 @@ Date | SAP amount
 20 December 2018|£140.98
 27 December 2018|£140.98
 3 January 2019|£140.98
-| **Total SAP: £6677.34**
+| **Total SAP: £6521.58**
 
 %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/100.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/100.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is not entitled to Statutory Paternity Pay. To qualify:
 
-+ their average weekly earnings (£12.50) between Thursday, 02 November 2017 and Monday, 01 January 2018 must be at least £113.00
++ their average weekly earnings (£11.54) between Thursday, 02 November 2017 and Monday, 01 January 2018 must be at least £113.00
 
 Send them form OSPP1 confirming this within 28 days of their pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/first.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/fourth.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/last.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/second.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/third.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/first.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/fourth.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/last.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/second.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/third.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/first.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/fourth.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/last.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/second.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/third.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/first.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/fourth.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/last.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/second.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/third.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/first.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/fourth.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/last.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/second.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/third.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/first.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/fourth.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/last.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/second.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/third.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/first.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/fourth.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/last.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/second.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/third.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/first_day_of_the_month.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/first_day_of_the_month.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_day_of_the_month.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_day_of_the_month.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/0.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/0.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/1.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/1.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/2.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/2.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/3.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/3.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/4.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/4.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/5.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/5.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/6.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/6.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/specific_date_each_month/14.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/specific_date_each_month/14.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/specific_date_each_month/29.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/specific_date_each_month/29.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/weekly_starting.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/weekly_starting.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/100.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/100.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is not entitled to Statutory Paternity Pay. To qualify:
 
-+ their average weekly earnings (£12.50) between Thursday, 02 November 2017 and Monday, 01 January 2018 must be at least £113.00
++ their average weekly earnings (£11.54) between Thursday, 02 November 2017 and Monday, 01 January 2018 must be at least £113.00
 
 Send them form OSPP1 confirming this within 28 days of their pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/first.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/fourth.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/last.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/second.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/third.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/first.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/fourth.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/last.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/second.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/third.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/first.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/fourth.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/last.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/second.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/third.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/first.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/fourth.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/last.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/second.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/third.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/first.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/fourth.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/last.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/second.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/third.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/first.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/fourth.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/last.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/second.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/third.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/first.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/fourth.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/last.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/second.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/third.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/first_day_of_the_month.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/first_day_of_the_month.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_day_of_the_month.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_day_of_the_month.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/0.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/0.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/1.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/1.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/2.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/2.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/3.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/3.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/4.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/4.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/5.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/5.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/6.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/6.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/specific_date_each_month/14.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/specific_date_each_month/14.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/specific_date_each_month/29.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/specific_date_each_month/29.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/weekly_starting.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/weekly_starting.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/100.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/100.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is not entitled to Statutory Paternity Pay. To qualify:
 
-+ their average weekly earnings (£12.50) between Thursday, 02 November 2017 and Monday, 01 January 2018 must be at least £113.00
++ their average weekly earnings (£11.54) between Thursday, 02 November 2017 and Monday, 01 January 2018 must be at least £113.00
 
 Send them form OSPP1 confirming this within 28 days of their pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/first.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/fourth.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/last.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/second.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/third.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/first.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/fourth.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/last.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/second.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/third.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/first.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/fourth.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/last.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/second.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/third.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/first.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/fourth.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/last.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/second.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/third.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/first.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/fourth.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/last.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/second.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/third.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/first.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/fourth.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/last.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/second.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/third.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/first.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/fourth.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/last.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/second.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/third.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/first_day_of_the_month.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/first_day_of_the_month.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_day_of_the_month.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_day_of_the_month.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/0.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/0.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/1.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/1.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/2.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/2.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/3.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/3.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/4.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/4.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/5.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/5.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/6.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/6.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/specific_date_each_month/14.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/specific_date_each_month/14.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/specific_date_each_month/29.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/specific_date_each_month/29.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/weekly_starting.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/weekly_starting.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/100.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/100.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is not entitled to Statutory Paternity Pay. To qualify:
 
-+ their average weekly earnings (£12.50) between Thursday, 02 November 2017 and Monday, 01 January 2018 must be at least £113.00
++ their average weekly earnings (£11.54) between Thursday, 02 November 2017 and Monday, 01 January 2018 must be at least £113.00
 
 Send them form OSPP1 confirming this within 28 days of their pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/first.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/fourth.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/last.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/second.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/third.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/first.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/fourth.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/last.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/second.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/third.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/first.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/fourth.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/last.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/second.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/third.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/first.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/fourth.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/last.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/second.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/third.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/first.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/fourth.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/last.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/second.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/third.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/first.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/fourth.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/last.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/second.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/third.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/first.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/fourth.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/last.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/second.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/third.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/first_day_of_the_month.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/first_day_of_the_month.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_day_of_the_month.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_day_of_the_month.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/0.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/0.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/1.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/1.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/2.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/2.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/3.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/3.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/4.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/4.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/5.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/5.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/6.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/6.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/specific_date_each_month/14.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/specific_date_each_month/14.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/specific_date_each_month/29.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/specific_date_each_month/29.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/weekly_starting.txt
+++ b/test/artefacts/maternity-paternity-calculator/adoption/paternity/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/weekly_starting.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Friday/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Friday/first.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Friday/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Friday/fourth.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Friday/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Friday/last.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Friday/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Friday/second.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Friday/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Friday/third.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Monday/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Monday/first.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Monday/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Monday/fourth.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Monday/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Monday/last.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Monday/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Monday/second.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Monday/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Monday/third.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Saturday/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Saturday/first.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Saturday/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Saturday/fourth.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Saturday/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Saturday/last.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Saturday/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Saturday/second.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Saturday/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Saturday/third.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Sunday/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Sunday/first.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Sunday/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Sunday/fourth.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Sunday/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Sunday/last.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Sunday/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Sunday/second.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Sunday/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Sunday/third.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Thursday/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Thursday/first.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Thursday/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Thursday/fourth.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Thursday/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Thursday/last.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Thursday/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Thursday/second.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Thursday/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Thursday/third.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Tuesday/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Tuesday/first.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Tuesday/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Tuesday/fourth.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Tuesday/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Tuesday/last.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Tuesday/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Tuesday/second.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Tuesday/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Tuesday/third.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Wednesday/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Wednesday/first.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Wednesday/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Wednesday/fourth.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Wednesday/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Wednesday/last.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Wednesday/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Wednesday/second.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Wednesday/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Wednesday/third.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/first_day_of_the_month.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/first_day_of_the_month.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/last_day_of_the_month.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/last_day_of_the_month.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/last_working_day_of_the_month/0.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/last_working_day_of_the_month/0.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/last_working_day_of_the_month/1.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/last_working_day_of_the_month/1.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/last_working_day_of_the_month/2.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/last_working_day_of_the_month/2.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/last_working_day_of_the_month/3.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/last_working_day_of_the_month/3.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/last_working_day_of_the_month/4.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/last_working_day_of_the_month/4.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/last_working_day_of_the_month/5.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/last_working_day_of_the_month/5.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/last_working_day_of_the_month/6.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/last_working_day_of_the_month/6.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/specific_date_each_month/17.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/specific_date_each_month/17.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/specific_date_each_month/29.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/specific_date_each_month/29.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/weekly_starting.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/weekly_starting.txt
@@ -9,9 +9,9 @@ Write to them within 28 days of their leave request confirming this.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Friday/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Friday/first.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,9 +23,9 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-5 January 2018|£241.08
-2 February 2018|£1350.00
-2 March 2018|£816.59
+5 January 2018|£222.53
+2 February 2018|£1246.16
+2 March 2018|£783.22
 6 April 2018|£704.90
 4 May 2018|£563.92
 1 June 2018|£563.92
@@ -33,7 +33,7 @@ Date | SMP amount
 3 August 2018|£563.92
 7 September 2018|£704.90
 5 October 2018|£463.22
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Friday/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Friday/fourth.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,8 +23,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-26 January 2018|£1253.58
-23 February 2018|£1013.11
+26 January 2018|£1157.15
+23 February 2018|£953.78
 23 March 2018|£563.92
 27 April 2018|£704.90
 25 May 2018|£563.92
@@ -33,7 +33,7 @@ Date | SMP amount
 24 August 2018|£563.92
 28 September 2018|£704.90
 26 October 2018|£40.28
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Friday/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Friday/last.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,8 +23,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-26 January 2018|£1253.58
-23 February 2018|£1013.11
+26 January 2018|£1157.15
+23 February 2018|£953.78
 30 March 2018|£704.90
 27 April 2018|£563.92
 25 May 2018|£563.92
@@ -33,7 +33,7 @@ Date | SMP amount
 31 August 2018|£704.90
 28 September 2018|£563.92
 26 October 2018|£40.28
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Friday/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Friday/second.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,9 +23,9 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-12 January 2018|£578.58
-9 February 2018|£1350.00
-9 March 2018|£620.07
+12 January 2018|£534.07
+9 February 2018|£1246.16
+9 March 2018|£612.66
 13 April 2018|£704.90
 11 May 2018|£563.92
 8 June 2018|£563.92
@@ -33,7 +33,7 @@ Date | SMP amount
 10 August 2018|£563.92
 14 September 2018|£704.90
 12 October 2018|£322.24
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Friday/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Friday/third.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,8 +23,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-19 January 2018|£916.08
-16 February 2018|£1209.63
+19 January 2018|£845.61
+16 February 2018|£1124.34
 16 March 2018|£563.92
 20 April 2018|£704.90
 18 May 2018|£563.92
@@ -33,7 +33,7 @@ Date | SMP amount
 17 August 2018|£563.92
 21 September 2018|£704.90
 19 October 2018|£181.26
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Monday/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Monday/first.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,9 +23,9 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-1 January 2018|£48.22
-5 February 2018|£1687.50
-5 March 2018|£732.37
+1 January 2018|£44.51
+5 February 2018|£1557.70
+5 March 2018|£710.12
 2 April 2018|£563.92
 7 May 2018|£704.90
 4 June 2018|£563.92
@@ -33,7 +33,7 @@ Date | SMP amount
 6 August 2018|£704.90
 3 September 2018|£563.92
 1 October 2018|£543.78
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Monday/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Monday/fourth.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,8 +23,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-22 January 2018|£1060.72
-26 February 2018|£1266.39
+22 January 2018|£979.13
+26 February 2018|£1192.22
 26 March 2018|£563.92
 23 April 2018|£563.92
 28 May 2018|£704.90
@@ -33,7 +33,7 @@ Date | SMP amount
 27 August 2018|£704.90
 24 September 2018|£563.92
 22 October 2018|£120.84
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Monday/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Monday/last.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,8 +23,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-29 January 2018|£1398.22
-26 February 2018|£928.89
+29 January 2018|£1290.67
+26 February 2018|£880.68
 26 March 2018|£563.92
 30 April 2018|£704.90
 28 May 2018|£563.92
@@ -33,7 +33,7 @@ Date | SMP amount
 27 August 2018|£563.92
 24 September 2018|£563.92
 29 October 2018|£120.84
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Monday/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Monday/second.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,8 +23,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-8 January 2018|£385.72
-12 February 2018|£1659.43
+8 January 2018|£356.05
+12 February 2018|£1533.34
 12 March 2018|£563.92
 9 April 2018|£563.92
 14 May 2018|£704.90
@@ -33,7 +33,7 @@ Date | SMP amount
 13 August 2018|£704.90
 10 September 2018|£563.92
 8 October 2018|£402.80
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Monday/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Monday/third.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,8 +23,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-15 January 2018|£723.22
-19 February 2018|£1462.91
+15 January 2018|£667.59
+19 February 2018|£1362.78
 19 March 2018|£563.92
 16 April 2018|£563.92
 21 May 2018|£704.90
@@ -33,7 +33,7 @@ Date | SMP amount
 20 August 2018|£704.90
 17 September 2018|£563.92
 15 October 2018|£261.82
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Saturday/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Saturday/first.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,9 +23,9 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-6 January 2018|£289.29
-3 February 2018|£1350.00
-3 March 2018|£788.52
+6 January 2018|£267.04
+3 February 2018|£1246.16
+3 March 2018|£758.85
 7 April 2018|£704.90
 5 May 2018|£563.92
 2 June 2018|£563.92
@@ -33,7 +33,7 @@ Date | SMP amount
 4 August 2018|£563.92
 1 September 2018|£563.92
 6 October 2018|£584.06
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Saturday/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Saturday/fourth.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,8 +23,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-27 January 2018|£1301.79
-24 February 2018|£985.04
+27 January 2018|£1201.66
+24 February 2018|£929.41
 24 March 2018|£563.92
 28 April 2018|£704.90
 26 May 2018|£563.92
@@ -33,7 +33,7 @@ Date | SMP amount
 25 August 2018|£563.92
 22 September 2018|£563.92
 27 October 2018|£161.12
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Saturday/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Saturday/last.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,8 +23,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-27 January 2018|£1301.79
-24 February 2018|£985.04
+27 January 2018|£1201.66
+24 February 2018|£929.41
 31 March 2018|£704.90
 28 April 2018|£563.92
 26 May 2018|£563.92
@@ -33,7 +33,7 @@ Date | SMP amount
 25 August 2018|£563.92
 29 September 2018|£704.90
 27 October 2018|£20.14
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Saturday/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Saturday/second.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,9 +23,9 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-13 January 2018|£626.79
-10 February 2018|£1350.00
-10 March 2018|£592.00
+13 January 2018|£578.58
+10 February 2018|£1246.16
+10 March 2018|£588.29
 14 April 2018|£704.90
 12 May 2018|£563.92
 9 June 2018|£563.92
@@ -33,7 +33,7 @@ Date | SMP amount
 11 August 2018|£563.92
 8 September 2018|£563.92
 13 October 2018|£443.08
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Saturday/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Saturday/third.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,8 +23,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-20 January 2018|£964.29
-17 February 2018|£1181.56
+20 January 2018|£890.12
+17 February 2018|£1099.97
 17 March 2018|£563.92
 21 April 2018|£704.90
 19 May 2018|£563.92
@@ -33,7 +33,7 @@ Date | SMP amount
 18 August 2018|£563.92
 15 September 2018|£563.92
 20 October 2018|£302.10
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Sunday/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Sunday/first.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,9 +23,9 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-7 January 2018|£337.50
-4 February 2018|£1350.00
-4 March 2018|£760.44
+7 January 2018|£311.54
+4 February 2018|£1246.16
+4 March 2018|£734.48
 1 April 2018|£563.92
 6 May 2018|£704.90
 3 June 2018|£563.92
@@ -33,7 +33,7 @@ Date | SMP amount
 5 August 2018|£704.90
 2 September 2018|£563.92
 7 October 2018|£563.92
-| **Total SMP: £6677.34**
+| **Total SMP: £6521.58**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Sunday/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Sunday/fourth.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,8 +23,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-28 January 2018|£1350.00
-25 February 2018|£956.96
+28 January 2018|£1246.16
+25 February 2018|£905.05
 25 March 2018|£563.92
 22 April 2018|£563.92
 27 May 2018|£704.90
@@ -33,7 +33,7 @@ Date | SMP amount
 26 August 2018|£704.90
 23 September 2018|£563.92
 28 October 2018|£140.98
-| **Total SMP: £6677.34**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Sunday/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Sunday/last.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,8 +23,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-28 January 2018|£1350.00
-25 February 2018|£956.96
+28 January 2018|£1246.16
+25 February 2018|£905.05
 25 March 2018|£563.92
 29 April 2018|£704.90
 27 May 2018|£563.92
@@ -32,7 +32,7 @@ Date | SMP amount
 29 July 2018|£704.90
 26 August 2018|£563.92
 30 September 2018|£704.90
-| **Total SMP: £6677.34**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Sunday/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Sunday/second.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,8 +23,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-14 January 2018|£675.00
-11 February 2018|£1350.00
+14 January 2018|£623.08
+11 February 2018|£1246.16
 11 March 2018|£563.92
 8 April 2018|£563.92
 13 May 2018|£704.90
@@ -33,7 +33,7 @@ Date | SMP amount
 12 August 2018|£704.90
 9 September 2018|£563.92
 14 October 2018|£422.94
-| **Total SMP: £6677.34**
+| **Total SMP: £6521.58**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Sunday/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Sunday/third.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,8 +23,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-21 January 2018|£1012.50
-18 February 2018|£1153.48
+21 January 2018|£934.63
+18 February 2018|£1075.61
 18 March 2018|£563.92
 15 April 2018|£563.92
 20 May 2018|£704.90
@@ -33,7 +33,7 @@ Date | SMP amount
 19 August 2018|£704.90
 16 September 2018|£563.92
 21 October 2018|£281.96
-| **Total SMP: £6677.34**
+| **Total SMP: £6521.60**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Thursday/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Thursday/first.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,9 +23,9 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-4 January 2018|£192.86
-1 February 2018|£1350.00
-1 March 2018|£844.67
+4 January 2018|£178.03
+1 February 2018|£1246.16
+1 March 2018|£807.58
 5 April 2018|£704.90
 3 May 2018|£563.92
 7 June 2018|£704.90
@@ -33,7 +33,7 @@ Date | SMP amount
 2 August 2018|£563.92
 6 September 2018|£704.90
 4 October 2018|£483.36
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Thursday/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Thursday/fourth.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,8 +23,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-25 January 2018|£1205.36
-22 February 2018|£1041.19
+25 January 2018|£1112.65
+22 February 2018|£978.14
 22 March 2018|£563.92
 26 April 2018|£704.90
 24 May 2018|£563.92
@@ -33,7 +33,7 @@ Date | SMP amount
 23 August 2018|£563.92
 27 September 2018|£704.90
 25 October 2018|£60.42
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Thursday/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Thursday/last.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,8 +23,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-25 January 2018|£1205.36
-22 February 2018|£1041.19
+25 January 2018|£1112.65
+22 February 2018|£978.14
 29 March 2018|£704.90
 26 April 2018|£563.92
 31 May 2018|£704.90
@@ -33,7 +33,7 @@ Date | SMP amount
 30 August 2018|£704.90
 27 September 2018|£563.92
 25 October 2018|£60.42
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Thursday/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Thursday/second.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,9 +23,9 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-11 January 2018|£530.36
-8 February 2018|£1350.00
-8 March 2018|£648.15
+11 January 2018|£489.57
+8 February 2018|£1246.16
+8 March 2018|£637.02
 12 April 2018|£704.90
 10 May 2018|£563.92
 14 June 2018|£704.90
@@ -33,7 +33,7 @@ Date | SMP amount
 9 August 2018|£563.92
 13 September 2018|£704.90
 11 October 2018|£342.38
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Thursday/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Thursday/third.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,8 +23,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-18 January 2018|£867.86
-15 February 2018|£1237.71
+18 January 2018|£801.11
+15 February 2018|£1148.70
 15 March 2018|£563.92
 19 April 2018|£704.90
 17 May 2018|£563.92
@@ -33,7 +33,7 @@ Date | SMP amount
 16 August 2018|£563.92
 20 September 2018|£704.90
 18 October 2018|£201.40
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Tuesday/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Tuesday/first.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,9 +23,9 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-2 January 2018|£96.43
-6 February 2018|£1687.50
-6 March 2018|£704.30
+2 January 2018|£89.02
+6 February 2018|£1557.70
+6 March 2018|£685.75
 3 April 2018|£563.92
 1 May 2018|£563.92
 5 June 2018|£704.90
@@ -33,7 +33,7 @@ Date | SMP amount
 7 August 2018|£704.90
 4 September 2018|£563.92
 2 October 2018|£523.64
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Tuesday/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Tuesday/fourth.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,8 +23,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-23 January 2018|£1108.93
-27 February 2018|£1238.32
+23 January 2018|£1023.64
+27 February 2018|£1167.85
 27 March 2018|£563.92
 24 April 2018|£563.92
 22 May 2018|£563.92
@@ -33,7 +33,7 @@ Date | SMP amount
 28 August 2018|£704.90
 25 September 2018|£563.92
 23 October 2018|£100.70
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Tuesday/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Tuesday/last.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,8 +23,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-30 January 2018|£1446.43
-27 February 2018|£900.82
+30 January 2018|£1335.18
+27 February 2018|£856.31
 27 March 2018|£563.92
 24 April 2018|£563.92
 29 May 2018|£704.90
@@ -33,7 +33,7 @@ Date | SMP amount
 28 August 2018|£563.92
 25 September 2018|£563.92
 30 October 2018|£100.70
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Tuesday/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Tuesday/second.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,8 +23,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-9 January 2018|£433.93
-13 February 2018|£1631.36
+9 January 2018|£400.56
+13 February 2018|£1508.97
 13 March 2018|£563.92
 10 April 2018|£563.92
 8 May 2018|£563.92
@@ -33,7 +33,7 @@ Date | SMP amount
 14 August 2018|£704.90
 11 September 2018|£563.92
 9 October 2018|£382.66
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Tuesday/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Tuesday/third.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,8 +23,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-16 January 2018|£771.43
-20 February 2018|£1434.84
+16 January 2018|£712.10
+20 February 2018|£1338.41
 20 March 2018|£563.92
 17 April 2018|£563.92
 15 May 2018|£563.92
@@ -33,7 +33,7 @@ Date | SMP amount
 21 August 2018|£704.90
 18 September 2018|£563.92
 16 October 2018|£241.68
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Wednesday/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Wednesday/first.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,9 +23,9 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-3 January 2018|£144.65
-7 February 2018|£1687.50
-7 March 2018|£676.22
+3 January 2018|£133.52
+7 February 2018|£1557.70
+7 March 2018|£661.39
 4 April 2018|£563.92
 2 May 2018|£563.92
 6 June 2018|£704.90
@@ -33,7 +33,7 @@ Date | SMP amount
 1 August 2018|£563.92
 5 September 2018|£704.90
 3 October 2018|£503.50
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Wednesday/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Wednesday/fourth.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,8 +23,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-24 January 2018|£1157.15
-28 February 2018|£1210.24
+24 January 2018|£1068.14
+28 February 2018|£1143.49
 28 March 2018|£563.92
 25 April 2018|£563.92
 23 May 2018|£563.92
@@ -33,7 +33,7 @@ Date | SMP amount
 22 August 2018|£563.92
 26 September 2018|£704.90
 24 October 2018|£80.56
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Wednesday/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Wednesday/last.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,8 +23,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-31 January 2018|£1494.65
-28 February 2018|£872.74
+31 January 2018|£1379.68
+28 February 2018|£831.95
 28 March 2018|£563.92
 25 April 2018|£563.92
 30 May 2018|£704.90
@@ -33,7 +33,7 @@ Date | SMP amount
 29 August 2018|£704.90
 26 September 2018|£563.92
 31 October 2018|£80.56
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Wednesday/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Wednesday/second.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,8 +23,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-10 January 2018|£482.15
-14 February 2018|£1603.28
+10 January 2018|£445.06
+14 February 2018|£1484.61
 14 March 2018|£563.92
 11 April 2018|£563.92
 9 May 2018|£563.92
@@ -33,7 +33,7 @@ Date | SMP amount
 8 August 2018|£563.92
 12 September 2018|£704.90
 10 October 2018|£362.52
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Wednesday/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Wednesday/third.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,8 +23,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-17 January 2018|£819.65
-21 February 2018|£1406.76
+17 January 2018|£756.60
+21 February 2018|£1314.05
 21 March 2018|£563.92
 18 April 2018|£563.92
 16 May 2018|£563.92
@@ -33,7 +33,7 @@ Date | SMP amount
 15 August 2018|£563.92
 19 September 2018|£704.90
 17 October 2018|£221.54
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/first_day_of_the_month.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/first_day_of_the_month.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,9 +23,9 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-1 January 2018|£48.22
-1 February 2018|£1494.65
-1 March 2018|£844.67
+1 January 2018|£44.51
+1 February 2018|£1379.68
+1 March 2018|£807.58
 1 April 2018|£624.34
 1 May 2018|£604.20
 1 June 2018|£624.34
@@ -33,7 +33,7 @@ Date | SMP amount
 1 August 2018|£624.34
 1 September 2018|£624.34
 1 October 2018|£584.06
-| **Total SMP: £6677.36**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/last_day_of_the_month.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/last_day_of_the_month.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,8 +23,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-31 January 2018|£1494.65
-28 February 2018|£872.74
+31 January 2018|£1379.68
+28 February 2018|£831.95
 31 March 2018|£624.34
 30 April 2018|£604.20
 31 May 2018|£624.34
@@ -32,7 +32,7 @@ Date | SMP amount
 31 July 2018|£624.34
 31 August 2018|£624.34
 30 September 2018|£604.20
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/last_working_day_of_the_month/0.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/last_working_day_of_the_month/0.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,8 +23,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-28 January 2018|£1350.00
-25 February 2018|£956.96
+28 January 2018|£1246.16
+25 February 2018|£905.05
 25 March 2018|£563.92
 29 April 2018|£704.90
 27 May 2018|£563.92
@@ -32,7 +32,7 @@ Date | SMP amount
 29 July 2018|£704.90
 26 August 2018|£563.92
 30 September 2018|£704.90
-| **Total SMP: £6677.34**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/last_working_day_of_the_month/1.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/last_working_day_of_the_month/1.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,8 +23,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-29 January 2018|£1398.22
-26 February 2018|£928.89
+29 January 2018|£1290.67
+26 February 2018|£880.68
 26 March 2018|£563.92
 30 April 2018|£704.90
 28 May 2018|£563.92
@@ -32,7 +32,7 @@ Date | SMP amount
 30 July 2018|£704.90
 27 August 2018|£563.92
 24 September 2018|£563.92
-| **Total SMP: £6556.51**
+| **Total SMP: £6400.75**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/last_working_day_of_the_month/2.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/last_working_day_of_the_month/2.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,8 +23,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-30 January 2018|£1446.43
-27 February 2018|£900.82
+30 January 2018|£1335.18
+27 February 2018|£856.31
 27 March 2018|£563.92
 24 April 2018|£563.92
 29 May 2018|£704.90
@@ -32,7 +32,7 @@ Date | SMP amount
 31 July 2018|£704.90
 28 August 2018|£563.92
 25 September 2018|£563.92
-| **Total SMP: £6576.65**
+| **Total SMP: £6420.89**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/last_working_day_of_the_month/3.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/last_working_day_of_the_month/3.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,8 +23,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-31 January 2018|£1494.65
-28 February 2018|£872.74
+31 January 2018|£1379.68
+28 February 2018|£831.95
 28 March 2018|£563.92
 25 April 2018|£563.92
 30 May 2018|£704.90
@@ -32,7 +32,7 @@ Date | SMP amount
 25 July 2018|£563.92
 29 August 2018|£704.90
 26 September 2018|£563.92
-| **Total SMP: £6596.79**
+| **Total SMP: £6441.03**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/last_working_day_of_the_month/4.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/last_working_day_of_the_month/4.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,8 +23,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-25 January 2018|£1205.36
-22 February 2018|£1041.19
+25 January 2018|£1112.65
+22 February 2018|£978.14
 29 March 2018|£704.90
 26 April 2018|£563.92
 31 May 2018|£704.90
@@ -32,7 +32,7 @@ Date | SMP amount
 26 July 2018|£563.92
 30 August 2018|£704.90
 27 September 2018|£563.92
-| **Total SMP: £6616.93**
+| **Total SMP: £6461.17**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/last_working_day_of_the_month/5.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/last_working_day_of_the_month/5.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,8 +23,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-26 January 2018|£1253.58
-23 February 2018|£1013.11
+26 January 2018|£1157.15
+23 February 2018|£953.78
 30 March 2018|£704.90
 27 April 2018|£563.92
 25 May 2018|£563.92
@@ -32,7 +32,7 @@ Date | SMP amount
 27 July 2018|£563.92
 31 August 2018|£704.90
 28 September 2018|£563.92
-| **Total SMP: £6637.07**
+| **Total SMP: £6481.31**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/last_working_day_of_the_month/6.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/last_working_day_of_the_month/6.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,8 +23,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-27 January 2018|£1301.79
-24 February 2018|£985.04
+27 January 2018|£1201.66
+24 February 2018|£929.41
 31 March 2018|£704.90
 28 April 2018|£563.92
 26 May 2018|£563.92
@@ -32,7 +32,7 @@ Date | SMP amount
 28 July 2018|£563.92
 25 August 2018|£563.92
 29 September 2018|£704.90
-| **Total SMP: £6657.21**
+| **Total SMP: £6501.45**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/specific_date_each_month/17.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/specific_date_each_month/17.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,8 +23,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-17 January 2018|£819.65
-17 February 2018|£1326.20
+17 January 2018|£756.60
+17 February 2018|£1233.49
 17 March 2018|£563.92
 17 April 2018|£624.34
 17 May 2018|£604.20
@@ -33,7 +33,7 @@ Date | SMP amount
 17 August 2018|£624.34
 17 September 2018|£624.34
 17 October 2018|£261.82
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/specific_date_each_month/29.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/specific_date_each_month/29.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,8 +23,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-31 January 2018|£1494.65
-28 February 2018|£872.74
+31 January 2018|£1379.68
+28 February 2018|£831.95
 31 March 2018|£624.34
 30 April 2018|£604.20
 31 May 2018|£624.34
@@ -32,7 +32,7 @@ Date | SMP amount
 31 July 2018|£624.34
 31 August 2018|£624.34
 30 September 2018|£604.20
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/weekly_starting.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/no/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/weekly_starting.txt
@@ -12,7 +12,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -23,12 +23,12 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-7 January 2018|£337.50
-14 January 2018|£337.50
-21 January 2018|£337.50
-28 January 2018|£337.50
-4 February 2018|£337.50
-11 February 2018|£337.50
+7 January 2018|£311.54
+14 January 2018|£311.54
+21 January 2018|£311.54
+28 January 2018|£311.54
+4 February 2018|£311.54
+11 February 2018|£311.54
 18 February 2018|£140.98
 25 February 2018|£140.98
 4 March 2018|£140.98
@@ -62,7 +62,7 @@ Date | SMP amount
 16 September 2018|£140.98
 23 September 2018|£140.98
 30 September 2018|£140.98
-| **Total SMP: £6677.34**
+| **Total SMP: £6521.58**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Friday/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Friday/first.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Friday/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Friday/fourth.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Friday/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Friday/last.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Friday/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Friday/second.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Friday/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Friday/third.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Monday/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Monday/first.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Monday/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Monday/fourth.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Monday/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Monday/last.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Monday/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Monday/second.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Monday/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Monday/third.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Saturday/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Saturday/first.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Saturday/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Saturday/fourth.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Saturday/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Saturday/last.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Saturday/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Saturday/second.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Saturday/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Saturday/third.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Sunday/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Sunday/first.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Sunday/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Sunday/fourth.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Sunday/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Sunday/last.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Sunday/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Sunday/second.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Sunday/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Sunday/third.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Thursday/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Thursday/first.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Thursday/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Thursday/fourth.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Thursday/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Thursday/last.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Thursday/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Thursday/second.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Thursday/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Thursday/third.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Tuesday/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Tuesday/first.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Tuesday/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Tuesday/fourth.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Tuesday/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Tuesday/last.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Tuesday/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Tuesday/second.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Tuesday/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Tuesday/third.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Wednesday/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Wednesday/first.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Wednesday/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Wednesday/fourth.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Wednesday/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Wednesday/last.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Wednesday/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Wednesday/second.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Wednesday/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/a_certain_week_day_each_month/Wednesday/third.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/first_day_of_the_month.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/first_day_of_the_month.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/last_day_of_the_month.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/last_day_of_the_month.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/last_working_day_of_the_month/0.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/last_working_day_of_the_month/0.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/last_working_day_of_the_month/1.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/last_working_day_of_the_month/1.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/last_working_day_of_the_month/2.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/last_working_day_of_the_month/2.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/last_working_day_of_the_month/3.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/last_working_day_of_the_month/3.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/last_working_day_of_the_month/4.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/last_working_day_of_the_month/4.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/last_working_day_of_the_month/5.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/last_working_day_of_the_month/5.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/last_working_day_of_the_month/6.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/last_working_day_of_the_month/6.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/specific_date_each_month/17.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/specific_date_each_month/17.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/specific_date_each_month/29.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/usual_paydates/specific_date_each_month/29.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/weekly_starting.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/100.0/weekly_starting.txt
@@ -14,9 +14,9 @@ The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 ##Statutory maternity pay
 
 The employee is not entitled to statutory maternity pay.
-Their average weekly earnings are £12.5 (you can’t round this figure up or down). To qualify:
+Their average weekly earnings are £11.53846 (you can’t round this figure up or down). To qualify:
 
-+ their average weekly earnings (£12.5) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
++ their average weekly earnings (£11.53846) between Tuesday, 25 July 2017 and Tuesday, 19 September 2017 must be at least £113.00
 
 You must write confirming this within 28 days of their maternity pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Friday/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Friday/first.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,9 +28,9 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-5 January 2018|£241.08
-2 February 2018|£1350.00
-2 March 2018|£816.59
+5 January 2018|£222.53
+2 February 2018|£1246.16
+2 March 2018|£783.22
 6 April 2018|£704.90
 4 May 2018|£563.92
 1 June 2018|£563.92
@@ -38,7 +38,7 @@ Date | SMP amount
 3 August 2018|£563.92
 7 September 2018|£704.90
 5 October 2018|£463.22
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Friday/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Friday/fourth.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,8 +28,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-26 January 2018|£1253.58
-23 February 2018|£1013.11
+26 January 2018|£1157.15
+23 February 2018|£953.78
 23 March 2018|£563.92
 27 April 2018|£704.90
 25 May 2018|£563.92
@@ -38,7 +38,7 @@ Date | SMP amount
 24 August 2018|£563.92
 28 September 2018|£704.90
 26 October 2018|£40.28
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Friday/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Friday/last.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,8 +28,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-26 January 2018|£1253.58
-23 February 2018|£1013.11
+26 January 2018|£1157.15
+23 February 2018|£953.78
 30 March 2018|£704.90
 27 April 2018|£563.92
 25 May 2018|£563.92
@@ -38,7 +38,7 @@ Date | SMP amount
 31 August 2018|£704.90
 28 September 2018|£563.92
 26 October 2018|£40.28
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Friday/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Friday/second.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,9 +28,9 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-12 January 2018|£578.58
-9 February 2018|£1350.00
-9 March 2018|£620.07
+12 January 2018|£534.07
+9 February 2018|£1246.16
+9 March 2018|£612.66
 13 April 2018|£704.90
 11 May 2018|£563.92
 8 June 2018|£563.92
@@ -38,7 +38,7 @@ Date | SMP amount
 10 August 2018|£563.92
 14 September 2018|£704.90
 12 October 2018|£322.24
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Friday/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Friday/third.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,8 +28,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-19 January 2018|£916.08
-16 February 2018|£1209.63
+19 January 2018|£845.61
+16 February 2018|£1124.34
 16 March 2018|£563.92
 20 April 2018|£704.90
 18 May 2018|£563.92
@@ -38,7 +38,7 @@ Date | SMP amount
 17 August 2018|£563.92
 21 September 2018|£704.90
 19 October 2018|£181.26
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Monday/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Monday/first.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,9 +28,9 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-1 January 2018|£48.22
-5 February 2018|£1687.50
-5 March 2018|£732.37
+1 January 2018|£44.51
+5 February 2018|£1557.70
+5 March 2018|£710.12
 2 April 2018|£563.92
 7 May 2018|£704.90
 4 June 2018|£563.92
@@ -38,7 +38,7 @@ Date | SMP amount
 6 August 2018|£704.90
 3 September 2018|£563.92
 1 October 2018|£543.78
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Monday/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Monday/fourth.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,8 +28,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-22 January 2018|£1060.72
-26 February 2018|£1266.39
+22 January 2018|£979.13
+26 February 2018|£1192.22
 26 March 2018|£563.92
 23 April 2018|£563.92
 28 May 2018|£704.90
@@ -38,7 +38,7 @@ Date | SMP amount
 27 August 2018|£704.90
 24 September 2018|£563.92
 22 October 2018|£120.84
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Monday/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Monday/last.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,8 +28,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-29 January 2018|£1398.22
-26 February 2018|£928.89
+29 January 2018|£1290.67
+26 February 2018|£880.68
 26 March 2018|£563.92
 30 April 2018|£704.90
 28 May 2018|£563.92
@@ -38,7 +38,7 @@ Date | SMP amount
 27 August 2018|£563.92
 24 September 2018|£563.92
 29 October 2018|£120.84
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Monday/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Monday/second.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,8 +28,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-8 January 2018|£385.72
-12 February 2018|£1659.43
+8 January 2018|£356.05
+12 February 2018|£1533.34
 12 March 2018|£563.92
 9 April 2018|£563.92
 14 May 2018|£704.90
@@ -38,7 +38,7 @@ Date | SMP amount
 13 August 2018|£704.90
 10 September 2018|£563.92
 8 October 2018|£402.80
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Monday/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Monday/third.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,8 +28,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-15 January 2018|£723.22
-19 February 2018|£1462.91
+15 January 2018|£667.59
+19 February 2018|£1362.78
 19 March 2018|£563.92
 16 April 2018|£563.92
 21 May 2018|£704.90
@@ -38,7 +38,7 @@ Date | SMP amount
 20 August 2018|£704.90
 17 September 2018|£563.92
 15 October 2018|£261.82
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Saturday/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Saturday/first.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,9 +28,9 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-6 January 2018|£289.29
-3 February 2018|£1350.00
-3 March 2018|£788.52
+6 January 2018|£267.04
+3 February 2018|£1246.16
+3 March 2018|£758.85
 7 April 2018|£704.90
 5 May 2018|£563.92
 2 June 2018|£563.92
@@ -38,7 +38,7 @@ Date | SMP amount
 4 August 2018|£563.92
 1 September 2018|£563.92
 6 October 2018|£584.06
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Saturday/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Saturday/fourth.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,8 +28,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-27 January 2018|£1301.79
-24 February 2018|£985.04
+27 January 2018|£1201.66
+24 February 2018|£929.41
 24 March 2018|£563.92
 28 April 2018|£704.90
 26 May 2018|£563.92
@@ -38,7 +38,7 @@ Date | SMP amount
 25 August 2018|£563.92
 22 September 2018|£563.92
 27 October 2018|£161.12
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Saturday/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Saturday/last.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,8 +28,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-27 January 2018|£1301.79
-24 February 2018|£985.04
+27 January 2018|£1201.66
+24 February 2018|£929.41
 31 March 2018|£704.90
 28 April 2018|£563.92
 26 May 2018|£563.92
@@ -38,7 +38,7 @@ Date | SMP amount
 25 August 2018|£563.92
 29 September 2018|£704.90
 27 October 2018|£20.14
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Saturday/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Saturday/second.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,9 +28,9 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-13 January 2018|£626.79
-10 February 2018|£1350.00
-10 March 2018|£592.00
+13 January 2018|£578.58
+10 February 2018|£1246.16
+10 March 2018|£588.29
 14 April 2018|£704.90
 12 May 2018|£563.92
 9 June 2018|£563.92
@@ -38,7 +38,7 @@ Date | SMP amount
 11 August 2018|£563.92
 8 September 2018|£563.92
 13 October 2018|£443.08
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Saturday/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Saturday/third.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,8 +28,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-20 January 2018|£964.29
-17 February 2018|£1181.56
+20 January 2018|£890.12
+17 February 2018|£1099.97
 17 March 2018|£563.92
 21 April 2018|£704.90
 19 May 2018|£563.92
@@ -38,7 +38,7 @@ Date | SMP amount
 18 August 2018|£563.92
 15 September 2018|£563.92
 20 October 2018|£302.10
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Sunday/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Sunday/first.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,9 +28,9 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-7 January 2018|£337.50
-4 February 2018|£1350.00
-4 March 2018|£760.44
+7 January 2018|£311.54
+4 February 2018|£1246.16
+4 March 2018|£734.48
 1 April 2018|£563.92
 6 May 2018|£704.90
 3 June 2018|£563.92
@@ -38,7 +38,7 @@ Date | SMP amount
 5 August 2018|£704.90
 2 September 2018|£563.92
 7 October 2018|£563.92
-| **Total SMP: £6677.34**
+| **Total SMP: £6521.58**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Sunday/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Sunday/fourth.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,8 +28,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-28 January 2018|£1350.00
-25 February 2018|£956.96
+28 January 2018|£1246.16
+25 February 2018|£905.05
 25 March 2018|£563.92
 22 April 2018|£563.92
 27 May 2018|£704.90
@@ -38,7 +38,7 @@ Date | SMP amount
 26 August 2018|£704.90
 23 September 2018|£563.92
 28 October 2018|£140.98
-| **Total SMP: £6677.34**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Sunday/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Sunday/last.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,8 +28,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-28 January 2018|£1350.00
-25 February 2018|£956.96
+28 January 2018|£1246.16
+25 February 2018|£905.05
 25 March 2018|£563.92
 29 April 2018|£704.90
 27 May 2018|£563.92
@@ -37,7 +37,7 @@ Date | SMP amount
 29 July 2018|£704.90
 26 August 2018|£563.92
 30 September 2018|£704.90
-| **Total SMP: £6677.34**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Sunday/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Sunday/second.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,8 +28,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-14 January 2018|£675.00
-11 February 2018|£1350.00
+14 January 2018|£623.08
+11 February 2018|£1246.16
 11 March 2018|£563.92
 8 April 2018|£563.92
 13 May 2018|£704.90
@@ -38,7 +38,7 @@ Date | SMP amount
 12 August 2018|£704.90
 9 September 2018|£563.92
 14 October 2018|£422.94
-| **Total SMP: £6677.34**
+| **Total SMP: £6521.58**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Sunday/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Sunday/third.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,8 +28,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-21 January 2018|£1012.50
-18 February 2018|£1153.48
+21 January 2018|£934.63
+18 February 2018|£1075.61
 18 March 2018|£563.92
 15 April 2018|£563.92
 20 May 2018|£704.90
@@ -38,7 +38,7 @@ Date | SMP amount
 19 August 2018|£704.90
 16 September 2018|£563.92
 21 October 2018|£281.96
-| **Total SMP: £6677.34**
+| **Total SMP: £6521.60**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Thursday/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Thursday/first.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,9 +28,9 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-4 January 2018|£192.86
-1 February 2018|£1350.00
-1 March 2018|£844.67
+4 January 2018|£178.03
+1 February 2018|£1246.16
+1 March 2018|£807.58
 5 April 2018|£704.90
 3 May 2018|£563.92
 7 June 2018|£704.90
@@ -38,7 +38,7 @@ Date | SMP amount
 2 August 2018|£563.92
 6 September 2018|£704.90
 4 October 2018|£483.36
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Thursday/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Thursday/fourth.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,8 +28,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-25 January 2018|£1205.36
-22 February 2018|£1041.19
+25 January 2018|£1112.65
+22 February 2018|£978.14
 22 March 2018|£563.92
 26 April 2018|£704.90
 24 May 2018|£563.92
@@ -38,7 +38,7 @@ Date | SMP amount
 23 August 2018|£563.92
 27 September 2018|£704.90
 25 October 2018|£60.42
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Thursday/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Thursday/last.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,8 +28,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-25 January 2018|£1205.36
-22 February 2018|£1041.19
+25 January 2018|£1112.65
+22 February 2018|£978.14
 29 March 2018|£704.90
 26 April 2018|£563.92
 31 May 2018|£704.90
@@ -38,7 +38,7 @@ Date | SMP amount
 30 August 2018|£704.90
 27 September 2018|£563.92
 25 October 2018|£60.42
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Thursday/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Thursday/second.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,9 +28,9 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-11 January 2018|£530.36
-8 February 2018|£1350.00
-8 March 2018|£648.15
+11 January 2018|£489.57
+8 February 2018|£1246.16
+8 March 2018|£637.02
 12 April 2018|£704.90
 10 May 2018|£563.92
 14 June 2018|£704.90
@@ -38,7 +38,7 @@ Date | SMP amount
 9 August 2018|£563.92
 13 September 2018|£704.90
 11 October 2018|£342.38
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Thursday/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Thursday/third.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,8 +28,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-18 January 2018|£867.86
-15 February 2018|£1237.71
+18 January 2018|£801.11
+15 February 2018|£1148.70
 15 March 2018|£563.92
 19 April 2018|£704.90
 17 May 2018|£563.92
@@ -38,7 +38,7 @@ Date | SMP amount
 16 August 2018|£563.92
 20 September 2018|£704.90
 18 October 2018|£201.40
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Tuesday/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Tuesday/first.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,9 +28,9 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-2 January 2018|£96.43
-6 February 2018|£1687.50
-6 March 2018|£704.30
+2 January 2018|£89.02
+6 February 2018|£1557.70
+6 March 2018|£685.75
 3 April 2018|£563.92
 1 May 2018|£563.92
 5 June 2018|£704.90
@@ -38,7 +38,7 @@ Date | SMP amount
 7 August 2018|£704.90
 4 September 2018|£563.92
 2 October 2018|£523.64
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Tuesday/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Tuesday/fourth.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,8 +28,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-23 January 2018|£1108.93
-27 February 2018|£1238.32
+23 January 2018|£1023.64
+27 February 2018|£1167.85
 27 March 2018|£563.92
 24 April 2018|£563.92
 22 May 2018|£563.92
@@ -38,7 +38,7 @@ Date | SMP amount
 28 August 2018|£704.90
 25 September 2018|£563.92
 23 October 2018|£100.70
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Tuesday/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Tuesday/last.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,8 +28,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-30 January 2018|£1446.43
-27 February 2018|£900.82
+30 January 2018|£1335.18
+27 February 2018|£856.31
 27 March 2018|£563.92
 24 April 2018|£563.92
 29 May 2018|£704.90
@@ -38,7 +38,7 @@ Date | SMP amount
 28 August 2018|£563.92
 25 September 2018|£563.92
 30 October 2018|£100.70
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Tuesday/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Tuesday/second.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,8 +28,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-9 January 2018|£433.93
-13 February 2018|£1631.36
+9 January 2018|£400.56
+13 February 2018|£1508.97
 13 March 2018|£563.92
 10 April 2018|£563.92
 8 May 2018|£563.92
@@ -38,7 +38,7 @@ Date | SMP amount
 14 August 2018|£704.90
 11 September 2018|£563.92
 9 October 2018|£382.66
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Tuesday/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Tuesday/third.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,8 +28,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-16 January 2018|£771.43
-20 February 2018|£1434.84
+16 January 2018|£712.10
+20 February 2018|£1338.41
 20 March 2018|£563.92
 17 April 2018|£563.92
 15 May 2018|£563.92
@@ -38,7 +38,7 @@ Date | SMP amount
 21 August 2018|£704.90
 18 September 2018|£563.92
 16 October 2018|£241.68
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Wednesday/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Wednesday/first.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,9 +28,9 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-3 January 2018|£144.65
-7 February 2018|£1687.50
-7 March 2018|£676.22
+3 January 2018|£133.52
+7 February 2018|£1557.70
+7 March 2018|£661.39
 4 April 2018|£563.92
 2 May 2018|£563.92
 6 June 2018|£704.90
@@ -38,7 +38,7 @@ Date | SMP amount
 1 August 2018|£563.92
 5 September 2018|£704.90
 3 October 2018|£503.50
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Wednesday/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Wednesday/fourth.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,8 +28,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-24 January 2018|£1157.15
-28 February 2018|£1210.24
+24 January 2018|£1068.14
+28 February 2018|£1143.49
 28 March 2018|£563.92
 25 April 2018|£563.92
 23 May 2018|£563.92
@@ -38,7 +38,7 @@ Date | SMP amount
 22 August 2018|£563.92
 26 September 2018|£704.90
 24 October 2018|£80.56
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Wednesday/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Wednesday/last.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,8 +28,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-31 January 2018|£1494.65
-28 February 2018|£872.74
+31 January 2018|£1379.68
+28 February 2018|£831.95
 28 March 2018|£563.92
 25 April 2018|£563.92
 30 May 2018|£704.90
@@ -38,7 +38,7 @@ Date | SMP amount
 29 August 2018|£704.90
 26 September 2018|£563.92
 31 October 2018|£80.56
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Wednesday/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Wednesday/second.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,8 +28,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-10 January 2018|£482.15
-14 February 2018|£1603.28
+10 January 2018|£445.06
+14 February 2018|£1484.61
 14 March 2018|£563.92
 11 April 2018|£563.92
 9 May 2018|£563.92
@@ -38,7 +38,7 @@ Date | SMP amount
 8 August 2018|£563.92
 12 September 2018|£704.90
 10 October 2018|£362.52
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Wednesday/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/Wednesday/third.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,8 +28,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-17 January 2018|£819.65
-21 February 2018|£1406.76
+17 January 2018|£756.60
+21 February 2018|£1314.05
 21 March 2018|£563.92
 18 April 2018|£563.92
 16 May 2018|£563.92
@@ -38,7 +38,7 @@ Date | SMP amount
 15 August 2018|£563.92
 19 September 2018|£704.90
 17 October 2018|£221.54
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/first_day_of_the_month.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/first_day_of_the_month.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,9 +28,9 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-1 January 2018|£48.22
-1 February 2018|£1494.65
-1 March 2018|£844.67
+1 January 2018|£44.51
+1 February 2018|£1379.68
+1 March 2018|£807.58
 1 April 2018|£624.34
 1 May 2018|£604.20
 1 June 2018|£624.34
@@ -38,7 +38,7 @@ Date | SMP amount
 1 August 2018|£624.34
 1 September 2018|£624.34
 1 October 2018|£584.06
-| **Total SMP: £6677.36**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/last_day_of_the_month.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/last_day_of_the_month.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,8 +28,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-31 January 2018|£1494.65
-28 February 2018|£872.74
+31 January 2018|£1379.68
+28 February 2018|£831.95
 31 March 2018|£624.34
 30 April 2018|£604.20
 31 May 2018|£624.34
@@ -37,7 +37,7 @@ Date | SMP amount
 31 July 2018|£624.34
 31 August 2018|£624.34
 30 September 2018|£604.20
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/last_working_day_of_the_month/0.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/last_working_day_of_the_month/0.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,8 +28,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-28 January 2018|£1350.00
-25 February 2018|£956.96
+28 January 2018|£1246.16
+25 February 2018|£905.05
 25 March 2018|£563.92
 29 April 2018|£704.90
 27 May 2018|£563.92
@@ -37,7 +37,7 @@ Date | SMP amount
 29 July 2018|£704.90
 26 August 2018|£563.92
 30 September 2018|£704.90
-| **Total SMP: £6677.34**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/last_working_day_of_the_month/1.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/last_working_day_of_the_month/1.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,8 +28,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-29 January 2018|£1398.22
-26 February 2018|£928.89
+29 January 2018|£1290.67
+26 February 2018|£880.68
 26 March 2018|£563.92
 30 April 2018|£704.90
 28 May 2018|£563.92
@@ -37,7 +37,7 @@ Date | SMP amount
 30 July 2018|£704.90
 27 August 2018|£563.92
 24 September 2018|£563.92
-| **Total SMP: £6556.51**
+| **Total SMP: £6400.75**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/last_working_day_of_the_month/2.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/last_working_day_of_the_month/2.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,8 +28,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-30 January 2018|£1446.43
-27 February 2018|£900.82
+30 January 2018|£1335.18
+27 February 2018|£856.31
 27 March 2018|£563.92
 24 April 2018|£563.92
 29 May 2018|£704.90
@@ -37,7 +37,7 @@ Date | SMP amount
 31 July 2018|£704.90
 28 August 2018|£563.92
 25 September 2018|£563.92
-| **Total SMP: £6576.65**
+| **Total SMP: £6420.89**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/last_working_day_of_the_month/3.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/last_working_day_of_the_month/3.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,8 +28,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-31 January 2018|£1494.65
-28 February 2018|£872.74
+31 January 2018|£1379.68
+28 February 2018|£831.95
 28 March 2018|£563.92
 25 April 2018|£563.92
 30 May 2018|£704.90
@@ -37,7 +37,7 @@ Date | SMP amount
 25 July 2018|£563.92
 29 August 2018|£704.90
 26 September 2018|£563.92
-| **Total SMP: £6596.79**
+| **Total SMP: £6441.03**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/last_working_day_of_the_month/4.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/last_working_day_of_the_month/4.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,8 +28,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-25 January 2018|£1205.36
-22 February 2018|£1041.19
+25 January 2018|£1112.65
+22 February 2018|£978.14
 29 March 2018|£704.90
 26 April 2018|£563.92
 31 May 2018|£704.90
@@ -37,7 +37,7 @@ Date | SMP amount
 26 July 2018|£563.92
 30 August 2018|£704.90
 27 September 2018|£563.92
-| **Total SMP: £6616.93**
+| **Total SMP: £6461.17**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/last_working_day_of_the_month/5.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/last_working_day_of_the_month/5.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,8 +28,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-26 January 2018|£1253.58
-23 February 2018|£1013.11
+26 January 2018|£1157.15
+23 February 2018|£953.78
 30 March 2018|£704.90
 27 April 2018|£563.92
 25 May 2018|£563.92
@@ -37,7 +37,7 @@ Date | SMP amount
 27 July 2018|£563.92
 31 August 2018|£704.90
 28 September 2018|£563.92
-| **Total SMP: £6637.07**
+| **Total SMP: £6481.31**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/last_working_day_of_the_month/6.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/last_working_day_of_the_month/6.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,8 +28,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-27 January 2018|£1301.79
-24 February 2018|£985.04
+27 January 2018|£1201.66
+24 February 2018|£929.41
 31 March 2018|£704.90
 28 April 2018|£563.92
 26 May 2018|£563.92
@@ -37,7 +37,7 @@ Date | SMP amount
 28 July 2018|£563.92
 25 August 2018|£563.92
 29 September 2018|£704.90
-| **Total SMP: £6657.21**
+| **Total SMP: £6501.45**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/specific_date_each_month/17.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/specific_date_each_month/17.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,8 +28,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-17 January 2018|£819.65
-17 February 2018|£1326.20
+17 January 2018|£756.60
+17 February 2018|£1233.49
 17 March 2018|£563.92
 17 April 2018|£624.34
 17 May 2018|£604.20
@@ -38,7 +38,7 @@ Date | SMP amount
 17 August 2018|£624.34
 17 September 2018|£624.34
 17 October 2018|£261.82
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/specific_date_each_month/29.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/usual_paydates/specific_date_each_month/29.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,8 +28,8 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-31 January 2018|£1494.65
-28 February 2018|£872.74
+31 January 2018|£1379.68
+28 February 2018|£831.95
 31 March 2018|£624.34
 30 April 2018|£604.20
 31 May 2018|£624.34
@@ -37,7 +37,7 @@ Date | SMP amount
 31 July 2018|£624.34
 31 August 2018|£624.34
 30 September 2018|£604.20
-| **Total SMP: £6677.35**
+| **Total SMP: £6521.59**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/weekly_starting.txt
+++ b/test/artefacts/maternity-paternity-calculator/maternity/2018-01-01/yes/2018-01-01/yes/yes/2017-09-19/2017-07-24/monthly/3000.0/weekly_starting.txt
@@ -17,7 +17,7 @@ The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they
 
 Pay | Key facts
 -|-
-Average weekly earnings | £375.0 (don't round this up or down)
+Average weekly earnings | £346.15385 (don't round this up or down)
 Latest date to claim SMP |  4 December 2017
 SMP start date due to pregnancy related illness|  3 December 2017
 Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
@@ -28,12 +28,12 @@ Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as
 
 Date | SMP amount
 -|-
-7 January 2018|£337.50
-14 January 2018|£337.50
-21 January 2018|£337.50
-28 January 2018|£337.50
-4 February 2018|£337.50
-11 February 2018|£337.50
+7 January 2018|£311.54
+14 January 2018|£311.54
+21 January 2018|£311.54
+28 January 2018|£311.54
+4 February 2018|£311.54
+11 February 2018|£311.54
 18 February 2018|£140.98
 25 February 2018|£140.98
 4 March 2018|£140.98
@@ -67,7 +67,7 @@ Date | SMP amount
 16 September 2018|£140.98
 23 September 2018|£140.98
 30 September 2018|£140.98
-| **Total SMP: £6677.34**
+| **Total SMP: £6521.58**
 
 *[SMP]: Statutory Maternity Pay
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/100.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/100.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is not entitled to Statutory Paternity Pay. To qualify:
 
-+ their average weekly earnings (£12.50) between Thursday, 02 November 2017 and Monday, 01 January 2018 must be at least £113.00
++ their average weekly earnings (£11.54) between Thursday, 02 November 2017 and Monday, 01 January 2018 must be at least £113.00
 
 Send them form OSPP1 confirming this within 28 days of their pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/first.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/fourth.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/last.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/second.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/third.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/first.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/fourth.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/last.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/second.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/third.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/first.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/fourth.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/last.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/second.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/third.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/first.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/fourth.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/last.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/second.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/third.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/first.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/fourth.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/last.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/second.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/third.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/first.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/fourth.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/last.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/second.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/third.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/first.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/fourth.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/last.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/second.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/third.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/first_day_of_the_month.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/first_day_of_the_month.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_day_of_the_month.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_day_of_the_month.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/0.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/0.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/1.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/1.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/2.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/2.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/3.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/3.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/4.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/4.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/5.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/5.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/6.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/6.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/specific_date_each_month/14.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/specific_date_each_month/14.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/specific_date_each_month/29.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/specific_date_each_month/29.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/weekly_starting.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/weekly_starting.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/100.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/100.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is not entitled to Statutory Paternity Pay. To qualify:
 
-+ their average weekly earnings (£12.50) between Thursday, 02 November 2017 and Monday, 01 January 2018 must be at least £113.00
++ their average weekly earnings (£11.54) between Thursday, 02 November 2017 and Monday, 01 January 2018 must be at least £113.00
 
 Send them form OSPP1 confirming this within 28 days of their pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/first.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/fourth.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/last.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/second.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/third.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/first.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/fourth.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/last.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/second.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/third.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/first.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/fourth.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/last.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/second.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/third.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/first.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/fourth.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/last.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/second.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/third.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/first.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/fourth.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/last.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/second.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/third.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/first.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/fourth.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/last.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/second.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/third.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/first.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/fourth.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/last.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/second.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/third.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/first_day_of_the_month.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/first_day_of_the_month.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_day_of_the_month.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_day_of_the_month.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/0.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/0.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/1.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/1.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/2.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/2.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/3.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/3.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/4.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/4.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/5.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/5.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/6.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/6.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/specific_date_each_month/14.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/specific_date_each_month/14.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/specific_date_each_month/29.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/specific_date_each_month/29.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/weekly_starting.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/no/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/weekly_starting.txt
@@ -10,7 +10,7 @@ Write to them within 28 days of their leave request confirming this.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/100.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/100.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is not entitled to Statutory Paternity Pay. To qualify:
 
-+ their average weekly earnings (£12.50) between Thursday, 02 November 2017 and Monday, 01 January 2018 must be at least £113.00
++ their average weekly earnings (£11.54) between Thursday, 02 November 2017 and Monday, 01 January 2018 must be at least £113.00
 
 Send them form OSPP1 confirming this within 28 days of their pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/first.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/fourth.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/last.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/second.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/third.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/first.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/fourth.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/last.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/second.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/third.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/first.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/fourth.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/last.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/second.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/third.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/first.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/fourth.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/last.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/second.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/third.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/first.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/fourth.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/last.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/second.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/third.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/first.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/fourth.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/last.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/second.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/third.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/first.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/fourth.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/last.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/second.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/third.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/first_day_of_the_month.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/first_day_of_the_month.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_day_of_the_month.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_day_of_the_month.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/0.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/0.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/1.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/1.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/2.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/2.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/3.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/3.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/4.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/4.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/5.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/5.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/6.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/6.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/specific_date_each_month/14.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/specific_date_each_month/14.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/specific_date_each_month/29.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/specific_date_each_month/29.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/weekly_starting.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/one_week/2018-01-01/2017-11-01/monthly/3000.0/weekly_starting.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/100.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/100.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is not entitled to Statutory Paternity Pay. To qualify:
 
-+ their average weekly earnings (£12.50) between Thursday, 02 November 2017 and Monday, 01 January 2018 must be at least £113.00
++ their average weekly earnings (£11.54) between Thursday, 02 November 2017 and Monday, 01 January 2018 must be at least £113.00
 
 Send them form OSPP1 confirming this within 28 days of their pay request.
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/first.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/fourth.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/last.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/second.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/0/third.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/first.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/fourth.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/last.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/second.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/1/third.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/first.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/fourth.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/last.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/second.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/2/third.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/first.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/fourth.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/last.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/second.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/3/third.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/first.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/fourth.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/last.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/second.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/4/third.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/first.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/fourth.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/last.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/second.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/5/third.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/first.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/first.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/fourth.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/fourth.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/last.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/last.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/second.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/second.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/third.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/a_certain_week_day_each_month/6/third.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/first_day_of_the_month.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/first_day_of_the_month.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_day_of_the_month.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_day_of_the_month.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/0.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/0.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/1.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/1.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/2.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/2.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/3.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/3.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/4.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/4.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/5.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/5.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/6.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/last_working_day_of_the_month/6.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/specific_date_each_month/14.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/specific_date_each_month/14.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/specific_date_each_month/29.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/usual_paydates/specific_date_each_month/29.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/weekly_starting.txt
+++ b/test/artefacts/maternity-paternity-calculator/paternity/yes/2018-01-01/2018-01-01/yes/yes/yes/yes/yes/2018-01-01/two_weeks/2018-01-01/2017-11-01/monthly/3000.0/weekly_starting.txt
@@ -14,7 +14,7 @@ The employee is entitled to Statutory Paternity Leave.
 
 The employee is entitled to SPP.
 
-Their average weekly earnings are: £375.00
+Their average weekly earnings are: £346.15
 
 ## SPP calculation
 

--- a/test/data/maternity-paternity-calculator-files.yml
+++ b/test/data/maternity-paternity-calculator-files.yml
@@ -1,7 +1,7 @@
 ---
 lib/data/rates/maternity_paternity_adoption.yml: e4a27ae88a179412e306197e4f4a229c
 lib/data/rates/maternity_paternity_birth.yml: ecc6ef0c3163cc0c5448858ad89161a5
-lib/smart_answer/calculators/maternity_paternity_calculator.rb: 8cfeae4a7a8d2f470570072be9321354
+lib/smart_answer/calculators/maternity_paternity_calculator.rb: 5050353d5eb37b612114d522d2ca8290
 lib/smart_answer_flows/maternity-paternity-calculator/adoption_calculator_flow.rb: 03b9c4ccd375468423d9ab14ba5a42af
 lib/smart_answer_flows/maternity-paternity-calculator/maternity_calculator_flow.rb: 4e8f9d4fb0c0feca7b0122b19e80e501
 lib/smart_answer_flows/maternity-paternity-calculator/maternity_paternity_calculator.govspeak.erb: 53228ba67887be950b27acea0147ad00

--- a/test/integration/smart_answer_flows/adoption_calculator_test.rb
+++ b/test/integration/smart_answer_flows/adoption_calculator_test.rb
@@ -99,7 +99,7 @@ class AdoptionCalculatorTest < ActiveSupport::TestCase
                             # QA12
                             should "go to outcome" do
                               assert_current_node :adoption_leave_and_pay
-                              assert_state_variable :average_weekly_earnings, "375.00"
+                              assert_state_variable :average_weekly_earnings, "346.15"
                             end
                           end # weekly_starting
                           context "answer based on usual paydates" do

--- a/test/integration/smart_answer_flows/maternity_calculator_test.rb
+++ b/test/integration/smart_answer_flows/maternity_calculator_test.rb
@@ -481,8 +481,8 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
                         end
 
                         should "calculate the dates and payment amounts" do
-                          assert_state_variable "average_weekly_earnings", 225.9725
-                          assert_state_variable "smp_a", "203.38"
+                          assert_state_variable "average_weekly_earnings", 208.59
+                          assert_state_variable "smp_a", "187.73"
                           assert_state_variable "smp_b", "135.45" # Uses the statutory maternity rate
                         end
                       end

--- a/test/integration/smart_answer_flows/paternity_calculator_test.rb
+++ b/test/integration/smart_answer_flows/paternity_calculator_test.rb
@@ -237,7 +237,7 @@ class PaternityCalculatorTest < ActiveSupport::TestCase
                                     should "go to outcome" do
                                       assert_current_node :paternity_leave_and_pay
                                       assert_state_variable "has_contract", "yes"
-                                      assert_state_variable :pay_dates_and_pay, "18 June 2013|£112.50"
+                                      assert_state_variable :pay_dates_and_pay, "18 June 2013|£103.85"
                                     end
                                   end #QP14 end SPP calculated weekly
                                 end #QP13 end earings above 109 between relevant period

--- a/test/unit/calculators/maternity_paternity_calculator_test.rb
+++ b/test/unit/calculators/maternity_paternity_calculator_test.rb
@@ -302,7 +302,7 @@ module SmartAnswer::Calculators
         should "work out the weekly average for a monthly pay pattern" do
           @calculator.pay_pattern = "monthly"
           @calculator.earnings_for_pay_period = 16000
-          assert_equal 2000.0, @calculator.average_weekly_earnings
+          assert_equal 1846.15385, @calculator.average_weekly_earnings
         end
       end
       context "HMRC scenarios" do
@@ -324,10 +324,10 @@ module SmartAnswer::Calculators
           @calculator.last_payday = Date.parse("2012-10-31")
           @calculator.pay_pattern = "monthly"
           @calculator.earnings_for_pay_period = 1600
-          assert_equal 200.0, @calculator.average_weekly_earnings
+          assert_equal 184.61538, @calculator.average_weekly_earnings
           @calculator.last_payday = Date.parse("2012-10-26")
           @calculator.earnings_for_pay_period = 1250.75
-          assert_equal 156.34375, @calculator.average_weekly_earnings
+          assert_equal 144.31731, @calculator.average_weekly_earnings
         end
       end
 
@@ -786,10 +786,10 @@ module SmartAnswer::Calculators
           expected_pay_dates = %w(2015-04-07 2015-04-14 2015-04-21 2015-04-28 2015-05-05 2015-05-12 2015-05-19 2015-05-26 2015-06-02 2015-06-09 2015-06-16 2015-06-23 2015-06-30 2015-07-07 2015-07-14 2015-07-21 2015-07-28 2015-08-04 2015-08-11 2015-08-18 2015-08-25 2015-09-01 2015-09-08 2015-09-15 2015-09-22 2015-09-29 2015-10-06 2015-10-13 2015-10-20 2015-10-27 2015-11-03 2015-11-10 2015-11-17 2015-11-24 2015-12-01 2015-12-08 2015-12-15 2015-12-22 2015-12-29)
           @calculator.pay_pattern = 'monthly'
           @calculator.earnings_for_pay_period = 3000
-          assert_equal 375.0, @calculator.average_weekly_earnings.round(2)
+          assert_equal 346.15, @calculator.average_weekly_earnings.round(2)
           assert_equal expected_pay_dates, @calculator.paydates_and_pay.map { |p| p[:date].to_s }
 
-          assert_equal [(375 * 0.9).round(2)], @calculator.paydates_and_pay.first(6).map { |p| p[:pay] }.uniq
+          assert_equal [(346.15385 * 0.9).round(2)], @calculator.paydates_and_pay.first(6).map { |p| p[:pay] }.uniq
           assert_equal [139.58], @calculator.paydates_and_pay[6..-1].map { |p| p[:pay] }.uniq
         end
       end


### PR DESCRIPTION
The alteration in previous PR #3022 is now causing issues for users in
calculations for weekly earnings. We are reverting this change so that
the higher reported problem can be fixed. This commit does not affect
the content changes that were in PR #3022.