### PR TITLE
Update Lower Earning Limit for 2018

### DIFF
--- a/lib/data/rates/maternity_paternity_adoption.yml
+++ b/lib/data/rates/maternity_paternity_adoption.yml
@@ -18,5 +18,8 @@
   end_date: 2017-04-05
   lower_earning_limit_rate: 112
 - start_date: 2017-04-06
-  end_date: 2100-04-05
+  end_date: 2018-04-05
   lower_earning_limit_rate: 113
+- start_date: 2018-04-06
+  end_date: 2100-04-05
+  lower_earning_limit_rate: 116

--- a/lib/data/rates/maternity_paternity_birth.yml
+++ b/lib/data/rates/maternity_paternity_birth.yml
@@ -21,5 +21,8 @@
   end_date: 2017-04-05
   lower_earning_limit_rate: 112
 - start_date: 2017-04-06
-  end_date: 2100-04-05
+  end_date: 2018-04-05
   lower_earning_limit_rate: 113
+- start_date: 2018-04-06
+  end_date: 2100-04-05
+  lower_earning_limit_rate: 116

--- a/lib/data/rates/statutory_sick_pay.yml
+++ b/lib/data/rates/statutory_sick_pay.yml
@@ -36,5 +36,5 @@
 
 - start_date: 2018-04-06
   end_date: 2019-04-05
-  lower_earning_limit_rate: 113
+  lower_earning_limit_rate: 116
   ssp_weekly_rate: 92.05

--- a/lib/smart_answer/calculators/pay_leave_for_parents_calculator.rb
+++ b/lib/smart_answer/calculators/pay_leave_for_parents_calculator.rb
@@ -45,8 +45,10 @@ module SmartAnswer::Calculators
         SmartAnswer::Money.new(112)
       when 2017
         SmartAnswer::Money.new(113)
+      when 2018
+        SmartAnswer::Money.new(116)
       else
-        SmartAnswer::Money.new(113)
+        SmartAnswer::Money.new(116)
       end
     end
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes.txt
@@ -1,4 +1,4 @@
-Has the mother earned (or will she have earned) more than £113 per week in this job between 27 August 2011 and 22 October 2011?
+Has the mother earned (or will she have earned) more than £116 per week in this job between 27 August 2011 and 22 October 2011?
 
 
 

--- a/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/yes/yes/yes.txt
+++ b/test/artefacts/pay-leave-for-parents/yes/2012-02-01/employee/employee/yes/yes/yes/yes/yes.txt
@@ -1,4 +1,4 @@
-Has the mother’s partner earned (or will they have earned) more than £113 per week in this job between 27 August 2011 and 22 October 2011?
+Has the mother’s partner earned (or will they have earned) more than £116 per week in this job between 27 August 2011 and 22 October 2011?
 
 
 

--- a/test/data/calculate-statutory-sick-pay-files.yml
+++ b/test/data/calculate-statutory-sick-pay-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/data/rates/statutory_sick_pay.yml: bc07c2dae5e4d3662209022610701e42
+lib/data/rates/statutory_sick_pay.yml: 457c2ff565737cb61c5ae291ffdabbfd
 lib/smart_answer/calculators/statutory_sick_pay_calculator.rb: dfadf2018ab0f7fb07548df87ecb0a93
 lib/smart_answer_flows/calculate-statutory-sick-pay/calculate_statutory_sick_pay.govspeak.erb: f91dc1d321c164a06271889100875600
 lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/already_getting_maternity.govspeak.erb: 258fd4422c4ae665c83d5ee1e061bbff

--- a/test/data/maternity-paternity-calculator-files.yml
+++ b/test/data/maternity-paternity-calculator-files.yml
@@ -1,6 +1,6 @@
 ---
-lib/data/rates/maternity_paternity_adoption.yml: e4a27ae88a179412e306197e4f4a229c
-lib/data/rates/maternity_paternity_birth.yml: ecc6ef0c3163cc0c5448858ad89161a5
+lib/data/rates/maternity_paternity_adoption.yml: 27d62ac5a1059b4808863af7e6c01454
+lib/data/rates/maternity_paternity_birth.yml: 81372de867cc42069db9a8d4e093db49
 lib/smart_answer/calculators/maternity_paternity_calculator.rb: 49b717184039c5b2c4ff95bf952edc1c
 lib/smart_answer_flows/maternity-paternity-calculator/adoption_calculator_flow.rb: '09e789b16a456694455277e7bfb0f4b0'
 lib/smart_answer_flows/maternity-paternity-calculator/maternity_calculator_flow.rb: bac17d939530b170c596c65334a96e33

--- a/test/data/pay-leave-for-parents-files.yml
+++ b/test/data/pay-leave-for-parents-files.yml
@@ -1,5 +1,5 @@
 ---
-lib/smart_answer/calculators/pay_leave_for_parents_calculator.rb: e7a3b6cde09c6edd25fb5eb0625b6df4
+lib/smart_answer/calculators/pay_leave_for_parents_calculator.rb: b0792944d953f192887fc049bfafb5e0
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_additional_pat_leave.govspeak.erb: dcede84d936f876a3c91c1457c3afc01
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_additional_pat_pay.govspeak.erb: ed1d2668c5c1762258aad38bccf4c158
 lib/smart_answer_flows/pay-leave-for-parents/outcomes/_birth_nothing.govspeak.erb: b550c42385547ccb1eab92cb3b3bff0b

--- a/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
@@ -263,22 +263,22 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
     end
   end
 
-  context "average weekly earnings is less than the LEL on sick start date" do
+  context "average weekly earnings is less than the current LEL on sick start date" do
     setup do
       add_response 'none' # Q1
       add_response 'yes' # Q2
       add_response 'no' # Q3
-      add_response '2013-06-10' # Q4
-      add_response '2013-06-20' # Q5
+      add_response '2018-06-10' # Q4
+      add_response '2018-06-20' # Q5
       add_response 'no' # Q11
       add_response 'before_payday' # Q5.1
       add_response 'weekly' # Q5.2
-      add_response '100' # Q7
+      add_response '115' # Q7
       add_response '7' # Q7.1
       add_response '1,2,3,4,5' # Q13
     end
-    should "take you to result A5 as awe < LEL (as of 2013-06-10)" do
-      assert_equal current_state.calculator.employee_average_weekly_earnings, 100
+    should "take you to result A5 as awe < LEL (as of 2018-06-10)" do
+      assert_equal current_state.calculator.employee_average_weekly_earnings, 115
       assert_current_node :not_earned_enough
     end
   end

--- a/test/integration/smart_answer_flows/maternity_calculator_test.rb
+++ b/test/integration/smart_answer_flows/maternity_calculator_test.rb
@@ -449,6 +449,26 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
       end
     end # April 9th
 
+    context "check for correct LEL Saturday, 14 April 2018 monthly" do
+      setup do
+        add_response Date.parse("2018-07-26")
+        add_response Date.parse("2018-06-29")
+        add_response :yes
+        add_response Date.parse("2018-04-06")
+        add_response Date.parse("2018-02-07")
+        add_response :monthly
+        add_response 956
+        add_response "2"
+        add_response "weekly_starting"
+      end
+
+      should "have LEL of 116" do
+        assert_state_variable :to_saturday_formatted, "Saturday, 14 April 2018"
+        assert_state_variable "lower_earning_limit", sprintf("%.2f", 116)
+        assert_current_node :maternity_leave_and_pay_result
+      end
+    end
+
     context "check for correct LEL Saturday, 12 April 2014 monthly" do
       setup do
         add_response Date.parse("2014-07-26")

--- a/test/unit/calculators/pay_leave_for_parents_calculator_test.rb
+++ b/test/unit/calculators/pay_leave_for_parents_calculator_test.rb
@@ -123,6 +123,18 @@ module SmartAnswer
         end
       end
 
+      context "due date in 2018-2019 range" do
+        setup do
+          @date = Date.parse("2019-01-01")
+          @calculator = PayLeaveForParentsCalculator.new
+          @calculator.due_date = @date
+        end
+
+        should "return £116 for lower_earnings_amount" do
+          assert_equal 116, @calculator.lower_earnings_amount
+        end
+      end
+
       context "due date outside all ranges" do
         setup do
           @date = Date.parse("2022-01-01")
@@ -131,7 +143,7 @@ module SmartAnswer
         end
 
         should "return the latest_pay_leave known lower_earnings_amount" do
-          assert_equal 113, @calculator.lower_earnings_amount
+          assert_equal 116, @calculator.lower_earnings_amount
         end
       end
     end


### PR DESCRIPTION
https://trello.com/c/PoDp7miK/136-urgent-change-lower-earning-limit-rates-lel-across-all-smart-answers-1

Updates lower earning limits for maternity and sick pay calculators with 2018 threshold.

#### Preview
https://smart-answers-preview-pr-3511.herokuapp.com
