### PR TITLE
Publish "/part-year-profit-tax-credits" start page as a transaction

### DIFF
--- a/app/presenters/flow_content_item.rb
+++ b/app/presenters/flow_content_item.rb
@@ -26,6 +26,10 @@ class FlowContentItem
     flow_presenter.content_id
   end
 
+  def flow_content_id
+    flow_presenter.flow_content_id
+  end
+
 private
 
   def routes
@@ -36,7 +40,11 @@ private
   end
 
   def base_path
-    '/' + flow_presenter.slug
+    if flow_presenter.transaction_start_page?
+      "/#{flow_presenter.slug}/y"
+    else
+      "/#{flow_presenter.slug}"
+    end
   end
 
   def json_path

--- a/app/presenters/flow_registration_presenter.rb
+++ b/app/presenters/flow_registration_presenter.rb
@@ -15,12 +15,24 @@ class FlowRegistrationPresenter
     @flow.content_id
   end
 
+  def flow_content_id
+    @flow.flow_content_id
+  end
+
+  def transaction_start_page?
+    @flow.transaction_start_page?
+  end
+
   def title
     start_node.title
   end
 
   def description
     start_node.meta_description
+  end
+
+  def body
+    start_node.body
   end
 
   def external_related_links

--- a/app/services/content_item_publisher.rb
+++ b/app/services/content_item_publisher.rb
@@ -2,8 +2,12 @@ class ContentItemPublisher
   def publish(flow_presenters)
     flow_presenters.each do |smart_answer|
       content_item = FlowContentItem.new(smart_answer)
-      Services.publishing_api.put_content(content_item.content_id, content_item.payload)
-      Services.publishing_api.publish(content_item.content_id, 'minor')
+      if smart_answer.transaction_start_page?
+        create_and_publish_transaction_start_page(content_item)
+      else
+        Services.publishing_api.put_content(content_item.content_id, content_item.payload)
+        Services.publishing_api.publish(content_item.content_id, 'minor')
+      end
     end
   end
 
@@ -21,6 +25,24 @@ class ContentItemPublisher
     raise "The destination or path isn't defined" unless path.present? && destination.present?
 
     add_redirect_to_publishing_api(path, destination)
+  end
+
+  def create_and_publish_transaction_start_page(content_item)
+    presenter = content_item.flow_presenter
+    base_path = "/#{presenter.slug}"
+    flow_content_id = content_item.flow_content_id
+
+    reserve_path_for_publishing_app(base_path, "publisher")
+    publish_transaction_start_page(
+      content_item.content_id,
+      base_path,
+      publishing_app: "publisher",
+      title: presenter.title,
+      content: presenter.body,
+      link: "#{base_path}/y"
+    )
+    Services.publishing_api.put_content(flow_content_id, content_item.payload)
+    Services.publishing_api.publish(flow_content_id, "minor")
   end
 
   def remove_smart_answer_from_search(base_path)
@@ -193,7 +215,7 @@ private
     create_and_publish_via_publishing_api(payload, content_id)
   end
 
-  def create_and_publish_via_publishing_api(payload, content_id=SecureRandom.uuid)
+  def create_and_publish_via_publishing_api(payload, content_id = SecureRandom.uuid)
     response = Services.publishing_api.put_content(content_id, payload)
     raise "This content item has not been created" unless response.code == 200
     Services.publishing_api.publish(content_id, :major)

--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -28,6 +28,11 @@ module SmartAnswer
       @content_id
     end
 
+    def flow_content_id(flow_content_id = nil)
+      @flow_content_id = flow_content_id unless flow_content_id.nil?
+      @flow_content_id
+    end
+
     def name(name = nil)
       @name = name unless name.nil?
       @name
@@ -44,6 +49,10 @@ module SmartAnswer
 
     def draft?
       status == :draft
+    end
+
+    def transaction_start_page?
+      content_id.present? && flow_content_id.present?
     end
 
     def status(s = nil)

--- a/lib/smart_answer_flows/part-year-profit-tax-credits.rb
+++ b/lib/smart_answer_flows/part-year-profit-tax-credits.rb
@@ -2,10 +2,10 @@ module SmartAnswer
   class PartYearProfitTaxCreditsFlow < Flow
     def define
       name 'part-year-profit-tax-credits'
-
       status :published
       satisfies_need "103438"
       content_id "de6723a5-7256-4bfd-aad3-82b04b06b73e"
+      flow_content_id "22e523d6-a153-4f66-b0fa-53ec46bcd61f"
 
       date_question :when_did_your_tax_credits_award_end? do
         from { Calculators::PartYearProfitTaxCreditsCalculator::TAX_CREDITS_AWARD_ENDS_EARLIEST_DATE }

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -4,4 +4,28 @@ namespace :publishing_api do
     flow_presenters = RegisterableSmartAnswers.new.flow_presenters
     ContentItemPublisher.new.publish(flow_presenters)
   end
+
+  desc "Publish transaction start page via publishing api"
+  task :publish_start_page_as_transaction, [:content_id, :base_path, :publishing_app, :title, :content, :link] => :environment do |_, args|
+    raise "Missing content id parameter" unless args.content_id
+    raise "Missing base path parameter" unless args.base_path
+    raise "Missing publishing_app parameter" unless args.publishing_app
+    raise "Missing title parameter" unless args.title
+    raise "Missing content parameter" unless args.content
+    raise "Missing link parameter" unless args.link
+
+    ContentItemPublisher.new.reserve_path_for_publishing_app(
+      args.base_path,
+      args.publishing_app
+    )
+
+    ContentItemPublisher.new.publish_transaction_start_page(
+      args.content_id,
+      args.base_path,
+      publishing_app: args.publishing_app,
+      title: args.title,
+      content: args.content,
+      link: args.link
+    )
+  end
 end

--- a/test/fixtures/smart_answer_flows/flow-sample.rb
+++ b/test/fixtures/smart_answer_flows/flow-sample.rb
@@ -4,6 +4,7 @@ module SmartAnswer
       name 'flow-sample'
       satisfies_need 4242
       content_id "f26e566e-2557-4921-b944-9373c32255f1"
+      flow_content_id "e87b0e18-eccf-4ad7-9e4d-aaefad726883"
 
       multiple_choice :hotter_or_colder? do
         option :hotter

--- a/test/unit/flow_content_item_test.rb
+++ b/test/unit/flow_content_item_test.rb
@@ -10,7 +10,7 @@ module SmartAnswer
     end
 
     test '#payload returns a valid content-item' do
-      presenter = FlowRegistrationPresenter.new(stub('flow', name: 'bridge-of-death', content_id: '3e6f33b8-0723-4dd5-94a2-cab06f23a685', external_related_links: nil))
+      presenter = FlowRegistrationPresenter.new(stub('flow', name: 'bridge-of-death', content_id: '3e6f33b8-0723-4dd5-94a2-cab06f23a685', external_related_links: nil, transaction_start_page?: false))
       content_item = FlowContentItem.new(presenter)
 
       payload = content_item.payload
@@ -19,7 +19,7 @@ module SmartAnswer
     end
 
     test '#payload returns a valid content-item with external related links' do
-      presenter = FlowRegistrationPresenter.new(stub('flow', name: 'bridge-of-death', content_id: '3e6f33b8-0723-4dd5-94a2-cab06f23a685', external_related_links: [{ title: "hmrc", url: "https://hmrc.gov.uk" }]))
+      presenter = FlowRegistrationPresenter.new(stub('flow', name: 'bridge-of-death', content_id: '3e6f33b8-0723-4dd5-94a2-cab06f23a685', external_related_links: [{ title: "hmrc", url: "https://hmrc.gov.uk" }], transaction_start_page?: false))
       content_item = FlowContentItem.new(presenter)
 
       payload = content_item.payload
@@ -28,12 +28,21 @@ module SmartAnswer
     end
 
     test '#base_path is the name of the flow' do
-      presenter = FlowRegistrationPresenter.new(stub('flow', name: 'bridge-of-death', content_id: '25b98dfb-fabe-4b16-b587-072c8233f6bc', external_related_links: nil))
+      presenter = FlowRegistrationPresenter.new(stub('flow', name: 'bridge-of-death', content_id: '25b98dfb-fabe-4b16-b587-072c8233f6bc', external_related_links: nil, transaction_start_page?: false))
       content_item = FlowContentItem.new(presenter)
 
       base_path = content_item.payload[:base_path]
 
       assert_equal "/bridge-of-death", base_path
+    end
+
+    test '#base_path belonging to the flow if smart answer start page is defined as a transaction format' do
+      presenter = FlowRegistrationPresenter.new(stub('flow', name: 'bridge-of-death', flow_content_id: 'e87b0e18-eccf-4ad7-9e4d-aaefad726883', content_id: '25b98dfb-fabe-4b16-b587-072c8233f6bc', external_related_links: nil, transaction_start_page?: true))
+      content_item = FlowContentItem.new(presenter)
+
+      base_path = content_item.payload[:base_path]
+
+      assert_equal "/bridge-of-death/y", base_path
     end
   end
 end

--- a/test/unit/flow_registration_presenter_test.rb
+++ b/test/unit/flow_registration_presenter_test.rb
@@ -23,8 +23,14 @@ class FlowRegistrationPresenterTest < ActiveSupport::TestCase
   end
 
   context "content_id" do
-    should "use the flow content_id" do
+    should "use the transaction start page content_id" do
       assert_equal "f26e566e-2557-4921-b944-9373c32255f1", @presenter.content_id
+    end
+  end
+
+  context "flow content_id" do
+    should "use the flow content_id" do
+      assert_equal "e87b0e18-eccf-4ad7-9e4d-aaefad726883", @presenter.flow_content_id
     end
   end
 
@@ -43,6 +49,12 @@ class FlowRegistrationPresenterTest < ActiveSupport::TestCase
   context "description" do
     should "use the meta_description from the start node template" do
       assert_equal "FLOW_DESCRIPTION", @presenter.description
+    end
+  end
+
+  context "content body" do
+    should "use the body from the start node template" do
+      assert_match %r{FLOW_BODY}, @presenter.body
     end
   end
 

--- a/test/unit/flow_test.rb
+++ b/test/unit/flow_test.rb
@@ -10,12 +10,34 @@ class FlowTest < ActiveSupport::TestCase
     assert_equal "sweet-or-savoury", s.name
   end
 
+  test "returns true if content_id and flow_content_id are defined" do
+    flow = SmartAnswer::Flow.new
+    flow.content_id "content_id"
+    flow.flow_content_id "flow_content_id"
+
+    assert flow.transaction_start_page?
+  end
+
+  test "returns false if content_id and flow_content_id aren't defined" do
+    flow = SmartAnswer::Flow.new
+
+    refute flow.transaction_start_page?
+  end
+
   test "Can set the content_id" do
     s = SmartAnswer::Flow.new do
       content_id "587920ff-b854-4adb-9334-451b45652467"
     end
 
     assert_equal "587920ff-b854-4adb-9334-451b45652467", s.content_id
+  end
+
+  test "Can set the flow content id" do
+    flow = SmartAnswer::Flow.new do
+      flow_content_id "587920ff-b854-4adb-9334-451b45652467"
+    end
+
+    assert_equal "587920ff-b854-4adb-9334-451b45652467", flow.flow_content_id
   end
 
   test "Defaults the external_related_links to nil" do

--- a/test/unit/flow_test.rb
+++ b/test/unit/flow_test.rb
@@ -34,10 +34,10 @@ class FlowTest < ActiveSupport::TestCase
 
   test "Can set the flow content id" do
     flow = SmartAnswer::Flow.new do
-      flow_content_id "587920ff-b854-4adb-9334-451b45652467"
+      flow_content_id "e87b0e18-eccf-4ad7-9e4d-aaefad726883"
     end
 
-    assert_equal "587920ff-b854-4adb-9334-451b45652467", flow.flow_content_id
+    assert_equal "e87b0e18-eccf-4ad7-9e4d-aaefad726883", flow.flow_content_id
   end
 
   test "Defaults the external_related_links to nil" do

--- a/test/unit/services/content_item_publisher_test.rb
+++ b/test/unit/services/content_item_publisher_test.rb
@@ -237,6 +237,133 @@ class ContentItemPublisherTest < ActiveSupport::TestCase
     end
   end
 
+  context "#publish_transaction_start_page" do
+    setup do
+      SecureRandom.stubs(:uuid).returns('content-id')
+      create_url = "https://publishing-api.test.gov.uk/v2/content/content-id"
+      @create_request = stub_request(:put, create_url)
+      publish_url = "https://publishing-api.test.gov.uk/v2/content/content-id/publish"
+      @publish_request = stub_request(:post, publish_url)
+    end
+
+    should "raise exception if content id is not supplied" do
+      exception = assert_raises(RuntimeError) do
+        ContentItemPublisher.new.publish_transaction_start_page(
+          nil,
+          "/base-path",
+          publishing_app: "publisher",
+          title: "Sample transaction title",
+          content: "Sample transaction content",
+          link: "/path/to/smartanswers/y"
+        )
+      end
+
+      assert_equal "The content id isn't supplied", exception.message
+    end
+
+    should "raise exception if base path is not supplied" do
+      exception = assert_raises(RuntimeError) do
+        ContentItemPublisher.new.publish_transaction_start_page(
+          "content_id",
+          nil,
+          publishing_app: "publisher",
+          title: "Sample transaction title",
+          content: "Sample transaction content",
+          link: "/path/to/smartanswers/y"
+        )
+      end
+
+      assert_equal "The base path isn't supplied", exception.message
+    end
+
+    should "raise exception if publishing_app is not supplied" do
+      exception = assert_raises(RuntimeError) do
+        ContentItemPublisher.new.publish_transaction_start_page(
+          "content_id",
+          "/base-path",
+          publishing_app: nil,
+          title: "Sample transaction title",
+          content: "Sample transaction content",
+          link: "/path/to/smartanswers/y"
+        )
+      end
+
+      assert_equal "The publishing_app isn't supplied", exception.message
+    end
+
+    should "raise exception if title is not supplied" do
+      exception = assert_raises(RuntimeError) do
+        ContentItemPublisher.new.publish_transaction_start_page(
+          "content_id",
+          "/base-path",
+          publishing_app: "publisher",
+          title: nil,
+          content: "Sample transaction content",
+          link: "/path/to/smartanswers/y"
+        )
+      end
+
+      assert_equal "The title isn't supplied", exception.message
+    end
+
+    should "raise exception if content is not supplied" do
+      exception = assert_raises(RuntimeError) do
+        ContentItemPublisher.new.publish_transaction_start_page(
+          "content_id",
+          "/base-path",
+          publishing_app: "publisher",
+          title: "Sample transaction title",
+          content: nil,
+          link: "/path/to/smartanswers/y"
+        )
+      end
+
+      assert_equal "The content isn't supplied", exception.message
+    end
+
+    should "raise exception if link is not supplied" do
+      exception = assert_raises(RuntimeError) do
+        ContentItemPublisher.new.publish_transaction_start_page(
+          "content_id",
+          "/base-path",
+          publishing_app: "publisher",
+          title: "Sample transaction title",
+          content: "Sample transaction content",
+          link: nil
+        )
+      end
+
+      assert_equal "The link isn't supplied", exception.message
+    end
+
+    should "send publish transaction message to publish_transaction_start_page_via_publishing_api" do
+      ContentItemPublisher.any_instance.expects(:publish_transaction_start_page_via_publishing_api).once
+
+      ContentItemPublisher.new.publish_transaction_start_page(
+        "content-id",
+        "/base-path",
+        publishing_app: "publisher",
+        title: "Sample transaction title",
+        content: "Sample transaction content",
+        link: "/path/to/smartanswers/y"
+      )
+    end
+
+    should "send publish transaction request to publish_transaction_start_page_via_publishing_api" do
+      ContentItemPublisher.new.publish_transaction_start_page(
+        "content-id",
+        "/base-path",
+        publishing_app: "publisher",
+        title: "Sample transaction title",
+        content: "Sample transaction content",
+        link: "/path/to/smartanswers/y"
+      )
+
+      assert_requested @create_request
+      assert_requested @publish_request
+    end
+  end
+
   context "#publish_answer" do
     setup do
       SecureRandom.stubs(:uuid).returns('content-id')

--- a/test/unit/tasks/publishing_api_test.rb
+++ b/test/unit/tasks/publishing_api_test.rb
@@ -1,0 +1,99 @@
+require 'test_helper'
+
+class PublisingApiRakeTest < ActiveSupport::TestCase
+  context "publishing_api:publish_start_page_as_transaction rake task" do
+    setup do
+      Rake::Task["publishing_api:publish_start_page_as_transaction"].reenable
+    end
+
+    should "raise exception when content_id isn't supplied" do
+      exception = assert_raises RuntimeError do
+        Rake::Task["publishing_api:publish_start_page_as_transaction"].invoke
+      end
+
+      assert_equal "Missing content id parameter", exception.message
+    end
+
+    should "raise exception when base_path isn't supplied" do
+      exception = assert_raises RuntimeError do
+        Rake::Task["publishing_api:publish_start_page_as_transaction"].invoke("content-id", nil)
+      end
+
+      assert_equal "Missing base path parameter", exception.message
+    end
+
+    should "raise exception when destination isn't supplied" do
+      exception = assert_raises RuntimeError do
+        Rake::Task["publishing_api:publish_start_page_as_transaction"].invoke(
+          "content-id",
+          "/base-path",
+          nil
+        )
+      end
+
+      assert_equal "Missing publishing_app parameter", exception.message
+    end
+
+    should "raise exception when title isn't supplied" do
+      exception = assert_raises RuntimeError do
+        Rake::Task["publishing_api:publish_start_page_as_transaction"].invoke(
+          "content-id",
+          "/base-path",
+          "publisher",
+          nil
+        )
+      end
+
+      assert_equal "Missing title parameter", exception.message
+    end
+
+    should "raise exception when content isn't supplied" do
+      exception = assert_raises RuntimeError do
+        Rake::Task["publishing_api:publish_start_page_as_transaction"].invoke(
+          "content-id",
+          "/base-path",
+          "publisher",
+          "Title",
+          nil
+        )
+      end
+
+      assert_equal "Missing content parameter", exception.message
+    end
+
+    should "raise exception when link isn't supplied" do
+      exception = assert_raises RuntimeError do
+        Rake::Task["publishing_api:publish_start_page_as_transaction"].invoke(
+          "content-id",
+          "/base-path",
+          "publisher",
+          "Title",
+          "Sample Content",
+          nil
+        )
+      end
+
+      assert_equal "Missing link parameter", exception.message
+    end
+
+    should "invoke the reserve_path_for_publishing_app and publish_transaction_start_page from ContentItemPublisher" do
+      content_item_publisher_mock = ContentItemPublisher.any_instance
+
+      content_item_publisher_mock.stubs(:reserve_path_for_publishing_app).returns(nil)
+      content_item_publisher_mock.stubs(:publish_transaction_start_page)
+        .returns(nil)
+
+      content_item_publisher_mock.expects(:publish_transaction_start_page).once
+      content_item_publisher_mock.expects(:reserve_path_for_publishing_app).once
+
+      Rake::Task["publishing_api:publish_start_page_as_transaction"].invoke(
+        "content-id",
+        "/base-path",
+        "publisher",
+        "Title",
+        "Sample content",
+        "/path/to/smartnanswer"
+      )
+    end
+  end
+end


### PR DESCRIPTION
This publishes the start page of "/part-year-profit-tax-credits" as a mainstream publisher transaction to the publishing-api with a start_button pointing to "/part-year-profit-tax-credits/y", and sets up the ground work for doing this for the start pages of all the other smart-answers.

Here we set up a flag that identifies the smart answers whose start pages will be published as a transaction. Those start pages will retain the existing content-id of the smart answer when they are published as transactions, and we will need to create a new content-id (the "flow_content_id") for the rest of the smart answer (any page under the "smart-answer-slug/y" path) to be republished.

We use the flow registration presenter to expose the contents of the start page (title, description, body) to the rake task that will publish the transaction. The rake task publishing_api:publish will run on deploy and carry out the republishings.

This has been tested on integration and works as expected - the start page content-item has the same content-id as before, but its document_type is a transaction and publishing-app a transaction. The content and formatting are also the same. The paths under "part-year-profit-tax-credits/y" have the new flow_content_id and their content-item is has a smartanswer document_type and smartanswers as its publishing-app. 

cc @ikennaokpala @chrisroos 

https://trello.com/c/arlZczQO/423-2-republish-smart-answer-part-year-profits-to-finalise-your-tax-credits-start-page-as-a-transaction-page

And: https://trello.com/c/yhkabR7v/673-5-convert-smart-answers-start-pages-into-transactions-in-publisher