### PR TITLE
Correction of Artefact sentence

### DIFF
--- a/doc/retirement-log.md
+++ b/doc/retirement-log.md
@@ -12,13 +12,13 @@
   - Date of retirement:  [06/04/2017](https://github.com/alphagov/smart-answers/releases/tag/release_3549)
   - Associated [pull request](https://github.com/alphagov/smart-answers/pull/2996)
   - Redirects from `/state-pension-topup` (and all descendants i.e `/state-pension-topup/\*`) to `/state-pension-top-up`
-  - Artefact on publisher remain un-change and it's slug changed to `/state-pension-topup`.
+  - Artefact on publisher remains unchanged.
 
 - PIP Checker
   - Date of retirement:  [22/06/2017](https://github.com/alphagov/smart-answers/releases/tag/release_3626)
   - Associated [pull request](https://github.com/alphagov/smart-answers/pull/3035)
   - Redirects from `/pip-checker` (and all descendants i.e `/pip-checker/\*`) to `/pip`
-  - Artefact on publisher remain un-change and it's slug changed to `/pip-checker`.
+  - Artefact on publisher remains unchanged.
 
 - Legalisation document Checker
   - Date of retirement:  [01/08/2017](https://github.com/alphagov/smart-answers/releases/tag/release_3690)
@@ -30,4 +30,4 @@
       retire:unpublish[3f1673a7-62b5-4ea0-883d-faa602e7f6a9]
       retire:publish_redirect[/legalisation-document-checker/y,/get-document-legalised]
     ```
-  - Artefact on publisher remain un-change and it's slug changed to `/legalisation-document-checker`.
+  - Artefact on publisher remains unchanged.


### PR DESCRIPTION
Related to #3170 

## Description  

This pull request makes a correction to the artefact on publisher line that states the smart answer's artefact remains unchanged but slug changed.

This is just meant to simply indicate that artefact has not been modified