### PR TITLE
[WIP] Adoption from abroad validation

### DIFF
--- a/lib/smart_answer_flows/maternity-paternity-calculator/adoption_calculator_flow.rb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/adoption_calculator_flow.rb
@@ -51,7 +51,12 @@ module SmartAnswer
           end
 
           calculate :a_leave_earliest_start do
-            adoption_placement_date - 14
+            if adoption_is_from_abroad
+              # TODO: Confirm value for overseas
+              adoption_placement_date - 14
+            else
+              adoption_placement_date - 14
+            end
           end
 
           calculate :a_leave_earliest_start_formatted do
@@ -59,7 +64,11 @@ module SmartAnswer
           end
 
           calculate :a_leave_latest_start do
-            adoption_placement_date + 1
+            if adoption_is_from_abroad
+              adoption_placement_date + 27
+            else
+              adoption_placement_date + 1
+            end
           end
 
           calculate :a_leave_latest_start_formatted do

--- a/lib/smart_answer_flows/maternity-paternity-calculator/adoption_calculator_flow.rb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/adoption_calculator_flow.rb
@@ -2,7 +2,6 @@ module SmartAnswer
   class MaternityPaternityCalculatorFlow < Flow
     class AdoptionCalculatorFlow < Flow
       def define
-        ## QA0
         multiple_choice :taking_paternity_or_maternity_leave_for_adoption? do
           option :paternity
           option :maternity
@@ -10,14 +9,26 @@ module SmartAnswer
           next_node do |response|
             case response
             when 'paternity'
-              question :employee_date_matched_paternity_adoption? #QAP1
+              question :employee_date_matched_paternity_adoption?
             when 'maternity'
-              question :date_of_adoption_match? # QA1
+              question :adoption_from_abroad?
             end
           end
         end
 
-        ## QA1
+        multiple_choice :adoption_from_abroad? do
+          option :uk
+          option :abroad
+
+          calculate :adoption_is_from_abroad do |response|
+            response == "abroad"
+          end
+
+          next_node do
+            question :date_of_adoption_match?
+          end
+        end
+
         date_question :date_of_adoption_match? do
           calculate :match_date do |response|
             response
@@ -31,7 +42,6 @@ module SmartAnswer
           end
         end
 
-        ## QA2
         date_question :date_of_adoption_placement? do
           calculate :adoption_placement_date do |response|
             placement_date = response
@@ -69,7 +79,6 @@ module SmartAnswer
           end
         end
 
-        ## QA3
         multiple_choice :adoption_did_the_employee_work_for_you? do
           option :yes
           option :no
@@ -84,7 +93,6 @@ module SmartAnswer
           end
         end
 
-        ## QA4
         multiple_choice :adoption_employment_contract? do
           option :yes
           option :no
@@ -98,7 +106,6 @@ module SmartAnswer
           end
         end
 
-        ## QA5
         multiple_choice :adoption_is_the_employee_on_your_payroll? do
           option :yes
           option :no
@@ -124,7 +131,6 @@ module SmartAnswer
           end
         end
 
-        ## QA6
         date_question :adoption_date_leave_starts? do
           calculate :adoption_date_leave_starts do |response|
             adoption_leave_start_date = response
@@ -167,7 +173,6 @@ module SmartAnswer
           end
         end
 
-        # QA7
         date_question :last_normal_payday_adoption? do
           from { 2.years.ago(Date.today) }
           to { 2.years.since(Date.today) }
@@ -183,7 +188,6 @@ module SmartAnswer
           end
         end
 
-        # QA8
         date_question :payday_eight_weeks_adoption? do
           from { 2.year.ago(Date.today) }
           to { 2.years.since(Date.today) }
@@ -212,7 +216,6 @@ module SmartAnswer
           end
         end
 
-        # QA9
         multiple_choice :pay_frequency_adoption? do
           option :weekly
           option :every_2_weeks
@@ -233,7 +236,6 @@ module SmartAnswer
           end
         end
 
-        ## QA10
         money_question :earnings_for_pay_period_adoption? do
           on_response do |response|
             calculator.earnings_for_pay_period = response
@@ -260,7 +262,6 @@ module SmartAnswer
           end
         end
 
-        ## QA11
         multiple_choice :how_do_you_want_the_sap_calculated? do
           option :weekly_starting
           option :usual_paydates

--- a/lib/smart_answer_flows/maternity-paternity-calculator/questions/adoption_date_leave_starts.govspeak.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/questions/adoption_date_leave_starts.govspeak.erb
@@ -4,7 +4,6 @@
 
 <% content_for :hint do %>
   Leave can’t start before <%= a_leave_earliest_start_formatted %> or after <%= a_leave_latest_start_formatted %>.
-  For overseas adoptions your leave must start within 28 days of the child arriving in the UK.
 <% end %>
 
 <% content_for :leave_starts_too_early do %>

--- a/lib/smart_answer_flows/maternity-paternity-calculator/questions/adoption_from_abroad.govspeak.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/questions/adoption_from_abroad.govspeak.erb
@@ -1,0 +1,8 @@
+<% content_for :title do %>
+  Is the employee adopting a child from the UK or from abroad?
+<% end %>
+
+<% options(
+  "uk": "UK",
+  "abroad": "Abroad",
+) %>

--- a/lib/smart_answer_flows/maternity-paternity-calculator/questions/date_of_adoption_match.govspeak.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/questions/date_of_adoption_match.govspeak.erb
@@ -3,5 +3,7 @@
 <% end %>
 
 <% content_for :hint do %>
-  For overseas adoptions, enter the official notification date (the permission to adopt from abroad).
+  <% if adoption_is_from_abroad %>
+    Enter the official notification date (the permission to adopt from abroad).
+  <% end %>
 <% end %>

--- a/lib/smart_answer_flows/maternity-paternity-calculator/questions/date_of_adoption_placement.govspeak.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/questions/date_of_adoption_placement.govspeak.erb
@@ -1,9 +1,9 @@
 <% content_for :title do %>
-  When will the child be placed with the employee?
-<% end %>
-
-<% content_for :hint do %>
-  For overseas adoptions enter the date of arrival in the UK.
+  <% if adoption_is_from_abroad %>
+    When will the child arrive in the UK?
+  <% else %>
+    When will the child be placed with the employee?
+  <% end %>
 <% end %>
 
 <% content_for :error_message do %>

--- a/test/unit/smart_answer_flows/adoption_calculator_flow_test.rb
+++ b/test/unit/smart_answer_flows/adoption_calculator_flow_test.rb
@@ -22,14 +22,35 @@ module SmartAnswer
           .with_stubbed_calculator
       end
 
-      should "respond to 'maternity' with date_of_adoption_match?" do
+      should "respond to 'maternity' with adoption_from_abroad?" do
         @question.answer_with("maternity")
-        assert_node_has_name(:date_of_adoption_match?, @question.next_node)
+        assert_node_has_name(:adoption_from_abroad?, @question.next_node)
       end
 
       should "respond to 'paternity' with employee_date_matched_paternity_adoption?" do
         @question.answer_with("paternity")
         assert_node_has_name(:employee_date_matched_paternity_adoption?, @question.next_node, belongs_to_another_flow: true)
+      end
+    end
+
+    context "when answering adoption_from_abroad?" do
+      setup do
+        @question = TestNode.new(@flow, :adoption_from_abroad?)
+      end
+
+      should "respond with date_of_adoption_match?" do
+        @question.answer_with('uk')
+        assert_node_has_name(:date_of_adoption_match?, @question.next_node)
+      end
+
+      should "set adoption_is_from_abroad to true when answering with 'abroad'" do
+        @question.answer_with('abroad')
+        assert(@question.next_node.adoption_is_from_abroad)
+      end
+
+      should "set adoption_is_from_abroad to false when answering with 'uk'" do
+        @question.answer_with('uk')
+        refute(@question.next_node.adoption_is_from_abroad)
       end
     end
 

--- a/test/unit/smart_answer_flows/adoption_calculator_flow_test.rb
+++ b/test/unit/smart_answer_flows/adoption_calculator_flow_test.rb
@@ -73,22 +73,44 @@ module SmartAnswer
           .with(match_date: Date.parse("1 October 2017"))
       end
 
-      should "ask adoption_did_the_employee_work_for_you? next" do
-        @question.answer_with(Date.parse("1 November 2017"))
-        assert_node_has_name(:adoption_did_the_employee_work_for_you?, @question.next_node)
+      context "with an adoption from the UK" do
+        setup do
+          @question.with(adoption_is_from_abroad: false)
+        end
+
+        should "ask adoption_did_the_employee_work_for_you? next" do
+          @question.answer_with(Date.today)
+          assert_node_has_name(:adoption_did_the_employee_work_for_you?, @question.next_node)
+        end
+
+        context "with a placement date of 15 November 2017" do
+          setup do
+            @question.answer_with(Date.parse("15 November 2017"))
+          end
+
+          should "have an earliest leave start date 14 days prior" do
+            assert_equal(Date.parse("1 November 2017"), @question.next_node.a_leave_earliest_start)
+          end
+
+          should "have a latest start date 1 day after placement" do
+            assert_equal(Date.parse("16 November 2017"), @question.next_node.a_leave_latest_start)
+          end
+        end
       end
 
-      context "with a placement date of 15 November 2017" do
+      context "with an adoption from abroad and the child entering the UK on 1 November 2017" do
         setup do
-          @question.answer_with(Date.parse("15 November 2017"))
+          @question.with(adoption_is_from_abroad: true)
+            .answer_with(Date.parse("1 November 2017"))
         end
 
-        should "have an earliest leave start date 14 days prior" do
-          assert_equal(Date.parse("1 November 2017"), @question.next_node.a_leave_earliest_start)
+        should "have an earliest start date..." do
+          refute("TODO: Check this")
         end
 
-        should "have a latest start date 1 day after placement" do
-          assert_equal(Date.parse("16 November 2017"), @question.next_node.a_leave_latest_start)
+        should "have a latest start date of 28 November 2017" do
+          assert_equal(Date.parse("28 November 2017"), @question.next_node.a_leave_latest_start)
+          refute("TODO: Check this")
         end
       end
     end


### PR DESCRIPTION
This change builds on top of the changes made in the `adoption-leave-validation` branch. It adds a question to the Adoption calculator flow, asking if the child is being adopted from abroad.

This information can be used to update the copy for some questions, and to add validation for when the employee's adoption leave can start (which is different depending on if the child is being adopted from the UK or abroad).

## Screenshot

![adoption-abroad](https://user-images.githubusercontent.com/12036746/32848671-f4d7e07a-ca24-11e7-94a5-fe4a3e7f2a44.png)