### PR TITLE
Exclude test artefacts from linting

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,4 @@
 AllCops:
   Exclude:
+    - 'test/artefacts/**/*'
     - 'tmp/**/*'


### PR DESCRIPTION
Updating a calculator can cause thousands of test artefacts to change, which significantly slows down the linter: it can [take around 30 minutes](https://ci.integration.publishing.service.gov.uk/job/smartanswers/job/pay-leave-for-parents-wording/) rather than a few seconds on CI.

These test artefacts are automatically generated and are not Ruby, so they don't need to be linted.