### PR TITLE
[DO NOT MERGE] Add content to statutory sick pay start page 

### DIFF
--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/calculate_statutory_sick_pay.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/calculate_statutory_sick_pay.govspeak.erb
@@ -15,9 +15,16 @@
 
   - you pay Class 1 National Insurance contributions for your employee (or would do if not for their age or their level of earnings)
   - your employee was sick for 4 or more days in a row (including non-working days)
-  - your employee has told you they’re sick within your own time limit (or 7 days if you don’t have one)
+  - your employee has told you they’re sick within your own time limit (or 7 days if you do not have one)
 
-  ^ You can’t use the calculator for periods of sickness before 6 April 2011.^
+  ^ You cannot use the calculator for periods of sickness before 6 April 2011.^
 
   *[SSP]: Statutory Sick Pay
+  
+  ###Different periods of sick leave
+
+  You can combine periods of sick leave if the gap between them is 8 weeks or less. These are called ‘linked Periods of Incapacity for Work (PIW)’.
+
+  If there’s more than one linked PIW, you’ll need to [work out the SSP manually](/guidance/statutory-sick-pay-manually-calculate-your-employees-payments#link-period-of-incapacity-for-work).
+
 <% end %>

--- a/test/artefacts/calculate-statutory-sick-pay/calculate-statutory-sick-pay.txt
+++ b/test/artefacts/calculate-statutory-sick-pay/calculate-statutory-sick-pay.txt
@@ -8,11 +8,17 @@ You’re only responsible for paying SSP if:
 
 - you pay Class 1 National Insurance contributions for your employee (or would do if not for their age or their level of earnings)
 - your employee was sick for 4 or more days in a row (including non-working days)
-- your employee has told you they’re sick within your own time limit (or 7 days if you don’t have one)
+- your employee has told you they’re sick within your own time limit (or 7 days if you do not have one)
 
-^ You can’t use the calculator for periods of sickness before 6 April 2011.^
+^ You cannot use the calculator for periods of sickness before 6 April 2011.^
 
 *[SSP]: Statutory Sick Pay
+
+###Different periods of sick leave
+
+You can combine periods of sick leave if the gap between them is 8 weeks or less. These are called ‘linked Periods of Incapacity for Work (PIW)’.
+
+If there’s more than one linked PIW, you’ll need to [work out the SSP manually](/guidance/statutory-sick-pay-manually-calculate-your-employees-payments#link-period-of-incapacity-for-work).
 
 
 

--- a/test/data/calculate-statutory-sick-pay-files.yml
+++ b/test/data/calculate-statutory-sick-pay-files.yml
@@ -1,7 +1,7 @@
 ---
 lib/data/rates/statutory_sick_pay.yml: 457c2ff565737cb61c5ae291ffdabbfd
 lib/smart_answer/calculators/statutory_sick_pay_calculator.rb: dfadf2018ab0f7fb07548df87ecb0a93
-lib/smart_answer_flows/calculate-statutory-sick-pay/calculate_statutory_sick_pay.govspeak.erb: f91dc1d321c164a06271889100875600
+lib/smart_answer_flows/calculate-statutory-sick-pay/calculate_statutory_sick_pay.govspeak.erb: 790ec25f190669066ae8066481ca2ddd
 lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/already_getting_maternity.govspeak.erb: 258fd4422c4ae665c83d5ee1e061bbff
 lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/entitled_to_sick_pay.govspeak.erb: 948d6c5966a30455942bc41f364f12cf
 lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/maximum_entitlement_reached.govspeak.erb: eb12d5290c873df20fd23ff9eb06c273


### PR DESCRIPTION
The calculator doesn't allow users to add more than one linked period of
sickness, so we want to direct users to content that explains how to
manually work out statutory sick pay.

This also fixes two negative contractions: don't and can't.

*Deployment*: this will require a rake task to be run when deployed, to publish the start page to the publishing-api.

[Trello](https://trello.com/b/16mTLUnP/platform-health-doing)