### PR TITLE
Fix start page rendering in preview

### DIFF
--- a/app/views/smart_answers/landing.html.erb
+++ b/app/views/smart_answers/landing.html.erb
@@ -22,7 +22,12 @@
           <a rel="nofollow" href="<%= smart_answer_path(@name.to_s, started: "y") %>" class="big button"><%= start_node.start_button_text %></a>
         </p>
       </div>
-      <%= start_node.post_body %>
+      <% unless start_node.post_body.blank? %>
+        <div id="before-you-start">
+          <h2>Before you start</h2>
+          <%= start_node.post_body %>
+        </div>
+      <% end %>
     </div>
   </article>
 </div>

--- a/app/views/smart_answers/landing.html.erb
+++ b/app/views/smart_answers/landing.html.erb
@@ -10,24 +10,28 @@
   <% end %>
 <% end %>
 
-<%= render partial: 'page_title', locals: { title: start_node.title } %>
+<div class="transaction">
+  <%= render partial: 'page_title', locals: { title: start_node.title } %>
 
-<div class="article-container group">
-  <article role="article" class="group" data-debug-template-path="<%= start_node.relative_erb_template_path %>">
-    <div class="inner">
-      <div class="intro">
-        <%= start_node.body %>
+  <div class="article-container group">
+    <article role="article" class="group" data-debug-template-path="<%= start_node.relative_erb_template_path %>">
+      <div class="inner">
+        <section class="intro">
+          <%= start_node.body %>
 
-        <p class="get-started">
-          <a rel="nofollow" href="<%= smart_answer_path(@name.to_s, started: "y") %>" class="big button"><%= start_node.start_button_text %></a>
-        </p>
+          <p class="get-started">
+            <a rel="nofollow" href="<%= smart_answer_path(@name.to_s, started: "y") %>" class="big button" role="button"><%= start_node.start_button_text %></a>
+          </p>
+        </section>
+        <section class="more">
+          <% unless start_node.post_body.blank? %>
+            <div id="before-you-start">
+              <h2>Before you start</h2>
+              <%= start_node.post_body %>
+            </div>
+          <% end %>
+        </section>
       </div>
-      <% unless start_node.post_body.blank? %>
-        <div id="before-you-start">
-          <h2>Before you start</h2>
-          <%= start_node.post_body %>
-        </div>
-      <% end %>
-    </div>
-  </article>
+    </article>
+  </div>
 </div>


### PR DESCRIPTION
Smart answer smart pages are normally [rendered by frontend](https://github.com/alphagov/frontend/blob/master/app/views/simple_smart_answers/show.html.erb), but smart-answers renders them itself in dev and when previewing the branch on Heroku.

This change fixes the rendering in dev/preview:
- Show the "Before you start" subheader if the smart answer has content to be displayed below the "Start now" button
- Add the arrow symbol to the "Start now" button

Before:
<img width="620" alt="screen shot 2018-01-29 at 14 10 30" src="https://user-images.githubusercontent.com/754712/35515579-8436c530-0501-11e8-92fd-1d80f0c94dd5.png">

After:
<img width="610" alt="screen shot 2018-01-29 at 14 10 13" src="https://user-images.githubusercontent.com/754712/35515584-89308c1a-0501-11e8-8cf2-aa52aeaddf9d.png">
