### PR TITLE
Ask GA to strip dates from arguments sent to it

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,7 @@
     <%= yield :head %>
 
     <% if @content_item %>
-      <%= render partial: 'govuk_component/analytics_meta_tags', locals: { content_item: @content_item, strip_postcode_pii: true } %>
+      <%= render partial: 'govuk_component/analytics_meta_tags', locals: { content_item: @content_item, strip_date_pii: true, strip_postcode_pii: true } %>
     <% end %>
   </head>
 <body class="mainstream">


### PR DESCRIPTION
**This will have no effect until the change to static (PR: https://github.com/alphagov/static/pull/1386) is deployed.**

Smart answers can include a date of birth in the URL, which is potentially bad. So we remove them. Same approach as #3372.

---

[Trello card](https://trello.com/c/zZzJHa8j/99-strip-dob-from-smart-answer-urls-before-sending-to-ga-2)