### PR TITLE
Send update_type with put content

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "sprockets-rails"
 
 gem 'airbrake', git: 'https://github.com/alphagov/airbrake'
 gem 'ast'
-gem 'gds-api-adapters', '~> 42.0.0'
+gem 'gds-api-adapters', '~> 47.2'
 gem 'govspeak', '~> 3.3.0'
 gem 'govuk-content-schema-test-helpers', '~> 1.3.0'
 gem 'govuk_frontend_toolkit', '>= 6.0.4'
@@ -33,7 +33,7 @@ gem 'uglifier'
 gem 'uk_postcode', '~> 1.0.1'
 gem 'unicorn', '4.8.3'
 gem 'rails_stdout_logging'
-gem 'govuk_navigation_helpers', '~> 6.0.1'
+gem 'govuk_navigation_helpers', '~> 6.3.0'
 gem 'govuk_ab_testing', '~> 2.0'
 gem 'statsd-ruby', '1.3.0', require: 'statsd'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,7 +63,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.7.0)
-    gds-api-adapters (42.0.0)
+    gds-api-adapters (47.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -86,8 +86,8 @@ GEM
     govuk_frontend_toolkit (6.0.4)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (6.0.1)
-      gds-api-adapters (~> 42.0)
+    govuk_navigation_helpers (6.3.0)
+      gds-api-adapters (>= 43.0)
     htmlentities (4.3.4)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
@@ -259,13 +259,13 @@ DEPENDENCIES
   byebug
   capybara (= 2.14.0)
   ci_reporter
-  gds-api-adapters (~> 42.0.0)
+  gds-api-adapters (~> 47.2)
   govspeak (~> 3.3.0)
   govuk-content-schema-test-helpers (~> 1.3.0)
   govuk-lint
   govuk_ab_testing (~> 2.0)
   govuk_frontend_toolkit (>= 6.0.4)
-  govuk_navigation_helpers (~> 6.0.1)
+  govuk_navigation_helpers (~> 6.3.0)
   htmlentities (~> 4)
   json
   logstasher (= 0.4.8)
@@ -302,4 +302,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.14.5
+   1.15.1

--- a/app/presenters/flow_content_item.rb
+++ b/app/presenters/flow_content_item.rb
@@ -9,6 +9,7 @@ class FlowContentItem
     {
       base_path: base_path,
       title: flow_presenter.title,
+      update_type: 'minor',
       details: {
           external_related_links: external_related_links
       },

--- a/app/presenters/start_page_content_item.rb
+++ b/app/presenters/start_page_content_item.rb
@@ -10,6 +10,7 @@ class StartPageContentItem
       base_path: base_path,
       title: flow_presenter.title,
       description: flow_presenter.description,
+      update_type: 'minor',
       details: {
           external_related_links: external_related_links,
           introductory_paragraph: [

--- a/app/services/content_item_publisher.rb
+++ b/app/services/content_item_publisher.rb
@@ -3,11 +3,11 @@ class ContentItemPublisher
     flow_presenters.each do |smart_answer|
       start_page_content_item = StartPageContentItem.new(smart_answer)
       Services.publishing_api.put_content(start_page_content_item.content_id, start_page_content_item.payload)
-      Services.publishing_api.publish(start_page_content_item.content_id, 'minor')
+      Services.publishing_api.publish(start_page_content_item.content_id)
 
       flow_content_item = FlowContentItem.new(smart_answer)
       Services.publishing_api.put_content(flow_content_item.content_id, flow_content_item.payload)
-      Services.publishing_api.publish(flow_content_item.content_id, 'minor')
+      Services.publishing_api.publish(flow_content_item.content_id)
     end
   end
 
@@ -125,6 +125,7 @@ private
     payload = {
       base_path: base_path,
       title: title,
+      update_type: "major",
       document_type: :transaction,
       publishing_app: publishing_app,
       rendering_app: :frontend,
@@ -154,6 +155,6 @@ private
     content_id = SecureRandom.uuid
     response = Services.publishing_api.put_content(content_id, payload)
     raise "This content item has not been created" unless response.code == 200
-    Services.publishing_api.publish(content_id, :major)
+    Services.publishing_api.publish(content_id)
   end
 end


### PR DESCRIPTION
We are deprecating sending the `update_type` in publish requests made to the
Publishing API, and now expect clients to send `update_type` in PUT requests
instead.  We also upgrade `gds-api-adapters` to bring this app up to date with
the new expected behaviour, as well as `govuk_navigation_helpers` to resolve
some dependency issues.

https://trello.com/c/LnJlkb9e/987-5-deprecate-the-usage-of-updatetype-in-publish-for-publishing-api-and-update-usage-across-govuk