### PR TITLE
Upgrade govuk_app_config to 1.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,7 @@ gem 'rails', '5.0.5'
 gem "railties"
 gem "sprockets-rails"
 
-# Upgrade to Sentry
-gem "govuk_app_config", "~> 0.2.0"
+gem 'govuk_app_config'
 
 gem 'ast'
 gem "gds-api-adapters", "~> 51.1.0"
@@ -16,7 +15,6 @@ gem 'govuk-content-schema-test-helpers', '~> 1.3.0'
 gem 'govuk_frontend_toolkit', '>= 6.0.4'
 gem 'htmlentities', '~> 4'
 gem 'json'
-gem 'logstasher', '1.2.2'
 gem 'lrucache', '0.1.4'
 gem 'method_source'
 gem 'parser'
@@ -28,7 +26,6 @@ gem 'slimmer', '~> 11.1.1'
 gem 'tilt', '2.0.8'
 gem 'uglifier'
 gem 'uk_postcode', '~> 1.0.1'
-gem 'unicorn', '5.4.0'
 gem 'rails_stdout_logging'
 gem 'govuk_navigation_helpers', '~> 6.3.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,7 +72,7 @@ GEM
     erubi (1.7.0)
     erubis (2.7.0)
     execjs (2.7.0)
-    faraday (0.13.1)
+    faraday (0.14.0)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.18)
     gds-api-adapters (51.1.0)
@@ -96,9 +96,11 @@ GEM
       rubocop (~> 0.51.0)
       rubocop-rspec (~> 1.19.0)
       scss_lint
-    govuk_app_config (0.2.0)
-      sentry-raven (~> 2.6.3)
+    govuk_app_config (1.2.1)
+      logstasher (~> 1.2.2)
+      sentry-raven (~> 2.7.1)
       statsd-ruby (~> 1.4.0)
+      unicorn (~> 5.4.0)
     govuk_frontend_toolkit (7.2.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
@@ -203,7 +205,8 @@ GEM
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    request_store (1.3.2)
+    request_store (1.4.0)
+      rack (>= 1.4)
     rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
@@ -235,7 +238,7 @@ GEM
     scss_lint (0.56.0)
       rake (>= 0.9, < 13)
       sass (~> 3.5.3)
-    sentry-raven (2.6.3)
+    sentry-raven (2.7.1)
       faraday (>= 0.7.6, < 1.0)
     shoulda (3.5.0)
       shoulda-context (~> 1.0, >= 1.0.1)
@@ -305,12 +308,11 @@ DEPENDENCIES
   govspeak (~> 3.3.0)
   govuk-content-schema-test-helpers (~> 1.3.0)
   govuk-lint
-  govuk_app_config (~> 0.2.0)
+  govuk_app_config
   govuk_frontend_toolkit (>= 6.0.4)
   govuk_navigation_helpers (~> 6.3.0)
   htmlentities (~> 4)
   json
-  logstasher (= 1.2.2)
   lrucache (= 0.1.4)
   method_source
   minitest (~> 5.11)
@@ -337,11 +339,10 @@ DEPENDENCIES
   timecop
   uglifier
   uk_postcode (~> 1.0.1)
-  unicorn (= 5.4.0)
   webmock (= 1.20.4)
 
 RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.15.1
+   1.16.1

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,12 +60,7 @@ Rails.application.configure do
 
   config.action_controller.asset_host = ENV['GOVUK_ASSET_HOST']
 
-  if ENV['RUNNING_ON_HEROKU'].blank?
-    # Enable JSON-style logging
-    config.logstasher.enabled = true
-    config.logstasher.logger = Logger.new("#{Rails.root}/log/#{Rails.env}.json.log")
-    config.logstasher.suppress_app_logs = true
-  else
+  if ENV['RUNNING_ON_HEROKU']
     # flush output to the underlying OS without buffering
     STDOUT.sync = true
 

--- a/config/initializers/logstasher.rb
+++ b/config/initializers/logstasher.rb
@@ -1,9 +1,0 @@
-if Object.const_defined?('LogStasher') && LogStasher.enabled
-  LogStasher.add_custom_fields do |fields|
-    # Mirrors Nginx request logging, e.g GET /path/here HTTP/1.1
-    fields[:request] = "#{request.request_method} #{request.fullpath} #{request.headers['SERVER_PROTOCOL']}"
-    # Pass the request id to logging
-    fields[:govuk_request_id] = request.headers['GOVUK-Request-Id']
-    fields[:varnish_id] = request.headers['X-Varnish']
-  end
-end


### PR DESCRIPTION
Including config changes for logstasher.

The bump to 0.2.0 enabled debug logging which is sending a lot of data to logit.