### PR TITLE
Use the unpublish type of vanish for some retiring

### DIFF
--- a/app/services/content_item_publisher.rb
+++ b/app/services/content_item_publisher.rb
@@ -21,6 +21,12 @@ class ContentItemPublisher
     )
   end
 
+  def unpublish_with_vanish(content_id)
+    raise "Content id has not been supplied" unless content_id.present?
+
+    Services.publishing_api.unpublish(content_id, type: "vanish")
+  end
+
   def publish_redirect(path, destination)
     raise "The destination or path isn't defined" unless path.present? && destination.present?
 

--- a/doc/retiring-a-smart-answer.md
+++ b/doc/retiring-a-smart-answer.md
@@ -202,7 +202,7 @@ In this document is prescribed the steps that need to be taken:
     RAKE_TASK = <rake task name only (no bundle exec rake) …. > 
     ```
     ```
-    (bundle exec rake) retire:unpublish[67764435-e8ed-4700-a657-2e0432cb1f5b]
+    (bundle exec rake) retire:unpublish_with_vanish[67764435-e8ed-4700-a657-2e0432cb1f5b]
     (bundle exec rake) retire:change_owning_application[/student-finance-forms,publisher]
     ```
   Verify success on Publishing API with:

--- a/lib/tasks/retire.rake
+++ b/lib/tasks/retire.rake
@@ -18,6 +18,13 @@ namespace :retire do
     ContentItemPublisher.new.unpublish(args.content_id)
   end
 
+  desc "Unpublish a smart answer from publishing-api, with an unpublish type of vanish"
+  task :unpublish_with_vanish, [:content_id] => :environment do |_, args|
+    raise "Missing content-id parameter" unless args.content_id
+
+    ContentItemPublisher.new.unpublish_with_vanish(args.content_id)
+  end
+
   desc "Create redirect for a smart answer's paths on the publishing-api"
   task :publish_redirect, [:path, :destination] => :environment do |_, args|
     raise "Missing path parameter" unless args.path


### PR DESCRIPTION
When retiring a smart answer, and replacing it with a simple smart
answer, use an unpublishing type of "vanish" for unpublishing the
smart answer.

Previously, unpublishing the smart answer with a type of "gone" would
leave the route in place for the smart answer, and being a more
specific route than the simple smart answer, this would take
precedence.

Until recently, unpublishing with a type of vanish wouldn't have
removed the route from the router, but this should now happen.

### Extra background

I started looking at this when I was on 2ndline, as there was a problem with the display of the Student Finance Forms simple smart answer on the draft stack. As described in https://github.com/alphagov/smart-answers/pull/3255 , the route in the router for the smart answer had been manually deleted from the live router, but still existed on the draft router, which meant that parts of the simple smart answer couldn't be seen.

There is a somewhat unwritten and poorly followed architectural principle with the publishing platform, that the only app to change the state of the content stores should be the Publishing API, and the only app to change the state in the Router/Router API should be the Content Store (with data from the Publishing API). I think this is a good direction to move in, as it centralises and simplifies the state, holding it all in the Publishing API, and sending it out to where its needed.

Following on from this, manually deleting routes from the Router API isn't ideal. Even more unfortunate was that at the time, this was most probably the best practical approach, as up until recently, there was no way of deleting routes from the Router API, from the Publishing API.

However, this is something that should now be supported, as the Content Store should now delete routes from the Router API, when the corresponding content is removed [1]. The Publishing API removes content from the Content Store when you unpublish with a type of "vanish", which brings me back to this change. To replace a smart answer with a simple smart answer, if the unpublishing type of "vanish" is used, this should work without requiring any manual intervention in the Router API.

1: https://github.com/alphagov/content-store/pull/329