### PR TITLE
Revert "Bump mocha from 1.4.0 to 1.7.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ group :test do
   gem 'ci_reporter'
   gem 'minitest', '~> 5.11'
   gem 'minitest-focus', '~> 1.1', '>= 1.1.2'
-  gem 'mocha', '1.7.0', require: false
+  gem 'mocha', '1.4.0', require: false
   gem 'poltergeist', '1.18.1'
   gem 'shoulda', '~> 3.6.0'
   gem 'simplecov', '~> 0.16.1', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,7 +162,7 @@ GEM
     minitest (5.11.3)
     minitest-focus (1.1.2)
       minitest (>= 4, < 6)
-    mocha (1.7.0)
+    mocha (1.4.0)
       metaclass (~> 0.0.1)
     money (6.12.0)
       i18n (>= 0.6.4, < 1.1)
@@ -347,7 +347,7 @@ DEPENDENCIES
   method_source
   minitest (~> 5.11)
   minitest-focus (~> 1.1, >= 1.1.2)
-  mocha (= 1.7.0)
+  mocha (= 1.4.0)
   nokogiri
   parser
   plek (= 2.1.1)


### PR DESCRIPTION
Reverts alphagov/smart-answers#3637

As per https://github.com/alphagov/smart-answers/pull/3633 "Regression tests have been failing on master since this was merged. I had a quick look, but couldn't figure out how to fix it. Reverting for now to unblock deployments."

