### PR TITLE
Upgrade GDS API Adapters to 50.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem "sprockets-rails"
 gem "govuk_app_config", "~> 0.2.0"
 
 gem 'ast'
-gem "gds-api-adapters", "~> 47.9.1"
+gem "gds-api-adapters", "~> 50.1.0"
 gem 'govspeak', '~> 3.3.0'
 gem 'govuk-content-schema-test-helpers', '~> 1.3.0'
 gem 'govuk_frontend_toolkit', '>= 6.0.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
     faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.18)
-    gds-api-adapters (47.9.1)
+    gds-api-adapters (50.1.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -300,7 +300,7 @@ DEPENDENCIES
   byebug
   capybara (= 2.14.0)
   ci_reporter
-  gds-api-adapters (~> 47.9.1)
+  gds-api-adapters (~> 50.1.0)
   govspeak (~> 3.3.0)
   govuk-content-schema-test-helpers (~> 1.3.0)
   govuk-lint


### PR DESCRIPTION
After upgrading webmock in https://github.com/alphagov/smart-answers/pull/3271
GDS API adapters was also required to be updated to fix the regression tests