### PR TITLE
Marriage abroad: Same sex Content update for Italy

### DIFF
--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/italy/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/italy/_same_sex.govspeak.erb
@@ -48,7 +48,7 @@ You’ll need to get a Nulla Osta if you’re in Italy.
 
 To get a Nulla Osta, [make an appointment at the British Embassy in Rome](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rome/notice-of-marriage-or-civil-partnership/slot_picker) to give notice of your civil partnership. Your partner doesn’t have to come with you.
 
-If you can’t get to the embassy, download the [Nulla Osta application pack](/government/publications/nulla-osta-application-pack-for-marriages-in-italy), fill in the affirmation and notice of marriage and sign them in front of an [Italian notary](http://www.notaries-directory.eu/). You’ll have to pay a fee. Send the signed documents and supporting documents to the embassy.
+If you can’t get to the embassy, download the [Nulla Osta application pack](/government/publications/nulla-osta-application-pack-for-marriages-in-italy), fill in the declaration and registration form and sign them in front of an [Italian notary](http://www.notaries-directory.eu/). You’ll have to pay a fee. Send the signed documents and supporting documents to the embassy.
 
 $A
 British Embassy Rome

--- a/test/artefacts/marriage-abroad/italy/same_sex.txt
+++ b/test/artefacts/marriage-abroad/italy/same_sex.txt
@@ -50,7 +50,7 @@ You’ll need to get a Nulla Osta if you’re in Italy.
 
 To get a Nulla Osta, [make an appointment at the British Embassy in Rome](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rome/notice-of-marriage-or-civil-partnership/slot_picker) to give notice of your civil partnership. Your partner doesn’t have to come with you.
 
-If you can’t get to the embassy, download the [Nulla Osta application pack](/government/publications/nulla-osta-application-pack-for-marriages-in-italy), fill in the affirmation and notice of marriage and sign them in front of an [Italian notary](http://www.notaries-directory.eu/). You’ll have to pay a fee. Send the signed documents and supporting documents to the embassy.
+If you can’t get to the embassy, download the [Nulla Osta application pack](/government/publications/nulla-osta-application-pack-for-marriages-in-italy), fill in the declaration and registration form and sign them in front of an [Italian notary](http://www.notaries-directory.eu/). You’ll have to pay a fee. Send the signed documents and supporting documents to the embassy.
 
 $A
 British Embassy Rome

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -359,7 +359,7 @@ lib/smart_answer_flows/marriage-abroad/outcomes/countries/ireland/_opposite_sex.
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/ireland/_same_sex.govspeak.erb: 8b85a31d089af46889eb665136403ce0
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/ireland/_title.govspeak.erb: c7f3e2d5e41aa82806b1aedbe69b33b8
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/italy/_opposite_sex.govspeak.erb: aa8ceb9107db058e83f54e298abe24ff
-lib/smart_answer_flows/marriage-abroad/outcomes/countries/italy/_same_sex.govspeak.erb: 5f0c04a679de229a21e80b215e74a50a
+lib/smart_answer_flows/marriage-abroad/outcomes/countries/italy/_same_sex.govspeak.erb: 57a93fbbf2dd3254d13acf2b4eb02ee4
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/italy/_title.govspeak.erb: 9ed9b141d5d5418375ec81e96fe67ca7
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/japan/_title.govspeak.erb: b136a47f052cbd595714742008d771a5
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/japan/ceremony_country/partner_british/_opposite_sex.govspeak.erb: 795dab5793cb71505fc24bc044345eab


### PR DESCRIPTION
Supersedes #3152 

[Trello card](https://trello.com/c/HDfCubtm/693-1-getting-married-in-italy-same-sex-marriage-content-change-request-content-change-request)

## Description 

This PR makes changes to the same sex outcome for marriage in Italy under section `Get a Nulla Osta` in paragraph that starts "If you can't get to the embassy, ` current text "fill in the affirmation and notice of marriage and sign them` has been changed to be `fill in the declaration and registration form and sign them`.


## Factcheck

[Preview link](https://smart-answers-preview-pr-3157.herokuapp.com/marriage-abroad/y/italy/same_sex)
[GOVUK](https://gov.uk/marriage-abroad/y/italy/same_sex)

## Expected changes
- Content update affected same sex marriage in Italy.

### Before
![screen shot 2017-07-27 at 10 53 30](https://user-images.githubusercontent.com/84896/28664955-fd6e9b1a-72b9-11e7-8f06-2d621035c4d6.png)

### After

![screen shot 2017-07-27 at 10 53 57](https://user-images.githubusercontent.com/84896/28664966-042f8a7c-72ba-11e7-965f-2464926eff02.png)
