### PR TITLE
Trello-386: workaround 500's on smartanswers

### DIFF
--- a/lib/services.rb
+++ b/lib/services.rb
@@ -22,7 +22,8 @@ module Services
 
   def self.content_store
     @content_store ||= GdsApi::ContentStore.new(
-      Plek.new.find('content-store')
+      Plek.new.find('content-store'),
+      timeout: 8
     )
   end
 


### PR DESCRIPTION
Since migrating the content-store to AWS, we are seeing timeouts on
some requests on smartanswers when it makes calls to retrieve content items.
The latency has increased since the migration so we need to temporarily
increase the timeout time for the calls to the content-store.
The default timeout is 4 seconds we are doubling it to 8 seconds until
the frontends are migrated to AWS.

More info here: https://github.com/alphagov/gds-api-adapters/blob/a83d405df57f84fbf7080903a485d562a1350543/README.md#setting-the-timeout

Here the timeout exceptions are being rescued as 503's: https://github.com/alphagov/smart-answers/blob/09c7f542e758c307f282dba349ee620a0ffd3cc0/app/controllers/application_controller.rb

Pair: @ronocg <conor.glynn@digital.cabinet-office.gov.uk>
 @karlbaker02 <karl.baker@digital.cabinet-office.gov.uk>