### PR TITLE
Wrap post code errors in a `StandardError` class

### DIFF
--- a/lib/smart_answer/calculators/landlord_immigration_check_calculator.rb
+++ b/lib/smart_answer/calculators/landlord_immigration_check_calculator.rb
@@ -18,16 +18,12 @@ module SmartAnswer::Calculators
       if response.dig("_response_info", "status") == "ok"
         response["results"]
       else
-        report_error(response)
+        Airbrake.notify(PostCodeLookupError.new(postcode))
         raise postcode_lookup_exception
       end
     rescue GdsApi::BaseError => e
-      report_error(e)
+      Airbrake.notify(e)
       raise postcode_lookup_exception
-    end
-
-    def report_error(hash_or_exception)
-      Airbrake.notify(hash_or_exception)
     end
 
     def postcode_lookup_exception
@@ -37,5 +33,7 @@ module SmartAnswer::Calculators
     def from_somewhere_else?
       @nationality == "somewhere-else"
     end
+
+    class PostCodeLookupError < StandardError; end
   end
 end

--- a/test/data/landlord-immigration-check-files.yml
+++ b/test/data/landlord-immigration-check-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer/calculators/landlord_immigration_check_calculator.rb: a735cf2ccf3d01817b77ad7dea9f4448
+lib/smart_answer/calculators/landlord_immigration_check_calculator.rb: 8087a6ef17c31e17063242943fd53a4f
 lib/smart_answer_flows/landlord-immigration-check/landlord_immigration_check.govspeak.erb: fc5098e5876826a7360b69e4b163feea
 lib/smart_answer_flows/landlord-immigration-check/outcomes/_landlord_code_of_practice.govspeak.erb: cfb1261ac17c7aa40445173406459290
 lib/smart_answer_flows/landlord-immigration-check/outcomes/outcome_can_not_continue_renting.govspeak.erb: ddb33bbfc2857647dbd6b9ec919eca99


### PR DESCRIPTION
Due to some combination of our usage of an old fork of Airbrake, and a
forked version of Errbit, usage of `Airbrake#notify` does not appear
to work when called with a string or hash. These appear in Errbit as
empty hashes, which is obviously not ideal for error reporting.

This change ensures that we invoke `Airbrake#notify` with an actual
`StandardError` object, which does present the error correctly.