### PR TITLE
Estimate your penalty for self assessment 2018 edition

### DIFF
--- a/lib/smart_answer/calculators/self_assessment_penalties.rb
+++ b/lib/smart_answer/calculators/self_assessment_penalties.rb
@@ -13,18 +13,21 @@ module SmartAnswer::Calculators
         "2013-14": ONLINE_FILING_DEADLINE_YEAR.starting_in(2015).begins_on,
         "2014-15": ONLINE_FILING_DEADLINE_YEAR.starting_in(2016).begins_on,
         "2015-16": ONLINE_FILING_DEADLINE_YEAR.starting_in(2017).begins_on,
+        "2016-17": ONLINE_FILING_DEADLINE_YEAR.starting_in(2018).begins_on,
       },
       offline_filing_deadline: {
         "2012-13": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2013).begins_on,
         "2013-14": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2014).begins_on,
         "2014-15": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2015).begins_on,
         "2015-16": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2016).begins_on,
+        "2016-17": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2017).begins_on,
       },
       payment_deadline: {
         "2012-13": PAYMENT_DEADLINE_YEAR.starting_in(2014).begins_on,
         "2013-14": PAYMENT_DEADLINE_YEAR.starting_in(2015).begins_on,
         "2014-15": PAYMENT_DEADLINE_YEAR.starting_in(2016).begins_on,
         "2015-16": PAYMENT_DEADLINE_YEAR.starting_in(2017).begins_on,
+        "2016-17": PAYMENT_DEADLINE_YEAR.starting_in(2018).begins_on,
       },
     }.freeze
 
@@ -38,6 +41,8 @@ module SmartAnswer::Calculators
         SmartAnswer::YearRange.tax_year.starting_in(2014)
       when '2015-16'
         SmartAnswer::YearRange.tax_year.starting_in(2015)
+      when '2016-17'
+        SmartAnswer::YearRange.tax_year.starting_in(2016)
       end
     end
 
@@ -55,6 +60,8 @@ module SmartAnswer::Calculators
         PENALTY_YEAR.starting_in(2017).begins_on
       when '2015-16'
         PENALTY_YEAR.starting_in(2018).begins_on
+      when '2016-17'
+        PENALTY_YEAR.starting_in(2019).begins_on
       end
     end
 

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
@@ -12,6 +12,7 @@ module SmartAnswer
         option :"2013-14"
         option :"2014-15"
         option :"2015-16"
+        option :"2016-17"
 
         on_response do |response|
           self.calculator = Calculators::SelfAssessmentPenalties.new

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties/questions/which_year.govspeak.erb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties/questions/which_year.govspeak.erb
@@ -6,5 +6,6 @@
   "2012-13": "6 April 2012 to 5 April 2013",
   "2013-14": "6 April 2013 to 5 April 2014",
   "2014-15": "6 April 2014 to 5 April 2015",
-  "2015-16": "6 April 2015 to 5 April 2016"
+  "2015-16": "6 April 2015 to 5 April 2016",
+  "2016-17": "6 April 2016 to 5 April 2017"
 ) %>

--- a/test/artefacts/estimate-self-assessment-penalties/2016-17/online/2017-04-07/2017-04-08.txt
+++ b/test/artefacts/estimate-self-assessment-penalties/2016-17/online/2017-04-07/2017-04-08.txt
@@ -1,0 +1,8 @@
+You don't have to pay a penalty
+
+You sent your tax return on or before the deadline, so you don’t have to pay a penalty.
+
+You paid your bill on time, so there is no interest or penalty for late payment.
+
+
+

--- a/test/artefacts/estimate-self-assessment-penalties/2016-17/paper/2017-04-07/2017-04-08.txt
+++ b/test/artefacts/estimate-self-assessment-penalties/2016-17/paper/2017-04-07/2017-04-08.txt
@@ -1,0 +1,8 @@
+You don't have to pay a penalty
+
+You sent your tax return on or before the deadline, so you don’t have to pay a penalty.
+
+You paid your bill on time, so there is no interest or penalty for late payment.
+
+
+

--- a/test/artefacts/estimate-self-assessment-penalties/y.txt
+++ b/test/artefacts/estimate-self-assessment-penalties/y.txt
@@ -8,6 +8,7 @@ For which tax year do you want the estimate?
   * 2013-14: 6 April 2013 to 5 April 2014
   * 2014-15: 6 April 2014 to 5 April 2015
   * 2015-16: 6 April 2015 to 5 April 2016
+  * 2016-17: 6 April 2016 to 5 April 2017
 
 
 

--- a/test/data/estimate-self-assessment-penalties-files.yml
+++ b/test/data/estimate-self-assessment-penalties-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer/calculators/self_assessment_penalties.rb: 6b796c127653623dbb1cbf2dd33697b1
+lib/smart_answer/calculators/self_assessment_penalties.rb: 1f49d08d7c526a37f1c360acadcd1879
 lib/smart_answer_flows/estimate-self-assessment-penalties/estimate_self_assessment_penalties.govspeak.erb: d35eaf0334a9e871fa14294682fb7322
 lib/smart_answer_flows/estimate-self-assessment-penalties/outcomes/filed_and_paid_on_time.govspeak.erb: c7c2b164d05b3f757bc9ee9439aa560a
 lib/smart_answer_flows/estimate-self-assessment-penalties/outcomes/late.govspeak.erb: b88d8257149cb0af87681e03493ace43
@@ -7,7 +7,7 @@ lib/smart_answer_flows/estimate-self-assessment-penalties/questions/how_much_tax
 lib/smart_answer_flows/estimate-self-assessment-penalties/questions/how_submitted.govspeak.erb: c3fffa8a0386144630fae76250114191
 lib/smart_answer_flows/estimate-self-assessment-penalties/questions/when_paid.govspeak.erb: fd629bd5e95648f5a22246a423cfd026
 lib/smart_answer_flows/estimate-self-assessment-penalties/questions/when_submitted.govspeak.erb: 590022eac4fbf8db1976da66d777f776
-lib/smart_answer_flows/estimate-self-assessment-penalties/questions/which_year.govspeak.erb: 3431fda0cc0bf6c0c7670c04ef38458c
-lib/smart_answer_flows/estimate-self-assessment-penalties.rb: 4a5bfa1f464e67803ac0395943fd129c
-test/data/estimate-self-assessment-penalties-questions-and-responses.yml: 93dcab8e10c0f76286c3d432505c45bb
-test/data/estimate-self-assessment-penalties-responses-and-expected-results.yml: 0d48b872d6a38861912032981a446777
+lib/smart_answer_flows/estimate-self-assessment-penalties/questions/which_year.govspeak.erb: c639bc3d5f7853b948253bd15e63d95a
+lib/smart_answer_flows/estimate-self-assessment-penalties.rb: 52f1ce36e6d51089027ee1d51714db42
+test/data/estimate-self-assessment-penalties-questions-and-responses.yml: 7406d83d24abf7f0b5dbb1f024ba9f23
+test/data/estimate-self-assessment-penalties-responses-and-expected-results.yml: 1ec492f64552a1fce3638b756c7b8d6a

--- a/test/data/estimate-self-assessment-penalties-questions-and-responses.yml
+++ b/test/data/estimate-self-assessment-penalties-questions-and-responses.yml
@@ -4,6 +4,7 @@
 - 2013-14
 - 2014-15
 - 2015-16
+- 2016-17
 :how_submitted?:
 - online
 - paper
@@ -16,6 +17,7 @@
 - 2014-04-07 # 2013-14 - After start of next tax year (2014-04-06)
 - 2015-04-07 # 2014-15 - After start of next tax year (2015-04-06)
 - 2016-04-07 # 2015-16 - After start of next tax year (2016-04-06)
+- 2017-04-07 # 2016-17 - After start of next tax year (2017-04-06)
 :when_paid?:
 - 2013-04-06 # 2012-13 - Paid before submitted (2013-04-07)
 - 2013-04-08 # 2012-13 - Paid after submitted (2013-04-07)
@@ -25,6 +27,7 @@
 - 2014-04-08 # 2013-14 - Paid after submitted
 - 2015-04-08 # 2014-15 - Paid after submitted
 - 2016-04-08 # 2015-16 - Paid after submitted
+- 2017-04-08 # 2016-17 - Paid after submitted
 :how_much_tax?:
 - 500
 - 6003 # Estimated bill value greater than £6002

--- a/test/data/estimate-self-assessment-penalties-responses-and-expected-results.yml
+++ b/test/data/estimate-self-assessment-penalties-responses-and-expected-results.yml
@@ -3677,3 +3677,260 @@
   - '2016-04-08'
   :next_node: :filed_and_paid_on_time
   :outcome_node: true
+- :current_node: :which_year?
+  :responses:
+  - 2016-17
+  :next_node: :how_submitted?
+  :outcome_node: false
+- :current_node: :how_submitted?
+  :responses:
+  - 2016-17
+  - online
+  :next_node: :when_submitted?
+  :outcome_node: false
+- :current_node: :when_submitted?
+  :responses:
+  - 2016-17
+  - online
+  - '2014-04-05'
+  :next_node: :when_submitted?
+  :outcome_node: false
+- :current_node: :when_submitted?
+  :responses:
+  - 2016-17
+  - online
+  - '2014-04-07'
+  :next_node: :when_submitted?
+  :outcome_node: false
+- :current_node: :when_submitted?
+  :responses:
+  - 2016-17
+  - online
+  - '2015-01-31'
+  :next_node: :when_submitted?
+  :outcome_node: false
+- :current_node: :when_submitted?
+  :responses:
+  - 2016-17
+  - online
+  - '2015-04-30'
+  :next_node: :when_submitted?
+  :outcome_node: false
+- :current_node: :when_submitted?
+  :responses:
+  - 2016-17
+  - online
+  - '2015-07-31'
+  :next_node: :when_submitted?
+  :outcome_node: false
+- :current_node: :when_submitted?
+  :responses:
+  - 2016-17
+  - online
+  - '2015-04-07'
+  :next_node: :when_submitted?
+  :outcome_node: false
+- :current_node: :when_submitted?
+  :responses:
+  - 2016-17
+  - online
+  - '2016-04-07'
+  :next_node: :when_submitted?
+  :outcome_node: false
+- :current_node: :when_submitted?
+  :responses:
+  - 2016-17
+  - online
+  - '2017-04-07'
+  :next_node: :when_paid?
+  :outcome_node: false
+- :current_node: :when_paid?
+  :responses:
+  - 2016-17
+  - online
+  - '2017-04-07'
+  - '2014-04-06'
+  :next_node: :when_paid?
+  :outcome_node: false
+- :current_node: :when_paid?
+  :responses:
+  - 2016-17
+  - online
+  - '2017-04-07'
+  - '2014-04-08'
+  :next_node: :when_paid?
+  :outcome_node: false
+- :current_node: :when_paid?
+  :responses:
+  - 2016-17
+  - online
+  - '2017-04-07'
+  - '2015-01-31'
+  :next_node: :when_paid?
+  :outcome_node: false
+- :current_node: :when_paid?
+  :responses:
+  - 2016-17
+  - online
+  - '2017-04-07'
+  - '2015-03-02'
+  :next_node: :when_paid?
+  :outcome_node: false
+- :current_node: :when_paid?
+  :responses:
+  - 2016-17
+  - online
+  - '2017-04-07'
+  - '2016-01-31'
+  :next_node: :when_paid?
+  :outcome_node: false
+- :current_node: :when_paid?
+  :responses:
+  - 2016-17
+  - online
+  - '2017-04-07'
+  - '2015-04-08'
+  :next_node: :when_paid?
+  :outcome_node: false
+- :current_node: :when_paid?
+  :responses:
+  - 2016-17
+  - online
+  - '2017-04-07'
+  - '2016-04-08'
+  :next_node: :when_paid?
+  :outcome_node: false
+- :current_node: :when_paid?
+  :responses:
+  - 2016-17
+  - online
+  - '2017-04-07'
+  - '2017-04-08'
+  :next_node: :filed_and_paid_on_time
+  :outcome_node: true
+- :current_node: :how_submitted?
+  :responses:
+  - 2016-17
+  - paper
+  :next_node: :when_submitted?
+  :outcome_node: false
+- :current_node: :when_submitted?
+  :responses:
+  - 2016-17
+  - paper
+  - '2014-04-05'
+  :next_node: :when_submitted?
+  :outcome_node: false
+- :current_node: :when_submitted?
+  :responses:
+  - 2016-17
+  - paper
+  - '2014-04-07'
+  :next_node: :when_submitted?
+  :outcome_node: false
+- :current_node: :when_submitted?
+  :responses:
+  - 2016-17
+  - paper
+  - '2015-01-31'
+  :next_node: :when_submitted?
+  :outcome_node: false
+- :current_node: :when_submitted?
+  :responses:
+  - 2016-17
+  - paper
+  - '2015-04-30'
+  :next_node: :when_submitted?
+  :outcome_node: false
+- :current_node: :when_submitted?
+  :responses:
+  - 2016-17
+  - paper
+  - '2015-07-31'
+  :next_node: :when_submitted?
+  :outcome_node: false
+- :current_node: :when_submitted?
+  :responses:
+  - 2016-17
+  - paper
+  - '2015-04-07'
+  :next_node: :when_submitted?
+  :outcome_node: false
+- :current_node: :when_submitted?
+  :responses:
+  - 2016-17
+  - paper
+  - '2016-04-07'
+  :next_node: :when_submitted?
+  :outcome_node: false
+- :current_node: :when_submitted?
+  :responses:
+  - 2016-17
+  - paper
+  - '2017-04-07'
+  :next_node: :when_paid?
+  :outcome_node: false
+- :current_node: :when_paid?
+  :responses:
+  - 2016-17
+  - paper
+  - '2017-04-07'
+  - '2014-04-06'
+  :next_node: :when_paid?
+  :outcome_node: false
+- :current_node: :when_paid?
+  :responses:
+  - 2016-17
+  - paper
+  - '2017-04-07'
+  - '2014-04-08'
+  :next_node: :when_paid?
+  :outcome_node: false
+- :current_node: :when_paid?
+  :responses:
+  - 2016-17
+  - paper
+  - '2017-04-07'
+  - '2015-01-31'
+  :next_node: :when_paid?
+  :outcome_node: false
+- :current_node: :when_paid?
+  :responses:
+  - 2016-17
+  - paper
+  - '2017-04-07'
+  - '2015-03-02'
+  :next_node: :when_paid?
+  :outcome_node: false
+- :current_node: :when_paid?
+  :responses:
+  - 2016-17
+  - paper
+  - '2017-04-07'
+  - '2016-01-31'
+  :next_node: :when_paid?
+  :outcome_node: false
+- :current_node: :when_paid?
+  :responses:
+  - 2016-17
+  - paper
+  - '2017-04-07'
+  - '2015-04-08'
+  :next_node: :when_paid?
+  :outcome_node: false
+- :current_node: :when_paid?
+  :responses:
+  - 2016-17
+  - paper
+  - '2017-04-07'
+  - '2016-04-08'
+  :next_node: :when_paid?
+  :outcome_node: false
+- :current_node: :when_paid?
+  :responses:
+  - 2016-17
+  - paper
+  - '2017-04-07'
+  - '2017-04-08'
+  :next_node: :filed_and_paid_on_time
+  :outcome_node: true

--- a/test/unit/calculators/self_assessment_penalties_test.rb
+++ b/test/unit/calculators/self_assessment_penalties_test.rb
@@ -9,18 +9,21 @@ module SmartAnswer::Calculators
           "2013-14": Date.new(2015, 1, 31),
           "2014-15": Date.new(2016, 1, 31),
           "2015-16": Date.new(2017, 1, 31),
+          "2016-17": Date.new(2018, 1, 31),
         },
         offline_filing_deadline: {
           "2012-13": Date.new(2013, 10, 31),
           "2013-14": Date.new(2014, 10, 31),
           "2014-15": Date.new(2015, 10, 31),
           "2015-16": Date.new(2016, 10, 31),
+          "2016-17": Date.new(2017, 10, 31),
         },
         payment_deadline: {
           "2012-13": Date.new(2014, 1, 31),
           "2013-14": Date.new(2015, 1, 31),
           "2014-15": Date.new(2016, 1, 31),
           "2015-16": Date.new(2017, 1, 31),
+          "2016-17": Date.new(2018, 1, 31),
         },
       }
 
@@ -53,6 +56,11 @@ module SmartAnswer::Calculators
 
         assert_equal Date.new(2016, 4, 6), @calculator.start_of_next_tax_year
       end
+      should 'return 2017-04-06 if tax-year is 2017-16' do
+        @calculator.tax_year = '2016-17'
+
+        assert_equal Date.new(2017, 4, 6), @calculator.start_of_next_tax_year
+      end
     end
 
     context 'one_year_after_start_date_for_penalties' do
@@ -75,6 +83,11 @@ module SmartAnswer::Calculators
         @calculator.tax_year = '2015-16'
 
         assert_equal Date.new(2018, 2, 1), @calculator.one_year_after_start_date_for_penalties
+      end
+      should 'return 2019-02-01 if tax-year is 2016-17' do
+        @calculator.tax_year = '2016-17'
+
+        assert_equal Date.new(2019, 2, 1), @calculator.one_year_after_start_date_for_penalties
       end
     end
 


### PR DESCRIPTION
We're updating this smart answer for users who've missed the deadline for 2016-17 tax returns.

- On outcome https://www.gov.uk/estimate-self-assessment-penalties/y, we've added a '6 April 2016 to 5 April 2017' option.

- The deadlines are all the same as the ones already in `lib/smart_answer/calculators/self_assessment_penalties.rb`:
-- offline filing deadline = 31 October
-- online filing deadline = 31 January
-- payment deadline = 31 January

- If the user missed the deadline(s), the calculations are the same as the ones already
in `lib/smart_answer/calculators/self_assessment_penalties.rb`

For: https://trello.com/c/91tw7cZJ/124-1-before-6-april-estimate-your-penalty-for-self-assessment