### PR TITLE
Replacing the anchor with hint

### DIFF
--- a/lib/smart_answer_flows/simplified-expenses-checker/questions/is_vehicle_green.govspeak.erb
+++ b/lib/smart_answer_flows/simplified-expenses-checker/questions/is_vehicle_green.govspeak.erb
@@ -1,5 +1,9 @@
 <% content_for :title do %>
-  What are the car’s <a href="/get-vehicle-information-from-dvla">CO2 emissions</a>?
+  What are the car’s CO2 emissions?
+<% end %>
+
+<% content_for :hint do %>
+  Check your car's <a href="/get-vehicle-information-from-dvla">CO2 emissions</a>.
 <% end %>
 
 <% options(

--- a/test/artefacts/simplified-expenses-checker/car/using_home_for_business/new/2345.txt
+++ b/test/artefacts/simplified-expenses-checker/car/using_home_for_business/new/2345.txt
@@ -1,8 +1,8 @@
-What are the car’s <a href="/get-vehicle-information-from-dvla">CO2 emissions</a>?
+What are the car’s CO2 emissions?
 
 
 
-
+Check your car's <a href="/get-vehicle-information-from-dvla">CO2 emissions</a>.
 
   * low: 75g/km or less (or it’s electric)
   * medium: between 75g/km and 130g/km

--- a/test/data/simplified-expenses-checker-files.yml
+++ b/test/data/simplified-expenses-checker-files.yml
@@ -14,7 +14,7 @@ lib/smart_answer_flows/simplified-expenses-checker/questions/drive_business_mile
 lib/smart_answer_flows/simplified-expenses-checker/questions/home_or_business_premises_expense.govspeak.erb: be3746a7772c7f22003d9814aa11b07a
 lib/smart_answer_flows/simplified-expenses-checker/questions/hours_work_home.govspeak.erb: 41b408209957ac9297effcf53d31a15e
 lib/smart_answer_flows/simplified-expenses-checker/questions/how_much_expect_to_claim.govspeak.erb: 619162f97b2e5b00bdcf412fc0179a9a
-lib/smart_answer_flows/simplified-expenses-checker/questions/is_vehicle_green.govspeak.erb: 87f861ff21097f0e71da4eddccf14570
+lib/smart_answer_flows/simplified-expenses-checker/questions/is_vehicle_green.govspeak.erb: 0bb8b56a5a9594217810fa0d99bf5cee
 lib/smart_answer_flows/simplified-expenses-checker/questions/people_live_on_premises.govspeak.erb: 7f2526953dd971df560a129336734d86
 lib/smart_answer_flows/simplified-expenses-checker/questions/price_of_vehicle.govspeak.erb: 6bd3b953125705033aa4e740dfd89ab9
 lib/smart_answer_flows/simplified-expenses-checker/questions/type_of_expense.govspeak.erb: 6accfbd7201311005baa73c335999688


### PR DESCRIPTION
[Trello card](https://trello.com/c/8Hgtl17t/280-21-updates-for-simplified-expenses-smart-answer)

## Description

This PR fixes an error where link disrupts the question listing especially on the question that come after it.

The content design team have provided content for the hint.

Link: https://www.gov.uk/simplified-expenses-checker/y/car/using_home_for_business/new/2345/low

![screen shot 2017-09-29 at 16 21 07](https://user-images.githubusercontent.com/84896/31023001-72239bcc-a532-11e7-8e6d-e48fab053a33.png)

## Factcheck

[Preview link](https://smart-answers-preview-pr-3222.herokuapp.com/simplified-expenses-checker/y/car/using_home_for_business/new/2345)
[GOVUK](https://gov.uk/simplified-expenses-checker/y/car/using_home_for_business/new/2345)

### Expected changes
- Changed anchor with hint with content and link

### Before

![screen shot 2017-09-29 at 16 15 59](https://user-images.githubusercontent.com/84896/31022695-848939e4-a531-11e7-8989-3d1496861437.png)

### After

![screen shot 2017-09-29 at 16 15 45](https://user-images.githubusercontent.com/84896/31022704-88df3160-a531-11e7-911e-0ea4182bebb1.png)
