### PR TITLE
Fix Maternity Smart Answer Error

### DIFF
--- a/lib/smart_answer/calculators/maternity_paternity_calculator.rb
+++ b/lib/smart_answer/calculators/maternity_paternity_calculator.rb
@@ -265,13 +265,18 @@ module SmartAnswer::Calculators
     end
 
     def paydates_last_working_day_of_the_month
-      end_date = Date.civil(pay_end_date.year, pay_end_date.month, -1)
+      first_pay_day = last_working_day_of_the_month(pay_start_date)
 
-      [].tap do |ary|
-        pay_start_date.step(end_date) do |d|
-          ary << d if d.day == Date.new(d.year, d.month, last_working_day_of_the_month_offset(d)).day
+      [first_pay_day].tap do |dates|
+        while dates.last < pay_end_date
+          date = dates.last + 1.month
+          dates << Date.new(date.year, date.month, last_working_day_of_the_month_offset(date))
         end
       end
+    end
+
+    def last_working_day_of_the_month(date)
+      Date.new(date.year, date.month, last_working_day_of_the_month_offset(date))
     end
 
     def paydates_monthly

--- a/test/data/maternity-paternity-calculator-files.yml
+++ b/test/data/maternity-paternity-calculator-files.yml
@@ -1,7 +1,7 @@
 ---
 lib/data/rates/maternity_paternity_adoption.yml: e4a27ae88a179412e306197e4f4a229c
 lib/data/rates/maternity_paternity_birth.yml: ecc6ef0c3163cc0c5448858ad89161a5
-lib/smart_answer/calculators/maternity_paternity_calculator.rb: 40d9817eb3d1d3908c7ece0935ee892b
+lib/smart_answer/calculators/maternity_paternity_calculator.rb: 7909ca553d163bfb3fdb42284c4f758f
 lib/smart_answer_flows/maternity-paternity-calculator/adoption_calculator_flow.rb: c4ff1e446d0a362a0ac5eee631453d12
 lib/smart_answer_flows/maternity-paternity-calculator/maternity_calculator_flow.rb: bac17d939530b170c596c65334a96e33
 lib/smart_answer_flows/maternity-paternity-calculator/maternity_paternity_calculator.govspeak.erb: 019bbbe8b47309afce398e707263d0e5

--- a/test/unit/calculators/maternity_paternity_calculator_test.rb
+++ b/test/unit/calculators/maternity_paternity_calculator_test.rb
@@ -530,6 +530,7 @@ module SmartAnswer::Calculators
           end
         end
       end
+
       context "paydates and pay" do
         setup do
           @calculator = MaternityPaternityCalculator.new(Date.parse('21 January 2013'))
@@ -626,6 +627,27 @@ module SmartAnswer::Calculators
           assert_equal 371.26, paydates_and_pay.last[:pay]
         end
       end
+
+      context "End of SMP period falls between payday and end of calendar month" do
+        setup do
+          @calculator = MaternityPaternityCalculator.new(Date.parse('8 October 2017'))
+          @calculator.leave_start_date = Date.parse('1 October 2017')
+          @calculator.work_days = [1, 2, 3, 4, 5]
+        end
+
+        should "calculate pay due on the last working day of the month" do
+          @calculator.pay_method = 'last_working_day_of_the_month'
+          @calculator.stubs(:average_weekly_earnings).returns(203.0769)
+          paydates_and_pay = @calculator.paydates_and_pay
+
+          assert_equal 10, paydates_and_pay.size
+          assert_equal '2017-10-31', paydates_and_pay.first[:date].to_s
+          assert_equal 809.41, paydates_and_pay.first[:pay]
+          assert_equal '2018-07-31', paydates_and_pay.last[:date].to_s
+          assert_equal 20.14, paydates_and_pay.last[:pay]
+        end
+      end
+
       context "HMRC test scenario for SMP Pay week offset" do
         setup do
           @calculator = MaternityPaternityCalculator.new(Date.parse('22 February 2013'))


### PR DESCRIPTION
There's a problem with the calculator when the last SMP payment is after the last working day
of the month. This was spotted for June 2018, but we think it would happen whenever this
scenario arises.

Previously the code iterated the SMP payments according to the last working day of each month
but it did not tackle the scenario where the final SMP payment is outside of the last working
day of leave.

The new code iterates through the last working day of each month while the last working day of
the month is less than the final SMP pay date. This ensures that all payments are made. In this
scenario an extra month is added to which the last payment will be made.