### PR TITLE
Retrieve ContentItem via ContentItemRetriever Service

### DIFF
--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -116,24 +116,12 @@ private
   end
 
   def setup_navigation_helpers_and_content_item
-    @content_item = Services.content_store.content_item("/" + params[:id]).to_hash
-
-    # The GOV.UK analytics component[1] automatically sets `govuk:analytics:organisations`
-    # if there's a `organisations` key in the links. This will be sent to Google
-    # Analytics At the moment we want to avoid setting this because it will flood
-    # the analytics reports with (unexpected) data. We are currently working on
-    # a solution to this conundrum[2].
-    #
-    # [1] http://govuk-component-guide.herokuapp.com/components/analytics_meta_tags
-    # [2] https://trello.com/c/DkR63grd
-    if @content_item["links"]
-      @content_item["links"].delete("organisations")
-    end
-
-    @navigation_helpers = GovukNavigationHelpers::NavigationHelper.new(@content_item)
-  rescue GdsApi::HTTPNotFound, GdsApi::HTTPGone
+    @content_item = ContentItemRetriever.without_links_organisations(params[:id])
     @navigation_helpers = nil
-    @content_item = nil
+
+    if @content_item.present?
+      @navigation_helpers = GovukNavigationHelpers::NavigationHelper.new(@content_item)
+    end
   end
 
   def breadcrumbs

--- a/app/services/content_item_retriever.rb
+++ b/app/services/content_item_retriever.rb
@@ -1,0 +1,32 @@
+class ContentItemRetriever
+  def self.fetch(slug)
+    Services.content_store.content_item("/#{slug}")
+      .to_hash.with_indifferent_access
+
+  rescue GdsApi::HTTPNotFound, GdsApi::HTTPGone
+    {}
+  end
+
+  def self.without_links_organisations(slug)
+    # The GOV.UK analytics component[1] automatically sets `govuk:analytics:organisations`
+    # if there's a `organisations` key in the links. This will be sent to Google
+    # Analytics At the moment we want to avoid setting this because it will flood
+    # the analytics reports with (unexpected) data. We are currently working on
+    # a solution to this conundrum[2].
+    #
+    # [1] http://govuk-component-guide.herokuapp.com/components/analytics_meta_tags
+    # [2] https://trello.com/c/DkR63grd
+    content_item = fetch(slug)
+    content_item[:links].delete(:organisations) if valid_links_organisations?(content_item)
+
+    content_item
+  end
+
+  def self.valid_links_organisations?(content_item)
+    content_item.has_key?(:links) &&
+      content_item[:links].is_a?(Hash) &&
+      content_item[:links].has_key?(:organisations)
+  end
+
+  private_class_method :valid_links_organisations?
+end

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -67,6 +67,48 @@ class SmartAnswersControllerTest < ActionController::TestCase
       assert_select "h1", /Smart answers controller sample/
     end
 
+    context "when a smart answer exist on the content store" do
+      setup do
+        @content_item = {
+            base_path: "/smart-answers-controller-sample",
+            links: {
+              taxons: [
+                {
+                  title: "A Taxon",
+                  base_path: "/a-taxon",
+                }
+              ],
+            },
+          }.with_indifferent_access
+        ContentItemRetriever.stubs(:without_links_organisations)
+          .returns(@content_item)
+        get :show, params: { id: "smart-answers-controller-sample" }
+      end
+
+      should "assign response from content store" do
+        assert_equal @content_item, assigns(:content_item)
+      end
+
+      should "assign navigation_helpers" do
+        assert_kind_of GovukNavigationHelpers::NavigationHelper, assigns(:navigation_helpers)
+      end
+    end
+
+    context "when a smart answer does not exist on the content store" do
+      setup do
+        ContentItemRetriever.stubs(:without_links_organisations).returns({})
+        get :show, params: { id: "smart-answers-controller-sample" }
+      end
+
+      should "assign empty hash to content_item" do
+        assert_equal Hash.new, assigns(:content_item)
+      end
+
+      should "assign nil to navigation_helpers" do
+        assert_nil assigns(:navigation_helpers)
+      end
+    end
+
     should "not have noindex tag on landing page" do
       get :show, params: { id: 'smart-answers-controller-sample' }
       assert_select "meta[name=robots][content=noindex]", count: 0

--- a/test/unit/services/content_item_retriever_test.rb
+++ b/test/unit/services/content_item_retriever_test.rb
@@ -1,0 +1,79 @@
+require "test_helper"
+
+  class ContentItemRetrieverTest < ActiveSupport::TestCase
+    setup do
+      @slug = "example-smart-answer"
+      @content_store_response = {
+        base_path: "/#{@slug}",
+        content_id: "c22fa786-6c0d-4e38-a82f-c8ca341f9260",
+        title: "Example Smart Answer",
+        links: {
+          organisations: [
+            {
+              base_path: "path/to/an/organisations/content",
+              content_id: "3fb96b2b-8c29-43dc-83c9-489866d7cc38",
+              document_type: "organisations"
+            }
+          ]
+        }
+      }.with_indifferent_access
+      @request_url = "https://content-store.test.gov.uk/content/#{@slug}"
+    end
+
+    context "fetch" do
+      should "make request to content store for content item" do
+        response = { status: 200, body: {}.to_json }
+        content_store_request = stub_request(:get, @request_url).to_return(response)
+
+        ContentItemRetriever.fetch(@slug)
+
+        assert_requested content_store_request
+      end
+
+      context "when content item exist" do
+        should "return content item from content store" do
+          response = { status: 200, body: @content_store_response.to_json }
+          content_store_request = stub_request(:get, @request_url).to_return(response)
+
+          content_item = ContentItemRetriever.fetch(@slug)
+
+          assert_equal content_item, @content_store_response
+        end
+      end
+
+      context "when content item can't be found" do
+        should "return empty content item hash" do
+          response = { status: 404, body: {}.to_json }
+          content_store_request = stub_request(:get, @request_url).to_return(response)
+
+          assert_equal ContentItemRetriever.fetch(@slug), {}
+        end
+      end
+
+      context "when content item can't be found" do
+        should "return empty content item hash" do
+          response = { status: 410, body: {}.to_json }
+          content_store_request = stub_request(:get, @request_url).to_return(response)
+
+          assert_equal ContentItemRetriever.fetch(@slug), {}
+        end
+      end
+    end
+
+    context "without_links_organisations" do
+      setup do
+        ContentItemRetriever.stubs(:fetch).returns(@content_store_response)
+      end
+
+      should "send message to fetch at least once" do
+        ContentItemRetriever.expects(:fetch).at_least_once.returns(@content_store_response)
+        ContentItemRetriever.without_links_organisations(@slug)
+      end
+
+      should "returns content item with organisations property under links" do
+        content_item = ContentItemRetriever.without_links_organisations(@slug)
+
+        assert_equal content_item[:links], {}
+      end
+    end
+  end


### PR DESCRIPTION
[Trello card](https://trello.com/c/SxnTo8i8/677-5-instructions-for-getting-started-in-the-documentation-does-not-work)

## Motivation
Sequel to the issue raised in [1], it appears that recent AB testing efforts have introduced code that makes it hard to create a new smart answer. Existing smart answers have not been affected.

If the `smart-answer` is not in the content store, then content_item instance variable is set to nil instead of the response from the content store.

The idea here is to return a hash after the request, such that no matter how many times it is executed, even if the slug/smart answer isn't defined on the content store the same type (i.e Hash) is returned.

In theory, the aforementioned is also regarded as idempotence

This PR moves the request for the content item to a class level method called fetch defined within a ContentItemRetriever Service.

Also inline with the existing code, a without_links_organisations class level method has also been defined to cater for the removal of organisations under the links key.

Tests have also been written to cover the aforementioned areas, including controller tests that ratify the assignment of navigation_helper and content_item instance variables.

[1] https://github.com/alphagov/smart-answers/issues/3136

## Expected changes
- Refactor the retrieval of content item from content store.
- Split assignment of navigation helpers and content item.
- Add tests to ratify the aforementioned changes
- Make it possible again to create a new smart answer