### PR TITLE
Ask GA to strip postcodes from arguments sent to it

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,7 @@
     <%= yield :head %>
 
     <% if @content_item %>
-      <%= render partial: 'govuk_component/analytics_meta_tags', locals: { content_item: @content_item } %>
+      <%= render partial: 'govuk_component/analytics_meta_tags', locals: { content_item: @content_item, strip_postcode_pii: true } %>
     <% end %>
   </head>
 <body class="mainstream">


### PR DESCRIPTION
For: https://trello.com/c/vISRi8lY/58-investigate-preventing-pii-being-sent-to-ga

Some smart answers have a postcode entry field where the provided value
ends up in the url. We want to remove this from any arguments sent to
Google Analytics so we provide the parameter to the `analytics_meta_tags`
component partial that will set the metatag that is used by our JS code
to control this behaviour (it's off by default).  This behaviour is
turned on by default for "smart-answer" formats, but for some reason the
content item loaded by this app is the start page at `/<slug>`, which is a
transaction, rather than the smart answer document itself from `/<slug>/y`
so the default behaviour doesn't kick in because static sees the page as
a transaction, not a smart answer.

Relies on alphagov/static#1183 to be merged and deployed before this option will be respected and acted upon.