### PR TITLE
Raise an error if the Worldwide API does not return any countries

### DIFF
--- a/test/unit/world_location_test.rb
+++ b/test/unit/world_location_test.rb
@@ -99,6 +99,35 @@ class WorldLocationTest < ActiveSupport::TestCase
         end
       end
     end
+
+    context "the Worldwide API returns no locations" do
+      setup do
+        stub_request(:get, "#{GdsApi::TestHelpers::Worldwide::WORLDWIDE_API_ENDPOINT}/api/world-locations")
+          .to_return(
+            status: 200,
+            body: {
+              "results" => [],
+            }.to_json,
+            headers: {},
+          )
+      end
+
+      should "raise an error" do
+        assert_raises WorldLocation::NoLocationsFromWorldwideApiError do
+          WorldLocation.all
+        end
+      end
+
+      should "raise an error regardless of caching" do
+        assert_raises WorldLocation::NoLocationsFromWorldwideApiError do
+          WorldLocation.all
+        end
+
+        assert_raises WorldLocation::NoLocationsFromWorldwideApiError do
+          WorldLocation.all
+        end
+      end
+    end
   end
 
   context "finding a location by slug" do


### PR DESCRIPTION
We recently had an incident where the Worldwide API was not returning
any countries to Smart Answers.

As such, the country select questions presented users with empty
dropdowns. This case is irrecoverable by the user, so we should fail
loudly.

This change checks if we receive any locations from the API. If not,
then we raise an exception. This will achieve two things:

- The error will be logged to Errbit
- The user will be presented with a generic 500 error page, informing
  them that something has gone wrong at our end.