### PR TITLE
Updated Acas helpline information

### DIFF
--- a/lib/smart_answer_flows/shared/minimum_wage/_acas_information.govspeak.erb
+++ b/lib/smart_answer_flows/shared/minimum_wage/_acas_information.govspeak.erb
@@ -4,8 +4,7 @@ This result is an estimate. If you have any questions, call the confidential hel
 $C
 **Acas helpline**\\
 Telephone: 0300 123 1100\\
-Monday to Friday, 8am to 8pm\\
-Saturday, 9am to 1pm\\
+Monday to Friday, 8am to 6pm\\
 [Find out about call charges](/call-charges)
 $C
 

--- a/test/data/am-i-getting-minimum-wage-files.yml
+++ b/test/data/am-i-getting-minimum-wage-files.yml
@@ -30,7 +30,7 @@ lib/smart_answer_flows/am-i-getting-minimum-wage/questions/what_is_overtime_pay_
 lib/smart_answer_flows/am-i-getting-minimum-wage/questions/what_was_overtime_pay_per_hour.govspeak.erb: 38abdccc0f2f10e6e56837336f4143bb
 lib/smart_answer_flows/am-i-getting-minimum-wage/questions/what_would_you_like_to_check.govspeak.erb: 599b46a748da805adc060788333cc967
 lib/smart_answer_flows/am-i-getting-minimum-wage.rb: 026e296b9c267ee64eb957ce669a77b0
-lib/smart_answer_flows/shared/minimum_wage/_acas_information.govspeak.erb: 582cdf982fa5619072ddd883bf4c1555
+lib/smart_answer_flows/shared/minimum_wage/_acas_information.govspeak.erb: 568374585ed6c74248a59d0c183cc954
 lib/smart_answer_flows/shared/minimum_wage_flow.rb: '02897a82553f8b813318c5afb282f627'
 test/data/am-i-getting-minimum-wage-questions-and-responses.yml: 6f1bda17d4cf060db127e45538dbd587
 test/data/am-i-getting-minimum-wage-responses-and-expected-results.yml: a8585d7d01f4ef5dee2f6a45f47dcf2b

--- a/test/data/minimum-wage-calculator-employers-files.yml
+++ b/test/data/minimum-wage-calculator-employers-files.yml
@@ -31,7 +31,7 @@ lib/smart_answer_flows/minimum-wage-calculator-employers/questions/what_is_overt
 lib/smart_answer_flows/minimum-wage-calculator-employers/questions/what_was_overtime_pay_per_hour.govspeak.erb: 82a7b7b692aac807fdd73c4f5b6aea22
 lib/smart_answer_flows/minimum-wage-calculator-employers/questions/what_would_you_like_to_check.govspeak.erb: 393c550c68d5b967c651d5c10ddddf6d
 lib/smart_answer_flows/minimum-wage-calculator-employers.rb: 7c0f8b6751be3acb6ae7f8ed98a3d798
-lib/smart_answer_flows/shared/minimum_wage/_acas_information.govspeak.erb: 582cdf982fa5619072ddd883bf4c1555
+lib/smart_answer_flows/shared/minimum_wage/_acas_information.govspeak.erb: 568374585ed6c74248a59d0c183cc954
 lib/smart_answer_flows/shared/minimum_wage_flow.rb: '02897a82553f8b813318c5afb282f627'
 test/data/minimum-wage-calculator-employers-questions-and-responses.yml: 6f1bda17d4cf060db127e45538dbd587
 test/data/minimum-wage-calculator-employers-responses-and-expected-results.yml: a8585d7d01f4ef5dee2f6a45f47dcf2b


### PR DESCRIPTION
https://trello.com/c/xMHqGdts/683-updating-acas-information-on-minimum-wage-smart-answers

- removed Saturday opening hours
- changed Monday to Friday opening hours from '8am to 8pm' to '8am to 6pm'