### PR TITLE
Send flow content to publishing API

### DIFF
--- a/app/presenters/flow_registration_presenter.rb
+++ b/app/presenters/flow_registration_presenter.rb
@@ -57,6 +57,28 @@ class FlowRegistrationPresenter
     end
   end
 
+  def flows_content
+    content = @flow.nodes.flat_map do |node|
+      case node
+      when SmartAnswer::Question::Base
+        pres = QuestionPresenter.new(node, nil, helpers: [MethodMissingHelper])
+        [pres.title, pres.body, pres.hint]
+      when SmartAnswer::Outcome
+        pres = OutcomePresenter.new(node, nil, helpers: [MethodMissingHelper])
+        [pres.title, pres.body]
+      end
+    end
+
+    content
+      .compact
+      .map do |html|
+        HTMLEntities.new
+          .decode(html)
+          .gsub(/(?:<[^>]+>|\s)+/, " ")
+          .strip
+      end
+  end
+
   def indexable_content
     HTMLEntities.new.decode(
       @flow.nodes.inject([start_node.body]) { |acc, node|

--- a/app/presenters/start_page_content_item.rb
+++ b/app/presenters/start_page_content_item.rb
@@ -12,19 +12,20 @@ class StartPageContentItem
       description: flow_presenter.description,
       update_type: 'minor',
       details: {
-          external_related_links: external_related_links,
-          introductory_paragraph: [
-            {
-              content: flow_presenter.start_page_body,
-              content_type: 'text/govspeak'
-            }
-          ],
-          more_information: [
-            content: flow_presenter.start_page_post_body,
+        external_related_links: external_related_links,
+        introductory_paragraph: [
+          {
+            content: flow_presenter.start_page_body,
             content_type: 'text/govspeak'
-          ],
-          transaction_start_link: base_path + '/y',
-          start_button_text: flow_presenter.start_page_button_text
+          }
+        ],
+        more_information: [
+          content: flow_presenter.start_page_post_body,
+          content_type: 'text/govspeak'
+        ],
+        transaction_start_link: base_path + '/y',
+        start_button_text: flow_presenter.start_page_button_text,
+        hidden_search_terms: flow_presenter.flows_content
       },
       schema_name: 'transaction',
       document_type: 'transaction',

--- a/test/unit/flow_registration_presenter_test.rb
+++ b/test/unit/flow_registration_presenter_test.rb
@@ -58,6 +58,26 @@ class FlowRegistrationPresenterTest < ActiveSupport::TestCase
     end
   end
 
+  context "flows_content" do
+    should "include all flow content" do
+      expected_content = [
+        "QUESTION_1_TITLE",
+        "QUESTION_1_BODY",
+        "QUESTION_1_HINT",
+        "QUESTION_2_TITLE",
+        "QUESTION_2_BODY LINK TEXT",
+        "QUESTION_2_HINT",
+        "OUTCOME_1_TITLE",
+        "OUTCOME_1_BODY",
+        "OUTCOME_2_TITLE",
+        "OUTCOME_2_BODY",
+        "OUTCOME_3_TITLE",
+        "OUTCOME_3_BODY"
+      ]
+      assert_equal expected_content, @presenter.flows_content
+    end
+  end
+
   context "indexable_content" do
     should "include all question node titles" do
       @content = @presenter.indexable_content

--- a/test/unit/services/content_item_publisher_test.rb
+++ b/test/unit/services/content_item_publisher_test.rb
@@ -12,7 +12,7 @@ class ContentItemPublisherTest < ActiveSupport::TestCase
     flow_draft_request = stub_request(:put, "https://publishing-api.test.gov.uk/v2/content/154829ba-ad5d-4dad-b11b-2908b7bec399")
     flow_publishing_request = stub_request(:post, "https://publishing-api.test.gov.uk/v2/content/154829ba-ad5d-4dad-b11b-2908b7bec399/publish")
 
-    presenter = FlowRegistrationPresenter.new(stub('flow', name: 'bridge-of-death', start_page_content_id: '3e6f33b8-0723-4dd5-94a2-cab06f23a685', flow_content_id: '154829ba-ad5d-4dad-b11b-2908b7bec399', external_related_links: nil))
+    presenter = FlowRegistrationPresenter.new(stub('flow', name: 'bridge-of-death', start_page_content_id: '3e6f33b8-0723-4dd5-94a2-cab06f23a685', flow_content_id: '154829ba-ad5d-4dad-b11b-2908b7bec399', external_related_links: nil, nodes: []))
 
     ContentItemPublisher.new.publish([presenter])
 

--- a/test/unit/start_page_content_item_test.rb
+++ b/test/unit/start_page_content_item_test.rb
@@ -13,6 +13,7 @@ module SmartAnswer
       stub('flow-registration-presenter',
         slug: 'flow-slug',
         title: 'flow-title',
+        flows_content: ['question title'],
         description: '',
         start_page_body: '',
         start_page_post_body: '',


### PR DESCRIPTION
This content has been added to the start page content item as that allows us to
index all the content fropm the flows back to the start page

https://trello.com/c/tSPsLjz3/489-make-smartanswers-indexable