### PR TITLE
Display an alert on heroku deployments

### DIFF
--- a/app/assets/stylesheets/smart_answers.scss
+++ b/app/assets/stylesheets/smart_answers.scss
@@ -376,3 +376,18 @@ $is-ie: false !default;
   }
 
 }
+
+//Heroku alert
+.heroku-alert {
+    margin: 0 15px 15px 15px;
+    border: 1px solid #B01117;
+    background-color: #B01117;
+    color: #FFF;
+    padding: 1em;
+    font-weight: bold;
+
+    a {
+      cursor: pointer;
+      color: #FFF3CF;
+    }
+}

--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -64,6 +64,11 @@ class SmartAnswersController < ApplicationController
 
 private
 
+  def heroku?
+    request.host.include? "herokuapp"
+  end
+  helper_method :heroku?
+
   def debug?
     Rails.env.development? && params[:debug]
   end

--- a/app/views/layouts/smart_answers.html.erb
+++ b/app/views/layouts/smart_answers.html.erb
@@ -28,6 +28,8 @@
 <%= render partial: 'govuk_component/breadcrumbs', locals: breadcrumbs %>
 
 <div class="grid-row">
+  <%= render partial: "smart_answers/heroku_alert" if heroku? %>
+
   <main id="content" role="main">
     <%= yield %>
 

--- a/app/views/smart_answers/_heroku_alert.html.erb
+++ b/app/views/smart_answers/_heroku_alert.html.erb
@@ -1,0 +1,1 @@
+<div class="heroku-alert">PLEASE NOTE THAT THIS IS ONLY A TEST VERSION, REFER TO <%= link_to "GOV.UK", request.url.gsub(/smart-answers-preview-pr-[0-9]{4}.herokuapp.com/,"www.gov.uk") %> FOR THE OFFICIAL VERSION OF THIS DOCUMENT</div>

--- a/test/integration/heroku_alert_test.rb
+++ b/test/integration/heroku_alert_test.rb
@@ -1,0 +1,25 @@
+require_relative "../integration_test_helper"
+
+class HerokuAlertTest < ActionDispatch::IntegrationTest
+  should "not generally display the heroku alert" do
+    visit "/"
+    assert page.has_text? "Smart Answers"
+    assert page.has_no_css? ".heroku-alert"
+  end
+
+  context "on heroku" do
+    setup do
+      Capybara.app_host = 'http://example.herokuapp.com'
+    end
+
+    should "display the heroku alert" do
+      visit "/"
+      assert page.has_text? "Smart Answers"
+      assert page.has_css? ".heroku-alert"
+    end
+
+    teardown do
+      Capybara.app_host = nil
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/goZxffsJ/735-investigate-protecting-the-heroku-smart-answer-preview-apps

We want to avoid the general public being confused about the
information in the Smart Answers preview apps on Heroku.

We are then displaying a big alert banner on top of each page of heroku
deployments, to make very clear that the information shouldn't be
relied upon, and the user should instead refer to gov.uk for the
official information.

## Preview
<img width="1081" alt="screen shot 2017-09-05 at 12 12 31" src="https://user-images.githubusercontent.com/6908677/30056584-88780208-9233-11e7-8da9-943c1582f4c1.png">
