### PR TITLE
Japan marriage abroad

### DIFF
--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/japan/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/japan/_opposite_sex.govspeak.erb
@@ -6,7 +6,7 @@ Contact the relevant municipal office in Japan to find out about local laws, inc
 
 ## Prove you’re free to get married
 
-You and your partner need to go to the embassy in Tokyo to confirm that you’re legally allowed to get married. This is called swearing an affirmation or affidavit. Check with the municipal office how long you can use it to get married.
+You need to go to the embassy in Tokyo to confirm that you’re legally allowed to get married. This is called swearing an affirmation or affidavit. Check with the municipal office how long you can use it to get married.
 
 If your partner is also British, they’ll need to swear their own affirmation.
 

--- a/test/artefacts/marriage-abroad/japan/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/japan/opposite_sex.txt
@@ -8,7 +8,7 @@ Contact the relevant municipal office in Japan to find out about local laws, inc
 
 ## Prove you’re free to get married
 
-You and your partner need to go to the embassy in Tokyo to confirm that you’re legally allowed to get married. This is called swearing an affirmation or affidavit. Check with the municipal office how long you can use it to get married.
+You need to go to the embassy in Tokyo to confirm that you’re legally allowed to get married. This is called swearing an affirmation or affidavit. Check with the municipal office how long you can use it to get married.
 
 If your partner is also British, they’ll need to swear their own affirmation.
 

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -406,7 +406,7 @@ lib/smart_answer_flows/marriage-abroad/outcomes/countries/italy/third_country/_o
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/italy/third_country/_same_sex.govspeak.erb: b2818b5c08161e0b6a8b8494524a2a90
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/italy/uk/_opposite_sex.govspeak.erb: c43ad58e36750346d929fc580ee1b02f
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/italy/uk/_same_sex.govspeak.erb: da9551c46e7c44a6f29dd7b4051b3990
-lib/smart_answer_flows/marriage-abroad/outcomes/countries/japan/_opposite_sex.govspeak.erb: dec33d2f936be64fbb0ce2dad12ecd56
+lib/smart_answer_flows/marriage-abroad/outcomes/countries/japan/_opposite_sex.govspeak.erb: 2d5fb2ec6624a18b759d1e8ac780a489
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/japan/_same_sex.govspeak.erb: f61ac1ede045e980c2f110a4ca284877
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/japan/_title.govspeak.erb: b136a47f052cbd595714742008d771a5
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/_title.govspeak.erb: 244778b903869fce5ce20769b189ad23


### PR DESCRIPTION
Supersedes: https://github.com/alphagov/smart-answers/pull/3241

Content change to "Marriage Abroad" smart answers for Japan

Trello
------
https://trello.com/c/h1nmPsTF/771-1-japan-marriage-abroad

Fact Check
-----------

Current: https://www.gov.uk/marriage-abroad/y/japan/opposite_sex
New: https://smart-answers-preview-pr-3250.herokuapp.com/marriage-abroad/y/japan/opposite_sex

Before
-----------
![getting married abroad gov uk](https://user-images.githubusercontent.com/10685841/32437315-d27f0aaa-c2de-11e7-99e5-62e504a6a24c.png)



After
-----------
![getting married abroad gov uk](https://user-images.githubusercontent.com/10685841/32437816-660dcc2e-c2e0-11e7-902a-5bd3ef1db62d.png)

