### PR TITLE
Avoid running regression tests twice

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,7 @@ node {
     repoName: 'smart-answers',
     overrideTestTask: {
       stage("Run tests") {
+        govuk.setEnvar("RUN_REGRESSION_TESTS", "")
         govuk.runTests()
       }
 


### PR DESCRIPTION
All job parameters are exposed as environment variables, so checking
the RUN_REGRESSION_TESTS box causes them to run twice: once by
`govuk.runTests()` and once by `bundle exec ruby
test/regression/smart_answers_regression_test.rb`

As we explicitly check for and run the regression tests after the
normal tests, never run them during the normal tests.