### PR TITLE
Remove deploy to Heroku link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 Read more in [Lisa Scott's GDS blog post](https://gds.blog.gov.uk/2012/02/16/smart-answers-are-smart/).
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
-
 ## Screenshots
 
 ![Student Finance Forms screenshot](./doc/assets/govuk-student-finance-forms.png)


### PR DESCRIPTION
Trello: https://trello.com/c/m1f54bYg/183-define-process-for-content-designers-to-work-on-smart-answers

We no longer advise people to deploy forks because a hobby dyno is required. I'm removing this link to avoid confusion over this.