### PR TITLE
[DO NOT MERGE] Replace README Heroku link with manual link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Read more in [Lisa Scott's GDS blog post](https://gds.blog.gov.uk/2012/02/16/smart-answers-are-smart/).
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+[Guide to editing smart answers as a content designer](https://docs.publishing.service.gov.uk/manual/content-design/editing-smart-answers.html)
 
 ## Screenshots
 


### PR DESCRIPTION
Trello: https://trello.com/c/m1f54bYg/183-define-process-for-content-designers-to-work-on-smart-answers

Do not merge until https://github.com/alphagov/govuk-developer-docs/pull/950 is live.

This removes the Heroku link as we no longer want content designers to deploy to their own fork on Smart Answers and instead replaces it with a link to the page in the GOV.UK manual with a guide for content designers to edit smart answers.

This does seem like a bit of a strange place to put this link but I can't think where else to put it without burying it deep in technical documentation.