### PR TITLE
Pay leave for parents: Pay Update content on take home pay

### DIFF
--- a/lib/smart_answer_flows/pay-leave-for-parents/questions/mother_salary.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/questions/mother_salary.govspeak.erb
@@ -3,5 +3,5 @@
 <% end %>
 
 <% content_for :post_body do %>
-  This is her take-home pay before any deductions, eg tax.
+  This is her pay before any deductions, eg tax.
 <% end %>

--- a/lib/smart_answer_flows/pay-leave-for-parents/questions/partner_salary.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/questions/partner_salary.govspeak.erb
@@ -3,5 +3,5 @@
 <% end %>
 
 <% content_for :post_body do %>
-  This is their take-home pay before any deductions, eg tax.
+  This is their pay before any deductions, eg tax.
 <% end %>

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes.txt
@@ -9,5 +9,5 @@ How much does the mother earn in this job (or did she earn, if she’s left the 
 
 
 
-This is her take-home pay before any deductions, eg tax.
+This is her pay before any deductions, eg tax.
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes.txt
@@ -9,5 +9,5 @@ How much does the mother’s partner earn in this job (or did they earn, if they
 
 
 
-This is their take-home pay before any deductions, eg tax.
+This is their pay before any deductions, eg tax.
 

--- a/test/data/pay-leave-for-parents-files.yml
+++ b/test/data/pay-leave-for-parents-files.yml
@@ -90,13 +90,13 @@ lib/smart_answer_flows/pay-leave-for-parents/questions/employment_status_of_moth
 lib/smart_answer_flows/pay-leave-for-parents/questions/employment_status_of_partner.govspeak.erb: a34db0d45e962f3aefa61fab29529a68
 lib/smart_answer_flows/pay-leave-for-parents/questions/mother_earned_at_least_390.govspeak.erb: f63e16170b110c0490f306d71aaa971a
 lib/smart_answer_flows/pay-leave-for-parents/questions/mother_earned_more_than_lower_earnings_limit.govspeak.erb: acfe91404042ee805365b28dc2463bf7
-lib/smart_answer_flows/pay-leave-for-parents/questions/mother_salary.govspeak.erb: 04ee8455757a9dea2b23d637d0cd05e5
+lib/smart_answer_flows/pay-leave-for-parents/questions/mother_salary.govspeak.erb: 16995c3f239bddfaa160a679cbc1f637
 lib/smart_answer_flows/pay-leave-for-parents/questions/mother_started_working_before_continuity_start_date.govspeak.erb: d0819dcadd3ba2315f638c92cde5c7f0
 lib/smart_answer_flows/pay-leave-for-parents/questions/mother_still_working_on_continuity_end_date.govspeak.erb: 4bbbf62cd73050e3ba2d134ee0b2e998
 lib/smart_answer_flows/pay-leave-for-parents/questions/mother_worked_at_least_26_weeks.govspeak.erb: 84b49fa06e5f41d02e0d207f7dbaaafb
 lib/smart_answer_flows/pay-leave-for-parents/questions/partner_earned_at_least_390.govspeak.erb: c06d5b8e54fc10e30eb1265eb37e5c7f
 lib/smart_answer_flows/pay-leave-for-parents/questions/partner_earned_more_than_lower_earnings_limit.govspeak.erb: 532e0468f189314aeb728f3332d7ffdf
-lib/smart_answer_flows/pay-leave-for-parents/questions/partner_salary.govspeak.erb: d74166b4402ab7eefc0fa2b0f53cd34c
+lib/smart_answer_flows/pay-leave-for-parents/questions/partner_salary.govspeak.erb: 05d70ddafc72460f1e398d0114ea1ab6
 lib/smart_answer_flows/pay-leave-for-parents/questions/partner_started_working_before_continuity_start_date.govspeak.erb: c34c0237f36902df658166c02a553810
 lib/smart_answer_flows/pay-leave-for-parents/questions/partner_still_working_on_continuity_end_date.govspeak.erb: 148ed4d11126f45b1a27b089b9666c54
 lib/smart_answer_flows/pay-leave-for-parents/questions/partner_worked_at_least_26_weeks.govspeak.erb: d9f1d868bbc5d89545a6f56396a9dd83


### PR DESCRIPTION
[Trello card](https://trello.com/c/RuhTgLnP/669-2-parental-leave-calculator-wording-change-to-2-outcomes)

## Description 

This PR removes the take home from:

'This is her/their take-home pay before any deductions, eg tax.'

This becomes:

'This is her/their  pay before any deductions, eg tax.'

This changes has been carried out based on instruction from the content
design team.

## Factcheck

[Preview link](https://smart-answers-pr-3123.herokuapp.com/pay-leave-for-parents/y/yes/2012-02-01/employee/employee/yes/yes)
[GOVUK](https://gov.uk/pay-leave-for-parents/y/yes/2012-02-01/employee/employee/yes/yes)

## Expected Changes
- Remove "take home" from sentence.

## Before
![screen shot 2017-07-03 at 16 17 50](https://user-images.githubusercontent.com/84896/27798950-39a117f0-600b-11e7-84d3-9efd9544ab2d.png)


## After

![screen shot 2017-07-03 at 16 18 02](https://user-images.githubusercontent.com/84896/27798953-403956f4-600b-11e7-93c3-94ee94f8ea1a.png)



## Affected outcomes

- https://smart-answers-pr-3123.herokuapp.com/pay-leave-for-parents/y/yes/2012-02-01/employee/employee/yes/yes
- https://smart-answers-pr-3123.herokuapp.com/pay-leave-for-parents/y/yes/2012-02-01/employee/employee/yes/yes/10000.0-year/yes/yes/yes