### PR TITLE
Change rummager payload document type

### DIFF
--- a/app/presenters/search_payload_presenter.rb
+++ b/app/presenters/search_payload_presenter.rb
@@ -25,7 +25,7 @@ class SearchPayloadPresenter
       description: description,
       indexable_content: indexable_content,
       link: "/#{slug}",
-      content_store_document_type: 'smart_answer',
+      content_store_document_type: 'transaction',
     }
   end
 end

--- a/test/unit/services/search_indexer_test.rb
+++ b/test/unit/services/search_indexer_test.rb
@@ -20,7 +20,7 @@ class SearchIndexerTest < ActiveSupport::TestCase
       description: flow_presenter.description,
       indexable_content: flow_presenter.indexable_content,
       link: "/#{flow_presenter.slug}",
-      content_store_document_type: 'smart_answer',
+      content_store_document_type: 'transaction',
     )
 
     SearchIndexer.call(flow_presenter)


### PR DESCRIPTION
The start page for a smartanswer is a `transaction` document type in the content store. This should be consistent in the search index.

https://trello.com/c/BTZkG7CX/400-fix-documenttype-of-smart-answer-start-pages-in-search-index