### PR TITLE
Update to child maintenance calculator

### DIFF
--- a/lib/smart_answer_flows/calculate-your-child-maintenance/questions/how_many_nights_children_stay_with_payee.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-child-maintenance/questions/how_many_nights_children_stay_with_payee.govspeak.erb
@@ -1,15 +1,15 @@
 <% content_for :title do %>
   <% if calculator.paying? %>
-    On average, how many nights a year do the children stay over with you?
+    On average, how many nights a week do the children stay over with you?
   <% else %>
-    On average, how many nights a year do the children stay over with the parent paying child maintenance?
+    On average, how many nights a week do the children stay over with the parent paying child maintenance?
   <% end %>
 <% end %>
 
 <% options(
-  "0": "Less than 52 (less than once a week)",
-  "1": "52 to 103 (1 to 2 nights a week)",
-  "2": "104 to 155 (2 to 3 nights a week)",
-  "3": "156 to 174 (approx. 3 nights a week)",
-  "4": "175 or more (more than 3 nights a week)"
+  "0": "Less than once a week (less than 52 nights a year)",
+  "1": "1 to 2 nights a week (52 to 103 a year)",
+  "2": "2 to 3 nights a week (104 to 155 a year)",
+  "3": "3 nights a week (156 to 174 a year)",
+  "4": "More than 3 nights a week (175 or more a year)"
 ) %>

--- a/test/artefacts/calculate-your-child-maintenance/pay/1_child/income_support.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/1_child/income_support.txt
@@ -4,11 +4,11 @@ On average, how many nights a year do the children stay over with you?
 
 
 
-  * 0: Less than 52 (less than once a week)
-  * 1: 52 to 103 (1 to 2 nights a week)
-  * 2: 104 to 155 (2 to 3 nights a week)
-  * 3: 156 to 174 (approx. 3 nights a week)
-  * 4: 175 or more (more than 3 nights a week)
+  * 0: Less than once a week (less than 52 nights a year)
+  * 1: 1 to 2 nights a week (52 to 103 a year)
+  * 2: 2 to 3 nights a week (104 to 155 a year)
+  * 3: 3 nights a week (156 to 174 a year)
+  * 4: More than 3 nights a week (175 or more a year)
 
 
 

--- a/test/data/calculate-your-child-maintenance-files.yml
+++ b/test/data/calculate-your-child-maintenance-files.yml
@@ -11,7 +11,7 @@ lib/smart_answer_flows/calculate-your-child-maintenance/questions/are_you_paying
 lib/smart_answer_flows/calculate-your-child-maintenance/questions/gets_benefits.govspeak.erb: a1d89ee24996fb75eb742fdd7fd0059c
 lib/smart_answer_flows/calculate-your-child-maintenance/questions/gross_income_of_payee.govspeak.erb: ad80b797bfaf10952dbdafe7db22ea49
 lib/smart_answer_flows/calculate-your-child-maintenance/questions/how_many_children_paid_for.govspeak.erb: 001be8b0612744be54c55dfc70351202
-lib/smart_answer_flows/calculate-your-child-maintenance/questions/how_many_nights_children_stay_with_payee.govspeak.erb: 630d2a7382321b05ea8cea6e0bc7eb8b
+lib/smart_answer_flows/calculate-your-child-maintenance/questions/how_many_nights_children_stay_with_payee.govspeak.erb: da5c029db45b8c0c08023e43f35ad48d
 lib/smart_answer_flows/calculate-your-child-maintenance/questions/how_many_other_children_in_payees_household.govspeak.erb: 4e46c8c418c265f56b7ff55e1da2e3ba
 lib/smart_answer_flows/calculate-your-child-maintenance.rb: 30e384510170ef38fcc2fc136e005eff
 test/data/calculate-your-child-maintenance-questions-and-responses.yml: c333b75ec8a4766eaebdf7fef3389988


### PR DESCRIPTION
These are some content updates to the [On average, how many nights a year do the children stay over with you?](https://www.gov.uk/calculate-your-child-maintenance/y/pay/1_child/none/300.0/0) page of the [Child maintenance calculator](https://www.gov.uk/calculate-your-child-maintenance).

These changes aim to improve the benchmarking task performance.

Trello card: [Content update to child maintenance calculator (benchmarking)](https://trello.com/c/5PghktgA/46-content-update-to-child-maintenance-calculator-benchmarking)

Original:
![original_child_maintenance_calculator_content](https://user-images.githubusercontent.com/19667619/38565363-01d2bbf2-3cd9-11e8-8848-08e5243626a9.png)

Update:
![child_maintenance_calculator_content_update](https://user-images.githubusercontent.com/19667619/38565207-9d5eac76-3cd8-11e8-9322-0291995b40fb.png)
