### PR TITLE
Navigate to partial template on GitHub from GOVUK

### DIFF
--- a/app.json
+++ b/app.json
@@ -8,7 +8,6 @@
     "PLEK_SERVICE_CONTENT_STORE_URI": "https://www.gov.uk/api" ,
     "PLEK_SERVICE_STATIC_URI": "https://assets-origin.integration.publishing.service.gov.uk/",
     "RUNNING_ON_HEROKU": "true",
-    "EXPOSE_GOVSPEAK": "true",
     "ERRBIT_ENV": "integration"
   },
   "image": "heroku/ruby",

--- a/app/assets/javascripts/helpers.js
+++ b/app/assets/javascripts/helpers.js
@@ -1,21 +1,36 @@
 var SmartAnswer = SmartAnswer || {};
 SmartAnswer.isStartPage = function(slug) { // Used mostly during A/B testing
-  return window.location.pathname.split("/").join("") == slug;
+  return window.location.pathname.split('/').join('') == slug;
 }
 
 function linkToTemplatesOnGithub() {
   $('*[data-debug-template-path]').each(function() {
-    var element = $(this);
-    var path = element.data('debug-template-path');
-    var filename = path.split('/').pop();
     var host = 'https://github.com';
     var organisation = 'alphagov';
     var repository = 'smart-answers'
     var branch = 'deployed-to-production';
+    var element = $(this);
+    var path = element.data('debug-template-path');
     var url = [host, organisation, repository, 'blob', branch, path].join('/');
+    var filename = path.split('/').pop();
     var anchor = $('<a>Template on GitHub</a>').attr('href', url).attr('style', 'color: deeppink;').attr('title', filename);
     element.prepend(anchor);
     element.attr('style', 'border: 3px solid deeppink; padding: 10px; margin: 3px');
     element.removeAttr('data-debug-template-path');
+  });
+
+  $('*[data-debug-partial-template-path]').each(function() {
+    var host = 'https://github.com';
+    var organisation = 'alphagov';
+    var repository = 'smart-answers'
+    var branch = 'deployed-to-production';
+    var element = $(this);
+    var path = element.data('debug-partial-template-path');
+    var url = [host, organisation, repository, 'blob', branch, path].join('/');
+    var filename = path.split('/').pop();
+    var anchor = $('<a>Partial template on GitHub</a>').attr('href', url).attr('style', 'color: hotpink;').attr('title', filename);
+    element.prepend(anchor);
+    element.attr('style', 'border: 3px dotted hotpink; padding: 10px; margin: 3px');
+    element.removeAttr('data-debug-partial-template-path');
   });
 };

--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -77,7 +77,7 @@ private
   def find_smart_answer
     @name = params[:id].to_sym
     @smart_answer = flow_registry.find(@name.to_s)
-    @presenter = FlowPresenter.new(request, @smart_answer)
+    @presenter = FlowPresenter.new(self, @smart_answer)
   end
 
   def flow_registry

--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -41,9 +41,7 @@ class SmartAnswersController < ApplicationController
         render json: ApiPresenter.new(@presenter).as_json
       end
 
-      if Rails.application.config.expose_govspeak
-        format.text { render page_type }
-      end
+      format.text { render page_type }
     end
 
     set_expiry

--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -8,8 +8,9 @@ class FlowPresenter
 
   def_delegators :@flow, :need_id
 
-  def initialize(request, flow)
-    @request = request
+  def initialize(controller, flow)
+    @controller = controller
+    @request = controller.request
     @params = request.params
     @flow = flow
     @node_presenters = {}
@@ -64,7 +65,7 @@ class FlowPresenter
                       else
                         NodePresenter
                       end
-    @node_presenters[node.name] ||= presenter_class.new(node, current_state)
+    @node_presenters[node.name] ||= presenter_class.new(node, current_state, controller: @controller)
   end
 
   def current_question_number
@@ -77,7 +78,7 @@ class FlowPresenter
 
   def start_node
     node = SmartAnswer::Node.new(@flow, @flow.name.underscore.to_sym)
-    @start_node ||= StartNodePresenter.new(node)
+    @start_node ||= StartNodePresenter.new(node, nil, controller: @controller)
   end
 
   def change_collapsed_question_link(question_number)

--- a/app/presenters/node_presenter.rb
+++ b/app/presenters/node_presenter.rb
@@ -2,8 +2,9 @@ class NodePresenter
   extend Forwardable
   delegate [:outcome?] => :@node
 
-  def initialize(node, state = nil)
+  def initialize(node, state = nil, options = {})
     @node = node
     @state = state || SmartAnswer::State.new(nil)
+    @options = options
   end
 end

--- a/app/presenters/outcome_presenter.rb
+++ b/app/presenters/outcome_presenter.rb
@@ -10,7 +10,8 @@ class OutcomePresenter < NodePresenter
         SmartAnswer::FormattingHelper,
         SmartAnswer::OverseasPassportsHelper,
         SmartAnswer::MarriageAbroadHelper
-      ] + helpers
+      ] + helpers,
+      controller: options[:controller]
     )
   end
 

--- a/app/presenters/outcome_presenter.rb
+++ b/app/presenters/outcome_presenter.rb
@@ -16,7 +16,7 @@ class OutcomePresenter < NodePresenter
   end
 
   def title
-    @renderer.single_line_of_content_for(:title)
+    outcome_title.text
   end
 
   def body(html: true)
@@ -29,5 +29,21 @@ class OutcomePresenter < NodePresenter
 
   def relative_erb_template_path
     @renderer.relative_erb_template_path
+  end
+
+  def partial_template_path
+    outcome_title.partial_template_path
+  end
+
+  def wrapped_with_debug_div?
+    outcome_title.wrapped_with_debug_div?
+  end
+
+private
+
+  def outcome_title
+    @outcome_title ||= SmartAnswer::Title.new(
+      @renderer.single_line_of_content_for(:title)
+    )
   end
 end

--- a/app/presenters/question_presenter.rb
+++ b/app/presenters/question_presenter.rb
@@ -7,7 +7,8 @@ class QuestionPresenter < NodePresenter
       template_directory: @node.template_directory.join('questions'),
       template_name: @node.filesystem_friendly_name,
       locals: @state.to_hash,
-      helpers: [SmartAnswer::FormattingHelper] + helpers
+      helpers: [SmartAnswer::FormattingHelper] + helpers,
+      controller: options[:controller]
     )
   end
 

--- a/app/presenters/question_presenter.rb
+++ b/app/presenters/question_presenter.rb
@@ -13,7 +13,7 @@ class QuestionPresenter < NodePresenter
   end
 
   def title
-    @renderer.single_line_of_content_for(:title)
+    question_title.text
   end
 
   def error
@@ -77,5 +77,21 @@ class QuestionPresenter < NodePresenter
 
   def default_error_message
     "Please answer this question"
+  end
+
+  def partial_template_path
+    question_title.partial_template_path
+  end
+
+  def wrapped_with_debug_div?
+    question_title.wrapped_with_debug_div?
+  end
+
+private
+
+  def question_title
+    @question_title ||= SmartAnswer::Title.new(
+      @renderer.single_line_of_content_for(:title)
+    )
   end
 end

--- a/app/presenters/start_node_presenter.rb
+++ b/app/presenters/start_node_presenter.rb
@@ -3,7 +3,8 @@ class StartNodePresenter < NodePresenter
     super(node, state)
     @renderer = options[:renderer] || SmartAnswer::ErbRenderer.new(
       template_directory: @node.template_directory,
-      template_name: @node.name.to_s
+      template_name: @node.name.to_s,
+      controller: options[:controller]
     )
   end
 

--- a/app/views/smart_answers/question.html.erb
+++ b/app/views/smart_answers/question.html.erb
@@ -14,7 +14,7 @@
 
       <div class="question" data-debug-template-path="<%= question.relative_erb_template_path %>">
         <% if question.wrapped_with_debug_div? %>
-          <div data-debug-template-path="<%= question.partial_template_path %>">
+          <div data-debug-partial-template-path="<%= question.partial_template_path %>">
             <h2 data-test="question"><%= question.title %></h2>
           </div>
         <% else %>

--- a/app/views/smart_answers/question.html.erb
+++ b/app/views/smart_answers/question.html.erb
@@ -13,9 +13,14 @@
     <div class="current-question" id="current-question">
 
       <div class="question" data-debug-template-path="<%= question.relative_erb_template_path %>">
-        <h2 data-test="question">
-          <%= question.title %>
-        </h2>
+        <% if question.wrapped_with_debug_div? %>
+          <div data-debug-template-path="<%= question.partial_template_path %>">
+            <h2 data-test="question"><%= question.title %></h2>
+          </div>
+        <% else %>
+          <h2 data-test="question"><%= question.title %></h2>
+        <% end %>
+
         <div class="question-body">
           <% if question.body.present? %>
             <article role="article">

--- a/app/views/smart_answers/result.html.erb
+++ b/app/views/smart_answers/result.html.erb
@@ -12,7 +12,11 @@
   <article class="outcome group">
     <div class="result-info" data-debug-template-path="<%= outcome.relative_erb_template_path %>">
       <div class="inner group">
-        <% if outcome.title.present? %>
+        <% if outcome.wrapped_with_debug_div? %>
+          <div data-debug-template-path="<%= outcome.partial_template_path %>">
+            <div class="summary"><h2 class="result-title"><%= outcome.title %></h2></div>
+          </div>
+        <% elsif outcome.title.present? %>
           <div class="summary"><h2 class="result-title"><%= outcome.title %></h2></div>
         <% end %>
 

--- a/app/views/smart_answers/result.html.erb
+++ b/app/views/smart_answers/result.html.erb
@@ -13,7 +13,7 @@
     <div class="result-info" data-debug-template-path="<%= outcome.relative_erb_template_path %>">
       <div class="inner group">
         <% if outcome.wrapped_with_debug_div? %>
-          <div data-debug-template-path="<%= outcome.partial_template_path %>">
+          <div data-debug-partial-template-path="<%= outcome.partial_template_path %>">
             <div class="summary"><h2 class="result-title"><%= outcome.title %></h2></div>
           </div>
         <% elsif outcome.title.present? %>

--- a/config/initializers/expose_govspeak.rb
+++ b/config/initializers/expose_govspeak.rb
@@ -1,5 +1,0 @@
-if Rails.env.production?
-  SmartAnswers::Application.config.expose_govspeak = ENV['EXPOSE_GOVSPEAK'].present?
-else
-  SmartAnswers::Application.config.expose_govspeak = true
-end

--- a/config/initializers/partial_renderer.rb
+++ b/config/initializers/partial_renderer.rb
@@ -1,0 +1,1 @@
+ActionView::PartialRenderer.prepend(SmartAnswerPartialTemplateWrapper)

--- a/doc/viewing-templates-as-govspeak.md
+++ b/doc/viewing-templates-as-govspeak.md
@@ -2,8 +2,6 @@
 
 Seeing [Govspeak](https://github.com/alphagov/govspeak) markup of Smart Answer pages can be useful to content designers when preparing content change requests or to developers inspecting generated Govspeak that later gets translated to HTML.
 
-This feature can be enabled by setting `EXPOSE_GOVSPEAK` to a non-empty value. It is enabled by default in the Integration environment and in Heroku apps deployed via the `startup_heroku.sh` script.
-
 The Govspeak version of the pages can be accessed by appending `.txt` to URLs.
 
 ## In Development environment

--- a/lib/smart_answer/erb_renderer.rb
+++ b/lib/smart_answer/erb_renderer.rb
@@ -10,11 +10,16 @@ module SmartAnswer
       end
     end
 
-    def initialize(template_directory:, template_name:, locals: {}, helpers: [])
+    def initialize(template_directory:, template_name:, locals: {}, helpers: [], controller: nil)
       @template_directory = template_directory
       @template_name = template_name
       @locals = locals
-      @view = ActionView::Base.new([@template_directory, FlowRegistry.instance.load_path])
+      @view = ActionView::Base.new(
+        [@template_directory, FlowRegistry.instance.load_path],
+        {},
+        controller
+      )
+      @view.lookup_context.prefixes = [] if any_lookup_prefixes?(controller)
       helpers.each { |helper| @view.extend(helper) }
       @view.extend(QuestionOptionsHelper)
     end
@@ -43,6 +48,11 @@ module SmartAnswer
     end
 
   private
+
+    def any_lookup_prefixes?(context)
+      context.is_a?(ActionController::Base) &&
+        context.lookup_context.prefixes.any?
+    end
 
     def erb_template_name
       "#{@template_name}.govspeak.erb"

--- a/lib/smart_answer/title.rb
+++ b/lib/smart_answer/title.rb
@@ -5,7 +5,7 @@ module SmartAnswer
     end
 
     def wrapped_with_debug_div?
-      @content.match(/^<div data-debug-template-path=.*><p>.*<\/p><\/div>$/i)
+      @content.match(/^<div data-debug-partial-template-path=.*><p>.*<\/p><\/div>$/i)
     end
 
     def text

--- a/lib/smart_answer/title.rb
+++ b/lib/smart_answer/title.rb
@@ -1,0 +1,29 @@
+module SmartAnswer
+  class Title
+    def initialize(content)
+      @content = content
+    end
+
+    def wrapped_with_debug_div?
+      @content.match(/^<div data-debug-template-path=.*><p>.*<\/p><\/div>$/i)
+    end
+
+    def text
+      return @content unless wrapped_with_debug_div?
+
+      document_fragment.children.first.children.first.children.text
+    end
+
+    def partial_template_path
+      return unless wrapped_with_debug_div?
+
+      document_fragment.children.first.attributes.first.last.value
+    end
+
+  private
+
+    def document_fragment
+      @document_fragment ||= Nokogiri::HTML::DocumentFragment.parse(@content)
+    end
+  end
+end

--- a/lib/smart_answer_partial_template_wrapper.rb
+++ b/lib/smart_answer_partial_template_wrapper.rb
@@ -8,7 +8,7 @@ module SmartAnswerPartialTemplateWrapper
     content_tag(
       :div,
       govspeak_to_html(content),
-      data: { debug_template_path: smart_answer_partial_path }
+      data: { debug_partial_template_path: smart_answer_partial_path }
     )
   end
 

--- a/lib/smart_answer_partial_template_wrapper.rb
+++ b/lib/smart_answer_partial_template_wrapper.rb
@@ -1,0 +1,65 @@
+module SmartAnswerPartialTemplateWrapper
+  include ActionView::Helpers::TagHelper
+
+  def render(context, options, block)
+    content = super(context, options, block)
+    return content unless valid_path_and_format?(context)
+
+    content_tag(
+      :div,
+      govspeak_to_html(content),
+      data: { debug_template_path: smart_answer_partial_path }
+    )
+  end
+
+private
+
+  def valid_path_and_format?(context)
+    smart_answer_partial_path? && html_format?(context)
+  end
+
+  def html_format?(context)
+    context.request&.format&.symbol.to_s == "html"
+  end
+
+  def govspeak_to_html(content)
+    Govspeak::Document.new(remove_leading_spaces(content))
+      .to_html
+      .strip
+      .html_safe
+  end
+
+  def remove_leading_spaces(content)
+    content.to_str.gsub(/^ +/, "")
+  end
+
+  def smart_answer_partial_path?
+    under_smart_answer_flow_directory? &&
+      template_identifier_file_name.include?("govspeak.erb")
+  end
+
+  def template_identifier_path
+    @template_identifier_path ||= @template ? @template.identifier : @path
+  end
+
+  def template_identifier_path_name
+    @template_identifier_path_name ||= Pathname.new(template_identifier_path)
+  end
+
+  def smart_answer_partial_path
+    @smart_answer_partial_path ||= template_identifier_path_name
+      .relative_path_from(Rails.root)
+      .to_s
+  end
+
+  def template_identifier_file_name
+    @template_identifier_file_name ||= template_identifier_path_name
+      .basename
+      .to_s
+  end
+
+  def under_smart_answer_flow_directory?
+    template_identifier_path.present? &&
+      template_identifier_path.include?("lib/smart_answer_flows")
+  end
+end

--- a/startup_heroku.sh
+++ b/startup_heroku.sh
@@ -23,7 +23,6 @@ GOVUK_APP_DOMAIN=integration.publishing.service.gov.uk \
 PLEK_SERVICE_CONTENT_STORE_URI=https://www.gov.uk/api \
 PLEK_SERVICE_STATIC_URI=https://assets-origin.integration.publishing.service.gov.uk/ \
 RUNNING_ON_HEROKU=true \
-EXPOSE_GOVSPEAK=true \
 ERRBIT_ENV=integration
 
 echo

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -198,18 +198,6 @@ class SmartAnswersControllerTest < ActionController::TestCase
         assert_match(/yes\: Yes/, response.body)
         assert_match(/no\: No/, response.body)
       end
-
-      context "when Rails.application.config.expose_govspeak is not set" do
-        setup do
-          Rails.application.config.stubs(:expose_govspeak).returns(false)
-        end
-
-        should "render not found" do
-          get :show, params: { id: 'smart-answers-controller-sample', started: 'y', responses: "yes", format: "txt" }
-
-          assert_response :missing
-        end
-      end
     end
 
     context "debugging" do

--- a/test/unit/erb_renderer_test.rb
+++ b/test/unit/erb_renderer_test.rb
@@ -250,6 +250,52 @@ Hello world
       end
     end
 
+    test 'can setup action view with controller' do
+      controller = SmartAnswersController.new
+      controller.request = ActionDispatch::TestRequest.create
+      prefixes = %w(smart_answers application)
+      lookup_context = ActionView::LookupContext.new([], {}, prefixes)
+      view = mock('ActionView::Base', lookup_context: lookup_context)
+
+      ActionView::Base
+        .expects(:new)
+        .with(is_a(Array), {}, is_a(ActionController::Base))
+        .returns(view)
+
+      ActionView::LookupContext
+        .any_instance
+        .expects(:prefixes=)
+        .with([])
+        .once
+
+      ErbRenderer.new(
+        template_directory: '/path',
+        template_name: 'temp-name',
+        locals: {},
+        helpers: [],
+        controller: controller
+      )
+    end
+
+    test 'can setup action view without a controller' do
+      ActionView::Base
+        .expects(:new)
+        .with(is_a(Array), {}, nil)
+
+      ActionView::LookupContext
+        .any_instance
+        .expects(:prefixes=)
+        .never
+
+      ErbRenderer.new(
+        template_directory: '/path',
+        template_name: 'temp-name',
+        locals: {},
+        helpers: [],
+        controller: nil
+      )
+    end
+
   private
 
     def content_for(key, template)

--- a/test/unit/flow_presenter_test.rb
+++ b/test/unit/flow_presenter_test.rb
@@ -6,8 +6,9 @@ class FlowPresenterTest < ActiveSupport::TestCase
       name 'flow-name'
       value_question :first_question_key
     end
-    @request = ActionDispatch::TestRequest.create
-    @flow_presenter = FlowPresenter.new(@request, @flow)
+    @controller = SmartAnswersController.new
+    @controller.request = ActionDispatch::TestRequest.create
+    @flow_presenter = FlowPresenter.new(@controller, @flow)
   end
 
   test '#presenter_for returns presenter for Date question' do

--- a/test/unit/outcome_presenter_test.rb
+++ b/test/unit/outcome_presenter_test.rb
@@ -6,6 +6,7 @@ module SmartAnswer
       outcome = Outcome.new(nil, :outcome_name)
       @renderer = stub('renderer')
       @presenter = OutcomePresenter.new(outcome, nil, renderer: @renderer)
+      @div = "<div data-debug-template-path='/path'><p>title-text</p></div>"
     end
 
     test 'renderer is constructed using template name and directory obtained from outcome node' do
@@ -51,6 +52,12 @@ module SmartAnswer
       assert_equal 'title-text', @presenter.title
     end
 
+    test '#title returns single line of content rendered for title block wrapped with debug div' do
+      @renderer.stubs(:single_line_of_content_for).with(:title).returns(@div)
+
+      assert_equal 'title-text', @presenter.title
+    end
+
     test '#body returns content rendered for body block with govspeak processing enabled by default' do
       @renderer.stubs(:content_for).with(:body, html: true).returns('body-html')
 
@@ -79,6 +86,30 @@ module SmartAnswer
       @renderer.stubs(:relative_erb_template_path).returns('relative-erb-template-path')
 
       assert_equal 'relative-erb-template-path', @presenter.relative_erb_template_path
+    end
+
+    test '#partial_template_path when wrapped with debug div returns path' do
+      @renderer.stubs(:single_line_of_content_for).with(:title).returns(@div)
+
+      assert_equal '/path', @presenter.partial_template_path
+    end
+
+    test '#partial_template_path when it isn\'t wrapped with debug div returns nil' do
+      @renderer.stubs(:single_line_of_content_for).with(:title).returns('Hello')
+
+      assert_nil @presenter.partial_template_path
+    end
+
+    test '#wrapped_with_debug_div? when wrapped with debug div returns true' do
+      @renderer.stubs(:single_line_of_content_for).with(:title).returns(@div)
+
+      assert @presenter.wrapped_with_debug_div?
+    end
+
+    test '#wrapped_with_debug_div? when it isn\'t wrapped with debug div returns false' do
+      @renderer.stubs(:single_line_of_content_for).with(:title).returns('Hello')
+
+      refute @presenter.wrapped_with_debug_div?
     end
   end
 end

--- a/test/unit/outcome_presenter_test.rb
+++ b/test/unit/outcome_presenter_test.rb
@@ -6,7 +6,7 @@ module SmartAnswer
       outcome = Outcome.new(nil, :outcome_name)
       @renderer = stub('renderer')
       @presenter = OutcomePresenter.new(outcome, nil, renderer: @renderer)
-      @div = "<div data-debug-template-path='/path'><p>title-text</p></div>"
+      @div = "<div data-debug-partial-template-path='/path'><p>title-text</p></div>"
     end
 
     test 'renderer is constructed using template name and directory obtained from outcome node' do

--- a/test/unit/question_presenter_test.rb
+++ b/test/unit/question_presenter_test.rb
@@ -6,7 +6,7 @@ module SmartAnswer
       @question = Question::Base.new(nil, :question_name?)
       @renderer = stub('renderer')
       @presenter = QuestionPresenter.new(@question, nil, renderer: @renderer)
-      @div = "<div data-debug-template-path='/path'><p>title-text</p></div>"
+      @div = "<div data-debug-partial-template-path='/path'><p>title-text</p></div>"
     end
 
     test 'renderer is constructed using template name and directory obtained from question node' do

--- a/test/unit/question_presenter_test.rb
+++ b/test/unit/question_presenter_test.rb
@@ -6,6 +6,7 @@ module SmartAnswer
       @question = Question::Base.new(nil, :question_name?)
       @renderer = stub('renderer')
       @presenter = QuestionPresenter.new(@question, nil, renderer: @renderer)
+      @div = "<div data-debug-template-path='/path'><p>title-text</p></div>"
     end
 
     test 'renderer is constructed using template name and directory obtained from question node' do
@@ -24,6 +25,12 @@ module SmartAnswer
 
     test '#title returns single line of content rendered for title block' do
       @renderer.stubs(:single_line_of_content_for).with(:title).returns('title-text')
+
+      assert_equal 'title-text', @presenter.title
+    end
+
+    test '#title returns single line of content rendered for title block wrapped with debug div' do
+      @renderer.stubs(:single_line_of_content_for).with(:title).returns(@div)
 
       assert_equal 'title-text', @presenter.title
     end
@@ -119,6 +126,30 @@ module SmartAnswer
       @renderer.stubs(:relative_erb_template_path).returns('relative-erb-template-path')
 
       assert_equal 'relative-erb-template-path', @presenter.relative_erb_template_path
+    end
+
+    test '#partial_template_path when wrapped with debug div returns path' do
+      @renderer.stubs(:single_line_of_content_for).with(:title).returns(@div)
+
+      assert_equal '/path', @presenter.partial_template_path
+    end
+
+    test '#partial_template_path when it isn\'t wrapped with debug div returns nil' do
+      @renderer.stubs(:single_line_of_content_for).with(:title).returns('Hello')
+
+      assert_nil @presenter.partial_template_path
+    end
+
+    test '#wrapped_with_debug_div? when wrapped with debug div returns true' do
+      @renderer.stubs(:single_line_of_content_for).with(:title).returns(@div)
+
+      assert @presenter.wrapped_with_debug_div?
+    end
+
+    test '#wrapped_with_debug_div? when it isn\'t wrapped with debug div returns false' do
+      @renderer.stubs(:single_line_of_content_for).with(:title).returns('Hello')
+
+      refute @presenter.wrapped_with_debug_div?
     end
   end
 end

--- a/test/unit/smart_answer_partial_template_wrapper_test.rb
+++ b/test/unit/smart_answer_partial_template_wrapper_test.rb
@@ -1,0 +1,72 @@
+require "test_helper"
+
+class SmartAnswerPartialTemplateWrapperTest < ActionView::TestCase
+  context "#render" do
+    setup do
+      @sample_renderer = SampleRenderer.new
+      @context = SmartAnswersController.new
+      @context.request = ActionDispatch::TestRequest.create
+    end
+
+    context "without wrapping div" do
+      setup do
+        @path = "/root/path/to/partial.html"
+        @sample_renderer.template = OpenStruct.new(identifier: @path)
+      end
+
+      should "return partial html content" do
+        assert_equal "<h1>Hello</h1>", @sample_renderer.render(@context, {}, nil)
+      end
+
+      should "return partial govspeak content when partial isn't under smart answer path" do
+        TestRenderer.any_instance.stubs(:render).returns("## Hello")
+
+        assert_equal "## Hello", @sample_renderer.render(@context, {}, nil)
+      end
+
+      should "return partial govspeak content when request format isn't html" do
+        path = "/root/lib/smart_answer_flows/m/partial.govspeak.erb"
+        @sample_renderer.template = OpenStruct.new(identifier: path)
+        TestRenderer.any_instance.stubs(:render).returns("## Hello")
+        Mime::Type.any_instance.stubs(:symbol).returns(:text)
+
+        assert_equal "## Hello", @sample_renderer.render(@context, {}, nil)
+      end
+    end
+
+    context "with wrapping div" do
+      setup do
+        @path = "/root/lib/smart_answer_flows/m/partial.govspeak.erb"
+        @sample_renderer.template = OpenStruct.new(identifier: @path)
+      end
+
+      should "return partial content when request is html and under smart answer path" do
+        assert_match(
+          /^<div data-debug-template-path=\".*#{@path}\"><h1>Hello<\/h1><\/div>/,
+          @sample_renderer.render(@context, {}, nil)
+        )
+      end
+
+      should "return html content for partials containing govspeak" do
+        TestRenderer.any_instance.stubs(:render).returns("## Hello")
+
+        assert_match(
+          /^<div data-debug-template-path=\".*#{@path}\"><h2 id=\"hello\">Hello<\/h2><\/div>/,
+          @sample_renderer.render(@context, {}, nil)
+        )
+      end
+    end
+  end
+end
+
+class TestRenderer
+  attr_accessor :template
+
+  def render(*)
+    "<h1>Hello</h1>"
+  end
+end
+
+class SampleRenderer < TestRenderer
+  include SmartAnswerPartialTemplateWrapper
+end

--- a/test/unit/smart_answer_partial_template_wrapper_test.rb
+++ b/test/unit/smart_answer_partial_template_wrapper_test.rb
@@ -42,7 +42,7 @@ class SmartAnswerPartialTemplateWrapperTest < ActionView::TestCase
 
       should "return partial content when request is html and under smart answer path" do
         assert_match(
-          /^<div data-debug-template-path=\".*#{@path}\"><h1>Hello<\/h1><\/div>/,
+          /^<div data-debug-partial-template-path=\".*#{@path}\"><h1>Hello<\/h1><\/div>/,
           @sample_renderer.render(@context, {}, nil)
         )
       end
@@ -51,7 +51,7 @@ class SmartAnswerPartialTemplateWrapperTest < ActionView::TestCase
         TestRenderer.any_instance.stubs(:render).returns("## Hello")
 
         assert_match(
-          /^<div data-debug-template-path=\".*#{@path}\"><h2 id=\"hello\">Hello<\/h2><\/div>/,
+          /^<div data-debug-partial-template-path=\".*#{@path}\"><h2 id=\"hello\">Hello<\/h2><\/div>/,
           @sample_renderer.render(@context, {}, nil)
         )
       end

--- a/test/unit/title_test.rb
+++ b/test/unit/title_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+
+module SmartAnswer
+  class TitleTest < ActiveSupport::TestCase
+    context "#wrapped_with_debug_div?" do
+      should "return true if content is wrapped with debug div" do
+        html = "<div data-debug-template-path=\"/path\"><p>Hello</p></div>"
+
+        assert Title.new(html).wrapped_with_debug_div?
+      end
+
+      should "return false if content isn't wrapped with debug div" do
+        refute Title.new("Hello").wrapped_with_debug_div?
+      end
+    end
+
+    context "#text" do
+      should "return text if content is wrapped with debug div" do
+        html = "<div data-debug-template-path=\"/path\"><p>Hello</p></div>"
+
+        assert_equal "Hello", Title.new(html).text
+      end
+
+      should "return unchanged content if content isn't wrapped with debug div" do
+        assert_equal "Hello", Title.new("Hello").text
+      end
+    end
+
+    context "#partial_template_path" do
+      should "return path to partial template if content is wrapped with debug div" do
+        html = "<div data-debug-template-path=\"/path\"><p>Hello</p></div>"
+
+        assert_equal "/path", Title.new(html).partial_template_path
+      end
+
+      should "return nil if content isn't wrapped with debug div" do
+        assert_nil Title.new("Hello").partial_template_path
+      end
+    end
+  end
+end

--- a/test/unit/title_test.rb
+++ b/test/unit/title_test.rb
@@ -4,7 +4,7 @@ module SmartAnswer
   class TitleTest < ActiveSupport::TestCase
     context "#wrapped_with_debug_div?" do
       should "return true if content is wrapped with debug div" do
-        html = "<div data-debug-template-path=\"/path\"><p>Hello</p></div>"
+        html = "<div data-debug-partial-template-path=\"/path\"><p>Hello</p></div>"
 
         assert Title.new(html).wrapped_with_debug_div?
       end
@@ -16,7 +16,7 @@ module SmartAnswer
 
     context "#text" do
       should "return text if content is wrapped with debug div" do
-        html = "<div data-debug-template-path=\"/path\"><p>Hello</p></div>"
+        html = "<div data-debug-partial-template-path=\"/path\"><p>Hello</p></div>"
 
         assert_equal "Hello", Title.new(html).text
       end
@@ -28,7 +28,7 @@ module SmartAnswer
 
     context "#partial_template_path" do
       should "return path to partial template if content is wrapped with debug div" do
-        html = "<div data-debug-template-path=\"/path\"><p>Hello</p></div>"
+        html = "<div data-debug-partial-template-path=\"/path\"><p>Hello</p></div>"
 
         assert_equal "/path", Title.new(html).partial_template_path
       end


### PR DESCRIPTION
Related PR https://github.com/alphagov/govuk-toolkit-chrome/pull/78
[Trello card](https://trello.com/c/OS0nF0tp/272-8-provide-a-way-for-content-designers-to-navigate-from-content-to-partial-templates-on-github)

## Motivation

When a content designer needs to edit smart answer content, they find it difficult to find the relevant template(s) and partial(s) that a outcome or question is comprised of.

This PR continues the spike from [this PR][1] with the aim of wrapping and tagging each partial for identification, highlighting and linking to the relevant partial template on GitHub.

An example can be found when looking at templates like [this one][2], that have nested partial templates within a content_for title.

This PR also caters for `.txt` requests by making sure that the wrapping debug div is only applied for standard HTML requests.

[1]: https://github.com/alphagov/smart-answers/pull/2642
[2]: https://www.gov.uk/marriage-abroad/y/sweden/uk/partner_british/same_sex

## Factcheck

[Preview link for html format](https://smart-answers-preview-pr-3195.herokuapp.com/marriage-abroad/y/sweden/uk/partner_british/same_sex)
[Preview link for text format](https://smart-answers-preview-pr-3195.herokuapp.com/marriage-abroad/y/sweden/uk/partner_british/same_sex.txt)

[GOVUK for html format](https://gov.uk/marriage-abroad/y/sweden/uk/partner_british/same_sex)

## Expected changes

- Content designers can now locate partial templates on Github


## Before

![screen shot 2017-08-22 at 09 20 29](https://user-images.githubusercontent.com/84896/29555631-30c25964-871b-11e7-8f46-87a18232397d.png)


## After

![screen shot 2017-08-23 at 09 23 28](https://user-images.githubusercontent.com/84896/29606003-c41bc866-87e4-11e7-98d8-cd250f95acc8.png)
