### PR TITLE
Improve DateRange negative case handling

### DIFF
--- a/lib/smart_answer/date_range.rb
+++ b/lib/smart_answer/date_range.rb
@@ -25,7 +25,6 @@ module SmartAnswer
     def initialize(begins_on: nil, ends_on: nil)
       @begins_on = (begins_on || EARLIEST_DATE).to_date
       @ends_on = (ends_on || LATEST_DATE).to_date
-      @ends_on = [@begins_on - 1, @ends_on].max unless infinite?
     end
 
     def include?(date)
@@ -72,7 +71,7 @@ module SmartAnswer
     end
 
     def empty?
-      number_of_days == 0
+      number_of_days <= 0
     end
 
     def begins_before?(other)

--- a/test/unit/date_range_test.rb
+++ b/test/unit/date_range_test.rb
@@ -253,6 +253,10 @@ module SmartAnswer
       should 'be empty' do
         assert @date_range.empty?
       end
+
+      should 'set the ends_on date to the date before the begins_on date' do
+        assert_equal Date.parse('2000-01-01'), @date_range.ends_on
+      end
     end
 
     context 'intersection of' do

--- a/test/unit/date_range_test.rb
+++ b/test/unit/date_range_test.rb
@@ -246,15 +246,15 @@ module SmartAnswer
         refute @date_range.include?(@date_range.ends_on)
       end
 
-      should 'contain zero days' do
-        assert_equal 0, @date_range.number_of_days
+      should 'contain a non positive amount days' do
+        refute @date_range.number_of_days.positive?
       end
 
       should 'be empty' do
         assert @date_range.empty?
       end
 
-      should 'set the ends_on date to the date before the begins_on date' do
+      should 'not modify the ends_on date' do
         assert_equal Date.parse('2000-01-01'), @date_range.ends_on
       end
     end


### PR DESCRIPTION
Trello: https://trello.com/c/YVhH1JFx/780-3-improve-daterange-corner-case-handling

If the end date is initialised to a date before the begins date,
`DateRange` silently sets it to the day before the begins date. This was
probably done to make it return 0 number of days. This is a strange
behaviour and could lead to unexpected results.

Instead of automatically set the end date, this PR allows the end date to
be before the begins date and makes DateRange return the exact amount of
negative number of days. The `empty?` method is also set to return
true in a case of negative or zero number of days.

This avoids to break the other related calculations (e.g.
`gap_between`) and doesn’t make changes to the end date initially set.