### PR TITLE
Tidy up Post Code lookup error handling

### DIFF
--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -123,6 +123,8 @@ module SmartAnswer
           state = node(state.current_node).transition(state, response)
           node(state.current_node).evaluate_precalculations(state)
         rescue BaseStateTransitionError => e
+          Airbrake.notify(e.log_exception) if e.is_a?(LoggedError)
+
           state.dup.tap do |new_state|
             new_state.error = e.message
             new_state.freeze

--- a/lib/smart_answer/logged_error.rb
+++ b/lib/smart_answer/logged_error.rb
@@ -1,0 +1,14 @@
+module SmartAnswer
+  class LoggedError < BaseStateTransitionError
+    def initialize(message = nil, log_message = nil)
+      super(message)
+      @log_message = log_message
+    end
+
+    # Airbrake#notify requires an Error as an argument, so instead
+    # of returning the message string, wrap it in an error
+    def log_exception
+      LoggedError.new(@log_message)
+    end
+  end
+end

--- a/test/data/landlord-immigration-check-files.yml
+++ b/test/data/landlord-immigration-check-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer/calculators/landlord_immigration_check_calculator.rb: 6d788c019279b822966e71820b0f0d5f
+lib/smart_answer/calculators/landlord_immigration_check_calculator.rb: 546bed2288d24b1d17f9cdab4773320b
 lib/smart_answer_flows/landlord-immigration-check/landlord_immigration_check.govspeak.erb: fc5098e5876826a7360b69e4b163feea
 lib/smart_answer_flows/landlord-immigration-check/outcomes/_landlord_code_of_practice.govspeak.erb: cfb1261ac17c7aa40445173406459290
 lib/smart_answer_flows/landlord-immigration-check/outcomes/outcome_can_not_continue_renting.govspeak.erb: ddb33bbfc2857647dbd6b9ec919eca99

--- a/test/data/landlord-immigration-check-files.yml
+++ b/test/data/landlord-immigration-check-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer/calculators/landlord_immigration_check_calculator.rb: 8087a6ef17c31e17063242943fd53a4f
+lib/smart_answer/calculators/landlord_immigration_check_calculator.rb: 6d788c019279b822966e71820b0f0d5f
 lib/smart_answer_flows/landlord-immigration-check/landlord_immigration_check.govspeak.erb: fc5098e5876826a7360b69e4b163feea
 lib/smart_answer_flows/landlord-immigration-check/outcomes/_landlord_code_of_practice.govspeak.erb: cfb1261ac17c7aa40445173406459290
 lib/smart_answer_flows/landlord-immigration-check/outcomes/outcome_can_not_continue_renting.govspeak.erb: ddb33bbfc2857647dbd6b9ec919eca99

--- a/test/unit/calculators/landlord_immigration_check_calculator_test.rb
+++ b/test/unit/calculators/landlord_immigration_check_calculator_test.rb
@@ -139,7 +139,7 @@ module SmartAnswer::Calculators
       end
 
       should 'raise an error' do
-        assert_raises SmartAnswer::BaseStateTransitionError do
+        assert_raises SmartAnswer::LoggedError do
           @calculator.rules_apply?
         end
       end

--- a/test/unit/flow_test.rb
+++ b/test/unit/flow_test.rb
@@ -276,6 +276,22 @@ class FlowTest < ActiveSupport::TestCase
       end
     end
 
+    context "a question raises a logged error" do
+      setup do
+        @error_message = "Sorry, that's not valid"
+        @log_message = "Logged message"
+        @flow.node(:do_you_like_jam?)
+          .stubs(:parse_input)
+          .with('bad')
+          .raises(SmartAnswer::LoggedError.new(@error_message, @log_message))
+      end
+
+      should "notify Airbrake" do
+        Airbrake.expects(:notify).with(SmartAnswer::LoggedError.new(@log_message))
+        @flow.process(%w{no bad})
+      end
+    end
+
     should "calculate the path traversed by a series of responses" do
       assert_equal [], @flow.path([])
       assert_equal [:do_you_like_chocolate?], @flow.path(%w{no})


### PR DESCRIPTION
When a postcode cannot be found in Imminence API, the endpoint
returns a `404` status. We should accept this error as standard control
logic, and raise a corresponding error within our own application. This
shows the user that the problem is to do with their input.

Any other error is an unexpected error, and should raise an exception
showing that the problem with lookup is at our end.

This change also removes the special logic for `GdsApi::BaseError`. We
should never get this error, and if we do, it’s truly exceptional and
the website should fail “noisily”. Removing this `rescue` block will
log the error directly to Errbit, and show the user a generic `500`
page, whilst also tidying up our own control logic.

Further, this change adds a `LoggedError`, which allows us to add logging
on top of our control logic.

## Acceptance Criteria

We currently are logging errors when non-existent post codes are looked up.
For example: 
https://errbit.publishing.service.gov.uk/apps/533c35ae0da1159384044f5f/problems/599a04c9657863558e8e3801

After deploying this change, we should no longer see errors of this kind, and
looking up - for example - W13 0FE should not log an error.