### PR TITLE
Fix state pension calculator for leap year births

### DIFF
--- a/lib/smart_answer/calculators/state_pension_age_calculator.rb
+++ b/lib/smart_answer/calculators/state_pension_age_calculator.rb
@@ -18,8 +18,12 @@ module SmartAnswer::Calculators
       Date.today >= earliest_application_date
     end
 
+    def pension_on_feb_29?
+      state_pension_date.month == 2 && state_pension_date.day == 29
+    end
+
     def state_pension_age
-      if birthday_on_feb_29?
+      if birthday_on_feb_29? && !pension_on_feb_29?
         SmartAnswer::DateRange.new(
           begins_on: dob,
           ends_on: state_pension_date - 1.day

--- a/test/data/state-pension-age-files.yml
+++ b/test/data/state-pension-age-files.yml
@@ -2,7 +2,7 @@
 lib/data/rates/state_pension.yml: e9879f3f27ec582c97705a38bdcdef3f
 lib/data/state_pension_date_query.rb: 6a5bc3072ae8b986f7ee6d47ecd5da41
 lib/data/state_pension_dates.yml: da1bdee8a5b42c489b3966c43b625113
-lib/smart_answer/calculators/state_pension_age_calculator.rb: 5d2b9c5ea358d9891b973106d0aea9fe
+lib/smart_answer/calculators/state_pension_age_calculator.rb: 2a686d6933a334b26643d43bd71f9d39
 lib/smart_answer_flows/state-pension-age/outcomes/bus_pass_result.govspeak.erb: dcd8e4132b25e8dd46b82f096837b974
 lib/smart_answer_flows/state-pension-age/outcomes/has_reached_sp_age.govspeak.erb: ea2d19d861931bfd81901ea1e83faa75
 lib/smart_answer_flows/state-pension-age/outcomes/not_yet_reached_sp_age.govspeak.erb: 07519a1d25f3b8ed310c9ed941989400

--- a/test/unit/calculators/state_pension_age_calculator_test.rb
+++ b/test/unit/calculators/state_pension_age_calculator_test.rb
@@ -92,7 +92,7 @@ module SmartAnswer::Calculators
           should "someone born on #{test_case[:birth_date]} and getting their pension on #{test_case[:pension_date]} should have a pension age of #{test_case[:age]}" do
             @calculator.stubs(:dob).returns(test_case[:birth_date])
             @calculator.stubs(:state_pension_date).returns(test_case[:pension_date])
-            assert_equal @calculator.state_pension_age, test_case[:expected_age]
+            assert_equal test_case[:expected_age], @calculator.state_pension_age
           end
         end
       end
@@ -128,7 +128,7 @@ module SmartAnswer::Calculators
           should "someone born on #{test_case[:birth_date]} and getting their pension on #{test_case[:pension_date]} should have a pension age of #{test_case[:age]}" do
             @calculator.stubs(:dob).returns(test_case[:birth_date])
             @calculator.stubs(:state_pension_date).returns(test_case[:pension_date])
-            assert_equal @calculator.state_pension_age, test_case[:expected_age]
+            assert_equal test_case[:expected_age], @calculator.state_pension_age
           end
         end
       end
@@ -157,7 +157,7 @@ module SmartAnswer::Calculators
         end
 
         should "be true for a date that is the 29th of Feb" do
-          assert_equal true, @calculator.pension_on_feb_29?
+          assert @calculator.pension_on_feb_29?
         end
       end
 
@@ -169,7 +169,7 @@ module SmartAnswer::Calculators
         end
 
         should "be false for a date that is not the 29th of Feb" do
-          assert_equal false, @calculator.pension_on_feb_29?
+          refute @calculator.pension_on_feb_29?
         end
       end
     end

--- a/test/unit/calculators/state_pension_age_calculator_test.rb
+++ b/test/unit/calculators/state_pension_age_calculator_test.rb
@@ -61,14 +61,75 @@ module SmartAnswer::Calculators
         end
       end
 
-      context 'given a state_pension_date on the 29th of Feb when the pension age is 68' do
-        setup do
-          @calculator.stubs(:dob).returns(Date.parse("29 Feb 1980"))
-          @calculator.stubs(:state_pension_date).returns(Date.parse('29 Feb 2048'))
+      context 'given variable changes to state pension age between 66 - 67 years for births between 6 Apr 1960 - 5 Mar 1961' do
+        [
+          {
+            birth_date: Date.parse('6 Apr 1960'),
+            pension_date: Date.parse('6 May 2026'),
+            expected_age: '66 years, 1 month'
+          },
+          {
+            birth_date: Date.parse('20 May 1960'),
+            pension_date: Date.parse('20 Jul 2026'),
+            expected_age: '66 years, 2 months'
+          },
+          {
+            birth_date: Date.parse('1 Jul 1960'),
+            pension_date: Date.parse('1 Oct 2026'),
+            expected_age: '66 years, 3 months'
+          },
+          {
+            birth_date: Date.parse('8 Dec 1960'),
+            pension_date: Date.parse('8 Sep 2027'),
+            expected_age: '66 years, 9 months'
+          },
+          {
+            birth_date: Date.parse('28 Feb 1961'),
+            pension_date: Date.parse('28 Jan 2028'),
+            expected_age: '66 years, 11 months'
+          },
+        ].each do |test_case|
+          should "someone born on #{test_case[:birth_date]} and getting their pension on #{test_case[:pension_date]} should have a pension age of #{test_case[:age]}" do
+            @calculator.stubs(:dob).returns(test_case[:birth_date])
+            @calculator.stubs(:state_pension_date).returns(test_case[:pension_date])
+            assert_equal @calculator.state_pension_age, test_case[:expected_age]
+          end
         end
+      end
 
-        should 'should return the number of years to your state pension' do
-          assert_equal @calculator.state_pension_age, '68 years'
+      context 'given a series of dates around 28 Feb test the calculated state_pension_age' do
+        [
+          {
+            birth_date: Date.parse('28 Feb 1980'),
+            pension_date: Date.parse('28 Feb 2048'),
+            expected_age: '68 years'
+          },
+          {
+            birth_date: Date.parse('29 Feb 1980'),
+            pension_date: Date.parse('29 Feb 2048'),
+            expected_age: '68 years'
+          },
+          {
+            birth_date: Date.parse('1 Mar 1980'),
+            pension_date: Date.parse('1 Mar 2048'),
+            expected_age: '68 years'
+          },
+          {
+            birth_date: Date.parse('28 Feb 1981'),
+            pension_date: Date.parse('28 Feb 2049'),
+            expected_age: '68 years'
+          },
+          {
+            birth_date: Date.parse('1 Mar 1981'),
+            pension_date: Date.parse('1 Mar 2049'),
+            expected_age: '68 years'
+          },
+        ].each do |test_case|
+          should "someone born on #{test_case[:birth_date]} and getting their pension on #{test_case[:pension_date]} should have a pension age of #{test_case[:age]}" do
+            @calculator.stubs(:dob).returns(test_case[:birth_date])
+            @calculator.stubs(:state_pension_date).returns(test_case[:pension_date])
+            assert_equal @calculator.state_pension_age, test_case[:expected_age]
+          end
         end
       end
     end
@@ -84,6 +145,32 @@ module SmartAnswer::Calculators
         @calculator = StatePensionAgeCalculator.new(
           gender: "male", dob: Date.parse("7 June 1960"))
         assert_equal false, @calculator.birthday_on_feb_29?
+      end
+    end
+
+    context '#pension_on_feb_29??' do
+      context 'pension due on 29th of Feb' do
+        setup do
+          @calculator = StatePensionAgeCalculator.new(
+            gender: "male", dob: Date.parse("29 Feb 1980"))
+          @calculator.stubs(:state_pension_date).returns(Date.parse('29 Feb 2048'))
+        end
+
+        should "be true for a date that is the 29th of Feb" do
+          assert_equal true, @calculator.pension_on_feb_29?
+        end
+      end
+
+      context 'pension not due on 29th of Feb' do
+        setup do
+          @calculator = StatePensionAgeCalculator.new(
+            gender: "male", dob: Date.parse("28 Aug 1974"))
+          @calculator.stubs(:state_pension_date).returns(Date.parse('28 Aug 2041'))
+        end
+
+        should "be false for a date that is not the 29th of Feb" do
+          assert_equal false, @calculator.pension_on_feb_29?
+        end
       end
     end
 

--- a/test/unit/calculators/state_pension_age_calculator_test.rb
+++ b/test/unit/calculators/state_pension_age_calculator_test.rb
@@ -60,6 +60,17 @@ module SmartAnswer::Calculators
           assert_equal @calculator.state_pension_age, '60 years'
         end
       end
+
+      context 'given a state_pension_date on the 29th of Feb when the pension age is 68' do
+        setup do
+          @calculator.stubs(:dob).returns(Date.parse("29 Feb 1980"))
+          @calculator.stubs(:state_pension_date).returns(Date.parse('29 Feb 2048'))
+        end
+
+        should 'should return the number of years to your state pension' do
+          assert_equal @calculator.state_pension_age, '68 years'
+        end
+      end
     end
 
     context "#birthday_on_feb_29??" do


### PR DESCRIPTION
This issue affects users born after 5th April 1976 on a leap year. These users will currently be eligible for their state pension on their 68 birthday (which will also be a leap year).

Currently users are given the correct entitlement date for their state pension but says their state pension age will be 67 years, 11 months, 30 days. This is because the calculator deducts a day for leap year births, but does not take into account the state pension date also being a leap year.

This fix updates the calculator to check whether the state pension date is also a leap year. If so no adjustment needs to be made to the state pension age.