### PR TITLE
Student finance forms: Update CCG Expenses form links

### DIFF
--- a/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_ccg_expenses.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_ccg_expenses.govspeak.erb
@@ -9,7 +9,7 @@
 
   Academic year | Form
   - | -
-  2017 to 2018 | CCG2: Childcare Costs Confirmation Form 2017 to 2018 (available in September 2017)
+  2017 to 2018 | [CCG2: Childcare Costs Confirmation Form 2017 to 2018 (PDF, 702KB)](http://media.slc.co.uk/sfe/1718/ft/sfe_ccg2_form_1718_d.pdf)
   2016 to 2017 | [CCG2: Childcare Costs Confirmation Form 2016 to 2017 (PDF, 202KB)](http://media.slc.co.uk/sfe/1617/ft/sfe_ccg2_form_1617_d.pdf)
   2015 to 2016 | [CCG2: Childcare Costs Confirmation Form 2015 to 2016 (PDF, 295KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_ccg2_form_1516_d.pdf)
   2014 to 2015 | [CCG2: Childcare Costs Confirmation Form 2014 to 2015 (PDF, 252KB)](http://media.slc.co.uk/sfe/1415/ft/sfe_ccg2_1415_d.pdf)

--- a/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_ccg_expenses.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_ccg_expenses.govspeak.erb
@@ -12,7 +12,6 @@
   2017 to 2018 | [CCG2: Childcare Costs Confirmation Form 2017 to 2018 (PDF, 702KB)](http://media.slc.co.uk/sfe/1718/ft/sfe_ccg2_form_1718_d.pdf)
   2016 to 2017 | [CCG2: Childcare Costs Confirmation Form 2016 to 2017 (PDF, 202KB)](http://media.slc.co.uk/sfe/1617/ft/sfe_ccg2_form_1617_d.pdf)
   2015 to 2016 | [CCG2: Childcare Costs Confirmation Form 2015 to 2016 (PDF, 295KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_ccg2_form_1516_d.pdf)
-  2014 to 2015 | [CCG2: Childcare Costs Confirmation Form 2014 to 2015 (PDF, 252KB)](http://media.slc.co.uk/sfe/1415/ft/sfe_ccg2_1415_d.pdf)
 
   ##Where to send your form(s)
 

--- a/test/artefacts/student-finance-forms/uk-full-time/ccg-expenses.txt
+++ b/test/artefacts/student-finance-forms/uk-full-time/ccg-expenses.txt
@@ -5,7 +5,7 @@ At the end of each term confirm your actual childcare costs. Use the CCG2 form f
 
 Academic year | Form
 - | -
-2017 to 2018 | CCG2: Childcare Costs Confirmation Form 2017 to 2018 (available in September 2017)
+2017 to 2018 | [CCG2: Childcare Costs Confirmation Form 2017 to 2018 (PDF, 702KB)](http://media.slc.co.uk/sfe/1718/ft/sfe_ccg2_form_1718_d.pdf)
 2016 to 2017 | [CCG2: Childcare Costs Confirmation Form 2016 to 2017 (PDF, 202KB)](http://media.slc.co.uk/sfe/1617/ft/sfe_ccg2_form_1617_d.pdf)
 2015 to 2016 | [CCG2: Childcare Costs Confirmation Form 2015 to 2016 (PDF, 295KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_ccg2_form_1516_d.pdf)
 2014 to 2015 | [CCG2: Childcare Costs Confirmation Form 2014 to 2015 (PDF, 252KB)](http://media.slc.co.uk/sfe/1415/ft/sfe_ccg2_1415_d.pdf)

--- a/test/artefacts/student-finance-forms/uk-full-time/ccg-expenses.txt
+++ b/test/artefacts/student-finance-forms/uk-full-time/ccg-expenses.txt
@@ -8,7 +8,6 @@ Academic year | Form
 2017 to 2018 | [CCG2: Childcare Costs Confirmation Form 2017 to 2018 (PDF, 702KB)](http://media.slc.co.uk/sfe/1718/ft/sfe_ccg2_form_1718_d.pdf)
 2016 to 2017 | [CCG2: Childcare Costs Confirmation Form 2016 to 2017 (PDF, 202KB)](http://media.slc.co.uk/sfe/1617/ft/sfe_ccg2_form_1617_d.pdf)
 2015 to 2016 | [CCG2: Childcare Costs Confirmation Form 2015 to 2016 (PDF, 295KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_ccg2_form_1516_d.pdf)
-2014 to 2015 | [CCG2: Childcare Costs Confirmation Form 2014 to 2015 (PDF, 252KB)](http://media.slc.co.uk/sfe/1415/ft/sfe_ccg2_1415_d.pdf)
 
 ##Where to send your form(s)
 

--- a/test/data/student-finance-forms-files.yml
+++ b/test/data/student-finance-forms-files.yml
@@ -6,7 +6,7 @@ lib/smart_answer_flows/student-finance-forms/outcomes/_where_to_send_your_forms_
 lib/smart_answer_flows/student-finance-forms/outcomes/_where_to_send_your_forms_uk.govspeak.erb: e32479a47518d9f72b5786d00bbf8ca7
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_ccg_1617.govspeak.erb: 55cf43443c590c8f1b5958f1a3531357
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_ccg_1718.govspeak.erb: ebc284dd517cdbd7f61cc1013dc3b4c8
-lib/smart_answer_flows/student-finance-forms/outcomes/outcome_ccg_expenses.govspeak.erb: 570744d56957c98a81c94e92bfe1869d
+lib/smart_answer_flows/student-finance-forms/outcomes/outcome_ccg_expenses.govspeak.erb: 530a9c72d47aa8e685d73a705580b436
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1617.govspeak.erb: eb39eb7dbd361f0649c94937a23cd8c3
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1617_pt.govspeak.erb: a90406871ee2fe369f95614dac5ebf3e
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1718.govspeak.erb: 6659edd247d78c00e3824a2e2ce1098e

--- a/test/data/student-finance-forms-files.yml
+++ b/test/data/student-finance-forms-files.yml
@@ -6,7 +6,7 @@ lib/smart_answer_flows/student-finance-forms/outcomes/_where_to_send_your_forms_
 lib/smart_answer_flows/student-finance-forms/outcomes/_where_to_send_your_forms_uk.govspeak.erb: e32479a47518d9f72b5786d00bbf8ca7
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_ccg_1617.govspeak.erb: 55cf43443c590c8f1b5958f1a3531357
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_ccg_1718.govspeak.erb: ebc284dd517cdbd7f61cc1013dc3b4c8
-lib/smart_answer_flows/student-finance-forms/outcomes/outcome_ccg_expenses.govspeak.erb: 4b7381c89f94d9f44317f4c91a7c7b94
+lib/smart_answer_flows/student-finance-forms/outcomes/outcome_ccg_expenses.govspeak.erb: 570744d56957c98a81c94e92bfe1869d
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1617.govspeak.erb: eb39eb7dbd361f0649c94937a23cd8c3
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1617_pt.govspeak.erb: a90406871ee2fe369f95614dac5ebf3e
 lib/smart_answer_flows/student-finance-forms/outcomes/outcome_dsa_1718.govspeak.erb: 6659edd247d78c00e3824a2e2ce1098e


### PR DESCRIPTION
Should be merged after #3148 

[Trello card](https://trello.com/c/SITboMRH/686-3-form-change-on-the-slc-student-finance-form-finder)

## Description 

This PR replaces the September 2017 text with the concrete link to the CCG form for 2017 - 2018.

Also removes removes the link to the CCG form for 2014 - 2015.

These changes have been done upon the request from the content design team.

More details about the changes can be found in [1].

[1] https://docs.google.com/document/d/1zdhTm-hjcZiohfLWSnT4odF-qK5hVkCfECanSk9bBjU/edit

## Factcheck

[Preview link](https://smart-answers-preview-pr-3149.herokuapp.com/student-finance-forms/y/uk-full-time/ccg-expenses)
[GOVUK](https://gov.uk/student-finance-forms/y/uk-full-time/ccg-expenses)

### Before

![screen shot 2017-07-24 at 11 03 49](https://user-images.githubusercontent.com/84896/28518446-d24c72a6-705f-11e7-943a-17ea1e421280.png)


### After

![screen shot 2017-07-24 at 11 10 38](https://user-images.githubusercontent.com/84896/28518702-c0dee3f4-7060-11e7-8f25-3d3ce872f135.png)

