### PR TITLE
Log the backtrace for timeout errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,6 +15,8 @@ protected
   def error(status_code, exception = nil)
     if exception
       GovukError.notify(exception)
+
+      Rails.logger.error exception.backtrace
     end
 
     error_message = "#{status_code} error"


### PR DESCRIPTION
Currently it's hard to tell where exactly the timeout errors are
coming from. So log the backtrace when this happens, as this is the
least worst way of doing this that I could find.