### PR TITLE
Smart answer improve accessibility - 1/11

### DIFF
--- a/lib/smart_answer_flows/calculate-married-couples-allowance/questions/how_much_expected_contributions_before_tax.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-married-couples-allowance/questions/how_much_expected_contributions_before_tax.govspeak.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :hint do %>
-  If none, please enter 0.
+  These are payments into pension schemes where your contributions are paid before your income is taxed (called ‘net pay arrangements’) or retirement annuity contracts (called ‘gross contributions’). Enter the total for the whole year. If none, enter 0.
 <% end %>
 
 <% content_for :error_message do %>

--- a/test/artefacts/calculate-married-couples-allowance/yes/yes/1950-01-01/28001.0/yes.txt
+++ b/test/artefacts/calculate-married-couples-allowance/yes/yes/1950-01-01/28001.0/yes.txt
@@ -2,7 +2,7 @@ How much do you expect to pay for the whole tax year into a retirement annuity c
 
 
 
-If none, please enter 0.
+These are payments into pension schemes where your contributions are paid before your income is taxed (called ‘net pay arrangements’) or retirement annuity contracts (called ‘gross contributions’). Enter the total for the whole year. If none, enter 0.
 
 
 

--- a/test/data/calculate-married-couples-allowance-files.yml
+++ b/test/data/calculate-married-couples-allowance-files.yml
@@ -10,7 +10,7 @@ lib/smart_answer_flows/calculate-married-couples-allowance/outcomes/husband_done
 lib/smart_answer_flows/calculate-married-couples-allowance/outcomes/sorry.govspeak.erb: d862e76cbe8111a3c04eb46fcd042e7a
 ? lib/smart_answer_flows/calculate-married-couples-allowance/questions/did_you_marry_or_civil_partner_before_5_december_2005.govspeak.erb
 : 293ac6ffb62fcf5907b9ff2a10c76c21
-lib/smart_answer_flows/calculate-married-couples-allowance/questions/how_much_expected_contributions_before_tax.govspeak.erb: b86c6502289c92c6b3938e6c69a59bb4
+lib/smart_answer_flows/calculate-married-couples-allowance/questions/how_much_expected_contributions_before_tax.govspeak.erb: 0413fc9154ed3f600257f450cb221cfd
 ? lib/smart_answer_flows/calculate-married-couples-allowance/questions/how_much_expected_contributions_with_tax_relief.govspeak.erb
 : c0bc019c2a0ff1333bceb59636aa71cf
 lib/smart_answer_flows/calculate-married-couples-allowance/questions/how_much_expected_gift_aided_donations.govspeak.erb: 3d04c9df0d023a80908d81d3e037f2c9


### PR DESCRIPTION
Trello: https://trello.com/c/ahwlLZR8/698-smart-answer-accessibility-changes-1-11

Update master to comply with:
https://github.com/katitirbhowan/smart-answers/blob/married-couples-allowance-pension-contributions/lib/smart_answer_flows/calculate-married-couples-allowance/questions/how_much_expected_contributions_before_tax.govspeak.erb

This reverts commit 672e2dff9f3eff92fef21b77d948bbd2c32e8ffd and reapplies the changes of the PR #3165. It was previously merged by mistake and then reverted.

## Preview
[Heroku Preview](https://smart-answers-preview-pr-3236.herokuapp.com/calculate-married-couples-allowance/y)
[Test Path example: https://smart-answers-preview-pr-3236.herokuapp.com/calculate-married-couples-allowance/y/yes/no/1923-01-02/150000.0/yes](https://smart-answers-preview-pr-3236.herokuapp.com/calculate-married-couples-allowance/y/yes/no/1923-01-02/150000.0/yes)


###  Before
<img width="687" alt="screen shot 2017-10-18 at 16 24 33" src="https://user-images.githubusercontent.com/6908677/31724041-e5dd40a2-b420-11e7-88a1-11d6360b0531.png">

###  After
<img width="658" alt="screen shot 2017-10-18 at 16 24 49" src="https://user-images.githubusercontent.com/6908677/31724055-edd5234c-b420-11e7-892e-af3435fcf022.png">

