### PR TITLE
Add 'none' checkbox option to Child maintenance calculator

### DIFF
--- a/app/assets/javascripts/helpers.js
+++ b/app/assets/javascripts/helpers.js
@@ -19,3 +19,27 @@ function linkToTemplatesOnGithub() {
     element.removeAttr('data-debug-template-path');
   });
 };
+
+/**
+ * Provides support for a 'none' checkbox option.
+ * When selected, all other options are deselected.
+ * When other options are selected the 'none' option
+ * is deselected.
+ */
+SmartAnswer.toggleCheckboxes = function() {
+  var checkboxSel = ".selectable input[type='checkbox']";
+  var noneCheckboxSel = checkboxSel + "[value='none']";
+  var $checkboxes = $(checkboxSel).not(noneCheckboxSel);
+  var $noneCheckbox = $(noneCheckboxSel);
+  var deselectOptions = function() {
+    var $checkbox = this.value === 'none' ? $checkboxes : $noneCheckbox;
+    if (this.checked) {
+      $checkbox.prop('checked', false);
+      $checkbox.parent().removeClass('selected'); // parent label class.
+    }
+  };
+  $checkboxes.change(deselectOptions);
+  $noneCheckbox.change(deselectOptions);
+};
+
+$(document).ready(SmartAnswer.toggleCheckboxes);

--- a/app/assets/stylesheets/smart_answers.scss
+++ b/app/assets/stylesheets/smart_answers.scss
@@ -240,6 +240,18 @@ $is-ie: false !default;
     margin-top: 0.5em;
   }
 
+  .question-body {
+    .none-option {
+      p {
+        clear: left;
+        display: block;
+        float: left;
+        margin-left: 5px;
+        margin-top: 20px;
+      }
+    }
+  }
+
   .current-question {
     padding: 1.5em 0 1em 0;
     margin: 1.5em 0 0 0;

--- a/app/presenters/checkbox_question_presenter.rb
+++ b/app/presenters/checkbox_question_presenter.rb
@@ -9,6 +9,14 @@ class CheckboxQuestionPresenter < QuestionWithOptionsPresenter
     end
   end
 
+  def none_option_label
+    @node.none_option_label
+  end
+
+  def none_option_prefix
+    @node.none_option_prefix
+  end
+
   def multiple_responses?
     true
   end

--- a/app/views/smart_answers/inputs/_checkbox_question.html.erb
+++ b/app/views/smart_answers/inputs/_checkbox_question.html.erb
@@ -6,5 +6,16 @@
         <%= option.label %>
       </label>
     </li>
- <% end %>
+  <% end %>
+  <% if question.none_option_label.present? %>
+    <li class="none-option">
+      <% if question.none_option_prefix.present? %>
+        <p><%= question.none_option_prefix %></p>
+      <% end %>
+      <label for="response_<%= question.options.size %>" class="selectable">
+        <%= check_box_tag "response[]", "none", prefill_value_is?("none"), id: "response_#{question.options.size}" %>
+        <%= question.none_option_label %>
+      </label>
+    </li>
+  <% end %>
 </ul>

--- a/lib/smart_answer/question/checkbox.rb
+++ b/lib/smart_answer/question/checkbox.rb
@@ -2,14 +2,14 @@ module SmartAnswer
   module Question
     class Checkbox < Base
       NONE_OPTION = 'none'
-      attr_reader :options
+
+      attr_reader :options, :none_option_label, :none_option_prefix
 
       def initialize(flow, name, &block)
         @options = []
+        @none_option = false
         super
       end
-
-      attr_reader :options
 
       def option(option_slug)
         raise InvalidNode.new("Can't use reserved option name '#{NONE_OPTION}'") if option_slug.to_s == NONE_OPTION
@@ -18,11 +18,17 @@ module SmartAnswer
       end
 
       def valid_option?(option)
-        @options.include?(option)
+        @options.include?(option) || option == NONE_OPTION
       end
 
       def parse_input(raw_input)
-        return NONE_OPTION if raw_input.blank? || raw_input == NONE_OPTION
+        if raw_input.blank?
+          # Raise on for blank input when showing a 'none' option as input is required.
+          raise SmartAnswer::InvalidResponse, "No option specified", caller if has_none_option?
+          return NONE_OPTION
+        end
+        return NONE_OPTION if raw_input == NONE_OPTION
+
         raw_input = raw_input.split(',') if raw_input.is_a?(String)
         raw_input.each do |option|
           raise SmartAnswer::InvalidResponse, "Illegal option #{option} for #{name}", caller unless valid_option?(option)
@@ -32,6 +38,15 @@ module SmartAnswer
 
       def to_response(input)
         input.split(',').reject { |v| v == NONE_OPTION }
+      end
+
+      def has_none_option?
+        none_option_label.present?
+      end
+
+      def set_none_option(label:, prefix: nil)
+        @none_option_label = label
+        @none_option_prefix = prefix
       end
     end
   end

--- a/lib/smart_answer_flows/calculate-your-child-maintenance.rb
+++ b/lib/smart_answer_flows/calculate-your-child-maintenance.rb
@@ -54,6 +54,8 @@ module SmartAnswer
           option benefit
         end
 
+        set_none_option(label: "None", prefix: "or")
+
         on_response do |response|
           calculator.benefits = response.split(",")
         end

--- a/lib/smart_answer_flows/calculate-your-child-maintenance/questions/gets_benefits.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-child-maintenance/questions/gets_benefits.govspeak.erb
@@ -1,13 +1,13 @@
 <% content_for :title do %>
   <% if calculator.paying? %>
-    Do you get any of these benefits?
+    Do you get any benefits or state pensions?
   <% else %>
-    Does the parent paying child maintenance get any of these benefits?
+    Does the parent paying child maintenance get any of these benefits or state pensions?
   <% end %>
 <% end %>
 
 <% content_for :hint do %>
-  If you do not receive any of these click 'Next step'.
+  If you do not receive any of these select 'None'.
 <% end %>
 
 <% options(calculator.state_benefits) %>

--- a/test/artefacts/calculate-your-child-maintenance/pay/1_child.txt
+++ b/test/artefacts/calculate-your-child-maintenance/pay/1_child.txt
@@ -1,8 +1,8 @@
-Do you get any of these benefits?
+Do you get any benefits or state pensions?
 
 
 
-If you do not receive any of these click 'Next step'.
+If you do not receive any of these select 'None'.
 
   * income_support: Income Support
   * ib_jobseekers_allowance: income-based Jobseeker’s Allowance

--- a/test/data/calculate-your-child-maintenance-files.yml
+++ b/test/data/calculate-your-child-maintenance-files.yml
@@ -8,11 +8,11 @@ lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/flat_rate_resul
 lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/nil_rate_result.govspeak.erb: cce0a8bd1df6f41baee3f2240ca56ad8
 lib/smart_answer_flows/calculate-your-child-maintenance/outcomes/reduced_and_basic_rates_result.govspeak.erb: 8df425011310a22051f3ea200fe4a5f7
 lib/smart_answer_flows/calculate-your-child-maintenance/questions/are_you_paying_or_receiving.govspeak.erb: 3a72cdea5e6d683193abc2b1df1f464e
-lib/smart_answer_flows/calculate-your-child-maintenance/questions/gets_benefits.govspeak.erb: a1d89ee24996fb75eb742fdd7fd0059c
+lib/smart_answer_flows/calculate-your-child-maintenance/questions/gets_benefits.govspeak.erb: bd1f0317eae10d8c12d52b9beb13e9d3
 lib/smart_answer_flows/calculate-your-child-maintenance/questions/gross_income_of_payee.govspeak.erb: ad80b797bfaf10952dbdafe7db22ea49
 lib/smart_answer_flows/calculate-your-child-maintenance/questions/how_many_children_paid_for.govspeak.erb: 001be8b0612744be54c55dfc70351202
 lib/smart_answer_flows/calculate-your-child-maintenance/questions/how_many_nights_children_stay_with_payee.govspeak.erb: 630d2a7382321b05ea8cea6e0bc7eb8b
 lib/smart_answer_flows/calculate-your-child-maintenance/questions/how_many_other_children_in_payees_household.govspeak.erb: 4e46c8c418c265f56b7ff55e1da2e3ba
-lib/smart_answer_flows/calculate-your-child-maintenance.rb: 30e384510170ef38fcc2fc136e005eff
+lib/smart_answer_flows/calculate-your-child-maintenance.rb: 9ec491f6489ff180a2dff790050c31a6
 test/data/calculate-your-child-maintenance-questions-and-responses.yml: c333b75ec8a4766eaebdf7fef3389988
 test/data/calculate-your-child-maintenance-responses-and-expected-results.yml: f8a85aa8c851dd5af9c92139de84e13f

--- a/test/fixtures/smart_answer_flows/checkbox-sample.rb
+++ b/test/fixtures/smart_answer_flows/checkbox-sample.rb
@@ -14,7 +14,7 @@ module SmartAnswer
 
         next_node do |response|
           if response == 'none'
-            outcome :margherita
+            question :confirm_no_toppings?
           else
             toppings = response.split(',')
             if toppings.include?('ice_cream')
@@ -22,6 +22,20 @@ module SmartAnswer
             else
               outcome :on_its_way
             end
+          end
+        end
+      end
+
+      checkbox_question :confirm_no_toppings? do
+        option :ask_me_again
+
+        set_none_option(label: "Definitely no toppings")
+
+        next_node do |response|
+          if response == 'none'
+            outcome :margherita
+          else
+            question :what_do_you_want_on_your_pizza?
           end
         end
       end

--- a/test/fixtures/smart_answer_flows/checkbox-sample/questions/confirm_no_toppings.govspeak.erb
+++ b/test/fixtures/smart_answer_flows/checkbox-sample/questions/confirm_no_toppings.govspeak.erb
@@ -1,0 +1,7 @@
+<% content_for :title do %>
+  Are you sure you don't want any toppings?
+<% end %>
+
+<% options(
+  "ask_me_again": "Hmm I'm not sure, ask me again please",
+) %>

--- a/test/integration/engine/checkbox_questions_test.rb
+++ b/test/integration/engine/checkbox_questions_test.rb
@@ -67,6 +67,26 @@ class CheckboxQuestionsTest < EngineIntegrationTest
         end
       end
 
+      # This question is configured with a 'none' option so it requires
+      # an explicit answer, clicking 'next step' without choosing an
+      # option fails validation.
+      within('.question') do
+        assert_page_has_content "Are you sure you don't want any toppings?"
+      end
+
+      click_on "Next step"
+
+      assert_equal current_path, "/checkbox-sample/y/none"
+
+      within(".error-message") do
+        assert_page_has_content "Please answer this question"
+      end
+
+      check "Definitely no toppings"
+      click_on "Next step"
+
+      assert_current_url "/checkbox-sample/y/none/none"
+
       within '.outcome:nth-child(1)' do
         assert_page_has_content "Ok, your margherita pizza is on its way"
       end

--- a/test/integration/engine/checkbox_questions_test.rb
+++ b/test/integration/engine/checkbox_questions_test.rb
@@ -1,11 +1,11 @@
 require_relative 'engine_test_helper'
 
 class CheckboxQuestionsTest < EngineIntegrationTest
-  with_and_without_javascript do
-    setup do
-      stub_smart_answer_in_content_store("checkbox-sample")
-    end
+  setup do
+    stub_smart_answer_in_content_store("checkbox-sample")
+  end
 
+  with_and_without_javascript do
     should "handle checkbox questions" do
       visit "/checkbox-sample/y"
 
@@ -67,9 +67,24 @@ class CheckboxQuestionsTest < EngineIntegrationTest
         end
       end
 
-      # This question is configured with a 'none' option so it requires
-      # an explicit answer, clicking 'next step' without choosing an
-      # option fails validation.
+      within('.question') do
+        assert_page_has_content "Are you sure you don't want any toppings?"
+      end
+
+      check "Definitely no toppings"
+
+      click_on "Next step"
+
+      assert_current_url "/checkbox-sample/y/none/none"
+
+      within '.outcome:nth-child(1)' do
+        assert_page_has_content "Ok, your margherita pizza is on its way"
+      end
+    end
+
+    should "expect explicit selection of 'none' option when present" do
+      visit "/checkbox-sample/y/none"
+
       within('.question') do
         assert_page_has_content "Are you sure you don't want any toppings?"
       end
@@ -81,17 +96,24 @@ class CheckboxQuestionsTest < EngineIntegrationTest
       within(".error-message") do
         assert_page_has_content "Please answer this question"
       end
+    end
+  end # with_and_without_javascript
+
+  with_javascript do
+    should "toggle options when none option is present" do
+      visit "/checkbox-sample/y/none"
 
       check "Definitely no toppings"
+      check "Hmm I'm not sure, ask me again please"
+      refute page.has_checked_field?("Definitely no toppings")
+
+      check "Definitely no toppings"
+      refute page.has_checked_field?("Hmm I'm not sure, ask me again please")
       click_on "Next step"
 
       assert_current_url "/checkbox-sample/y/none/none"
-
-      within '.outcome:nth-child(1)' do
-        assert_page_has_content "Ok, your margherita pizza is on its way"
-      end
     end
-  end # with_and_without_javascript
+  end
 
   should "calculate next_node correctly" do
     visit "/checkbox-sample/y"

--- a/test/unit/checkbox_question_test.rb
+++ b/test/unit/checkbox_question_test.rb
@@ -74,6 +74,26 @@ module SmartAnswer
           assert_equal 'none', @question.parse_input('none')
         end
       end
+
+      context "with an explicitly set 'none' option" do
+        setup do
+          @question.set_none_option(label: 'None', prefix: 'or')
+        end
+
+        should "set the none option label" do
+          assert_equal('None', @question.none_option_label)
+        end
+
+        should "set the none option prefix" do
+          assert_equal('or', @question.none_option_prefix)
+        end
+
+        should "raise if the response is blank" do
+          assert_raise InvalidResponse do
+            @question.parse_input(nil)
+          end
+        end
+      end
     end
 
     context "converting to a response" do


### PR DESCRIPTION
https://trello.com/c/yt8OnT7S/101-smart-answers-add-alternative-none-answer-to-list-of-options-2

* Adds a configurable 'none' option to checkbox questions.
* Makes this toggle-able against other options
* Configures this on child maintenance calculator benefits question

![screenshot from 2018-04-20 16-31-07](https://user-images.githubusercontent.com/93511/39060082-3f5a3720-44b8-11e8-8116-767fb6167a88.png)


#### Preview:

https://smart-answers-preview-pr-3491.herokuapp.com/calculate-your-child-maintenance/y/pay/1_child 