### PR TITLE
Increase the Content Store cache time

### DIFF
--- a/app/services/content_item_retriever.rb
+++ b/app/services/content_item_retriever.rb
@@ -1,6 +1,6 @@
 class ContentItemRetriever
   def self.fetch(slug)
-    item_hash = Rails.cache.fetch("ContentItemRetriever/#{slug}", expires_in: 5.minutes) do
+    item_hash = Rails.cache.fetch("ContentItemRetriever/#{slug}", expires_in: 30.minutes) do
       Services.content_store.content_item("/#{slug}").to_hash
     end
 


### PR DESCRIPTION
5 minutes reduces the failures by a lot, but there are still more
failed requests than I'd like.

Upping this to 30 minutes should avoid even more failures, and manual
cache clearing can be done if changes need to be made quickly.