### PR TITLE
Upgrade to mocha-1.7.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ group :test do
   gem 'ci_reporter'
   gem 'minitest', '~> 5.11'
   gem 'minitest-focus', '~> 1.1', '>= 1.1.2'
-  gem 'mocha', '1.4.0', require: false
+  gem 'mocha', '1.7.0', require: false
   gem 'poltergeist', '1.18.1'
   gem 'shoulda', '~> 3.6.0'
   gem 'simplecov', '~> 0.16.1', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,7 +162,7 @@ GEM
     minitest (5.11.3)
     minitest-focus (1.1.2)
       minitest (>= 4, < 6)
-    mocha (1.4.0)
+    mocha (1.7.0)
       metaclass (~> 0.0.1)
     money (6.12.0)
       i18n (>= 0.6.4, < 1.1)
@@ -347,7 +347,7 @@ DEPENDENCIES
   method_source
   minitest (~> 5.11)
   minitest-focus (~> 1.1, >= 1.1.2)
-  mocha (= 1.4.0)
+  mocha (= 1.7.0)
   nokogiri
   parser
   plek (= 2.1.1)
@@ -375,4 +375,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/test/regression/smart_answers_regression_test.rb
+++ b/test/regression/smart_answers_regression_test.rb
@@ -69,6 +69,8 @@ class SmartAnswersRegressionTest < ActionController::TestCase
 
         next if self.class.setup_has_run? && !self.class.teardown_hooks_installed?
 
+        mocha_setup
+
         WebMock.stub_request(:get, WorkingDays::BANK_HOLIDAYS_URL).to_return(body: File.open(fixture_file('bank_holidays.json')))
         Services.content_store.stubs(:content_item).returns({})
 


### PR DESCRIPTION
Dependabot tried to do this for us, but just upgrading the gem fails because the regression tests don't correctly set up mocha.  This *was* fine, but mocha-1.7 is a bit stricter, and it's no longer fine.

The correct way to do this set-up is to use Mocha's minitest (in our case) integration, and it actually advises against calling `mocha_setup` directly unless you're the author of an integration: https://github.com/freerange/mocha/blob/d336f49f13a13fdb039fc18497004d2f13c0e72a/lib/mocha/hooks.rb#L4-L12

However, pulling in the integration "properly" significantly slowed down the regression tests (about 1.3 tests / second in my VM, down from 15 / second), causing it to take several hours to run.  So I opted for calling `mocha_setup` directly, as the tests are slow enough as it is.

I've run the full regression tests locally with all passing, but I'll run them again on this PR, so CI will take a while.

---

[Trello card](https://trello.com/c/rmOFMvtB/410-upgrade-mocha-to-170-for-smart-answers)