### PR TITLE
Remove condition for presence of worldwide taxon

### DIFF
--- a/app/controllers/concerns/taxonomy_navigation.rb
+++ b/app/controllers/concerns/taxonomy_navigation.rb
@@ -1,17 +1,10 @@
 module TaxonomyNavigation
   def should_present_taxonomy_navigation_view?(content_item)
-    content_is_tagged_to_world_wide_taxonomy?(content_item) ||
-      (content_is_tagged_to_a_taxon?(content_item) &&
-        !content_is_tagged_to_browse_pages?(content_item))
+    content_is_tagged_to_a_taxon?(content_item) &&
+      !content_is_tagged_to_browse_pages?(content_item)
   end
 
 private
-
-  def content_is_tagged_to_world_wide_taxonomy?(content_item)
-    content_item.dig("links", "taxons").to_a.any? do |item|
-      item.fetch("base_path").starts_with?("/world")
-    end
-  end
 
   def content_is_tagged_to_a_taxon?(content_item)
     content_item.dig("links", "taxons").present?

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -247,28 +247,6 @@ class SmartAnswersControllerTest < ActionController::TestCase
         mock.stubs(:taxon_breadcrumbs).returns(breadcrumbs: ['TaxonBreadcrumb'])
       end
 
-      context "pages tagged to worldwidetaxonomy" do
-        setup do
-          @content_item[:links] = {
-              taxons: [
-                {
-                  title: "A Taxon",
-                  base_path: "/world/a-taxon",
-                }
-              ],
-            }
-        end
-
-        should "show taxon breadcrumbs" do
-          get :show, params: { id: 'education-sample' }
-
-          assert_match(/TaxonBreadcrumb/, response.body)
-          refute_match(/NormalBreadcrumb/, response.body)
-          sidebar = Nokogiri::HTML.parse(response.body).at_css(".related-container")
-          assert_match(/A Taxon/, sidebar)
-        end
-      end
-
       context "pages tagged to mainstream browse" do
         setup do
           @content_item[:links] = {
@@ -325,7 +303,7 @@ class SmartAnswersControllerTest < ActionController::TestCase
             taxons: [
               {
                 title: "A Taxon",
-                base_path: "/a-taxon",
+                base_path: "/world/a-taxon",
               }
             ],
           }


### PR DESCRIPTION
https://trello.com/c/TqnWwFif/101-mop-up-issues-with-the-world-wide-taxonomy

Simplifies the logic when presenting taxonomy navigation so that the presence of a worldwide
taxon no longer affects the navigation.

/cc @tijmenb 