### PR TITLE
remove ref/link to renewable heat premium payment

### DIFF
--- a/lib/smart_answer_flows/energy-grants-calculator/outcomes/_opt_renewal_heat.govspeak.erb
+++ b/lib/smart_answer_flows/energy-grants-calculator/outcomes/_opt_renewal_heat.govspeak.erb
@@ -1,1 +1,1 @@
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).


### PR DESCRIPTION
Deleted 'qualify for money towards a renewable heating system and' and link to /renewable-heat-premium-payment