### PR TITLE
Change the output of the artefact check test

### DIFF
--- a/test/regression/smart_answers_regression_test.rb
+++ b/test/regression/smart_answers_regression_test.rb
@@ -145,7 +145,7 @@ class SmartAnswersRegressionTest < ActionController::TestCase
 
       should "#{RUN_ME_LAST} and generate the same set of output files" do
         diff_output = `git status --short -- #{smart_answer_helper.path_to_outputs_for_flow}`
-        assert diff_output.blank?, "Changes in outcome page artefacts have been detected:\n#{diff_output}\nIf these changes are expected then re-generate the checksums, re-run the regression test, and commit all the changes."
+        assert diff_output.blank?, "Changes in outcome page artefacts have been detected:\n#{diff_output}\nIf these changes are expected then re-generate the checksums, commit all the changes, and re-run the regression test."
       end
     end
   end


### PR DESCRIPTION
The previous version suggested that you:

1. regenerate the checksums
2. run the test again
3. commit all the changes

However, as the test does a `git status` and checks for empty output you
actually have to commit the changes before you re-run the test, otherwise
the changes will still appear in the `git status` output.  So we change the
output of the test to suggest that you:

1. regenerate the checksums
2. commit all the changes
3. run the test again