### PR TITLE
Revert "Bump webmock from 1.20.4 to 3.1.1"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,5 +56,5 @@ group :test do
   gem 'simplecov', '~> 0.10.0', require: false
   gem 'simplecov-rcov', '~> 0.2.3', require: false
   gem 'timecop'
-  gem 'webmock', '3.1.1', require: false
+  gem 'webmock', '1.20.4', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,6 @@ GEM
       sass (>= 3.2.0)
     govuk_navigation_helpers (6.3.0)
       gds-api-adapters (>= 43.0)
-    hashdiff (0.3.7)
     htmlentities (4.3.4)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
@@ -282,10 +281,9 @@ GEM
     unicorn (5.4.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
-    webmock (3.1.1)
+    webmock (1.20.4)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
-      hashdiff
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -339,7 +337,7 @@ DEPENDENCIES
   uglifier
   uk_postcode (~> 1.0.1)
   unicorn (= 5.4.0)
-  webmock (= 3.1.1)
+  webmock (= 1.20.4)
 
 RUBY VERSION
    ruby 2.3.1p112


### PR DESCRIPTION
Reverts alphagov/smart-answers#3301

This broke the regression tests with errors like:

```
ActionView::Template::Error: Unable to fetch: 'http://static.dev.gov.uk/templates/locales/en-GB' because Failed to open TCP connection to static.dev.gov.uk:80 (getaddrinfo: Name or service not known)
```
