### PR TITLE
Update documentation for retiring a smart answer

### DIFF
--- a/doc/retirement-log.md
+++ b/doc/retirement-log.md
@@ -19,3 +19,15 @@
   - Associated [pull request](https://github.com/alphagov/smart-answers/pull/3035)
   - Redirects from `/pip-checker` (and all descendants i.e `/pip-checker/\*`) to `/pip`
   - Artefact on publisher remain un-change and it's slug changed to `/pip-checker`.
+
+- Legalisation document Checker
+  - Date of retirement:  [01/08/2017](https://github.com/alphagov/smart-answers/releases/tag/release_3690)
+  - Associated [pull request](https://github.com/alphagov/smart-answers/pull/3163)
+  - Redirects from `/legalisation-document-checker` (and all descendants i.e `/legalisation-document-checker/\*`) to `/get-document-legalised`
+    - This is the first retirement post the [splitting of the start pages from the rest of the flow](https://github.com/alphagov/smart-answers/pull/3126). So the retiring rake task is different and should be use onward.
+    ```ruby
+      retire:unpublish_redirect_remove_from_search[86acf061-f878-4da1-b05b-80c7ef61305c,/legalisation-document-checker,/get-document-legalised]
+      retire:unpublish[3f1673a7-62b5-4ea0-883d-faa602e7f6a9]
+      retire:publish_redirect[/legalisation-document-checker/y,/get-document-legalised]
+    ```
+  - Artefact on publisher remain un-change and it's slug changed to `/legalisation-document-checker`.

--- a/doc/retiring-a-smart-answer.md
+++ b/doc/retiring-a-smart-answer.md
@@ -2,7 +2,12 @@
 
 At some point a request might come in for the removal of a SmartAnswer, most likely this request will include redirecting paths belonging to the identified smart answer to a new destination or retain the start page of the smart answer.
 
-NB: It is very important, that after every retirement of a smart answer it is important that the steps and current state of the smart answer are recorded in [retirement log](retirement-log.md)
+### NB:
+
+  - It is important to bear in mind that a smart answer comprises of
+  two main content items, the start page and the flow. These two need to be retired.
+
+  - It is very important, that after every retirement of a smart answer it is important that the steps and current state of the smart answer are recorded in [retirement log](retirement-log.md)
 
 In this document is prescribed the steps that need to be taken:
 


### PR DESCRIPTION
Related to #3163 

## Description 

This PR updates the retirement log with the details for the retiring `/legalisation-document-checker` smart answer. Updates the retire a smart answer document to highlight the recent increase in content items that make up a smart answer. 


## Expected changes

- Update the retirement log with details of today's retirement of legalisation document checker smart answer. 
- Update to retire a smart answer document 