### PR TITLE
Change layout for smart answers to include contextual_sidebar

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,6 +1,5 @@
 //= require helpers
-//= require govuk_publishing_components/components/step-by-step-nav
-//= require govuk_publishing_components/components/feedback
+//= require govuk_publishing_components/all_components
 
 $(document).ready(function() {
   $('#current-error').focus();

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,4 +1,5 @@
 //= require helpers
+//= require govuk_publishing_components/components/step-by-step-nav
 //= require govuk_publishing_components/components/feedback
 
 $(document).ready(function() {

--- a/app/views/layouts/smart_answers.html.erb
+++ b/app/views/layouts/smart_answers.html.erb
@@ -15,7 +15,7 @@
     <%= render 'smartanswer_metadata' %>
   </main>
 
-  <% if @presenter.finished? %>
+  <% if defined?(@presenter.finished?) and @presenter.finished? %>
     <div class="related-container">
       <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: @content_item %>
     </div>

--- a/app/views/layouts/smart_answers.html.erb
+++ b/app/views/layouts/smart_answers.html.erb
@@ -14,6 +14,13 @@
 
     <%= render 'smartanswer_metadata' %>
   </main>
+
+  <% if @presenter.finished? %>
+    <div class="related-container">
+      <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: @content_item %>
+    </div>
+  <% end %>
+
 </div>
 
 <% parent_layout 'application' %>


### PR DESCRIPTION
# User need
As a user who has completed a service
I want to know what the next step is that I need to complete
So that I can finish the thing I am trying to do

# What
If a user is routed to a service from the step-by-step, they are sent away from GOV.UK to the service which is run and hosted by another department.

They don't return to GOV.UK until they complete the service and are routed to the done page.

e.g. https://www.gov.uk/done/apply-for-divorce

Done pages are created by content designers on GOV.UK, and should be created alongside a start page, so every service should have one.

Done pages were originally created to be used with [performance platform](https://www.gov.uk/performance/vehicle-tax) to make it possible to track whether users "complete" the service.

# Why
If we don't add the side-nav to the done page, users will have no easy to find their way to the next step.

Ticket: https://trello.com/c/FJTvAlWq/725-change-layout-for-smart-answers-to-include-contextualsidebar