### PR TITLE
Have jenkins check expected results file

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,17 @@ node {
     sassLint: false,
     repoName: 'smart-answers',
     overrideTestTask: {
+      stage("Check responses and expected results file for changes") {
+        sh("bundle exec rails runner script/generate-responses-and-expected-results-for-smart-answer.rb marriage-abroad")
+        def output = sh(script: "git status --short -- test/data/marriage-abroad-responses-and-expected-results.yml", returnStdout: true)
+
+        if (output?.trim()) {
+          def message = "'Expected results' file not generated for marriage abroad, please see docs/flattening-outcomes.md"
+          echo message
+          setBuildStatus(jobName, govuk.getFullCommitHash(), message, "FAILURE", repoName)
+        }
+      }
+
       stage("Run tests") {
         govuk.runTests()
       }

--- a/doc/flattening-outcomes.md
+++ b/doc/flattening-outcomes.md
@@ -3,7 +3,7 @@
 1. Put the country in the right section of `lib/data/marriage_abroad_data.yml` and `test/data/marriage-abroad-questions-and-responses.yml`
 2. `bundle exec rake marriage_abroad:flatten_outcomes[<your country>,<civil_partnership or same_sex_marriage>]` e.g. `marriage_abroad:flatten_outcomes[russia,same_sex_marriage]`
 3. Move the country to the right array in `test/integration/smart_answer_flows/marriage_abroad_test.rb`
-4. `bundle exec rails r script/generate-responses-and-expected-results-for-smart-answer.rb marriage-abroad`
+4. `bundle exec rails runner script/generate-responses-and-expected-results-for-smart-answer.rb marriage-abroad`
 5. Commit the changes to `test/data/marriage-abroad-responses-and-expected-results.yml`
 6. `bundle exec rake checksums:update`
 7. Commit the changes to `test/data/marriage-abroad-files.yml`


### PR DESCRIPTION
People often forget to run this script when working on Marriage Abroad tickets.  This fails the build if running the script generates any changes in the output file.

This adds approx 20-30s to each ~2min build.

https://trello.com/c/YsgD3NVE/279-have-ci-check-whether-the-expected-responses-file-needs-to-be-regenerated-on-smart-answer-prs

With pending changes:
```
Running custom test task
[Pipeline] stage
[Pipeline] { (Check responses and expected results file for changes)
[Pipeline] sh
[_have-jenkins-check-results-EEISYJB3T7KKXL7SPHVSNMBGIO3LJH57DB5P4GNWBVWRNLFOVMAA] Running shell script
+ bundle exec rails runner script/generate-responses-and-expected-results-for-smart-answer.rb marriage-abroad
I, [2018-07-02T08:14:49.875577 #11638]  INFO -- sentry: ** [Raven] Raven 2.7.4 configured not to capture errors: DSN not set
Responses and expected results written to /var/lib/jenkins/workspace/_have-jenkins-check-results-EEISYJB3T7KKXL7SPHVSNMBGIO3LJH57DB5P4GNWBVWRNLFOVMAA/test/data/marriage-abroad-responses-and-expected-results.yml
[Pipeline] sh
[_have-jenkins-check-results-EEISYJB3T7KKXL7SPHVSNMBGIO3LJH57DB5P4GNWBVWRNLFOVMAA] Running shell script
+ git status --short -- test/data/marriage-abroad-responses-and-expected-results.yml
[Pipeline] echo
'Expected results' file not generated for marriage abroad, please see docs/flattening-outcomes.md
[Pipeline] }
[Pipeline] // stage
[Pipeline] }
Lock released on resource [smartanswers-ci-agent-2-test]
[Pipeline] // lock
[Pipeline] step
Sending e-mails to: govuk-ci-notifications@digital.cabinet-office.gov.uk
[Pipeline] }
[Pipeline] // node
[Pipeline] End of Pipeline
```
<img width="736" alt="screenshot 2018-07-02 09 14 36" src="https://user-images.githubusercontent.com/109225/42152704-e57aa8de-7dd8-11e8-86c5-d57d844e91b5.png">

Without pending changes:
```
Running custom test task
[Pipeline] stage
[Pipeline] { (Check responses and expected results file for changes)
[Pipeline] sh
[_have-jenkins-check-results-EEISYJB3T7KKXL7SPHVSNMBGIO3LJH57DB5P4GNWBVWRNLFOVMAA] Running shell script
+ bundle exec rails runner script/generate-responses-and-expected-results-for-smart-answer.rb marriage-abroad
I, [2018-07-02T08:18:24.003336 #30180]  INFO -- sentry: ** [Raven] Raven 2.7.4 configured not to capture errors: DSN not set
Responses and expected results written to /var/lib/jenkins/workspace/_have-jenkins-check-results-EEISYJB3T7KKXL7SPHVSNMBGIO3LJH57DB5P4GNWBVWRNLFOVMAA/test/data/marriage-abroad-responses-and-expected-results.yml
[Pipeline] sh
[_have-jenkins-check-results-EEISYJB3T7KKXL7SPHVSNMBGIO3LJH57DB5P4GNWBVWRNLFOVMAA] Running shell script
+ git status --short -- test/data/marriage-abroad-responses-and-expected-results.yml
[Pipeline] }
[Pipeline] // stage
[Pipeline] stage
[Pipeline] { (Run tests)
[Pipeline] sh
[_have-jenkins-check-results-EEISYJB3T7KKXL7SPHVSNMBGIO3LJH57DB5P4GNWBVWRNLFOVMAA] Running shell script
+ bundle exec rake default
I, [2018-07-02T08:19:06.050244 #30459]  INFO -- sentry: ** [Raven] Raven 2.7.4 configured not to capture errors: DSN not set
Run options: --seed 55342

# Running:
```
<img width="735" alt="screenshot 2018-07-02 09 21 56" src="https://user-images.githubusercontent.com/109225/42152890-6534bdda-7dd9-11e8-85cd-0e9cdecad181.png">
