### PR TITLE
Configure smartanswers heroku apps to use hobby dyno plan

### DIFF
--- a/app.json
+++ b/app.json
@@ -12,5 +12,11 @@
     "ERRBIT_ENV": "integration"
   },
   "image": "heroku/ruby",
-  "buildpacks": [ { "url": "heroku/ruby" } ]
+  "buildpacks": [ { "url": "heroku/ruby" } ],
+  "formation": {
+    "web": {
+      "quantity": 1,
+      "size": "hobby"
+    }
+  }
 }


### PR DESCRIPTION
https://trello.com/c/lC5odjr8/125-use-a-different-heroku-account-to-preview-smart-answers-2

Rather than configure a new Heroku account for smart answers preview apps we've opted to promote the apps to hobby dynos.