### PR TITLE
Use a random secret token

### DIFF
--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -1,10 +1,2 @@
-# The values in this file are overwritten when deploying
-
-# Be sure to restart your server when you modify this file.
-
-# Your secret key for verifying the integrity of signed cookies.
-# If you change this key, all old signed cookies will become invalid!
-# Make sure the secret is at least 30 characters and all random,
-# no regular words or you'll be exposed to dictionary attacks.
-SmartAnswers::Application.config.secret_token = 'replacedondeploy'
-SmartAnswers::Application.config.secret_key_base = 'replacedondeployaswell'
+# We don't use sessions in this application, but Rails needs a secret key base anyway.
+SmartAnswers::Application.config.secret_key_base = SecureRandom.hex


### PR DESCRIPTION
We don't use sessions in this application, but Rails needs a secret key base anyway. A random value that changes between app deploys is fine.

This will stop brakeman from complaining.

https://trello.com/c/aOOWxMxu