### PR TITLE
Fix the GDS API Adapters logging configuration

### DIFF
--- a/config/initializers/gds_api.rb
+++ b/config/initializers/gds_api.rb
@@ -1,4 +1,6 @@
 require 'gds_api/base'
 
-GdsApi::Base.logger = Logger.new(Rails.root.join("log/#{Rails.env}.api_client.log"))
-GdsApi::Base.default_options = { cache_size: 100 }
+GdsApi::Base.default_options = {
+  logger: Logger.new(Rails.root.join("log/#{Rails.env}.api_client.log")),
+  cache_size: 150
+}


### PR DESCRIPTION
Due to how the GDS API Adapters work, setting the logger didn't work,
but passing it in as default_options does.