### PR TITLE
Strip PII from URLs

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,10 @@
     <%= yield :head %>
 
     <% if @content_item %>
-      <%= render "govuk_publishing_components/components/meta_tags", content_item: @content_item %>
+      <%= render "govuk_publishing_components/components/meta_tags",
+        content_item: @content_item,
+        strip_date_pii: true,
+        strip_postcode_pii: true %>
     <% end %>
   </head>
 <body class="mainstream">


### PR DESCRIPTION
This was accidentally removed in https://github.com/alphagov/smart-answers/pull/3506/files.

https://trello.com/c/2w1AKyuW

