### PR TITLE
Replace markdown links with html anchor

### DIFF
--- a/lib/smart_answer_flows/simplified-expenses-checker/questions/is_vehicle_green.govspeak.erb
+++ b/lib/smart_answer_flows/simplified-expenses-checker/questions/is_vehicle_green.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :title do %>
-  What are the car’s [CO2 emissions](/get-vehicle-information-from-dvla)?
+  What are the car’s <a href="/get-vehicle-information-from-dvla">CO2 emissions</a>?
 <% end %>
 
 <% options(

--- a/test/artefacts/simplified-expenses-checker/car/using_home_for_business/new/2345.txt
+++ b/test/artefacts/simplified-expenses-checker/car/using_home_for_business/new/2345.txt
@@ -1,4 +1,4 @@
-What are the car’s [CO2 emissions](/get-vehicle-information-from-dvla)?
+What are the car’s <a href="/get-vehicle-information-from-dvla">CO2 emissions</a>?
 
 
 

--- a/test/data/simplified-expenses-checker-files.yml
+++ b/test/data/simplified-expenses-checker-files.yml
@@ -14,7 +14,7 @@ lib/smart_answer_flows/simplified-expenses-checker/questions/drive_business_mile
 lib/smart_answer_flows/simplified-expenses-checker/questions/home_or_business_premises_expense.govspeak.erb: be3746a7772c7f22003d9814aa11b07a
 lib/smart_answer_flows/simplified-expenses-checker/questions/hours_work_home.govspeak.erb: 41b408209957ac9297effcf53d31a15e
 lib/smart_answer_flows/simplified-expenses-checker/questions/how_much_expect_to_claim.govspeak.erb: 619162f97b2e5b00bdcf412fc0179a9a
-lib/smart_answer_flows/simplified-expenses-checker/questions/is_vehicle_green.govspeak.erb: 8a4b9d3899c3a2da60f815ef3e9084d0
+lib/smart_answer_flows/simplified-expenses-checker/questions/is_vehicle_green.govspeak.erb: 87f861ff21097f0e71da4eddccf14570
 lib/smart_answer_flows/simplified-expenses-checker/questions/people_live_on_premises.govspeak.erb: 7f2526953dd971df560a129336734d86
 lib/smart_answer_flows/simplified-expenses-checker/questions/price_of_vehicle.govspeak.erb: 6bd3b953125705033aa4e740dfd89ab9
 lib/smart_answer_flows/simplified-expenses-checker/questions/type_of_expense.govspeak.erb: 6accfbd7201311005baa73c335999688


### PR DESCRIPTION
[Trello card](https://trello.com/c/8Hgtl17t/280-21-updates-for-simplified-expenses-smart-answer)

## Description 

This PR fixes an error where markdown link were used in a title content tag.

This title content tag isn't converted [1] from markdown to html [2] and hence this breaks.

[1] https://github.com/alphagov/smart-answers/blob/master/app/presenters/question_presenter.rb#L15
[2] https://github.com/alphagov/smart-answers/blob/master/lib/smart_answer/erb_renderer.rb#L23


## Factcheck

[Preview link](https://smart-answers-preview-pr-3218.herokuapp.com/simplified-expenses-checker/y/car/using_home_for_business/new/2345)
[GOVUK](https://gov.uk/simplified-expenses-checker/y/car/using_home_for_business/new/2345)

### Before
![screen shot 2017-09-28 at 15 51 05](https://user-images.githubusercontent.com/84896/30973385-e4637ece-a464-11e7-868b-1fb9bce12d5e.png)

### After
![screen shot 2017-09-28 at 15 52 47](https://user-images.githubusercontent.com/84896/30973475-19328aaa-a465-11e7-925c-7d1c9aadc28a.png)

