### PR TITLE
Use the meta tags component from the gem

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,7 @@
     <%= yield :head %>
 
     <% if @content_item %>
-      <%= render partial: 'govuk_component/analytics_meta_tags', locals: { content_item: @content_item, strip_date_pii: true, strip_postcode_pii: true } %>
+      <%= render "govuk_publishing_components/components/meta_tags", content_item: @content_item %>
     <% end %>
   </head>
 <body class="mainstream">


### PR DESCRIPTION
This replaces the analytics meta tags component from Static with the new [meta tags component](https://github.com/alphagov/govuk_publishing_components/pull/278) in the gem. There should be no changes in behaviour.

https://trello.com/c/2w1AKyuW