### PR TITLE
Remove ref/link to renewable heat premium payment

### DIFF
--- a/lib/smart_answer_flows/energy-grants-calculator/outcomes/_opt_renewal_heat.govspeak.erb
+++ b/lib/smart_answer_flows/energy-grants-calculator/outcomes/_opt_renewal_heat.govspeak.erb
@@ -1,1 +1,1 @@
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/on-or-after-1995/flat/ground_floor/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/on-or-after-1995/flat/top_floor/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/none/on-or-after-1995/house/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,7 +22,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,7 +22,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,7 +22,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -22,7 +22,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
@@ -38,7 +38,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/on-or-after-1995/flat/top_floor/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/pension_credit/on-or-after-1995/house/none.txt
@@ -38,7 +38,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/universal_credit/disabled/on-or-after-1995/house/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1950-01-01/working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/on-or-after-1995/flat/ground_floor/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/on-or-after-1995/flat/top_floor/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/none/on-or-after-1995/house/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/on-or-after-1995/flat/top_floor/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/pension_credit/on-or-after-1995/house/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/universal_credit/disabled/on-or-after-1995/house/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,permission/1954-01-01/working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/on-or-after-1995/flat/ground_floor/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/on-or-after-1995/flat/top_floor/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/none/on-or-after-1995/house/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/on-or-after-1995/flat/top_floor/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/pension_credit/on-or-after-1995/house/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/universal_credit/disabled/on-or-after-1995/house/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1950-01-01/working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/on-or-after-1995/flat/ground_floor/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/on-or-after-1995/flat/top_floor/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/none/on-or-after-1995/house/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/on-or-after-1995/flat/top_floor/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/pension_credit/on-or-after-1995/house/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/universal_credit/disabled/on-or-after-1995/house/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits,property/1954-01-01/working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/on-or-after-1995/flat/ground_floor/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/on-or-after-1995/flat/top_floor/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/none/on-or-after-1995/house/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/on-or-after-1995/flat/top_floor/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/pension_credit/on-or-after-1995/house/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/universal_credit/disabled/on-or-after-1995/house/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1950-01-01/working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/on-or-after-1995/flat/ground_floor/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/on-or-after-1995/flat/top_floor/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/none/on-or-after-1995/house/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/on-or-after-1995/flat/top_floor/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/pension_credit/on-or-after-1995/house/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -20,7 +20,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/universal_credit/disabled/on-or-after-1995/house/none.txt
@@ -36,7 +36,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -18,7 +18,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -32,7 +32,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/benefits/1954-01-01/working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -34,7 +34,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/on-or-after-1995/flat/ground_floor/none.txt
@@ -32,7 +32,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/on-or-after-1995/flat/top_floor/none.txt
@@ -30,7 +30,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1950-01-01/on-or-after-1995/house/none.txt
@@ -32,7 +32,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/on-or-after-1995/flat/ground_floor/none.txt
@@ -30,7 +30,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/on-or-after-1995/flat/top_floor/none.txt
@@ -28,7 +28,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/all_help/none/1954-01-01/on-or-after-1995/house/none.txt
@@ -30,7 +30,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/on-or-after-1995/flat/ground_floor/none.txt
@@ -28,7 +28,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/on-or-after-1995/flat/top_floor/none.txt
@@ -26,7 +26,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,permission/on-or-after-1995/house/none.txt
@@ -28,7 +28,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/on-or-after-1995/flat/ground_floor/none.txt
@@ -28,7 +28,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/on-or-after-1995/flat/top_floor/none.txt
@@ -26,7 +26,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits,property/on-or-after-1995/house/none.txt
@@ -28,7 +28,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -8,7 +8,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -8,7 +8,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -26,7 +26,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -8,7 +8,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -8,7 +8,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -26,7 +26,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -8,7 +8,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -8,7 +8,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -26,7 +26,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -8,7 +8,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -8,7 +8,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/on-or-after-1995/flat/ground_floor/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/on-or-after-1995/flat/top_floor/none.txt
@@ -26,7 +26,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/none/on-or-after-1995/house/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -8,7 +8,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -8,7 +8,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/on-or-after-1995/flat/top_floor/none.txt
@@ -26,7 +26,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/pension_credit/on-or-after-1995/house/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/universal_credit/disabled/on-or-after-1995/house/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -8,7 +8,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -8,7 +8,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -26,7 +26,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -8,7 +8,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -8,7 +8,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -26,7 +26,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -8,7 +8,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -8,7 +8,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -26,7 +26,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/benefits/working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/none/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/none/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/none/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/none/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/none/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/none/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/none/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/none/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/none/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/none/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/none/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/none/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/none/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/none/on-or-after-1995/flat/ground_floor/none.txt
@@ -26,7 +26,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/none/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/none/on-or-after-1995/flat/top_floor/none.txt
@@ -24,7 +24,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_boiler_measure/none/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_boiler_measure/none/on-or-after-1995/house/none.txt
@@ -26,7 +26,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/on-or-after-1995/flat/ground_floor/none.txt
@@ -28,7 +28,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/on-or-after-1995/flat/top_floor/none.txt
@@ -26,7 +26,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,permission/on-or-after-1995/house/none.txt
@@ -28,7 +28,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -16,7 +16,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/on-or-after-1995/flat/ground_floor/none.txt
@@ -28,7 +28,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/on-or-after-1995/flat/top_floor/none.txt
@@ -26,7 +26,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits,property/on-or-after-1995/house/none.txt
@@ -28,7 +28,7 @@ Under the Green Deal you could get some of these improvements without having to 
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -8,7 +8,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -8,7 +8,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -26,7 +26,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -8,7 +8,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -8,7 +8,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -26,7 +26,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -8,7 +8,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -8,7 +8,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -26,7 +26,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/child_tax_credit,esa,income_support,jsa,pension_credit,working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -8,7 +8,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -8,7 +8,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/on-or-after-1995/flat/ground_floor/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/on-or-after-1995/flat/top_floor/none.txt
@@ -26,7 +26,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/none/on-or-after-1995/house/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -8,7 +8,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -8,7 +8,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/on-or-after-1995/flat/ground_floor/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/on-or-after-1995/flat/top_floor/none.txt
@@ -26,7 +26,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/pension_credit/on-or-after-1995/house/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -14,7 +14,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/universal_credit/disabled/on-or-after-1995/house/none.txt
@@ -30,7 +30,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -8,7 +8,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -8,7 +8,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/ground_floor/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/flat/top_floor/none.txt
@@ -26,7 +26,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16,child_under_5,disabled,disabled_child,pensioner_premium,work_support_esa/on-or-after-1995/house/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -8,7 +8,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -8,7 +8,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/on-or-after-1995/flat/ground_floor/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/on-or-after-1995/flat/top_floor/none.txt
@@ -26,7 +26,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/child_under_16/on-or-after-1995/house/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -8,7 +8,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -8,7 +8,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -12,7 +12,7 @@ You may also be able to get some of the following improvements without having to
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/on-or-after-1995/flat/ground_floor/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/on-or-after-1995/flat/top_floor/none.txt
@@ -26,7 +26,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/benefits/working_tax_credit/disabled/on-or-after-1995/house/none.txt
@@ -28,7 +28,7 @@ You may also be able to get some of the following improvements without having to
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/1940s-1984/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/1940s-1984/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/1940s-1984/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,cavity_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/before-1940/flat/ground_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/before-1940/flat/top_floor/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -6,7 +6,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/before-1940/house/mains_gas,electric_heating,modern_double_glazing,loft_attic_conversion,loft_insulation,solid_wall_insulation,modern_boiler,draught_proofing.txt
@@ -10,7 +10,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - Better heating controls (eg room thermostats)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/on-or-after-1995/flat/ground_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/on-or-after-1995/flat/ground_floor/none.txt
@@ -26,7 +26,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/on-or-after-1995/flat/top_floor/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/on-or-after-1995/flat/top_floor/none.txt
@@ -24,7 +24,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/on-or-after-1995/house/none.txt
+++ b/test/artefacts/energy-grants-calculator/help_energy_efficiency/none/on-or-after-1995/house/none.txt
@@ -26,7 +26,7 @@ Based on your answers you might qualify for help from your energy supplier with 
 
 - Double glazing (or secondary glazing for listed properties)
 
-If your home is well insulated you could also qualify for money towards a [renewable heating system](/renewable-heat-premium-payment) and get paid for [generating your own electricity](/feed-in-tariffs).
+If your home is well insulated you could also get paid for [generating your own electricity](/feed-in-tariffs).
 
 ###Help and advice
 

--- a/test/data/energy-grants-calculator-files.yml
+++ b/test/data/energy-grants-calculator-files.yml
@@ -18,7 +18,7 @@ lib/smart_answer_flows/energy-grants-calculator/outcomes/_opt_draught_proofing.g
 lib/smart_answer_flows/energy-grants-calculator/outcomes/_opt_eco_help.govspeak.erb: e2b323e685d46e02ed8ea443053f937f
 lib/smart_answer_flows/energy-grants-calculator/outcomes/_opt_heat_pump.govspeak.erb: 324a4851d80db9b43dbdecccd6f5166c
 lib/smart_answer_flows/energy-grants-calculator/outcomes/_opt_loft_roof_insulation.govspeak.erb: 80ccd51cd0c5dcb90b42802747cbe506
-lib/smart_answer_flows/energy-grants-calculator/outcomes/_opt_renewal_heat.govspeak.erb: 3dc6f93074a51e34dbbbff19537497b8
+lib/smart_answer_flows/energy-grants-calculator/outcomes/_opt_renewal_heat.govspeak.erb: 61cd9de2d0e9aaa6ddb86813ea5e4d24
 lib/smart_answer_flows/energy-grants-calculator/outcomes/_opt_replacement_glazing.govspeak.erb: bcd892e1ebcfe5c5fa89b8a964bb8349
 lib/smart_answer_flows/energy-grants-calculator/outcomes/_opt_room_roof_insulation.govspeak.erb: 25524fdc220b32623b49fa13d92a7841
 lib/smart_answer_flows/energy-grants-calculator/outcomes/_opt_solar_water_heating.govspeak.erb: 0b47a142f85e44b22d6d1102bec5cba1


### PR DESCRIPTION
Brought over from https://github.com/alphagov/smart-answers/pull/3580

https://trello.com/c/2LSrkLKE/349-remove-renewable-heat-premium-payment-from-energy-grants-calculator