### PR TITLE
Update continuous integration docs

### DIFF
--- a/doc/continuous-integration.md
+++ b/doc/continuous-integration.md
@@ -1,34 +1,27 @@
 # Continuous integration
 
-## Main
+## Master
 
-The [govuk_smart_answers CI instance](https://ci.dev.publishing.service.gov.uk/job/govuk_smart_answers/) is triggered by new commits on the `master` branch of the [GitHub repo](https://github.com/alphagov/smart-answers). It runs the [`jenkins.sh`](https://github.com/alphagov/smart-answers/blob/master/jenkins.sh) script with the `RUN_REGRESSION_TESTS` not set. This script does the following:
+The [govuk_smart_answers master build](https://ci.integration.publishing.service.gov.uk/job/smartanswers/job/master/) is triggered by new commits on the `master` branch of the [GitHub repo](https://github.com/alphagov/smart-answers). It runs the [`Jenkinsfile`](https://github.com/alphagov/smart-answers/blob/master/Jenkinsfile). The `RUN_REGRESSION_TESTS` parameter is not set but the `Jenkinsfile` is configured so that regression tests are always run for builds of `master`. This script does the following:
 
 * Attempts to merge the current branch (`master`) into `master` - this should always succeed and is effectively a no-op
 * Checks out the latest [govuk-content-schemas](https://github.com/alphagov/govuk-content-schemas) which are used in a few of the tests
 * Installs the bundled gems
 * Runs govuk-lint-ruby (see [Rubocop docs](rubocop.md))
 * Runs the `test` rake task with `TEST_COVERAGE` enabled
+* Runs the `SmartAnswersRegressionTest` for all flows
 * Pre-compiles assets
 
 If any of these steps fails, the build fails-fast.
 
 ## Branches
 
-The [govuk_smartanswers_branches CI instance](https://ci.dev.publishing.service.gov.uk/job/govuk_smartanswers_branches/) is triggered by new commits on other branches of the [GitHub repo](https://github.com/alphagov/smart-answers). It runs the [`jenkins_branches.sh`](https://github.com/alphagov/smart-answers/blob/master/jenkins_branches.sh) script with the `RUN_REGRESSION_TESTS` not set.
+[Branch builds](https://ci.integration.publishing.service.gov.uk/job/smartanswers/) are triggered by new commits on other branches of the [GitHub repo](https://github.com/alphagov/smart-answers). They run the [`Jenkinsfile`](https://github.com/alphagov/smart-answers/blob/master/Jenkinsfile) with the `RUN_REGRESSION_TESTS` parameter not set.
 
-This script calls the [`jenkins.sh`](https://github.com/alphagov/smart-answers/blob/master/jenkins.sh) script wrapping it in code which sends notifications to GitHub, so that the build status is displayed on [pull request pages](https://github.com/alphagov/smart-answers/pulls).
+Jenkins sends notifications to GitHub, so that the build status is displayed on [pull request pages](https://github.com/alphagov/smart-answers/pulls).
 
-In this case the `jenkins.sh` script does the same as the [main CI instance](#main), but the attempt to merge the current branch into `master` may fail if there are merge conflicts whereupon the merge is aborted and the script fails fast.
+In this case the `Jenkins` script does the same as the [main CI build](#main) except for regression tests, which are skipped for branch builds to speed up build times.
 
-If the merge succeeds then the script continues as for the main CI instance.
+To run regression tests on a branch, find the branch's pipeline build in Jenkins and click "Build with parameters" in the sidebar. Tick the `RUN_REGRESSION_TESTS` parameter and leave the other parameters with their default values.
 
-## Regression
-
-The [govuk_smart_answers_regressions CI instance](https://ci.dev.publishing.service.gov.uk/job/govuk_smart_answers_regressions/) is triggered periodically (currently every 2 hours). It runs the [`jenkins.sh`](https://github.com/alphagov/smart-answers/blob/master/jenkins.sh) script with the `RUN_REGRESSION_TESTS` set. This script does the following:
-
-* Checks out the lastest [govuk-content-schemas](https://github.com/alphagov/govuk-content-schemas) which are used in a few of the tests
-* Installs the bundled gems
-* Runs the SmartAnswersRegressionTest for all flows
-
-If any of these steps fails, the build fails-fast.
+The attempt to merge the current branch into `master` may also fail if there are merge conflicts whereupon the merge is aborted and the script fails fast. If the merge succeeds then the script continues as for the main CI instance.

--- a/doc/deploying.md
+++ b/doc/deploying.md
@@ -2,17 +2,15 @@
 
 ## Integration
 
-This happens automatically as a post build action when the [govuk_smart_answers](https://ci.dev.publishing.service.gov.uk/job/govuk_smart_answers/) build passes on CI.
+This happens automatically as a post build action when the [govuk_smart_answers master build](https://ci.integration.publishing.service.gov.uk/job/smartanswers/job/master/) passes on CI.
 
 ### Manually
 
-If you have sufficient permissions, you can use the [Integration Deploy App](https://deploy.integration.publishing.service.gov.uk/job/Deploy_App/). Click the "Build with Parameters" link and enter "release" as the "TAG".
-
-If you do not have sufficient permissions, you can either kick the [main CI build](continuous-integration.md#main) in Jenkins or commit & push something to the `master` branch.
+You can use the [Integration Deploy App](https://deploy.integration.publishing.service.gov.uk/job/Deploy_App/). Click the "Build with Parameters" link and enter "release" as the "TAG".
 
 ## Production
 
-These are usually done with a Smart Answers developer sitting with someone from 2nd-line Support. You need to prepare and book a production deployment as folows:
+These are usually done with a Smart Answers developer sitting with someone from 2nd-line Support. You need to prepare a production deployment as follows:
 
 ### Create the Release in GitHub
 
@@ -58,14 +56,5 @@ TODO: List each of the Pull Requests that contain user facing changes here, for 
 
 * PR https://github.com/alphagov/smart-answers/pull/nnn - <title-of-pull-request>
 ```
-
-### Create the deployment calendar event
-
-1. Add an event to the "GOVUK Release Calender"
-
-  * Title: "Smart Answers (2nd line required)"
-  * Time: <The time you'd like to deploy>
-  * Duration: 30 minutes
-  * Description: https://github.com/alphagov/smart-answers/releases/tag/$RELEASE-TAG
 
 [smart-answers-releases]: https://github.com/alphagov/smart-answers/releases


### PR DESCRIPTION
Rewrite the CI docs to explain the current configuration, which uses Jenkins pipeline builds and a `Jenkinsfile` rather than separate builds for master, branches and regression tests.