### PR TITLE
Apply time freeze to failing time sensitive tests

### DIFF
--- a/test/integration/smart_answer_flows/calculate_employee_redundancy_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_employee_redundancy_pay_test.rb
@@ -7,6 +7,7 @@ class CalculateEmployeeRedundancyPayTest < ActiveSupport::TestCase
   include FlowTestHelper
 
   setup do
+    Timecop.freeze("2017-08-31")
     stub_shared_component_locales
     setup_for_testing_flow SmartAnswer::CalculateEmployeeRedundancyPayFlow
   end

--- a/test/integration/smart_answer_flows/calculate_your_redundancy_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_your_redundancy_pay_test.rb
@@ -7,6 +7,7 @@ class CalculateYourRedundancyPayTest < ActiveSupport::TestCase
   include FlowTestHelper
 
   setup do
+    Timecop.freeze("2017-08-31")
     stub_shared_component_locales
     setup_for_testing_flow SmartAnswer::CalculateYourRedundancyPayFlow
   end


### PR DESCRIPTION
[Trello card](https://trello.com/c/rf8IBYSh/737-fix-time-sensitive-tests)
## Motivation 

Following the failure of time sensitive tests that we discovered today
1st September 2017, we have applied a time freeze ending last month to
set the tone for these tests to run within.

This commit makes these changes to integration tests belonging to the
following:

- Calculate Your Redundancy Pay
- Calculate Employee Redundancy Pay