### PR TITLE
Revert "Bump mocha from 1.4.0 to 1.5.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ group :test do
   gem 'ci_reporter'
   gem 'minitest', '~> 5.11'
   gem 'minitest-focus', '~> 1.1', '>= 1.1.2'
-  gem 'mocha', '1.5.0', require: false
+  gem 'mocha', '1.4.0', require: false
   gem 'poltergeist', '1.17.0'
   gem 'shoulda', '~> 3.5.0'
   gem 'simplecov', '~> 0.16.1', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,7 +155,7 @@ GEM
     minitest (5.11.3)
     minitest-focus (1.1.2)
       minitest (>= 4, < 6)
-    mocha (1.5.0)
+    mocha (1.4.0)
       metaclass (~> 0.0.1)
     money (6.11.0)
       i18n (>= 0.6.4, < 1.1)
@@ -339,7 +339,7 @@ DEPENDENCIES
   method_source
   minitest (~> 5.11)
   minitest-focus (~> 1.1, >= 1.1.2)
-  mocha (= 1.5.0)
+  mocha (= 1.4.0)
   nokogiri
   parser
   plek (= 2.1.1)


### PR DESCRIPTION
Reverts alphagov/smart-answers#3464

This seems to have [broken the tests](https://ci.integration.publishing.service.gov.uk/job/smartanswers/job/master/3927/console)