### PR TITLE
API Implemenation to support clients like govchat et al 

### DIFF
--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -30,17 +30,20 @@ class SmartAnswersController < ApplicationController
     @title = @presenter.title
 
     respond_to do |format|
-      format.html {
+      format.html do
         if page_is_under_ab_test?(content_item)
           set_education_navigation_response_header(content_item)
         end
 
         render page_type
-      }
+      end
+
+      format.json do
+        render json: ApiPresenter.new(@presenter).as_json
+      end
+
       if Rails.application.config.expose_govspeak
-        format.text {
-          render page_type
-        }
+        format.text { render page_type }
       end
     end
 

--- a/app/presenters/api_presenter.rb
+++ b/app/presenters/api_presenter.rb
@@ -1,0 +1,46 @@
+# Alpha API presenter to support the chatbot firebreak (https://trello.com/b/OZ9IlfwI/govbot-firebreak)
+class ApiPresenter
+  include ActionView::Helpers::SanitizeHelper
+
+  attr_reader :flow_presenter
+  delegate :current_node, to: :flow_presenter
+
+  def initialize(flow_presenter)
+    @flow_presenter = flow_presenter
+  end
+
+  def as_json
+    {
+      _warning: "This is an unsupported API that will probably be removed!",
+    }.merge(payload)
+  end
+
+private
+
+  def payload
+    if current_node.is_a?(OutcomePresenter)
+      if current_node.title.present?
+        outcome_text = current_node.title
+      else
+        strip_tags(current_node.body(html: true)).strip.lines.first
+      end
+
+      {
+        state: "finished",
+        title: current_node.title,
+        body: current_node.body,
+        outcome: outcome_text,
+      }
+    else
+      {
+        state: "asking",
+        question_type: current_node.class.name.underscore.gsub("_presenter", ""),
+        title: current_node.title,
+        body: strip_tags(current_node.body),
+        hint: current_node.hint,
+        error: current_node.error,
+        questions: current_node.options.map(&:to_h)
+      }
+    end
+  end
+end

--- a/test/unit/api_presenter_test.rb
+++ b/test/unit/api_presenter_test.rb
@@ -1,0 +1,41 @@
+require_relative "../test_helper"
+
+class ApiPresenterTest < ActiveSupport::TestCase
+  def api_prsenter_for(current_node)
+    flow_presenter = stub(current_node: current_node)
+    ApiPresenter.new(flow_presenter).as_json
+  end
+
+  test "#as_json returns outcome response when journey has finished" do
+    current_node = stub(is_a?: true, title: "Title", body: "Flow body")
+
+    assert_equal(
+      api_prsenter_for(current_node),
+      {
+        _warning: "This is an unsupported API that will probably be removed!",
+        state: "finished",
+        title: "Title",
+        body: "Flow body",
+        outcome: "Title",
+      }
+    )
+  end
+
+  test "#as_json returns question response when journey is ongoing" do
+    current_node = stub(is_a?: false, title: "Title", body: "Flow body", hint: "hint", error: nil, options: {})
+
+    assert_equal(
+      api_prsenter_for(current_node),
+      {
+        _warning: "This is an unsupported API that will probably be removed!",
+        state: "asking",
+        question_type: "mocha/mock",
+        title: "Title",
+        body: "Flow body",
+        hint: "hint",
+        error: nil,
+        questions: [],
+      }
+    )
+  end
+end


### PR DESCRIPTION
[Trello card](https://trello.com/c/bzwnp9bw/3-create-a-smart-answers-apil)

## Motivation

In order to track the user's journey through a smart answer's flow, this PR adds JSON response that offers clients like gov chat bot to understand that the flow is all about and what it requires.

The JSON response contains details of questions whilst the journey in ongoing and outcome details are returned when the journey reaches a logical end.

**NB:**

The changes introduced here have not affected any regression test artefacts.

## Factcheck
[Preview link](https://gov-bot-one.herokuapp.com/marriage-abroad/y.json)

## Expected changes 
- Each smart answer flow request can now respond in JSON format.


