### PR TITLE
Marriage abroad: Update for opposite sex outcome Turkey

### DIFF
--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/turkey/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/turkey/_opposite_sex.govspeak.erb
@@ -14,7 +14,7 @@ s1. Download an [affirmation](/government/uploads/system/uploads/attachment_data
 s2. Print it out but don’t sign it.
 s3. Make an appointment to sign it - where you do this depends on where you are.
 
-^Affirmations should be filled in using black ink only.^
+^Affirmations must be filled in using black ink only.^
 
 ### If you’re in the UK
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/turkey/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/turkey/_opposite_sex.govspeak.erb
@@ -14,6 +14,7 @@ s1. Download an [affirmation](/government/uploads/system/uploads/attachment_data
 s2. Print it out but don’t sign it.
 s3. Make an appointment to sign it - where you do this depends on where you are.
 
+^Affirmations should be filled in using black ink only.^
 
 ### If you’re in the UK
 

--- a/test/artefacts/marriage-abroad/turkey/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/turkey/opposite_sex.txt
@@ -16,6 +16,8 @@ s1. Download an [affirmation](/government/uploads/system/uploads/attachment_data
 s2. Print it out but don’t sign it.
 s3. Make an appointment to sign it - where you do this depends on where you are.
 
+^Affirmations must be filled in using black ink only.^
+
 ### If you’re in the UK
 
 Make an appointment with a [UK notary or commissioner of oaths](http://www.thenotariessociety.org.uk/find-a-notary) to swear your affirmation. They’ll charge you a fee.

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -565,7 +565,7 @@ lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/uk/partner_loc
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/uk/partner_local/_same_sex.govspeak.erb: 467f8b2b113a89f251359fde1a65efa5
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/uk/partner_other/_opposite_sex.govspeak.erb: f947faa5385ccce5322f6a56b4f71e53
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/uk/partner_other/_same_sex.govspeak.erb: 467f8b2b113a89f251359fde1a65efa5
-lib/smart_answer_flows/marriage-abroad/outcomes/countries/turkey/_opposite_sex.govspeak.erb: a9f9918c8d7a100785e17e03df4d2cb5
+lib/smart_answer_flows/marriage-abroad/outcomes/countries/turkey/_opposite_sex.govspeak.erb: f44efa7ada0c8fc47ceaa4458ea2b31a
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/turkey/_same_sex.govspeak.erb: 4ac2c9180a2c2d3e783a266d61fdfd70
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/turkey/_title.govspeak.erb: 323cdb9e9165cdc8804dff528da5432f
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/usa/_opposite_sex.govspeak.erb: f4e5c834c8c564ab5a15bb67ba14af7b


### PR DESCRIPTION
[Trello card](https://trello.com/c/z42O8cxr/676-2-getting-married-in-turkey-opposite-sex-content-change-request-content-change-request)

## Description 

This PR holds content update made to the opposite sex marriage outcome for Turkey.

These changes have been made by the content designer 


### Factcheck

[Preview link](https://smart-answers-preview-pr-3139.herokuapp.com/marriage-abroad/y/turkey/opposite_sex)
[GOVUK](https://gov.uk/marriage-abroad/y/turkey/opposite_sex)

### Expected changes

- Content update affecting only opposite sex marriage in Turkey

### Before

![screen shot 2017-07-14 at 13 42 03](https://user-images.githubusercontent.com/84896/28212638-467127bc-689a-11e7-9336-c37093e0f370.png)

### After

![screen shot 2017-07-14 at 13 41 45](https://user-images.githubusercontent.com/84896/28212644-4b72a0ec-689a-11e7-8467-ddd9fc9a86f3.png)

