### PR TITLE
Marriage abroad: Opposite sex update for China

### DIFF
--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/china/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/china/_opposite_sex.govspeak.erb
@@ -31,7 +31,7 @@ You’ll need to bring:
 - your passport
 - proof of your address, for example a tenancy agreement, utility bill or driving licence
 - evidence if you’ve changed your name by deed poll
-- your partner’s Chinese ID card or Hukou (if they’re Chinese)
+- your partner’s Chinese ID card and Hukou (if they’re Chinese)
 - your partner’s passport (if they’re any other foreign national)
 
 If you or your partner have been married or in a civil partnership before, you’ll also need:

--- a/test/artefacts/marriage-abroad/china/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/china/opposite_sex.txt
@@ -33,7 +33,7 @@ You’ll need to bring:
 - your passport
 - proof of your address, for example a tenancy agreement, utility bill or driving licence
 - evidence if you’ve changed your name by deed poll
-- your partner’s Chinese ID card or Hukou (if they’re Chinese)
+- your partner’s Chinese ID card and Hukou (if they’re Chinese)
 - your partner’s passport (if they’re any other foreign national)
 
 If you or your partner have been married or in a civil partnership before, you’ll also need:

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -156,7 +156,7 @@ lib/smart_answer_flows/marriage-abroad/outcomes/countries/chile/uk/partner_local
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/chile/uk/partner_local/_same_sex.govspeak.erb: d361b659b8865c033577a66022e61f6f
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/chile/uk/partner_other/_opposite_sex.govspeak.erb: 402c5ef17562e5d85bd6fd4f9bfb0980
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/chile/uk/partner_other/_same_sex.govspeak.erb: d361b659b8865c033577a66022e61f6f
-lib/smart_answer_flows/marriage-abroad/outcomes/countries/china/_opposite_sex.govspeak.erb: b7fcf64ad0f6c2222af07fe74c5ad27c
+lib/smart_answer_flows/marriage-abroad/outcomes/countries/china/_opposite_sex.govspeak.erb: 8e1939a0048123b3fa53732f85f365c3
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/china/_same_sex.govspeak.erb: 4dd6d096a63386e1cd3db8168262c6e8
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/china/_title.govspeak.erb: 475112c09ab99bdd0d610ab1e79cb0fd
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/colombia/_title.govspeak.erb: 1174aaf165516eba4c46bce4d4f26748


### PR DESCRIPTION
[Trello card](https://trello.com/c/SxnTo8i8/677-instructions-for-getting-started-in-the-documentation-does-not-work)

## Description 

This PR holds content update made to the opposite sex marriage outcome for China.

These changes have been made by the content designer 


### Factcheck

[Preview link](https://smart-answers-preview-pr-3140.herokuapp.com/marriage-abroad/y/china/opposite_sex)
[GOVUK](https://gov.uk/marriage-abroad/y/china/opposite_sex)

### Expected changes

- Content update affecting only opposite sex marriage in China

### Before

![screen shot 2017-07-14 at 14 03 25](https://user-images.githubusercontent.com/84896/28213308-64d8caf4-689d-11e7-85af-001dfa0ec0d8.png)

### After


![screen shot 2017-07-14 at 14 03 10](https://user-images.githubusercontent.com/84896/28213269-41b86f48-689d-11e7-9419-0bc02f2ec019.png)

