### PR TITLE
Algeria marriage tool wording

### DIFF
--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/algeria/uk/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/algeria/uk/partner_british/_opposite_sex.erb
@@ -10,18 +10,9 @@ You can normally get a CNI by giving a notice of marriage at your local register
 
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Algeria to find out how long a CNI is valid under local law.^
 
-###Legalisation and translation
-
 You’ll need to exchange your UK-issued CNI for one that’s valid in Algeria at the nearest British embassy to where you’re getting married.
 
 [Make an appointment at the British Embassy in Algiers](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-algeria/exchange-a-certificate-of-no-impediment/slot_picker).
-
-You should also check if it needs to be:
-
-- ‘[legalised](/get-document-legalised)’ (certified as genuine)
-- translated - [find a translator abroad](/government/collections/list-of-lawyers), or in the UK through the [Institute of Linguists](http://www.ciol.org.uk)
-
-You should also check with the local authorities in Algeria to find out if you need to provide legalised and translated copies of any other documents.
 
 %The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/algeria/uk/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/algeria/uk/partner_british/_opposite_sex.erb
@@ -12,7 +12,9 @@ You can normally get a CNI by giving a notice of marriage at your local register
 
 ###Legalisation and translation
 
-You might need to exchange your UK-issued CNI for one that’s valid in Algeria at the nearest embassy or consulate to where you’re getting married.
+You’ll need to exchange your UK-issued CNI for one that’s valid in Algeria at the nearest British embassy to where you’re getting married.
+
+[Make an appointment at the British Embassy in Algiers](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-algeria/exchange-a-certificate-of-no-impediment/slot_picker).
 
 You should also check if it needs to be:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/algeria/uk/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/algeria/uk/partner_local/_opposite_sex.erb
@@ -10,19 +10,14 @@ You can normally get a CNI by giving a notice of marriage at your local register
 
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Algeria to find out how long a CNI is valid under local law.^
 
-###Legalisation and translation
+You’ll need to exchange your UK-issued CNI for one that’s valid in Algeria at the nearest British embassy to where you’re getting married.
 
-You might need to exchange your UK-issued CNI for one that’s valid in Algeria at the nearest embassy or consulate to where you’re getting married.
-
-You should also check if it needs to be:
-
-- ‘[legalised](/get-document-legalised)’ (certified as genuine)
-- translated - [find a translator abroad](/government/collections/list-of-lawyers), or in the UK through the [Institute of Linguists](http://www.ciol.org.uk)
-
-You should also check with the local authorities in Algeria to find out if you need to provide legalised and translated copies of any other documents.
+[Make an appointment at the British Embassy in Algiers](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-algeria/exchange-a-certificate-of-no-impediment/slot_picker).
 
 %The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
 
-<%= render partial: 'partner_naturalisation_in_uk' %>
+##Naturalisation of your partner if they move to the UK
+
+Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
 
 *[CNI]:certificate of no impediment

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/algeria/uk/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/algeria/uk/partner_other/_opposite_sex.erb
@@ -10,19 +10,14 @@ You can normally get a CNI by giving a notice of marriage at your local register
 
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Algeria to find out how long a CNI is valid under local law.^
 
-###Legalisation and translation
+You’ll need to exchange your UK-issued CNI for one that’s valid in Algeria at the nearest British embassy to where you’re getting married.
 
-You might need to exchange your UK-issued CNI for one that’s valid in Algeria at the nearest embassy or consulate to where you’re getting married.
-
-You should also check if it needs to be:
-
-- ‘[legalised](/get-document-legalised)’ (certified as genuine)
-- translated - [find a translator abroad](/government/collections/list-of-lawyers), or in the UK through the [Institute of Linguists](http://www.ciol.org.uk)
-
-You should also check with the local authorities in Algeria to find out if you need to provide legalised and translated copies of any other documents.
+[Make an appointment at the British Embassy in Algiers](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-algeria/exchange-a-certificate-of-no-impediment/slot_picker).
 
 %The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
 
-<%= render partial: 'partner_naturalisation_in_uk' %>
+##Naturalisation of your partner if they move to the UK
+
+Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
 
 *[CNI]:certificate of no impediment

--- a/test/artefacts/marriage-abroad/algeria/uk/partner_british/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/algeria/uk/partner_british/opposite_sex.txt
@@ -12,16 +12,9 @@ You can normally get a CNI by giving a notice of marriage at your local register
 
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Algeria to find out how long a CNI is valid under local law.^
 
-###Legalisation and translation
+You’ll need to exchange your UK-issued CNI for one that’s valid in Algeria at the nearest British embassy to where you’re getting married.
 
-You might need to exchange your UK-issued CNI for one that’s valid in Algeria at the nearest embassy or consulate to where you’re getting married.
-
-You should also check if it needs to be:
-
-- ‘[legalised](/get-document-legalised)’ (certified as genuine)
-- translated - [find a translator abroad](/government/collections/list-of-lawyers), or in the UK through the [Institute of Linguists](http://www.ciol.org.uk)
-
-You should also check with the local authorities in Algeria to find out if you need to provide legalised and translated copies of any other documents.
+[Make an appointment at the British Embassy in Algiers](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-algeria/exchange-a-certificate-of-no-impediment/slot_picker).
 
 %The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
 

--- a/test/artefacts/marriage-abroad/algeria/uk/partner_local/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/algeria/uk/partner_local/opposite_sex.txt
@@ -12,16 +12,9 @@ You can normally get a CNI by giving a notice of marriage at your local register
 
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Algeria to find out how long a CNI is valid under local law.^
 
-###Legalisation and translation
+You’ll need to exchange your UK-issued CNI for one that’s valid in Algeria at the nearest British embassy to where you’re getting married.
 
-You might need to exchange your UK-issued CNI for one that’s valid in Algeria at the nearest embassy or consulate to where you’re getting married.
-
-You should also check if it needs to be:
-
-- ‘[legalised](/get-document-legalised)’ (certified as genuine)
-- translated - [find a translator abroad](/government/collections/list-of-lawyers), or in the UK through the [Institute of Linguists](http://www.ciol.org.uk)
-
-You should also check with the local authorities in Algeria to find out if you need to provide legalised and translated copies of any other documents.
+[Make an appointment at the British Embassy in Algiers](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-algeria/exchange-a-certificate-of-no-impediment/slot_picker).
 
 %The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
 

--- a/test/artefacts/marriage-abroad/algeria/uk/partner_other/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/algeria/uk/partner_other/opposite_sex.txt
@@ -12,16 +12,9 @@ You can normally get a CNI by giving a notice of marriage at your local register
 
 ^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Algeria to find out how long a CNI is valid under local law.^
 
-###Legalisation and translation
+You’ll need to exchange your UK-issued CNI for one that’s valid in Algeria at the nearest British embassy to where you’re getting married.
 
-You might need to exchange your UK-issued CNI for one that’s valid in Algeria at the nearest embassy or consulate to where you’re getting married.
-
-You should also check if it needs to be:
-
-- ‘[legalised](/get-document-legalised)’ (certified as genuine)
-- translated - [find a translator abroad](/government/collections/list-of-lawyers), or in the UK through the [Institute of Linguists](http://www.ciol.org.uk)
-
-You should also check with the local authorities in Algeria to find out if you need to provide legalised and translated copies of any other documents.
+[Make an appointment at the British Embassy in Algiers](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-algeria/exchange-a-certificate-of-no-impediment/slot_picker).
 
 %The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
 

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -93,11 +93,11 @@ lib/smart_answer_flows/marriage-abroad/outcomes/countries/algeria/third_country/
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/algeria/third_country/partner_local/_same_sex.erb: 012aa5bd3ce9dce24c79aed0505c605f
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/algeria/third_country/partner_other/_opposite_sex.erb: 3b02e1e2f21e503bf4bc2c9e7fe361db
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/algeria/third_country/partner_other/_same_sex.erb: 012aa5bd3ce9dce24c79aed0505c605f
-lib/smart_answer_flows/marriage-abroad/outcomes/countries/algeria/uk/partner_british/_opposite_sex.erb: 380dda27cd5a818b454a79ccdb0485d9
+lib/smart_answer_flows/marriage-abroad/outcomes/countries/algeria/uk/partner_british/_opposite_sex.erb: 13c0a3d63c6ca68bac04417be7ab3171
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/algeria/uk/partner_british/_same_sex.erb: 012aa5bd3ce9dce24c79aed0505c605f
-lib/smart_answer_flows/marriage-abroad/outcomes/countries/algeria/uk/partner_local/_opposite_sex.erb: 3a727df0baee3022cc987bed0e7f160a
+lib/smart_answer_flows/marriage-abroad/outcomes/countries/algeria/uk/partner_local/_opposite_sex.erb: 54fbd61d28b00c1aea0599794f8bebb8
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/algeria/uk/partner_local/_same_sex.erb: 012aa5bd3ce9dce24c79aed0505c605f
-lib/smart_answer_flows/marriage-abroad/outcomes/countries/algeria/uk/partner_other/_opposite_sex.erb: 3a727df0baee3022cc987bed0e7f160a
+lib/smart_answer_flows/marriage-abroad/outcomes/countries/algeria/uk/partner_other/_opposite_sex.erb: 54fbd61d28b00c1aea0599794f8bebb8
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/algeria/uk/partner_other/_same_sex.erb: 012aa5bd3ce9dce24c79aed0505c605f
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/azerbaijan/_title.govspeak.erb: 78d1dc92913316a6804b14e892246c76
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/azerbaijan/ceremony_country/partner_british/_opposite_sex.erb: 8ac335db6ca9fbefe37c4b801cffa43b


### PR DESCRIPTION
## Trello
https://trello.com/c/iKa5EWH0/739-algeria-marriage-tool-change-to-wording-on-opposite-sex-marriage-content-change-request

## Content Affected
https://www.gov.uk/marriage-abroad/y/algeria

Where the user is in the UK, user will need to make an appointment at the Embassy in Algiers to exchange their Certificate of No Impediment for a local version: 

```
You’ll need to exchange your UK-issued CNI for one that’s valid in Algeria at the nearest British embassy to where you’re getting married.

Make an appointment at the British Embassy in Algiers.
```

## Factcheck
https://smart-answers-preview-pr-3203.herokuapp.com/marriage-abroad/y/algeria/uk/partner_british/opposite_sex
https://gov.uk/marriage-abroad/y/algeria/uk/partner_british/opposite_sex

## Before

![screen shot 2017-09-04 at 12 05 45](https://user-images.githubusercontent.com/84896/30023915-6a271822-9169-11e7-8cb5-5e94b83c08ce.png)

## After

![screen shot 2017-09-04 at 12 05 14](https://user-images.githubusercontent.com/84896/30023916-6ec4656a-9169-11e7-9e55-64a4133d960e.png)


### Affected outcomes

- https://smart-answers-preview-pr-3203.herokuapp.com/marriage-abroad/y/algeria/uk/partner_british/opposite_sex
- https://smart-answers-preview-pr-3203.herokuapp.com/marriage-abroad/y/algeria/uk/partner_local/opposite_sex
- https://smart-answers-preview-pr-3203.herokuapp.com/marriage-abroad/y/algeria/uk/partner_other/opposite_sex
