### PR TITLE
Send update_type with put content CNTD

### DIFF
--- a/app/services/content_item_publisher.rb
+++ b/app/services/content_item_publisher.rb
@@ -85,6 +85,7 @@ private
       document_type: :redirect,
       publishing_app: :smartanswers,
       schema_name: :redirect,
+      update_type: :major,
       redirects: [
         { path: path, type: :prefix, destination: destination, segments_mode: :ignore }
       ]
@@ -101,6 +102,7 @@ private
       schema_name: :answer,
       publishing_app: publishing_app,
       rendering_app: :frontend,
+      update_type: :major,
       locale: :en,
       details: {
         body: [
@@ -125,7 +127,7 @@ private
     payload = {
       base_path: base_path,
       title: title,
-      update_type: "major",
+      update_type: :major,
       document_type: :transaction,
       publishing_app: publishing_app,
       rendering_app: :frontend,


### PR DESCRIPTION
Sequel to the update from https://github.com/alphagov/smart-answers/pull/3153
I noticed a that not all the payloads were updated.

This commit updates the remaining payload, updating each with the
update_type property.

[1] https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/2566/console