### PR TITLE
Brazil marriage abroad - all user UK outcomes

### DIFF
--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/brazil/uk/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/brazil/uk/partner_british/_opposite_sex.erb
@@ -23,6 +23,25 @@ You should also check with the local authorities in Brazil to find out if you ne
 
 %The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
 
+##Make an affirmation or affidavit of marital status in Brazil
+
+If you live in the UK but are currently in Brazil, you can make an affirmation or affidavit of marital status at the nearest embassy or consulate.
+
+Book an appointment to administer an oath, affirmation or affidavit at the:
+
+* [British Embassy Brasilia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brasilia/oaths-affirmations-and-affidavits/slot_picker)
+* [British Consulate-General Sao Paulo](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-sao-paulo/oaths-affirmations-and-affidavits/slot_picker)
+* [British Consulate-General Rio de Janeiro](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-rio-de-janeiro/oaths-affirmations-and-affidavits/slot_picker)
+* [British Consulate-General Recife](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-recife/oaths-affirmations-and-affidavits/slot_picker)
+
+###What you need to bring to your appointment
+
+You need to bring:
+
+* the oath, affirmation or affidavit that you will swear or affirm
+* the [correct fee](https://www.gov.uk/government/publications/brazil-consular-fees)
+* proof of identity
+
 *[CNI]:certificate of no impediment
 
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/brazil/uk/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/brazil/uk/partner_british/_same_sex.erb
@@ -26,5 +26,23 @@ You should also check with the local authorities in Brazil to find out if you ne
 
 %The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
 
+##Make an affirmation or affidavit of marital status in Brazil
 
+If you live in the UK but are currently in Brazil, you can make an affirmation or affidavit of marital status at the nearest embassy or consulate.
 
+Book an appointment to administer an oath, affirmation or affidavit at the:
+
+* [British Embassy Brasilia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brasilia/oaths-affirmations-and-affidavits/slot_picker)
+* [British Consulate-General Sao Paulo](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-sao-paulo/oaths-affirmations-and-affidavits/slot_picker)
+* [British Consulate-General Rio de Janeiro](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-rio-de-janeiro/oaths-affirmations-and-affidavits/slot_picker)
+* [British Consulate-General Recife](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-recife/oaths-affirmations-and-affidavits/slot_picker)
+
+###What you need to bring to your appointment
+
+You need to bring:
+
+* the oath, affirmation or affidavit that you will swear or affirm
+* the [correct fee](https://www.gov.uk/government/publications/brazil-consular-fees)
+* proof of identity
+
+*[CNI]: certificate of no impediment

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/brazil/uk/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/brazil/uk/partner_local/_opposite_sex.erb
@@ -23,6 +23,25 @@ You should also check with the local authorities in Brazil to find out if you ne
 
 %The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
 
+##Make an affirmation or affidavit of marital status in Brazil
+
+If you live in the UK but are currently in Brazil, you can make an affirmation or affidavit of marital status at the nearest embassy or consulate.
+
+Book an appointment to administer an oath, affirmation or affidavit at the:
+
+* [British Embassy Brasilia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brasilia/oaths-affirmations-and-affidavits/slot_picker)
+* [British Consulate-General Sao Paulo](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-sao-paulo/oaths-affirmations-and-affidavits/slot_picker)
+* [British Consulate-General Rio de Janeiro](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-rio-de-janeiro/oaths-affirmations-and-affidavits/slot_picker)
+* [British Consulate-General Recife](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-recife/oaths-affirmations-and-affidavits/slot_picker)
+
+###What you need to bring to your appointment
+
+You need to bring:
+
+* the oath, affirmation or affidavit that you will swear or affirm
+* the [correct fee](https://www.gov.uk/government/publications/brazil-consular-fees)
+* proof of identity
+
 ##Naturalisation of your partner if they move to the UK
 
 Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/brazil/uk/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/brazil/uk/partner_local/_same_sex.erb
@@ -26,9 +26,29 @@ You should also check with the local authorities in Brazil to find out if you ne
 
 %The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
 
+##Make an affirmation or affidavit of marital status in Brazil
+
+If you live in the UK but are currently in Brazil, you can make an affirmation or affidavit of marital status at the nearest embassy or consulate.
+
+Book an appointment to administer an oath, affirmation or affidavit at the:
+
+* [British Embassy Brasilia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brasilia/oaths-affirmations-and-affidavits/slot_picker)
+* [British Consulate-General Sao Paulo](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-sao-paulo/oaths-affirmations-and-affidavits/slot_picker)
+* [British Consulate-General Rio de Janeiro](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-rio-de-janeiro/oaths-affirmations-and-affidavits/slot_picker)
+* [British Consulate-General Recife](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-recife/oaths-affirmations-and-affidavits/slot_picker)
+
+###What you need to bring to your appointment
+
+You need to bring:
+
+* the oath, affirmation or affidavit that you will swear or affirm
+* the [correct fee](https://www.gov.uk/government/publications/brazil-consular-fees)
+* proof of identity
+
 ##Naturalisation of your partner if they move to the UK
 
 Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
 
+*[CNI]: certificate of no impediment
 
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/brazil/uk/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/brazil/uk/partner_other/_opposite_sex.erb
@@ -23,6 +23,25 @@ You should also check with the local authorities in Brazil to find out if you ne
 
 %The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
 
+##Make an affirmation or affidavit of marital status in Brazil
+
+If you live in the UK but are currently in Brazil, you can make an affirmation or affidavit of marital status at the nearest embassy or consulate.
+
+Book an appointment to administer an oath, affirmation or affidavit at the:
+
+* [British Embassy Brasilia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brasilia/oaths-affirmations-and-affidavits/slot_picker)
+* [British Consulate-General Sao Paulo](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-sao-paulo/oaths-affirmations-and-affidavits/slot_picker)
+* [British Consulate-General Rio de Janeiro](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-rio-de-janeiro/oaths-affirmations-and-affidavits/slot_picker)
+* [British Consulate-General Recife](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-recife/oaths-affirmations-and-affidavits/slot_picker)
+
+###What you need to bring to your appointment
+
+You need to bring:
+
+* the oath, affirmation or affidavit that you will swear or affirm
+* the [correct fee](https://www.gov.uk/government/publications/brazil-consular-fees)
+* proof of identity
+
 ##Naturalisation of your partner if they move to the UK
 
 Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/brazil/uk/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/brazil/uk/partner_other/_same_sex.erb
@@ -26,9 +26,29 @@ You should also check with the local authorities in Brazil to find out if you ne
 
 %The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
 
+##Make an affirmation or affidavit of marital status in Brazil
+
+If you live in the UK but are currently in Brazil, you can make an affirmation or affidavit of marital status at the nearest embassy or consulate.
+
+Book an appointment to administer an oath, affirmation or affidavit at the:
+
+* [British Embassy Brasilia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brasilia/oaths-affirmations-and-affidavits/slot_picker)
+* [British Consulate-General Sao Paulo](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-sao-paulo/oaths-affirmations-and-affidavits/slot_picker)
+* [British Consulate-General Rio de Janeiro](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-rio-de-janeiro/oaths-affirmations-and-affidavits/slot_picker)
+* [British Consulate-General Recife](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-recife/oaths-affirmations-and-affidavits/slot_picker)
+
+###What you need to bring to your appointment
+
+You need to bring:
+
+* the oath, affirmation or affidavit that you will swear or affirm
+* the [correct fee](https://www.gov.uk/government/publications/brazil-consular-fees)
+* proof of identity
+
 ##Naturalisation of your partner if they move to the UK
 
 Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
 
+*[CNI]: certificate of no impediment
 
 


### PR DESCRIPTION
https://trello.com/c/z0UaY3xg/583-brazil-marriage-tool-british-nationals-who-normally-live-in-the-uk-can-obtain-an-affirmation-if-theyre-in-brazil-content-change

Updated content for the 6 outcomes where the user is in the UK to reflect the fact that users who live in the UK but are currently in Brazil can make an affirmation or affidavit of marital status in Brazil instead of getting a CNI.

This doesn’t affect the logic