### PR TITLE
Add current_path to the survey link in the beta banner

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,4 +2,8 @@ module ApplicationHelper
   def last_updated_date
     File.mtime(Rails.root.join('REVISION')).to_date rescue Date.today
   end
+
+  def current_path_without_query_string
+    request.original_fullpath.split("?", 2).first
+  end
 end

--- a/app/views/layouts/smart_answers.html.erb
+++ b/app/views/layouts/smart_answers.html.erb
@@ -16,7 +16,7 @@
       locals: {
         message: <<-MESSAGE
         This is a test version of the layout of this page.
-        <a id='taxonomy-survey' href='https://www.smartsurvey.co.uk/s/betasurvey2017' target='_blank' rel='noopener noreferrer'>
+        <a id='taxonomy-survey' href='https://www.smartsurvey.co.uk/s/betasurvey2017?c=#{current_path_without_query_string}' target='_blank' rel='noopener noreferrer'>
           Take the survey to help us improve it
         </a>
         MESSAGE

--- a/test/unit/application_helper_test.rb
+++ b/test/unit/application_helper_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class ApplicationHelperTest < ActionView::TestCase
+  tests ApplicationHelper
+
+  context '#current_path_without_query_string' do
+    should "return the path of the current request" do
+      self.stubs(:request).returns(ActionDispatch::TestRequest.new("PATH_INFO" => '/foo/bar'))
+      assert_equal '/foo/bar', current_path_without_query_string
+    end
+
+    should "return the path of the current request stripping off any query string parameters" do
+      self.stubs(:request).returns(ActionDispatch::TestRequest.new("PATH_INFO" => '/foo/bar', "QUERY_STRING" => 'ham=jam&spam=gram'))
+      assert_equal '/foo/bar', current_path_without_query_string
+    end
+  end
+end


### PR DESCRIPTION
For: https://trello.com/c/Bo5SQrIm/215-add-page-tracking-custom-dimension-into-education-beta-survey-banner

This lets the survey team know where each response has come from and
allows them to filter by section of the site.