### PR TITLE
Update parental leave calculator

### DIFF
--- a/lib/smart_answer/calculators/maternity_paternity_calculator.rb
+++ b/lib/smart_answer/calculators/maternity_paternity_calculator.rb
@@ -3,6 +3,7 @@ require_relative "../date_helper"
 module SmartAnswer::Calculators
   class MaternityPaternityCalculator
     include SmartAnswer::DateHelper
+    include SmartAnswer::RoundingHelper
 
     attr_reader :due_date, :expected_week, :qualifying_week, :employment_start, :notice_of_leave_deadline,
       :leave_earliest_start_date, :adoption_placement_date, :ssp_stop,
@@ -231,7 +232,7 @@ module SmartAnswer::Calculators
           # Pay period includes the date of payment hence the range starts the day after.
           pay = pay_for_period(last_paydate, paydate)
           if pay.positive?
-            ary << { date: paydate, pay: pay.round(2) }
+            ary << { date: paydate, pay: round_up_to_the_next_pence(pay) } # This must always be rounded up to the next pence.
             last_paydate = paydate + 1
           end
         end

--- a/lib/smart_answer/rounding_helper.rb
+++ b/lib/smart_answer/rounding_helper.rb
@@ -1,0 +1,7 @@
+module SmartAnswer
+  module RoundingHelper
+    def round_up_to_the_next_pence(value)
+      (value * 100).truncate(1).ceil / 100.0
+    end
+  end
+end

--- a/test/data/maternity-paternity-calculator-files.yml
+++ b/test/data/maternity-paternity-calculator-files.yml
@@ -1,7 +1,7 @@
 ---
 lib/data/rates/maternity_paternity_adoption.yml: 27d62ac5a1059b4808863af7e6c01454
 lib/data/rates/maternity_paternity_birth.yml: 81372de867cc42069db9a8d4e093db49
-lib/smart_answer/calculators/maternity_paternity_calculator.rb: 49b717184039c5b2c4ff95bf952edc1c
+lib/smart_answer/calculators/maternity_paternity_calculator.rb: 4f21c412d2a004ccc45314921ce619c8
 lib/smart_answer_flows/maternity-paternity-calculator/adoption_calculator_flow.rb: '09e789b16a456694455277e7bfb0f4b0'
 lib/smart_answer_flows/maternity-paternity-calculator/maternity_calculator_flow.rb: bac17d939530b170c596c65334a96e33
 lib/smart_answer_flows/maternity-paternity-calculator/maternity_paternity_calculator.govspeak.erb: '019bbbe8b47309afce398e707263d0e5'

--- a/test/integration/smart_answer_flows/maternity_calculator_test.rb
+++ b/test/integration/smart_answer_flows/maternity_calculator_test.rb
@@ -231,7 +231,7 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
                             assert_state_variable "average_weekly_earnings", 135.4
                             assert_state_variable "smp_a", "121.86"
                             assert_state_variable "smp_b", "121.86"
-                            assert_state_variable "total_smp", "4752.54"
+                            assert_state_variable "total_smp", "4752.55"
                           end
                         end
                       end
@@ -300,7 +300,7 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
                       assert_state_variable "pay_end_date", 39.weeks.since(leave_start) - 1
                       assert_state_variable "smp_a", "112.49"
                       assert_state_variable "smp_b", "112.49"
-                      assert_state_variable "total_smp", "4386.93"
+                      assert_state_variable "total_smp", "4387.02"
                     end
 
                     context "specific date each month" do

--- a/test/unit/calculators/maternity_paternity_calculator_test.rb
+++ b/test/unit/calculators/maternity_paternity_calculator_test.rb
@@ -496,7 +496,7 @@ module SmartAnswer::Calculators
         should "pay on the leave start date" do
           assert_equal '2013-03-01', @calculator.paydates_first_day_of_the_month.first.to_s
           assert_equal '2013-03-01', @calculator.paydates_and_pay.first[:date].to_s
-          assert_equal 38.57, @calculator.paydates_and_pay.first[:pay]
+          assert_equal 38.58, @calculator.paydates_and_pay.first[:pay]
           assert @calculator.paydates_and_pay.last[:date] > @calculator.pay_end_date, "Last paydate should be after SMP end date"
           assert @calculator.paydates_and_pay.last[:pay] > 0
         end
@@ -592,7 +592,7 @@ module SmartAnswer::Calculators
             "2013-10-10"
           ]
           assert_equal expected_pay_dates, paydates_and_pay.map { |p| p[:date].to_s }
-          assert_equal 32.14, paydates_and_pay.first[:pay]
+          assert_equal 32.15, paydates_and_pay.first[:pay]
           assert_equal 450, paydates_and_pay.second[:pay]
           assert_equal 270.9, paydates_and_pay[4][:pay]
           assert_equal 117.24, paydates_and_pay.last[:pay]
@@ -628,7 +628,7 @@ module SmartAnswer::Calculators
 
           assert_equal 10, paydates_and_pay.size
           assert_equal '2013-01-31', paydates_and_pay.first[:date].to_s
-          assert_equal 932.14, paydates_and_pay.first[:pay]
+          assert_equal 932.15, paydates_and_pay.first[:pay]
           assert_equal '2013-10-31', paydates_and_pay.last[:date].to_s
           assert_equal 39.08, paydates_and_pay.last[:pay]
         end
@@ -679,7 +679,7 @@ module SmartAnswer::Calculators
         should "calculate pay on paydates with April 2013 uprating" do
           paydates_and_pay =  @calculator.paydates_and_pay
 
-          assert_equal 25.71, paydates_and_pay.first[:pay]
+          assert_equal 25.72, paydates_and_pay.first[:pay]
           assert_equal 180.0, paydates_and_pay.second[:pay]
           assert_equal 173.64, paydates_and_pay[6][:pay]
           assert_equal 173.64, paydates_and_pay.find { |p| p[:date].to_s == '2013-03-08' }[:pay]
@@ -866,12 +866,13 @@ module SmartAnswer::Calculators
         should "calculate 39 weeks of dates and pay, first 6 weeks is 90% of avg weekly pay, \
                 the remaining weeks is the minimum of 90% of avg weekly pay or 139.58" do
           expected_pay_dates = %w(2015-04-07 2015-04-14 2015-04-21 2015-04-28 2015-05-05 2015-05-12 2015-05-19 2015-05-26 2015-06-02 2015-06-09 2015-06-16 2015-06-23 2015-06-30 2015-07-07 2015-07-14 2015-07-21 2015-07-28 2015-08-04 2015-08-11 2015-08-18 2015-08-25 2015-09-01 2015-09-08 2015-09-15 2015-09-22 2015-09-29 2015-10-06 2015-10-13 2015-10-20 2015-10-27 2015-11-03 2015-11-10 2015-11-17 2015-11-24 2015-12-01 2015-12-08 2015-12-15 2015-12-22 2015-12-29)
+          expected_pay = (346.15385 * 90).truncate(1).ceil / 100.0 #this applies the "round_up_to_the_next_pence" calculation
           @calculator.pay_pattern = 'monthly'
           @calculator.earnings_for_pay_period = 3000
           assert_equal 346.15, @calculator.average_weekly_earnings.round(2)
           assert_equal expected_pay_dates, @calculator.paydates_and_pay.map { |p| p[:date].to_s }
 
-          assert_equal [(346.15385 * 0.9).round(2)], @calculator.paydates_and_pay.first(6).map { |p| p[:pay] }.uniq
+          assert_equal [expected_pay], @calculator.paydates_and_pay.first(6).map { |p| p[:pay] }.uniq
           assert_equal [139.58], @calculator.paydates_and_pay[6..-1].map { |p| p[:pay] }.uniq
         end
       end

--- a/test/unit/rounding_helper_test.rb
+++ b/test/unit/rounding_helper_test.rb
@@ -1,0 +1,29 @@
+require_relative '../test_helper'
+
+module SmartAnswer
+  class RoundingHelperTest < ActiveSupport::TestCase
+    include RoundingHelper
+
+    context '#round_up_to_the_next_pence' do
+      should 'not round up 100' do
+        assert_equal 100, round_up_to_the_next_pence(100)
+      end
+
+      should 'not round up 100.01' do
+        assert_equal 100.01, round_up_to_the_next_pence(100.01)
+      end
+
+      should 'not round up 100.5' do
+        assert_equal 100.5, round_up_to_the_next_pence(100.5)
+      end
+
+      should 'not round up 100.0002' do
+        assert_equal 100.0, round_up_to_the_next_pence(100.0002)
+      end
+
+      should 'round up 100.011' do
+        assert_equal 100.02, round_up_to_the_next_pence(100.011)
+      end
+    end
+  end
+end


### PR DESCRIPTION
The final amount of the Average Weekly Earnings should be rounded up to the next pence. This means if the third decimal of pay is superior to zero, then the second decimal should
be rounded up. So £100.011 rounds up to £100.02.

I've extracted this to a helper to be able to test it separately. Got some good advice from @elliotcm on this.

https://trello.com/c/uH75vcF5/388-maternity-paternity-rounding-up-issue