### PR TITLE
Update content whitehall fixtures tests et al

### DIFF
--- a/lib/smart_answer/calculators/country_name_formatter.rb
+++ b/lib/smart_answer/calculators/country_name_formatter.rb
@@ -3,7 +3,6 @@ module SmartAnswer::Calculators
     COUNTRIES_WITH_DEFINITIVE_ARTICLES = %w(bahamas british-virgin-islands cayman-islands czech-republic democratic-republic-of-the-congo dominican-republic falkland-islands gambia maldives marshall-islands netherlands philippines seychelles solomon-islands south-georgia-and-south-sandwich-islands turks-and-caicos-islands united-arab-emirates)
 
     FRIENDLY_COUNTRY_NAME = {
-      "democratic-republic-of-the-congo" => "Democratic Republic of the Congo",
       "cote-d-ivoire" => "Cote d'Ivoire",
       "pitcairn" => "Pitcairn Island",
       "south-korea" => "South Korea",

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -2,7 +2,7 @@
 lib/data/marriage_abroad_data.yml: f839d74d4d40e074fd108fb84d705c50
 lib/data/marriage_abroad_services.yml: 40598840da892562da37f79c36b3208e
 lib/data/rates/marriage_abroad_consular_fees.yml: 20afc9d15de06e0a199761433b055d9f
-lib/smart_answer/calculators/country_name_formatter.rb: 583df7103672f581bf5510732c1b2be1
+lib/smart_answer/calculators/country_name_formatter.rb: 6e9aab3c79a59e54e056b473b9cc4151
 lib/smart_answer/calculators/marriage_abroad_calculator.rb: 0c0be55c3621e81a75af0f55827ad31c
 lib/smart_answer/calculators/marriage_abroad_data_query.rb: ff83e2e9f0f8c51c9e59abd8973b29f4
 lib/smart_answer/calculators/registrations_data_query.rb: 80250f09bc28d55a86148de2e7a76429

--- a/test/data/register-a-birth-files.yml
+++ b/test/data/register-a-birth-files.yml
@@ -3,7 +3,7 @@ lib/data/rates/births_and_deaths_document_return_fees.yml: 4ac203e9fd076c12f62b5
 lib/data/rates/register_a_birth.yml: 8d678c61d06f614a67e8faa1933b0ff5
 lib/data/registrations.yml: ffb11e760ce3aa07cf342caaedb3e6f5
 lib/data/translators.yml: 79abd2e0c2570130f7d832e4242c153a
-lib/smart_answer/calculators/country_name_formatter.rb: 583df7103672f581bf5510732c1b2be1
+lib/smart_answer/calculators/country_name_formatter.rb: 6e9aab3c79a59e54e056b473b9cc4151
 lib/smart_answer/calculators/register_a_birth_calculator.rb: bcd9df47986f493efd07b37b866a1487
 lib/smart_answer/calculators/registrations_data_query.rb: 80250f09bc28d55a86148de2e7a76429
 lib/smart_answer/calculators/translator_links.rb: 079592f6c5ede06d7c6ae4e8c5553127

--- a/test/data/register-a-death-files.yml
+++ b/test/data/register-a-death-files.yml
@@ -2,7 +2,7 @@
 lib/data/rates/births_and_deaths_document_return_fees.yml: 4ac203e9fd076c12f62b57f8d1b64ffc
 lib/data/rates/register_a_death.yml: f24583d68edd4b06242b5a92e08e25c3
 lib/data/translators.yml: 79abd2e0c2570130f7d832e4242c153a
-lib/smart_answer/calculators/country_name_formatter.rb: 583df7103672f581bf5510732c1b2be1
+lib/smart_answer/calculators/country_name_formatter.rb: 6e9aab3c79a59e54e056b473b9cc4151
 lib/smart_answer/calculators/register_a_death_calculator.rb: 18f8a996d537df9056ba149239cf487e
 lib/smart_answer/calculators/registrations_data_query.rb: 80250f09bc28d55a86148de2e7a76429
 lib/smart_answer/calculators/translator_links.rb: 079592f6c5ede06d7c6ae4e8c5553127

--- a/test/fixtures/worldwide/congo_organisations.json
+++ b/test/fixtures/worldwide/congo_organisations.json
@@ -30,10 +30,10 @@
               "postal-code": "",
               "locality": "Kinshasa",
               "region": "",
-              "country-name": "Democratic Republic of Congo"
+              "country-name": "Democratic Republic of the Congo"
             },
             "label": {
-              "value": "83, Avenue Roi Baudoin\r\nGombe\nKinshasa\nDemocratic Republic of Congo"
+              "value": "83, Avenue Roi Baudoin\r\nGombe\nKinshasa\nDemocratic Republic of the Congo"
             }
           },
           "contact_numbers": [
@@ -78,10 +78,10 @@
                 "postal-code": "",
                 "locality": "Gombe",
                 "region": "Kinshasa",
-                "country-name": "Democratic Republic of Congo"
+                "country-name": "Democratic Republic of the Congo"
               },
               "label": {
-                "value": "Malabar Group ( Fedex)\n491, Avenue Colonel Mondjiba\r\nOpposite ( English School CALI)\nGombe\nKinshasa\nDemocratic Republic of Congo"
+                "value": "Malabar Group ( Fedex)\n491, Avenue Colonel Mondjiba\r\nOpposite ( English School CALI)\nGombe\nKinshasa\nDemocratic Republic of the Congo"
               }
             },
             "contact_numbers": [

--- a/test/fixtures/worldwide/democratic-republic-of-the-congo_organisations.json
+++ b/test/fixtures/worldwide/democratic-republic-of-the-congo_organisations.json
@@ -30,10 +30,10 @@
               "postal-code": "",
               "locality": "Kinshasa",
               "region": "",
-              "country-name": "Democratic Republic of Congo"
+              "country-name": "Democratic Republic of the Congo"
             },
             "label": {
-              "value": "83, Avenue Roi Baudoin\r\nGombe\nKinshasa\nDemocratic Republic of Congo"
+              "value": "83, Avenue Roi Baudoin\r\nGombe\nKinshasa\nDemocratic Republic of the Congo"
             }
           },
           "contact_numbers": [
@@ -78,10 +78,10 @@
                 "postal-code": "",
                 "locality": "Gombe",
                 "region": "Kinshasa",
-                "country-name": "Democratic Republic of Congo"
+                "country-name": "Democratic Republic of the Congo"
               },
               "label": {
-                "value": "Malabar Group ( Fedex)\n491, Avenue Colonel Mondjiba\r\nOpposite ( English School CALI)\nGombe\nKinshasa\nDemocratic Republic of Congo"
+                "value": "Malabar Group ( Fedex)\n491, Avenue Colonel Mondjiba\r\nOpposite ( English School CALI)\nGombe\nKinshasa\nDemocratic Republic of the Congo"
               }
             },
             "contact_numbers": [
@@ -139,10 +139,10 @@
               "postal-code": "",
               "locality": "Kinshasa",
               "region": "",
-              "country-name": "Democratic Republic of Congo"
+              "country-name": "Democratic Republic of the Congo"
             },
             "label": {
-              "value": "Avenue Roi Baudouin 83\r\nPO Box 81049\nKinshasa\nDemocratic Republic of Congo"
+              "value": "Avenue Roi Baudouin 83\r\nPO Box 81049\nKinshasa\nDemocratic Republic of the Congo"
             }
           },
           "contact_numbers": [

--- a/test/integration/smart_answer_flows/marriage_abroad_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_test.rb
@@ -2323,7 +2323,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
   end
 
-  context "Marriage in Democratic Republic of Congo, living elsewhere, partner British, opposite sex" do
+  context "Marriage in Democratic Republic of the Congo, living elsewhere, partner British, opposite sex" do
     setup do
       add_response 'democratic-republic-of-the-congo'
       add_response 'third_country'

--- a/test/integration/smart_answer_flows/register_a_birth_test.rb
+++ b/test/integration/smart_answer_flows/register_a_birth_test.rb
@@ -512,7 +512,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
     end
   end
 
-  context "Democratic Republic of Congo" do
+  context "Democratic Republic of the Congo" do
     should "lead to an ORU outcome with a custom translator link" do
       add_response "democratic-republic-of-the-congo"
       add_response "mother"

--- a/test/integration/smart_answer_flows/register_a_death_test.rb
+++ b/test/integration/smart_answer_flows/register_a_death_test.rb
@@ -405,7 +405,7 @@ class RegisterADeathTest < ActiveSupport::TestCase
       end
     end
 
-    context "Democratic Republic of Congo" do
+    context "Democratic Republic of the Congo" do
       should "lead to an ORU outcome with a custom translator link" do
         add_response "democratic-republic-of-the-congo"
         add_response "in_the_uk"

--- a/test/unit/calculators/country_name_formatter_test.rb
+++ b/test/unit/calculators/country_name_formatter_test.rb
@@ -43,7 +43,7 @@ module SmartAnswer::Calculators
       end
 
       should 'return true if the country slug has a friendly name' do
-        assert @formatter.has_friendly_name?('democratic-republic-of-the-congo')
+        assert @formatter.has_friendly_name?('cote-d-ivoire')
       end
 
       should 'return false if the country slug does not have a friendly name' do
@@ -57,7 +57,7 @@ module SmartAnswer::Calculators
       end
 
       should 'return the friendly name for the country' do
-        assert_equal 'Democratic Republic of the Congo', @formatter.friendly_name('democratic-republic-of-the-congo')
+        assert_equal 'Cote d\'Ivoire', @formatter.friendly_name('cote-d-ivoire')
       end
     end
   end


### PR DESCRIPTION
[Trello card](https://trello.com/c/KTQKw5XQ/365-3-wording-change-in-smart-answer-country-name-repo-congo)

## Motivation 
As a result of data migration update to Whitehall from PR https://github.com/alphagov/whitehall/pull/3359, the friendly name entry is now redundant.

Removing  Democratic Republic of the Congo only affects checksums becuase the following smart answer share `smart_answer/calculators/country_name_formatter.rb` :

- Marriage abroad
- Register a birth
- Register a death

Worldwide fixtures have been updated against the recent change (i.e [1] and [2]) in name for Democratic Republic of the Congo. The embassy address also now uses the new name.

Regression test artefacts have not been affected because PR #2794 had defined the friendly name which changed the regression test artefacts to contain the name Democratic Republic of the Congo.

## Expected content changes

- None

[1] https://www.gov.uk/api/world-locations/democratic-republic-of-the-congo
[2] https://www.gov.uk/api/world-locations/democratic-republic-of-the-congo/organisations.json