### PR TITLE
Refactor statutory rate tests

### DIFF
--- a/lib/smart_answer/calculators/maternity_paternity_calculator.rb
+++ b/lib/smart_answer/calculators/maternity_paternity_calculator.rb
@@ -169,7 +169,7 @@ module SmartAnswer::Calculators
     end
 
     def statutory_maternity_rate
-      truncate((average_weekly_earnings / 100) * 90)
+      truncate((average_weekly_earnings.to_f / 100) * 90)
     end
 
     def round_up_to_nearest_penny(float)

--- a/test/data/maternity-paternity-calculator-files.yml
+++ b/test/data/maternity-paternity-calculator-files.yml
@@ -1,7 +1,7 @@
 ---
 lib/data/rates/maternity_paternity_adoption.yml: 27d62ac5a1059b4808863af7e6c01454
 lib/data/rates/maternity_paternity_birth.yml: 81372de867cc42069db9a8d4e093db49
-lib/smart_answer/calculators/maternity_paternity_calculator.rb: ec2e23681b1744086112be223998c639
+lib/smart_answer/calculators/maternity_paternity_calculator.rb: 666216a1615341d19b1fdab787102600
 lib/smart_answer_flows/maternity-paternity-calculator/adoption_calculator_flow.rb: '09e789b16a456694455277e7bfb0f4b0'
 lib/smart_answer_flows/maternity-paternity-calculator/maternity_calculator_flow.rb: bac17d939530b170c596c65334a96e33
 lib/smart_answer_flows/maternity-paternity-calculator/maternity_paternity_calculator.govspeak.erb: '019bbbe8b47309afce398e707263d0e5'


### PR DESCRIPTION
https://trello.com/c/oSBm2dr1/502-improve-maternity-paternity-calculator-tests-%F0%9F%8D%90-the-load

There was a bit of duplication in how we were testing the statutory leave rate. 
This often changes with the April budget so I've added a specific test covering the rates since 2012.

Also:

* Removed a few tests which covered the same calculation.
* Treat AWE as string input in the calculator for paternity pay (consistent with maternity pay)
* Linting fixes 