### PR TITLE
Replace poltergeist with govuk_test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,10 +45,10 @@ group :test do
   gem 'rails-controller-testing'
   gem 'capybara', '3.6.0'
   gem 'ci_reporter'
+  gem 'govuk_test'
   gem 'minitest', '~> 5.11'
   gem 'minitest-focus', '~> 1.1', '>= 1.1.2'
   gem 'mocha', '1.7.0', require: false
-  gem 'poltergeist', '1.18.1'
   gem 'shoulda', '~> 3.6.0'
   gem 'simplecov', '~> 0.16.1', require: false
   gem 'simplecov-rcov', '~> 0.2.3', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,8 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    archive-zip (0.11.0)
+      io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
     better_errors (2.4.0)
@@ -62,9 +64,13 @@ GEM
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
       xpath (~> 3.1)
+    childprocess (0.9.0)
+      ffi (~> 1.0, >= 1.0.11)
+    chromedriver-helper (1.2.0)
+      archive-zip (~> 0.10)
+      nokogiri (~> 1.8)
     ci_reporter (2.0.0)
       builder (>= 2.1.2)
-    cliver (0.3.2)
     coderay (1.1.2)
     commander (4.4.6)
       highline (~> 1.7.2)
@@ -123,6 +129,11 @@ GEM
       rouge
       sass-rails (>= 5.0.4)
       slimmer (>= 11.1.0)
+    govuk_test (0.1.0)
+      capybara
+      chromedriver-helper
+      puma
+      selenium-webdriver
     hashdiff (0.3.7)
     highline (1.7.10)
     htmlentities (4.3.4)
@@ -130,6 +141,7 @@ GEM
       domain_name (~> 0.5)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
+    io-like (0.3.0)
     jaro_winkler (1.5.1)
     json (2.1.0)
     json-schema (2.8.0)
@@ -178,15 +190,12 @@ GEM
     parser (2.5.1.2)
       ast (~> 2.4.0)
     plek (2.1.1)
-    poltergeist (1.18.1)
-      capybara (>= 2.1, < 4)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     powerpack (0.1.2)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     public_suffix (3.0.3)
+    puma (3.12.0)
     rack (2.0.5)
     rack-cache (1.8.0)
       rack (>= 0.4)
@@ -249,6 +258,7 @@ GEM
     rubocop-rspec (1.29.0)
       rubocop (>= 0.58.0)
     ruby-progressbar (1.10.0)
+    rubyzip (1.2.1)
     safe_yaml (1.0.4)
     sanitize (4.6.6)
       crass (~> 1.0.2)
@@ -268,6 +278,9 @@ GEM
     scss_lint (0.57.0)
       rake (>= 0.9, < 13)
       sass (~> 3.5.5)
+    selenium-webdriver (3.14.0)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.2)
     sentry-raven (2.7.4)
       faraday (>= 0.7.6, < 1.0)
     shoulda (3.6.0)
@@ -342,6 +355,7 @@ DEPENDENCIES
   govuk_app_config
   govuk_frontend_toolkit (>= 7.5.0)
   govuk_publishing_components (= 9.16.0)
+  govuk_test
   htmlentities (~> 4)
   json
   lrucache (= 0.1.4)
@@ -352,7 +366,6 @@ DEPENDENCIES
   nokogiri
   parser
   plek (= 2.1.1)
-  poltergeist (= 1.18.1)
   pry
   rack_strip_client_ip
   rails (= 5.2.1)

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -4,18 +4,7 @@ require 'capybara/rails'
 Capybara.server = :webrick
 Capybara.default_driver = :rack_test
 
-require 'capybara/poltergeist'
-
-# This additional configuration is a protective measure while
-# we have invalid ssl certs in the test environment, it
-# will ignore ssl errors when requesting scripts from
-# assets-origin.*
-#
-Capybara.register_driver :poltergeist do |app|
-  Capybara::Poltergeist::Driver.new(app, phantomjs_options: ['--ssl-protocol=TLSv1', '--ignore-ssl-errors=yes'])
-end
-
-Capybara.javascript_driver = :poltergeist
+GovukTest.configure
 
 class ActionDispatch::IntegrationTest
   include Capybara::DSL


### PR DESCRIPTION
https://trello.com/c/0QzuQFMb/415-epic-switch-app-test-suites-from-poltergeist-to-headless-chrome-using-govuktest

Poltergeist is no longer maintained so replace it with the Selenium headless chrome driver via govuk_test.