### PR TITLE
Cache Content Store responses

### DIFF
--- a/app/services/content_item_retriever.rb
+++ b/app/services/content_item_retriever.rb
@@ -1,8 +1,10 @@
 class ContentItemRetriever
   def self.fetch(slug)
-    Services.content_store.content_item("/#{slug}")
-      .to_hash.with_indifferent_access
+    item_hash = Rails.cache.fetch("ContentItemRetriever/#{slug}", expires_in: 5.minutes) do
+      Services.content_store.content_item("/#{slug}").to_hash
+    end
 
+    item_hash.with_indifferent_access
   rescue GdsApi::HTTPNotFound, GdsApi::HTTPGone
     {}
   end

--- a/test/unit/services/content_item_retriever_test.rb
+++ b/test/unit/services/content_item_retriever_test.rb
@@ -18,6 +18,7 @@ require "test_helper"
         }
       }.with_indifferent_access
       @request_url = "https://content-store.test.gov.uk/content/#{@slug}"
+      Rails.cache.clear
     end
 
     context "fetch" do


### PR DESCRIPTION
This is an attempt to workaround the significantly higher failure rate
for Content Store requests, while Smart Answers is running in Carrenza
and the Content Store in AWS.

Sometimes opening the connection times out, and debugging this is
tricky, so try to reduce the number of errors by adding some crude
caching.