### PR TITLE
Refactor student finance calculator

### DIFF
--- a/lib/smart_answer_flows/student-finance-calculator.rb
+++ b/lib/smart_answer_flows/student-finance-calculator.rb
@@ -82,20 +82,8 @@ module SmartAnswer
 
       #Q5
       money_question :whats_your_household_income? do
-        calculate :test_calculator do |response|
-          Calculators::StudentFinanceCalculator.new(
-            course_start: start_date,
-            household_income: response,
-            residence: where_living
-          )
-        end
-
-        calculate :maintenance_grant_amount do
-          test_calculator.maintenance_grant_amount
-        end
-
-        calculate :maintenance_loan_amount do
-          test_calculator.maintenance_loan_amount
+        on_response do |response|
+          calculator.household_income = response
         end
 
         next_node do

--- a/lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_uk_full_time_dental_medical_students.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_uk_full_time_dental_medical_students.govspeak.erb
@@ -7,7 +7,7 @@
 
   In each of your first 4 years, you could get:
 
-  <%= render partial: 'full_time_tuition.govspeak.erb', locals: { tuition_fee_amount: tuition_fee_amount, maintenance_loan_amount: maintenance_loan_amount, maintenance_grant_amount: maintenance_grant_amount, start_date: start_date } %>
+  <%= render partial: 'full_time_tuition.govspeak.erb', locals: { tuition_fee_amount: tuition_fee_amount, maintenance_loan_amount: calculator.maintenance_loan_amount, maintenance_grant_amount: calculator.maintenance_grant_amount, start_date: start_date } %>
 
   <% if uk_ft_circumstances.include?('children-under-17') %>
     - up to <%= format_money(calculator.childcare_grant_one_child) %> a week (1 child) or up to <%= format_money(calculator.childcare_grant_more_than_one_child) %> a week (2 or more children) [Childcare Grant](/childcare-grant)

--- a/lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_uk_full_time_students.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_uk_full_time_students.govspeak.erb
@@ -5,7 +5,7 @@
 
   You could get per year:
 
-  <%= render partial: 'full_time_tuition.govspeak.erb', locals: { tuition_fee_amount: tuition_fee_amount, maintenance_loan_amount: maintenance_loan_amount, maintenance_grant_amount: maintenance_grant_amount, start_date: start_date } %>
+  <%= render partial: 'full_time_tuition.govspeak.erb', locals: { tuition_fee_amount: tuition_fee_amount, maintenance_loan_amount: calculator.maintenance_loan_amount, maintenance_grant_amount: calculator.maintenance_grant_amount, start_date: start_date } %>
 
   ###Extra student funding
 

--- a/test/data/student-finance-calculator-files.yml
+++ b/test/data/student-finance-calculator-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer/calculators/student_finance_calculator.rb: c2c019945d85da23105a83b5b4110009
+lib/smart_answer/calculators/student_finance_calculator.rb: fd8117da418e5799990ec8fcaafae21e
 lib/smart_answer_flows/student-finance-calculator/outcomes/_disclaimer.govspeak.erb: 01560b7c2a22db8723b9837b785730c0
 lib/smart_answer_flows/student-finance-calculator/outcomes/_full_time_tuition.govspeak.erb: 3e67f2757180a94c97117bf632d9a937
 lib/smart_answer_flows/student-finance-calculator/outcomes/_next_steps.govspeak.erb: 6d4a15585ec75dd58d1069a668a4a35f
@@ -8,8 +8,8 @@ lib/smart_answer_flows/student-finance-calculator/outcomes/_nhs_part_time_fundin
 lib/smart_answer_flows/student-finance-calculator/outcomes/_uk_extra_help.govspeak.erb: 90735fa162ac5423beb796ef2c638d01
 lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_eu_students.govspeak.erb: 950a155f806d64b68ca1cb2246f09dda
 lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_uk_all_students.govspeak.erb: fe72d8ec95c1b0c0df8068ca941ad030
-lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_uk_full_time_dental_medical_students.govspeak.erb: dbed034bf76ba0d1f0fb382201f41c1f
-lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_uk_full_time_students.govspeak.erb: c4cfbc2cabb08b209a580dcad9ca90d8
+lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_uk_full_time_dental_medical_students.govspeak.erb: 56ac99934811e437c637a180656c74ec
+lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_uk_full_time_students.govspeak.erb: de68f437750e08749cff6d5bce801c7e
 lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_uk_part_time_dental_medical_students.govspeak.erb: 4f496e6a30c64e09ce94cb1113515b03
 lib/smart_answer_flows/student-finance-calculator/questions/are_you_studying_dental_hygiene_or_dental_therapy.govspeak.erb: 3871d433305955ff44b922b59a776eb1
 lib/smart_answer_flows/student-finance-calculator/questions/are_you_studying_one_of_these_dental_or_medical_courses.govspeak.erb: beb2d2ae6e55cc3857953e451f87e5e6
@@ -23,6 +23,6 @@ lib/smart_answer_flows/student-finance-calculator/questions/whats_your_household
 lib/smart_answer_flows/student-finance-calculator/questions/when_does_your_course_start.govspeak.erb: e50d9ddb84b2c6dc9a9177181ab38a80
 lib/smart_answer_flows/student-finance-calculator/questions/where_will_you_live_while_studying.govspeak.erb: 6971a090166992ed6c3a86865fbbf546
 lib/smart_answer_flows/student-finance-calculator/student_finance_calculator.govspeak.erb: 29289399e2b48e0f2cf87945149c146f
-lib/smart_answer_flows/student-finance-calculator.rb: 5de07f2d12f2a790290f139e0311451d
+lib/smart_answer_flows/student-finance-calculator.rb: 5a648463768ace78e38d41a47d2f544e
 test/data/student-finance-calculator-questions-and-responses.yml: 4d58f4807e1e27002aa73a963e0105b5
 test/data/student-finance-calculator-responses-and-expected-results.yml: d68a5f26b330b7d3646f9584aa7263d9

--- a/test/integration/smart_answer_flows/student_finance_calculator_test.rb
+++ b/test/integration/smart_answer_flows/student_finance_calculator_test.rb
@@ -51,13 +51,6 @@ class StudentFinanceCalculatorTest < ActiveSupport::TestCase
             assert_current_node :whats_your_household_income?
           end
 
-          context "household income higher than limit" do
-            should "reduce the maintenance loan amount by £1 for every £9.59 over the threshold" do
-              add_response '43875'
-              assert_state_variable :maintenance_loan_amount, 4840.0
-            end
-          end
-
           context "household income up to 25k" do
             setup do
               add_response '24500'
@@ -177,13 +170,6 @@ class StudentFinanceCalculatorTest < ActiveSupport::TestCase
           end
           should "ask whats your household income" do
             assert_current_node :whats_your_household_income?
-          end
-
-          context "household income higher than limit" do
-            should "reduce the maintenance loan amount by £1 for every £9.59 over the threshold" do
-              add_response '43875'
-              assert_state_variable :maintenance_loan_amount, 4707.0
-            end
           end
 
           context "household income up to 25k" do


### PR DESCRIPTION
Two small refactorings to make later changes easier:

- Move flow calculations into Calculator for student finance calculator

    Refactor maintenance loan and maintenance grant logic by moving it out of the flow class and into the calculator class. This helps keep the flow class focused on routing, as described in [doc/refactoring.md](https://github.com/alphagov/smart-answers/blob/master/doc/refactoring.md)

    This will make it easier to use the result of this calculation in other outcomes.

-  Inline Strategy class in StudentFinanceCalculator

    Refactor to remove unnecessary inner class. The calculations being delegated to it were no different to the other calculations performed inline in the calculator.