### PR TITLE
Remove need to include files at deploy time

### DIFF
--- a/config/initializers/flow_preview.rb
+++ b/config/initializers/flow_preview.rb
@@ -1,10 +1,8 @@
-# This file potentially overwritten on deploy
+# If an env var isn't to specify showing drafts we'll decide it based on Rails
+# environment
+show_drafts = ENV["SHOW_DRAFT_FLOWS"] ? true : !Rails.env.production?
 
-if Rails.env.production?
-  FLOW_REGISTRY_OPTIONS = {}
-else
-  FLOW_REGISTRY_OPTIONS = { show_drafts: true }
-end
+FLOW_REGISTRY_OPTIONS = { show_drafts: show_drafts }
 
 # Uncomment the following to run smartanswers with the test flows instead of the real ones
 #

--- a/config/initializers/gds_api.rb
+++ b/config/initializers/gds_api.rb
@@ -1,0 +1,4 @@
+require 'gds_api/base'
+
+GdsApi::Base.logger = Logger.new(Rails.root.join("log/#{Rails.env}.api_client.log"))
+GdsApi::Base.default_options = { cache_size: 100 }


### PR DESCRIPTION
This is to make way for the retiring of [alphagov-deployment](github.com/alphagov/alphagov-deployment) by moving in files that are added at deploy time and setting configuration by environment variables.

Related puppet change: https://github.com/alphagov/govuk-puppet/pull/6673