### PR TITLE
Improve arbitary input handling of CurrentQuestionHelper#default_for_date

### DIFF
--- a/app/helpers/current_question_helper.rb
+++ b/app/helpers/current_question_helper.rb
@@ -22,7 +22,10 @@ module CurrentQuestionHelper
   end
 
   def default_for_date(value)
-    value.blank? ? nil : value.to_i
+    integer = Integer(value)
+    integer.to_s == value.to_s ? integer : nil
+  rescue
+    nil
   end
 
   def prefill_value_for(question, attribute = nil)

--- a/test/unit/current_question_helper_test.rb
+++ b/test/unit/current_question_helper_test.rb
@@ -1,0 +1,47 @@
+require_relative '../test_helper'
+
+class CurrentQuestionHelperTest < ActionView::TestCase
+  tests CurrentQuestionHelper
+
+  context "default_for_date" do
+    should "return nil for a nil input" do
+      default = default_for_date(nil)
+      assert_nil(default)
+    end
+
+    should "return nil for an empty string input" do
+      default = default_for_date("")
+      assert_nil(default)
+    end
+
+    should "return nil for an array input" do
+      default = default_for_date(%w(foo bar))
+      assert_nil(default)
+    end
+
+    should "return an integer for an integer input" do
+      default = default_for_date(1)
+      assert_equal(1, default)
+    end
+
+    should "return an integer for a zero input" do
+      default = default_for_date(0)
+      assert_equal(0, default)
+    end
+
+    should "return an integer for a numerical string input" do
+      default = default_for_date("1")
+      assert_equal(1, default)
+    end
+
+    should "return nil for a non-numerical string input" do
+      default = default_for_date("foo")
+      assert_nil(default)
+    end
+
+    should "return nil for a float input" do
+      default = default_for_date(1.1)
+      assert_nil(default)
+    end
+  end
+end


### PR DESCRIPTION
We recently received alerts in [Sentry][1] for 500 errors when receiving certain inputs for a date. These alerts arose from passing an array response to a date question. Our handling of arbitrary inputs to the `CurrentQuestionHelper#default_for_date` was no robust enough to deal with this, and attempted to call `.to_i` on an `Array`, which throws a `NoMethodError`.

This change makes the method more robust by direclty attempting to cast to `Integer`, and rescuing errors by returning `nil`. This change also adds a number of tests to cover various types of input to the  method.

[1]: https://sentry.io/govuk/app-smart-answers/issues/396675536/