### PR TITLE
Move /visualise to /y/visualise

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   get 'healthcheck', to: proc { [200, {}, ['']] }
 
   constraints id: /[a-z0-9-]+/i do
-    get '/:id/visualise(.:format)', to: 'smart_answers#visualise', as: :visualise
+    get '/:id/y/visualise(.:format)', to: 'smart_answers#visualise', as: :visualise
 
     get '/:id(/:started(/*responses)).:format',
       to: 'smart_answers#show',

--- a/doc/visualising-flows.md
+++ b/doc/visualising-flows.md
@@ -1,12 +1,12 @@
 # Visualising flows
 
-To see an interactive visualisation of a smart answer flow, append `/visualise` to the root of a smartanswer URL e.g. `http://smartanswers.dev.gov.uk/<my-flow>/visualise/`
+To see an interactive visualisation of a smart answer flow, append `/y/visualise` to the root of a smartanswer URL e.g. `http://smartanswers.dev.gov.uk/<my-flow>/y/visualise/`
 
 To see a static visualisation of a smart answer flow, using Graphviz:
 
 ```bash
 # Download graphviz representation
-$ curl https://www.gov.uk/marriage-abroad/visualise.gv --silent > /tmp/marriage-abroad.gv
+$ curl https://www.gov.uk/marriage-abroad/y/visualise.gv --silent > /tmp/marriage-abroad.gv
 
 # Use Graphviz to generate a PNG
 $ dot /tmp/marriage-abroad.gv -Tpng > /tmp/marriage-abroad.png

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -44,8 +44,8 @@ class SmartAnswersControllerTest < ActionController::TestCase
 
     should "render links to visualise flows" do
       get :index
-      assert_select "ul li a[href='/flow-a/visualise']", text: "visualise"
-      assert_select "ul li a[href='/flow-b/visualise']", text: "visualise"
+      assert_select "ul li a[href='/flow-a/y/visualise']", text: "visualise"
+      assert_select "ul li a[href='/flow-b/y/visualise']", text: "visualise"
     end
   end
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/7SgBCc64/696-3-fix-broken-visualise-link)

## Motivation 

Following the changes from from pull request 3126, the /visualise path was affected and has been returning 404.

As a result of the aforementioned PR, this pull request changes the route for the visualise tool from /visualise to /y/visualise.

This is being done as the smaller change, compared to the other option which would entail significant changes like defining, allocating and storing each smart answer's visualise content item/content id/base path etc, on the content store.

We have decided to go with this option to make visualise available to content designers under the /y (i.e /y/visualise) and also allow smart answer controller to respond independent of a content store entry.

## NB

  - ### Reseting cache (optional):

    After Deploying this PR, it may be important to clear the cache for the smart answer visualise in question. Normally this may take up to 30 minutes to clear.

    These fabricator tasks are required:
    - `production cache.purge:"/smart-answer-base-path/y/visualise"`
    - `production cdn.purge_all:"/smart-answer-base-path/y/visualise"`

## Fact check
[Preview link](https://smart-answers-preview-pr-3166.herokuapp.com/additional-commodity-code/y/visualise)
[GOV.UK](https://gov.uk/additional-commodity-code/y/visualise)

## Expected changes
- Visualise path is now @ `/<smart-answer-slug>/y/visualise`

## Before

![screen shot 2017-07-31 at 13 32 52](https://user-images.githubusercontent.com/84896/28777878-dabf6a20-75f4-11e7-8165-5c4491e75b06.png)


## After

![screen shot 2017-07-31 at 13 46 57](https://user-images.githubusercontent.com/84896/28778332-c1622ff2-75f6-11e7-804a-34720bd7f8fa.png)


## Testing on integration

- https://www-origin.integration.publishing.service.gov.uk/additional-commodity-code/y/visualise
- https://deploy.integration.publishing.service.gov.uk/job/Deploy_App/1878/console