### PR TITLE
State pension age: Content change request

### DIFF
--- a/lib/smart_answer_flows/state-pension-age/outcomes/not_yet_reached_sp_age.govspeak.erb
+++ b/lib/smart_answer_flows/state-pension-age/outcomes/not_yet_reached_sp_age.govspeak.erb
@@ -6,6 +6,8 @@
 <% content_for :body do %>
   Your State Pension age is <%= calculator.state_pension_age %>.
 
+  ^[The State Pension age is under review](/government/news/proposed-new-timetable-for-state-pension-age-increases) and may change in the future.^
+
   <% if calculator.can_apply? %>
     You can [claim your State Pension](<%= calculator.how_to_claim_url %>) now. Your payments will start after you reach State Pension age.
 
@@ -20,8 +22,6 @@
   <% else %>
     You’ve already reached the Pension Credit qualifying age. Check if you’re eligible to claim [Pension Credit](/pension-credit/eligibility).
   <% end %>
-
-  The State Pension age is regularly reviewed and may change in the future. This may also affect Pension Credit.
 
   <% if calculator.before_state_pension_date?(days: 30) && calculator.over_16_years_old? %>
     ^You can get a [forecast or statement of how much State Pension you may get](/state-pension-statement).^

--- a/lib/smart_answer_flows/state-pension-age/state_pension_age.govspeak.erb
+++ b/lib/smart_answer_flows/state-pension-age/state_pension_age.govspeak.erb
@@ -13,6 +13,8 @@ Your State Pension age is worked out based on your gender and date of birth.
 
 You can [keep working after you reach State Pension age](/working-retirement-pension-age). ‘Default retirement age’ (a forced retirement age of 65) no longer exists.
 
+^[The State Pension age is under review](/government/news/proposed-new-timetable-for-state-pension-age-increases) and may change in the future.^
+
 Use this tool to check: 
 
 - when you'll reach State Pension age

--- a/test/artefacts/state-pension-age/age/1953-02-06/male.txt
+++ b/test/artefacts/state-pension-age/age/1953-02-06/male.txt
@@ -2,12 +2,12 @@ You’ll reach State Pension age on  6 February 2018.
 
 Your State Pension age is 65 years.
 
+^[The State Pension age is under review](/government/news/proposed-new-timetable-for-state-pension-age-increases) and may change in the future.^
+
 ##Pension Credit
 You might get [Pension Credit](/pension-credit) if you’re retired and on a low income.
 
 You’ve already reached the Pension Credit qualifying age. Check if you’re eligible to claim [Pension Credit](/pension-credit/eligibility).
-
-The State Pension age is regularly reviewed and may change in the future. This may also affect Pension Credit.
 
 ^You can get a [forecast or statement of how much State Pension you may get](/state-pension-statement).^
 

--- a/test/artefacts/state-pension-age/age/1953-04-05/male.txt
+++ b/test/artefacts/state-pension-age/age/1953-04-05/male.txt
@@ -2,12 +2,12 @@ You’ll reach State Pension age on  5 April 2018.
 
 Your State Pension age is 65 years.
 
+^[The State Pension age is under review](/government/news/proposed-new-timetable-for-state-pension-age-increases) and may change in the future.^
+
 ##Pension Credit
 You might get [Pension Credit](/pension-credit) if you’re retired and on a low income.
 
 You’ve already reached the Pension Credit qualifying age. Check if you’re eligible to claim [Pension Credit](/pension-credit/eligibility).
-
-The State Pension age is regularly reviewed and may change in the future. This may also affect Pension Credit.
 
 ^You can get a [forecast or statement of how much State Pension you may get](/state-pension-statement).^
 

--- a/test/artefacts/state-pension-age/age/1953-04-06/female.txt
+++ b/test/artefacts/state-pension-age/age/1953-04-06/female.txt
@@ -2,6 +2,8 @@ You’ll reach State Pension age on  6 July 2016.
 
 Your State Pension age is 63 years, 3 months.
 
+^[The State Pension age is under review](/government/news/proposed-new-timetable-for-state-pension-age-increases) and may change in the future.^
+
 You can [claim your State Pension](/new-state-pension/how-to-claim) now. Your payments will start after you reach State Pension age.
 
 Alternatively, you can [delay (defer) claiming](/deferring-state-pension).
@@ -10,8 +12,6 @@ Alternatively, you can [delay (defer) claiming](/deferring-state-pension).
 You might get [Pension Credit](/pension-credit) if you’re retired and on a low income.
 
 You'll reach the Pension Credit qualifying age on  6 July 2016.
-
-The State Pension age is regularly reviewed and may change in the future. This may also affect Pension Credit.
 
 ^You can get a [forecast or statement of how much State Pension you may get](/state-pension-statement).^
 

--- a/test/artefacts/state-pension-age/age/1953-04-06/male.txt
+++ b/test/artefacts/state-pension-age/age/1953-04-06/male.txt
@@ -2,12 +2,12 @@ You’ll reach State Pension age on  6 April 2018.
 
 Your State Pension age is 65 years.
 
+^[The State Pension age is under review](/government/news/proposed-new-timetable-for-state-pension-age-increases) and may change in the future.^
+
 ##Pension Credit
 You might get [Pension Credit](/pension-credit) if you’re retired and on a low income.
 
 You'll reach the Pension Credit qualifying age on  6 July 2016.
-
-The State Pension age is regularly reviewed and may change in the future. This may also affect Pension Credit.
 
 ^You can get a [forecast or statement of how much State Pension you may get](/state-pension-statement).^
 

--- a/test/artefacts/state-pension-age/age/1980-01-01/female.txt
+++ b/test/artefacts/state-pension-age/age/1980-01-01/female.txt
@@ -2,12 +2,12 @@ You’ll reach State Pension age on  1 January 2048.
 
 Your State Pension age is 68 years.
 
+^[The State Pension age is under review](/government/news/proposed-new-timetable-for-state-pension-age-increases) and may change in the future.^
+
 ##Pension Credit
 You might get [Pension Credit](/pension-credit) if you’re retired and on a low income.
 
 You'll reach the Pension Credit qualifying age on  1 January 2048.
-
-The State Pension age is regularly reviewed and may change in the future. This may also affect Pension Credit.
 
 ^You can get a [forecast or statement of how much State Pension you may get](/state-pension-statement).^
 

--- a/test/artefacts/state-pension-age/age/1980-01-01/male.txt
+++ b/test/artefacts/state-pension-age/age/1980-01-01/male.txt
@@ -2,12 +2,12 @@ You’ll reach State Pension age on  1 January 2048.
 
 Your State Pension age is 68 years.
 
+^[The State Pension age is under review](/government/news/proposed-new-timetable-for-state-pension-age-increases) and may change in the future.^
+
 ##Pension Credit
 You might get [Pension Credit](/pension-credit) if you’re retired and on a low income.
 
 You'll reach the Pension Credit qualifying age on  1 January 2048.
-
-The State Pension age is regularly reviewed and may change in the future. This may also affect Pension Credit.
 
 ^You can get a [forecast or statement of how much State Pension you may get](/state-pension-statement).^
 

--- a/test/artefacts/state-pension-age/age/2000-01-01/female.txt
+++ b/test/artefacts/state-pension-age/age/2000-01-01/female.txt
@@ -2,12 +2,12 @@ You’ll reach State Pension age on  1 January 2068.
 
 Your State Pension age is 68 years.
 
+^[The State Pension age is under review](/government/news/proposed-new-timetable-for-state-pension-age-increases) and may change in the future.^
+
 ##Pension Credit
 You might get [Pension Credit](/pension-credit) if you’re retired and on a low income.
 
 You'll reach the Pension Credit qualifying age on  1 January 2068.
-
-The State Pension age is regularly reviewed and may change in the future. This may also affect Pension Credit.
 
 ^You can get a [forecast or statement of how much State Pension you may get](/state-pension-statement).^
 

--- a/test/artefacts/state-pension-age/age/2000-01-01/male.txt
+++ b/test/artefacts/state-pension-age/age/2000-01-01/male.txt
@@ -2,12 +2,12 @@ You’ll reach State Pension age on  1 January 2068.
 
 Your State Pension age is 68 years.
 
+^[The State Pension age is under review](/government/news/proposed-new-timetable-for-state-pension-age-increases) and may change in the future.^
+
 ##Pension Credit
 You might get [Pension Credit](/pension-credit) if you’re retired and on a low income.
 
 You'll reach the Pension Credit qualifying age on  1 January 2068.
-
-The State Pension age is regularly reviewed and may change in the future. This may also affect Pension Credit.
 
 ^You can get a [forecast or statement of how much State Pension you may get](/state-pension-statement).^
 

--- a/test/artefacts/state-pension-age/state-pension-age.txt
+++ b/test/artefacts/state-pension-age/state-pension-age.txt
@@ -6,6 +6,8 @@ Your State Pension age is worked out based on your gender and date of birth.
 
 You can [keep working after you reach State Pension age](/working-retirement-pension-age). ‘Default retirement age’ (a forced retirement age of 65) no longer exists.
 
+^[The State Pension age is under review](/government/news/proposed-new-timetable-for-state-pension-age-increases) and may change in the future.^
+
 Use this tool to check: 
 
 - when you'll reach State Pension age

--- a/test/data/state-pension-age-files.yml
+++ b/test/data/state-pension-age-files.yml
@@ -5,11 +5,11 @@ lib/data/state_pension_dates.yml: da1bdee8a5b42c489b3966c43b625113
 lib/smart_answer/calculators/state_pension_age_calculator.rb: ca0fb1fc157b18afa7eaa8c03137920e
 lib/smart_answer_flows/state-pension-age/outcomes/bus_pass_result.govspeak.erb: dcd8e4132b25e8dd46b82f096837b974
 lib/smart_answer_flows/state-pension-age/outcomes/has_reached_sp_age.govspeak.erb: ea2d19d861931bfd81901ea1e83faa75
-lib/smart_answer_flows/state-pension-age/outcomes/not_yet_reached_sp_age.govspeak.erb: 6833521e60e6a10c3cddc72dc0b1cef7
+lib/smart_answer_flows/state-pension-age/outcomes/not_yet_reached_sp_age.govspeak.erb: 07519a1d25f3b8ed310c9ed941989400
 lib/smart_answer_flows/state-pension-age/questions/dob_age.govspeak.erb: 336a91fc32e8fc66011a9ae504111ae0
 lib/smart_answer_flows/state-pension-age/questions/gender.govspeak.erb: 4624dfdac5be156a8573cbc21245e36d
 lib/smart_answer_flows/state-pension-age/questions/which_calculation.govspeak.erb: 047d48d2d752d7b53c0b78f0eaedac3f
-lib/smart_answer_flows/state-pension-age/state_pension_age.govspeak.erb: 0a50ea49131a4bcd8f07c0110d94a89b
+lib/smart_answer_flows/state-pension-age/state_pension_age.govspeak.erb: 2300d80c8762e3830b0d6b9d60ebf58b
 lib/smart_answer_flows/state-pension-age.rb: 1bf275c47d8dc0bd49ee4d2fb3a863af
 test/data/state-pension-age-questions-and-responses.yml: 08343519227d88f31201fe6c3d4862fe
 test/data/state-pension-age-responses-and-expected-results.yml: df54f7e17e9ef6d5167cb359d16ede05


### PR DESCRIPTION
Supersedes #3145
[Trello card](https://trello.com/c/QI4zoiol/681-asap-state-pension-age-calculator-change)

## Description 
This PR contains content updates, requested by the department and is meant to add a callout linking to a news story on the state pension age review to the start page and 'not reached' outcome for state-pension-age.

### Factcheck

[Preview link](https://smart-answers-preview-pr-3146.herokuapp.com/state-pension-age/y/age/1953-02-06/male)
[GOVUK](https://gov.uk/state-pension-age/y/age/1953-02-06/male)

### Expected changes

- Content changes request to news story related to state pension

### Before

![screen shot 2017-07-20 at 10 45 29](https://user-images.githubusercontent.com/84896/28411413-99eea71e-6d38-11e7-8cd3-8968aaef7330.png)


### After


![screen shot 2017-07-20 at 10 44 53](https://user-images.githubusercontent.com/84896/28411419-9e2c5cb8-6d38-11e7-8c6d-290dc1b788c4.png)


### Affected outcomes

- https://smart-answers-preview-pr-3146.herokuapp.com/state-pension-age/y/age/1953-02-06/male
- https://smart-answers-preview-pr-3146.herokuapp.com/state-pension-age/y/age/1953-04-05/male
- https://smart-answers-preview-pr-3146.herokuapp.com/state-pension-age/y/age/1953-04-06/female
- https://smart-answers-preview-pr-3146.herokuapp.com/state-pension-age/y/age/1953-04-06/male
- https://smart-answers-preview-pr-3146.herokuapp.com/state-pension-age/y/age/1980-01-01/female
- https://smart-answers-preview-pr-3146.herokuapp.com/state-pension-age/y/age/1980-01-01/male
- https://smart-answers-preview-pr-3146.herokuapp.com/state-pension-age/y/age/2000-01-01/female
- https://smart-answers-preview-pr-3146.herokuapp.com/state-pension-age/y/age/2000-01-01/male
- https://smart-answers-preview-pr-3146.herokuapp.com/state-pension-age/y/state-pension-age
