### PR TITLE
Updating Benefit Cap calculator

### DIFF
--- a/lib/smart_answer_flows/benefit-cap-calculator/benefit_cap_calculator.govspeak.erb
+++ b/lib/smart_answer_flows/benefit-cap-calculator/benefit_cap_calculator.govspeak.erb
@@ -7,7 +7,8 @@
 <% end %>
 
 <% content_for :body do %>
-  There’s a limit on the total amount of benefits that most people aged 16 to 64 can get. This is called the [benefit cap](/benefit-cap).
+  
+The [benefit cap](/benefit-cap) limits the total amount of benefit you can get. It applies to most people aged 16 or over who have not reached [State Pension age](/state-pension-age).
 
   This calculator gives an estimate of how much your benefit might be capped.
 

--- a/test/artefacts/benefit-cap-calculator/benefit-cap-calculator.txt
+++ b/test/artefacts/benefit-cap-calculator/benefit-cap-calculator.txt
@@ -1,6 +1,7 @@
 Benefit cap calculator
 
-There’s a limit on the total amount of benefits that most people aged 16 to 64 can get. This is called the [benefit cap](/benefit-cap).
+
+The [benefit cap](/benefit-cap) limits the total amount of benefit you can get. It applies to most people aged 16 or over who have not reached [State Pension age](/state-pension-age).
 
 This calculator gives an estimate of how much your benefit might be capped.
 

--- a/test/data/benefit-cap-calculator-files.yml
+++ b/test/data/benefit-cap-calculator-files.yml
@@ -2,7 +2,7 @@
 lib/data/benefit_cap_data.yml: 90309e12c0009b38ae5de5bc08195d8e
 lib/list_validator.rb: a7f9210a3f89c7b63703606739be2f7e
 lib/smart_answer/calculators/benefit_cap_calculator_configuration.rb: 98a254b73085b28086fd1e21c743b8bd
-lib/smart_answer_flows/benefit-cap-calculator/benefit_cap_calculator.govspeak.erb: e1c2a5fc044662ff2ad6237a3177e75c
+lib/smart_answer_flows/benefit-cap-calculator/benefit_cap_calculator.govspeak.erb: 51cee0ea60865e312d60214348d324ac
 lib/smart_answer_flows/benefit-cap-calculator/outcomes/_dwp_contact_details.govspeak.erb: 0f359f8ad5ff8ce20da4a01ba3b8d635
 lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_affected_greater_than_cap.govspeak.erb: f11b28bc1dea010f98eb4a4fe65cb0d0
 lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_affected_greater_than_cap_london.govspeak.erb: fecd85661290c2a710430c9f7928cab1


### PR DESCRIPTION
https://trello.com/c/0S95k3It/1900-6-dec-state-pension-age-increase-from-65-to-66 

Updated intro for State Pension age chance ticket, linking to 'check your state pension age' page.

