### PR TITLE
Update Airbrake Gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "activesupport"
 gem "railties"
 gem "sprockets-rails"
 
-gem 'airbrake', git: 'https://github.com/alphagov/airbrake'
+gem 'airbrake', github: 'alphagov/airbrake', branch: 'silence-dep-warnings-for-rails-5'
 gem 'ast'
 gem 'gds-api-adapters', '~> 47.2'
 gem 'govspeak', '~> 3.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,27 @@
 GIT
-  remote: https://github.com/alphagov/airbrake
-  revision: f32020f03ca116d10f94d1b80bad2d41232cee10
+  remote: git://github.com/alphagov/airbrake.git
+  revision: ad9c926a56535c48f95c33824a76e10bc8f91179
+  branch: silence-dep-warnings-for-rails-5
   specs:
-    airbrake (3.1.15)
+    airbrake (4.3.8)
       builder
       multi_json
+      rails (>= 5.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     PriorityQueue (0.1.2)
+    actioncable (5.0.2)
+      actionpack (= 5.0.2)
+      nio4r (>= 1.2, < 3.0)
+      websocket-driver (~> 0.6.1)
+    actionmailer (5.0.2)
+      actionpack (= 5.0.2)
+      actionview (= 5.0.2)
+      activejob (= 5.0.2)
+      mail (~> 2.5, >= 2.5.4)
+      rails-dom-testing (~> 2.0)
     actionpack (5.0.2)
       actionview (= 5.0.2)
       activesupport (= 5.0.2)
@@ -28,12 +40,17 @@ GEM
       globalid (>= 0.3.6)
     activemodel (5.0.2)
       activesupport (= 5.0.2)
+    activerecord (5.0.2)
+      activemodel (= 5.0.2)
+      activesupport (= 5.0.2)
+      arel (~> 7.0)
     activesupport (5.0.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     addressable (2.3.8)
+    arel (7.1.4)
     ast (2.3.0)
     better_errors (2.1.1)
       coderay (>= 1.0.0)
@@ -105,6 +122,8 @@ GEM
       nokogiri (>= 1.5.9)
     lrucache (0.1.4)
       PriorityQueue (~> 0.1.2)
+    mail (2.6.6)
+      mime-types (>= 1.16, < 4)
     metaclass (0.0.4)
     method_source (0.8.2)
     mime-types (3.1)
@@ -118,6 +137,7 @@ GEM
       metaclass (~> 0.0.1)
     multi_json (1.12.1)
     netrc (0.11.0)
+    nio4r (2.1.0)
     nokogiri (1.8.0)
       mini_portile2 (~> 2.2.0)
     null_logger (0.0.1)
@@ -140,6 +160,18 @@ GEM
     rack-test (0.6.3)
       rack (>= 1.0)
     rack_strip_client_ip (0.0.2)
+    rails (5.0.2)
+      actioncable (= 5.0.2)
+      actionmailer (= 5.0.2)
+      actionpack (= 5.0.2)
+      actionview (= 5.0.2)
+      activejob (= 5.0.2)
+      activemodel (= 5.0.2)
+      activerecord (= 5.0.2)
+      activesupport (= 5.0.2)
+      bundler (>= 1.3.0, < 2.0)
+      railties (= 5.0.2)
+      sprockets-rails (>= 2.0.0)
     rails-controller-testing (1.0.2)
       actionpack (~> 5.x, >= 5.0.1)
       actionview (~> 5.x, >= 5.0.1)


### PR DESCRIPTION
This change uses a branch of our forked Airbrake gem, which silences
deprecation warnings for Rails 5.