### PR TITLE
Tidy up `DateRange` ends on logic

### DIFF
--- a/lib/smart_answer/date_range.rb
+++ b/lib/smart_answer/date_range.rb
@@ -25,7 +25,6 @@ module SmartAnswer
     def initialize(begins_on: nil, ends_on: nil)
       @begins_on = (begins_on || EARLIEST_DATE).to_date
       @ends_on = (ends_on || LATEST_DATE).to_date
-      @ends_on = [@begins_on - 1, @ends_on].max unless infinite?
     end
 
     def include?(date)
@@ -44,10 +43,12 @@ module SmartAnswer
     alias_method :last, :ends_on
 
     def number_of_days
+      return 0 unless is_valid?
       non_inclusive_days + 1
     end
 
     def non_inclusive_days
+      return 0 unless is_valid?
       infinite? ? Float::INFINITY : (@ends_on - @begins_on).to_i
     end
 
@@ -162,6 +163,11 @@ module SmartAnswer
     def whole_days_away
       begins_on_shifted_to_ends_on_month = (begins_on >> month_difference)
       (ends_on - begins_on_shifted_to_ends_on_month).to_i
+    end
+
+    def is_valid?
+      return true if infinite?
+      @ends_on >= @begins_on
     end
   end
 end

--- a/test/unit/date_range_test.rb
+++ b/test/unit/date_range_test.rb
@@ -248,6 +248,7 @@ module SmartAnswer
 
       should 'contain zero days' do
         assert_equal 0, @date_range.number_of_days
+        assert_equal 0, @date_range.non_inclusive_days
       end
 
       should 'be empty' do


### PR DESCRIPTION
The `DateRange` class currently handles the case of having an end date
before the start date in a confusing manner.

If I have an end date before a start date, the `DateRange` will rewrite
my end date to be 1 day before my start date, which is _still_ before
the start date, but _not_ the date that I set.

For example:

```ruby
range = DateRange.new(
  begins_on: Date.parse("13 Nov 2017"),
  ends_on: Date.parse("1 Nov 2017")
)

range.ends_on # => 12th November 2017
```

As far as I can tell, this confusing behaviour exists solely to abuse
the subtraction that occurs in `non_inclusive_days`, which will in turn
generate the desired answer of `0` when calling `number_of_days`.

However - assuming the same `range` variable as above, this flow looks
like:

```ruby
range.non_inclusive_days # => -1
range.number_of_days     # => -1 + 1 == 0
```

This abuse of magical addition is a little obscure.

This change removes this extra `ends_on` logic on initialization, and
instead explicitly handles the case where the date range is not valid.