### PR TITLE
Remove unreachable outcome_marriage_abroad_in_finland

### DIFF
--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -301,7 +301,6 @@ module SmartAnswer
       outcome :outcome_same_sex_marriage_and_civil_partnership_not_possible
       outcome :outcome_same_sex_marriage_in_dominican_republic
       outcome :outcome_marriage_abroad_in_country
-      outcome :outcome_marriage_abroad_in_finland
     end
   end
 end

--- a/test/data/marriage-abroad-files.yml
+++ b/test/data/marriage-abroad-files.yml
@@ -852,7 +852,7 @@ lib/smart_answer_flows/marriage-abroad/questions/legal_residency.govspeak.erb: 7
 lib/smart_answer_flows/marriage-abroad/questions/marriage_or_pacs.govspeak.erb: a51aecfac697188f90ca9efefcb2e0ea
 lib/smart_answer_flows/marriage-abroad/questions/partner_opposite_or_same_sex.govspeak.erb: 40d0c99a5be50f0625c6562f06fe4afd
 lib/smart_answer_flows/marriage-abroad/questions/what_is_your_partners_nationality.govspeak.erb: 80e04f36c75c232bede1a244d621471e
-lib/smart_answer_flows/marriage-abroad.rb: 3511890e6ccdd4d337187efdd91b27bf
+lib/smart_answer_flows/marriage-abroad.rb: dc879ed7fae5084ccd29149686f25372
 lib/smart_answer_flows/shared/_overseas_passports_embassies.govspeak.erb: 1dc349abcd6b21e1bf8c397d96fd02b8
 test/data/marriage-abroad-questions-and-responses.yml: 0f079512ee2f1fd27145bf9db84ef5eb
 test/data/marriage-abroad-responses-and-expected-results.yml: 0c49bc5d9955d3bef66715de7681b3f4


### PR DESCRIPTION
2c58f7f consolidated the Finland and Iceland logic, making Finland use
the `outcome_marriage_abroad_in_country` result.  But the existing
Finland-specific outcome was not removed.