### PR TITLE
Stop stripping organisation info from content item

### DIFF
--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -116,7 +116,7 @@ private
   end
 
   def setup_navigation_helpers_and_content_item
-    @content_item = ContentItemRetriever.without_links_organisations(params[:id])
+    @content_item = ContentItemRetriever.fetch(params[:id])
     @navigation_helpers = nil
 
     if @content_item.present?

--- a/app/services/content_item_retriever.rb
+++ b/app/services/content_item_retriever.rb
@@ -6,27 +6,4 @@ class ContentItemRetriever
   rescue GdsApi::HTTPNotFound, GdsApi::HTTPGone
     {}
   end
-
-  def self.without_links_organisations(slug)
-    # The GOV.UK analytics component[1] automatically sets `govuk:analytics:organisations`
-    # if there's a `organisations` key in the links. This will be sent to Google
-    # Analytics At the moment we want to avoid setting this because it will flood
-    # the analytics reports with (unexpected) data. We are currently working on
-    # a solution to this conundrum[2].
-    #
-    # [1] https://govuk-static.herokuapp.com/component-guide/analytics_meta_tags
-    # [2] https://trello.com/c/DkR63grd
-    content_item = fetch(slug)
-    content_item[:links].delete(:organisations) if valid_links_organisations?(content_item)
-
-    content_item
-  end
-
-  def self.valid_links_organisations?(content_item)
-    content_item.has_key?(:links) &&
-      content_item[:links].is_a?(Hash) &&
-      content_item[:links].has_key?(:organisations)
-  end
-
-  private_class_method :valid_links_organisations?
 end

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -79,7 +79,7 @@ class SmartAnswersControllerTest < ActionController::TestCase
               ],
             },
           }.with_indifferent_access
-        ContentItemRetriever.stubs(:without_links_organisations)
+        ContentItemRetriever.stubs(:fetch)
           .returns(@content_item)
         GovukNavigationHelpers::NavigationHelper.any_instance
           .stubs(:taxon_breadcrumbs)
@@ -99,7 +99,7 @@ class SmartAnswersControllerTest < ActionController::TestCase
 
     context "when a smart answer does not exist on the content store" do
       setup do
-        ContentItemRetriever.stubs(:without_links_organisations).returns({})
+        ContentItemRetriever.stubs(:fetch).returns({})
         get :show, params: { id: "smart-answers-controller-sample" }
       end
 

--- a/test/unit/services/content_item_retriever_test.rb
+++ b/test/unit/services/content_item_retriever_test.rb
@@ -59,21 +59,4 @@ require "test_helper"
         end
       end
     end
-
-    context "without_links_organisations" do
-      setup do
-        ContentItemRetriever.stubs(:fetch).returns(@content_store_response)
-      end
-
-      should "send message to fetch at least once" do
-        ContentItemRetriever.expects(:fetch).at_least_once.returns(@content_store_response)
-        ContentItemRetriever.without_links_organisations(@slug)
-      end
-
-      should "returns content item with organisations property under links" do
-        content_item = ContentItemRetriever.without_links_organisations(@slug)
-
-        assert_equal content_item[:links], {}
-      end
-    end
   end


### PR DESCRIPTION
For: https://trello.com/c/hpS5pFQe/237-investigate-new-navigation-impact-on-surveys

We stripped organisation info from the content item presented to the
view because it would result in the govuk:analytics:organisations meta
tag being set and this would be sent to Google Analytics (GA) as a custom
dimension. We did this because the tag was mostly used by whitehall and
departmental users wouldn't expect to see mainstream content appearing
in their GA reports for their department.

During migration the mainstream formats ported to government-frontend
started sending this info to GA and it didn't cause any problems. This
means we're happy to stop stripping this data and have all content items
that have organisation info send it to GA.