### PR TITLE
Define and apply List Validator.

### DIFF
--- a/lib/list_validator.rb
+++ b/lib/list_validator.rb
@@ -1,0 +1,11 @@
+class ListValidator
+  def initialize(list)
+    @list = list
+  end
+
+  def all_valid?(elements)
+    elements.present? &&
+      elements.is_a?(Array) &&
+      elements.all? { |element| @list.include?(element) }
+  end
+end

--- a/lib/smart_answer/calculators/benefit_cap_calculator_configuration.rb
+++ b/lib/smart_answer/calculators/benefit_cap_calculator_configuration.rb
@@ -26,9 +26,7 @@ module SmartAnswer::Calculators
     end
 
     def exempted_benefits?
-      exempted_benefits.present? &&
-        exempted_benefits.is_a?(Array) &&
-        valid_exempted_benefits?
+      ListValidator.new(exempt_benefits.keys).all_valid?(exempted_benefits)
     end
 
     def questions
@@ -61,13 +59,6 @@ module SmartAnswer::Calculators
     end
 
   private
-
-    def valid_exempted_benefits?
-      keys = exempt_benefits.keys
-      exempted_benefits.all? do |exempted_benefit|
-        keys.include?(exempted_benefit)
-      end
-    end
 
     def data
       @data ||= YAML.load_file(Rails.root.join('lib', 'data', 'benefit_cap_data.yml')).with_indifferent_access

--- a/lib/smart_answer/calculators/child_maintenance_calculator.rb
+++ b/lib/smart_answer/calculators/child_maintenance_calculator.rb
@@ -201,13 +201,7 @@ module SmartAnswer::Calculators
     end
 
     def state_benefits?
-      benefits.present? && benefits.is_a?(Array) && valid_state_benefits?
-    end
-
-  private
-
-    def valid_state_benefits?
-      benefits.map(&:to_sym).all? { |benefit| STATE_BENEFITS.keys.include?(benefit) }
+      ListValidator.new(state_benefits.keys).all_valid?(benefits.map(&:to_sym))
     end
   end
 end

--- a/test/data/benefit-cap-calculator-files.yml
+++ b/test/data/benefit-cap-calculator-files.yml
@@ -1,6 +1,7 @@
 ---
 lib/data/benefit_cap_data.yml: 90309e12c0009b38ae5de5bc08195d8e
-lib/smart_answer/calculators/benefit_cap_calculator_configuration.rb: 7b82be1caa065fcaec364405165a5a3e
+lib/list_validator.rb: a7f9210a3f89c7b63703606739be2f7e
+lib/smart_answer/calculators/benefit_cap_calculator_configuration.rb: 98a254b73085b28086fd1e21c743b8bd
 lib/smart_answer_flows/benefit-cap-calculator/benefit_cap_calculator.govspeak.erb: e1c2a5fc044662ff2ad6237a3177e75c
 lib/smart_answer_flows/benefit-cap-calculator/outcomes/_dwp_contact_details.govspeak.erb: 3bab6f0d1df0457dbf0ff7548150ba4f
 lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_affected_greater_than_cap.govspeak.erb: d8e15629e5e2285d0196131813bd4369

--- a/test/data/calculate-your-child-maintenance-files.yml
+++ b/test/data/calculate-your-child-maintenance-files.yml
@@ -1,6 +1,7 @@
 ---
 lib/data/child_maintenance_data.yml: a8cd91247e67f9f6bafdb93fb4ff8166
-lib/smart_answer/calculators/child_maintenance_calculator.rb: 467f35755c170c35f13c4c2370e965ae
+lib/list_validator.rb: a7f9210a3f89c7b63703606739be2f7e
+lib/smart_answer/calculators/child_maintenance_calculator.rb: 90561c929d1f42789955b042db05de37
 lib/smart_answer_flows/calculate-your-child-maintenance/_disclaimer.govspeak.erb: 4c59b8e3ac5f5071d11ee84e0d6a508b
 lib/smart_answer_flows/calculate-your-child-maintenance/calculate_your_child_maintenance.govspeak.erb: 970161fad7a881b3ae2969d405029af4
 lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/flat_rate_result.govspeak.erb: b690c19299bfaadf511d35335487e3b1

--- a/test/unit/calculators/benefit_cap_calculator_configuration_test.rb
+++ b/test/unit/calculators/benefit_cap_calculator_configuration_test.rb
@@ -51,44 +51,6 @@ module SmartAnswer::Calculators
         end
       end
 
-      context "#exempted_benefits?" do
-        should "returns true if exempted benefit list is valid" do
-          @config.exempted_benefits = %w(attendance_allowance war_pensions)
-
-          assert @config.exempted_benefits?
-        end
-
-        should "returns false if exempted benefit list isn't valid" do
-          @config.exempted_benefits = %w(arbitary_benefit)
-
-          refute @config.exempted_benefits?
-        end
-
-        should "returns false if exempted benefit list contains at least one invalid element" do
-          @config.exempted_benefits = %w(invalid_benefit war_pensions)
-
-          refute @config.exempted_benefits?
-        end
-
-        should "returns false if exempted benefit list isn't an array" do
-          @config.exempted_benefits = "invalid"
-
-          refute @config.exempted_benefits?
-        end
-
-        should "returns false if exempted benefit list is empty" do
-          @config.exempted_benefits = []
-
-          refute @config.exempted_benefits?
-        end
-
-        should "returns false if exempted benefit list is nil" do
-          @config.exempted_benefits = nil
-
-          refute @config.exempted_benefits?
-        end
-      end
-
       context "Flow configuration" do
         setup do
           BenefitCapCalculatorConfiguration.any_instance.stubs(:data).returns(

--- a/test/unit/calculators/child_maintenance_calculator_test.rb
+++ b/test/unit/calculators/child_maintenance_calculator_test.rb
@@ -242,47 +242,5 @@ module SmartAnswer::Calculators
         end
       end
     end
-
-    context "#state_benefits?" do
-      setup do
-        @calculator = ChildMaintenanceCalculator.new
-      end
-
-      should "returns true if state benefit list is valid" do
-        @calculator.benefits = %w(cb_jobseekers_allowance incapacity_benefit)
-
-        assert @calculator.state_benefits?
-      end
-
-      should "returns false if state benefit list isn't valid" do
-        @calculator.benefits = %w(arbitary_element)
-
-        refute @calculator.state_benefits?
-      end
-
-      should "returns false if state benefit list contains at least one invalid element" do
-        @calculator.benefits = %w(invalid_element cb_jobseekers_allowance)
-
-        refute @calculator.state_benefits?
-      end
-
-      should "returns false if state benefit list isn't an array" do
-        @calculator.benefits = "invalid"
-
-        refute @calculator.state_benefits?
-      end
-
-      should "returns false if state benefit list is empty" do
-        @calculator.benefits = []
-
-        refute @calculator.state_benefits?
-      end
-
-      should "returns false if state benefit list is nil" do
-        @calculator.benefits = nil
-
-        refute @calculator.state_benefits?
-      end
-    end
   end
 end

--- a/test/unit/list_validator_test.rb
+++ b/test/unit/list_validator_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+class ListValidatorTest < ActiveSupport::TestCase
+  context "#all_valid?" do
+    setup do
+      @list_validator = ListValidator.new(%i(a b c d))
+    end
+
+    should "returns true if list is valid" do
+      assert @list_validator.all_valid?(%i(a b))
+    end
+
+    should "returns false if list contents are of different type" do
+      refute @list_validator.all_valid?(%w(a b c))
+    end
+
+    should "returns false if list contents aren't valid" do
+      refute @list_validator.all_valid?(%i(arbitary invalid))
+    end
+
+    should "returns false if list contains at least one invalid element" do
+      refute @list_validator.all_valid?(%i(invalid a))
+    end
+
+    should "returns false if list isn't an array" do
+      refute @list_validator.all_valid?("string")
+    end
+
+    should "returns false if list is empty" do
+      refute @list_validator.all_valid?([])
+    end
+
+    should "returns false if list is nil" do
+      refute @list_validator.all_valid?(nil)
+    end
+  end
+end


### PR DESCRIPTION
[Trello card](https://trello.com/c/QtiKCxmd/718-dryup-reduce-duplication-after-accessibility-changes)

## Description 

Following the accessibility improvements, a few of repetitive predicate
methods have been defined and apply across the following smart answers changes:

- https://github.com/alphagov/smart-answers/pull/3181
- https://github.com/alphagov/smart-answers/pull/3180
- https://github.com/alphagov/smart-answers/pull/3179


This commit defines a list validator that reduces the duplication
introduced during the accessibility improvements.

The idea here is to check the supplied argument and its content that
exist in the list that serves as a source of truth.

if the type or contents don't match with the pre-defined list, false is
returned else true.

## Expected changes

- none (i.e flow or regression test artefacts have not been affected)