### PR TITLE
Amend Luxembourg consular appointment urls

### DIFF
--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/luxembourg/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/luxembourg/_opposite_sex.erb
@@ -14,7 +14,7 @@ This costs <%= format_money calculator.consular_fee(:affidavit_or_affirmation_fo
 
 ### Swearing an affirmation or affidavit
 
-s1. [Make an appointment at the embassy in Luxembourg](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-luxembourg/notice-of-marriage-or-civil-partnership/slot_picker) to swear your affirmation or affidavit.
+s1. [Make an appointment at the embassy in Luxembourg](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-luxembourg/oaths-affirmations-and-affidavits/slot_picker) to swear your affirmation or affidavit.
 s2. Download the [affirmation or affidavit](/government/publications/luxembourg-affirmationaffidavit-of-marital-status-forms).
 s3. Print it out but don't sign it - you need to sign it at the embassy.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/luxembourg/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/luxembourg/_same_sex.erb
@@ -14,7 +14,7 @@ This costs <%= format_money calculator.consular_fee(:affidavit_or_affirmation_fo
 
 ### Swearing an affirmation or affidavit
 
-s1. [Make an appointment at the embassy in Luxembourg](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-luxembourg/notice-of-marriage-or-civil-partnership/slot_picker) to swear your affirmation or affidavit.
+s1. [Make an appointment at the embassy in Luxembourg](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-luxembourg/oaths-affirmations-and-affidavits/slot_picker) to swear your affirmation or affidavit.
 s2. Download the [affirmation or affidavit](/government/publications/luxembourg-affirmationaffidavit-of-marital-status-forms).
 s3. Print it out but don't sign it - you need to sign it at the embassy.
 

--- a/test/artefacts/marriage-abroad/luxembourg/opposite_sex.txt
+++ b/test/artefacts/marriage-abroad/luxembourg/opposite_sex.txt
@@ -16,7 +16,7 @@ This costs £50 per person. You can pay by card (Mastercard or Visa) or with the
 
 ### Swearing an affirmation or affidavit
 
-s1. [Make an appointment at the embassy in Luxembourg](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-luxembourg/notice-of-marriage-or-civil-partnership/slot_picker) to swear your affirmation or affidavit.
+s1. [Make an appointment at the embassy in Luxembourg](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-luxembourg/oaths-affirmations-and-affidavits/slot_picker) to swear your affirmation or affidavit.
 s2. Download the [affirmation or affidavit](/government/publications/luxembourg-affirmationaffidavit-of-marital-status-forms).
 s3. Print it out but don't sign it - you need to sign it at the embassy.
 

--- a/test/artefacts/marriage-abroad/luxembourg/same_sex.txt
+++ b/test/artefacts/marriage-abroad/luxembourg/same_sex.txt
@@ -16,7 +16,7 @@ This costs £50 per person. You can pay by card (Mastercard or Visa) or with the
 
 ### Swearing an affirmation or affidavit
 
-s1. [Make an appointment at the embassy in Luxembourg](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-luxembourg/notice-of-marriage-or-civil-partnership/slot_picker) to swear your affirmation or affidavit.
+s1. [Make an appointment at the embassy in Luxembourg](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-luxembourg/oaths-affirmations-and-affidavits/slot_picker) to swear your affirmation or affidavit.
 s2. Download the [affirmation or affidavit](/government/publications/luxembourg-affirmationaffidavit-of-marital-status-forms).
 s3. Print it out but don't sign it - you need to sign it at the embassy.
 

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -496,8 +496,8 @@ lib/smart_answer_flows/marriage-abroad/outcomes/countries/latvia/uk/partner_loca
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/latvia/uk/partner_local/_same_sex.govspeak.erb: cc481d56f4ceed1fbe7f52b001ed86e6
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/latvia/uk/partner_other/_opposite_sex.govspeak.erb: 13a2434ff467168a471218b9279b95eb
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/latvia/uk/partner_other/_same_sex.govspeak.erb: f14a355018bfe4bafc0dd56ccf6d6abb
-lib/smart_answer_flows/marriage-abroad/outcomes/countries/luxembourg/_opposite_sex.erb: 515e5dcad6e4bc122448778c71a871c1
-lib/smart_answer_flows/marriage-abroad/outcomes/countries/luxembourg/_same_sex.erb: 515e5dcad6e4bc122448778c71a871c1
+lib/smart_answer_flows/marriage-abroad/outcomes/countries/luxembourg/_opposite_sex.erb: 6e04f052c6c9fb61301260a530344784
+lib/smart_answer_flows/marriage-abroad/outcomes/countries/luxembourg/_same_sex.erb: 6e04f052c6c9fb61301260a530344784
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/luxembourg/_title.govspeak.erb: 92dcede7d7b6f5b0f7f6972b18d72e28
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/maldives/_title.govspeak.erb: 00274dd1f2ee56ab2baacc0d9eef0372
 lib/smart_answer_flows/marriage-abroad/outcomes/countries/maldives/ceremony_country/partner_british/_opposite_sex.govspeak.erb: e4948813eb14668253d434c341f621f1


### PR DESCRIPTION
https://trello.com/c/I7ROTtfO/65-getting-married-abroad-luxembourg-change-request-amend-to-links

Amends the consular appointment links for Luxembourg outcomes.

* https://smart-answers-preview-pr-3478.herokuapp.com/marriage-abroad/y/luxembourg/opposite_sex
* https://smart-answers-preview-pr-3478.herokuapp.com/marriage-abroad/y/luxembourg/same_sex
