### PR TITLE
Changing pensions

### DIFF
--- a/lib/smart_answer/calculators/state_pension_age_calculator.rb
+++ b/lib/smart_answer/calculators/state_pension_age_calculator.rb
@@ -68,6 +68,10 @@ module SmartAnswer::Calculators
       old_state_pension? ? '/state-pension/how-to-claim' : '/new-state-pension/how-to-claim'
     end
 
+    def rolling_increase_period?
+      dob.between?(Date.parse("6 April 1970"), Date.parse("5 April 1978"))
+    end
+
   private
 
     def earliest_application_date

--- a/lib/smart_answer_flows/state-pension-age/outcomes/not_yet_reached_sp_age.govspeak.erb
+++ b/lib/smart_answer_flows/state-pension-age/outcomes/not_yet_reached_sp_age.govspeak.erb
@@ -6,12 +6,26 @@
 <% content_for :body do %>
   Your State Pension age is <%= calculator.state_pension_age %>.
 
-  ^[The State Pension age is under review](/government/news/proposed-new-timetable-for-state-pension-age-increases) and may change in the future.^
+  <% if calculator.rolling_increase_period? %>
+    ^This may increase by up to a year following [review of the State Pension age](/government/news/proposed-new-timetable-for-state-pension-age-increases).^
+  <% else %>
+    ^[The State Pension age is under review](/government/news/proposed-new-timetable-for-state-pension-age-increases) and may change in the future.^
+  <% end %>
 
   <% if calculator.can_apply? %>
     You can [claim your State Pension](<%= calculator.how_to_claim_url %>) now. Your payments will start after you reach State Pension age.
 
     Alternatively, you can [delay (defer) claiming](/deferring-state-pension).
+  <% end %>
+
+  <% if calculator.old_state_pension? %>
+    Find out more information about the [basic State Pension](/state-pension).
+  <% else %>
+    Find out more information about the [new State Pension](/new-state-pension).
+  <% end %>
+
+  <% if calculator.before_state_pension_date?(days: 30) && calculator.over_16_years_old? %>
+    ^You can get a [forecast or statement of how much State Pension you may get](/state-pension-statement).^
   <% end %>
 
   ##Pension Credit
@@ -23,13 +37,4 @@
     You’ve already reached the Pension Credit qualifying age. Check if you’re eligible to claim [Pension Credit](/pension-credit/eligibility).
   <% end %>
 
-  <% if calculator.before_state_pension_date?(days: 30) && calculator.over_16_years_old? %>
-    ^You can get a [forecast or statement of how much State Pension you may get](/state-pension-statement).^
-  <% end %>
-
-  <% if calculator.old_state_pension? %>
-    Find out more information about the [basic State Pension](/state-pension).
-  <% else %>
-    Find out more information about the [new State Pension](/new-state-pension).
-  <% end %>
 <% end %>

--- a/test/artefacts/state-pension-age/age/1953-02-06/male.txt
+++ b/test/artefacts/state-pension-age/age/1953-02-06/male.txt
@@ -4,14 +4,14 @@ Your State Pension age is 65 years.
 
 ^[The State Pension age is under review](/government/news/proposed-new-timetable-for-state-pension-age-increases) and may change in the future.^
 
+Find out more information about the [new State Pension](/new-state-pension).
+
+^You can get a [forecast or statement of how much State Pension you may get](/state-pension-statement).^
+
 ##Pension Credit
 You might get [Pension Credit](/pension-credit) if you’re retired and on a low income.
 
 You’ve already reached the Pension Credit qualifying age. Check if you’re eligible to claim [Pension Credit](/pension-credit/eligibility).
-
-^You can get a [forecast or statement of how much State Pension you may get](/state-pension-statement).^
-
-Find out more information about the [new State Pension](/new-state-pension).
 
 
 

--- a/test/artefacts/state-pension-age/age/1953-04-05/male.txt
+++ b/test/artefacts/state-pension-age/age/1953-04-05/male.txt
@@ -4,14 +4,14 @@ Your State Pension age is 65 years.
 
 ^[The State Pension age is under review](/government/news/proposed-new-timetable-for-state-pension-age-increases) and may change in the future.^
 
+Find out more information about the [new State Pension](/new-state-pension).
+
+^You can get a [forecast or statement of how much State Pension you may get](/state-pension-statement).^
+
 ##Pension Credit
 You might get [Pension Credit](/pension-credit) if you’re retired and on a low income.
 
 You’ve already reached the Pension Credit qualifying age. Check if you’re eligible to claim [Pension Credit](/pension-credit/eligibility).
-
-^You can get a [forecast or statement of how much State Pension you may get](/state-pension-statement).^
-
-Find out more information about the [new State Pension](/new-state-pension).
 
 
 

--- a/test/artefacts/state-pension-age/age/1953-04-06/female.txt
+++ b/test/artefacts/state-pension-age/age/1953-04-06/female.txt
@@ -4,14 +4,14 @@ Your State Pension age is 63 years, 3 months.
 
 ^[The State Pension age is under review](/government/news/proposed-new-timetable-for-state-pension-age-increases) and may change in the future.^
 
+Find out more information about the [new State Pension](/new-state-pension).
+
+^You can get a [forecast or statement of how much State Pension you may get](/state-pension-statement).^
+
 ##Pension Credit
 You might get [Pension Credit](/pension-credit) if you’re retired and on a low income.
 
 You'll reach the Pension Credit qualifying age on  6 July 2016.
-
-^You can get a [forecast or statement of how much State Pension you may get](/state-pension-statement).^
-
-Find out more information about the [new State Pension](/new-state-pension).
 
 
 

--- a/test/artefacts/state-pension-age/age/1953-04-06/male.txt
+++ b/test/artefacts/state-pension-age/age/1953-04-06/male.txt
@@ -4,14 +4,14 @@ Your State Pension age is 65 years.
 
 ^[The State Pension age is under review](/government/news/proposed-new-timetable-for-state-pension-age-increases) and may change in the future.^
 
+Find out more information about the [new State Pension](/new-state-pension).
+
+^You can get a [forecast or statement of how much State Pension you may get](/state-pension-statement).^
+
 ##Pension Credit
 You might get [Pension Credit](/pension-credit) if you’re retired and on a low income.
 
 You'll reach the Pension Credit qualifying age on  6 July 2016.
-
-^You can get a [forecast or statement of how much State Pension you may get](/state-pension-statement).^
-
-Find out more information about the [new State Pension](/new-state-pension).
 
 
 

--- a/test/artefacts/state-pension-age/age/1980-01-01/female.txt
+++ b/test/artefacts/state-pension-age/age/1980-01-01/female.txt
@@ -4,14 +4,14 @@ Your State Pension age is 68 years.
 
 ^[The State Pension age is under review](/government/news/proposed-new-timetable-for-state-pension-age-increases) and may change in the future.^
 
+Find out more information about the [new State Pension](/new-state-pension).
+
+^You can get a [forecast or statement of how much State Pension you may get](/state-pension-statement).^
+
 ##Pension Credit
 You might get [Pension Credit](/pension-credit) if you’re retired and on a low income.
 
 You'll reach the Pension Credit qualifying age on  1 January 2048.
-
-^You can get a [forecast or statement of how much State Pension you may get](/state-pension-statement).^
-
-Find out more information about the [new State Pension](/new-state-pension).
 
 
 

--- a/test/artefacts/state-pension-age/age/1980-01-01/male.txt
+++ b/test/artefacts/state-pension-age/age/1980-01-01/male.txt
@@ -4,14 +4,14 @@ Your State Pension age is 68 years.
 
 ^[The State Pension age is under review](/government/news/proposed-new-timetable-for-state-pension-age-increases) and may change in the future.^
 
+Find out more information about the [new State Pension](/new-state-pension).
+
+^You can get a [forecast or statement of how much State Pension you may get](/state-pension-statement).^
+
 ##Pension Credit
 You might get [Pension Credit](/pension-credit) if you’re retired and on a low income.
 
 You'll reach the Pension Credit qualifying age on  1 January 2048.
-
-^You can get a [forecast or statement of how much State Pension you may get](/state-pension-statement).^
-
-Find out more information about the [new State Pension](/new-state-pension).
 
 
 

--- a/test/artefacts/state-pension-age/age/2000-01-01/female.txt
+++ b/test/artefacts/state-pension-age/age/2000-01-01/female.txt
@@ -4,14 +4,14 @@ Your State Pension age is 68 years.
 
 ^[The State Pension age is under review](/government/news/proposed-new-timetable-for-state-pension-age-increases) and may change in the future.^
 
+Find out more information about the [new State Pension](/new-state-pension).
+
+^You can get a [forecast or statement of how much State Pension you may get](/state-pension-statement).^
+
 ##Pension Credit
 You might get [Pension Credit](/pension-credit) if you’re retired and on a low income.
 
 You'll reach the Pension Credit qualifying age on  1 January 2068.
-
-^You can get a [forecast or statement of how much State Pension you may get](/state-pension-statement).^
-
-Find out more information about the [new State Pension](/new-state-pension).
 
 
 

--- a/test/artefacts/state-pension-age/age/2000-01-01/male.txt
+++ b/test/artefacts/state-pension-age/age/2000-01-01/male.txt
@@ -4,14 +4,14 @@ Your State Pension age is 68 years.
 
 ^[The State Pension age is under review](/government/news/proposed-new-timetable-for-state-pension-age-increases) and may change in the future.^
 
+Find out more information about the [new State Pension](/new-state-pension).
+
+^You can get a [forecast or statement of how much State Pension you may get](/state-pension-statement).^
+
 ##Pension Credit
 You might get [Pension Credit](/pension-credit) if you’re retired and on a low income.
 
 You'll reach the Pension Credit qualifying age on  1 January 2068.
-
-^You can get a [forecast or statement of how much State Pension you may get](/state-pension-statement).^
-
-Find out more information about the [new State Pension](/new-state-pension).
 
 
 

--- a/test/data/state-pension-age-files.yml
+++ b/test/data/state-pension-age-files.yml
@@ -2,10 +2,10 @@
 lib/data/rates/state_pension.yml: e9879f3f27ec582c97705a38bdcdef3f
 lib/data/state_pension_date_query.rb: 6a5bc3072ae8b986f7ee6d47ecd5da41
 lib/data/state_pension_dates.yml: da1bdee8a5b42c489b3966c43b625113
-lib/smart_answer/calculators/state_pension_age_calculator.rb: 48ddd9ae8c6b4b4b49268012f6e74504
+lib/smart_answer/calculators/state_pension_age_calculator.rb: f1bb153b2a04c6339ec76b07a42d81e4
 lib/smart_answer_flows/state-pension-age/outcomes/bus_pass_result.govspeak.erb: dcd8e4132b25e8dd46b82f096837b974
 lib/smart_answer_flows/state-pension-age/outcomes/has_reached_sp_age.govspeak.erb: ea2d19d861931bfd81901ea1e83faa75
-lib/smart_answer_flows/state-pension-age/outcomes/not_yet_reached_sp_age.govspeak.erb: '07519a1d25f3b8ed310c9ed941989400'
+lib/smart_answer_flows/state-pension-age/outcomes/not_yet_reached_sp_age.govspeak.erb: bb51554e222e58dae1dfdcdd0bbe634e
 lib/smart_answer_flows/state-pension-age/questions/dob_age.govspeak.erb: 336a91fc32e8fc66011a9ae504111ae0
 lib/smart_answer_flows/state-pension-age/questions/gender.govspeak.erb: 4624dfdac5be156a8573cbc21245e36d
 lib/smart_answer_flows/state-pension-age/questions/which_calculation.govspeak.erb: 047d48d2d752d7b53c0b78f0eaedac3f

--- a/test/unit/calculators/state_pension_age_calculator_test.rb
+++ b/test/unit/calculators/state_pension_age_calculator_test.rb
@@ -343,5 +343,22 @@ module SmartAnswer::Calculators
         end
       end
     end
+
+    context "#rolling_increase_period?" do
+      should "be true for a date that is between 06/04/1970 and 05/04/1978" do
+        @calculator = StatePensionAgeCalculator.new(dob: Date.parse("6 April 1970"))
+        assert_equal true, @calculator.rolling_increase_period?
+      end
+
+      should "be false for a date that is before 06/04/1970" do
+        @calculator = StatePensionAgeCalculator.new(dob: Date.parse("5 April 1970"))
+        assert_equal false, @calculator.rolling_increase_period?
+      end
+
+      should "be false for a date that is after 05/04/1978" do
+        @calculator = StatePensionAgeCalculator.new(dob: Date.parse("6 April 1978"))
+        assert_equal false, @calculator.rolling_increase_period?
+      end
+    end
   end
 end


### PR DESCRIPTION
Reverts alphagov/smart-answers#3427

Original PR content below:

-----------------------------------------------------------------------
Changes requested can be found here: https://docs.google.com/document/d/1QZQrYyBEytxaU0npBjit3-nUJsKrhbKn34GZICTgSNw/edit

For: https://trello.com/c/SsZ8u5xF/110-2-state-pension-age-government-proposals

This PR does two things:

- moves 2 lines in the `not_yet_reached_sp_age.govspeak.erb` file that are under the
"Pension Credit" section to above the "Pension Credit section", as they are not actually
 related to that topic.
- adds a condition to notify only the people born between 06/04/1970 and 05/04/1978
that their pension age is going to increase

# Before
<img width="727" alt="screen shot 2018-03-29 at 13 33 23" src="https://user-images.githubusercontent.com/1354439/38088996-d2770084-3355-11e8-92e0-6841d6b77fde.png">


# After
<img width="813" alt="screen shot 2018-03-29 at 13 33 27" src="https://user-images.githubusercontent.com/1354439/38088998-d4fb85d2-3355-11e8-8954-ba308daeb8a1.png">

