### PR TITLE
Update EU citizens callout on start page

### DIFF
--- a/lib/smart_answer_flows/student-finance-calculator/student_finance_calculator.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-calculator/student_finance_calculator.govspeak.erb
@@ -12,7 +12,7 @@
   + 2017 to 2018
   + 2018 to 2019
 
- ^There will be no change to the rights and status of EU citizens living in the UK until 2021. You and your family can apply for ‘[settled status](https://www.gov.uk/settled-status-eu-citizens-families)' to continue living in the UK after June 2021. The scheme will open fully by March 2019.^
+ ^There will be no change to the rights and status of EU citizens currently living in the UK until 30 June 2021, or 31 December 2020 if the UK leaves the EU [without a deal](https://www.gov.uk/government/publications/policy-paper-on-citizens-rights-in-the-event-of-a-no-deal-brexit). You and your family can apply to the [EU Settlement Scheme](https://www.gov.uk/settled-status-eu-citizens-families) to continue living in the UK. The scheme will open fully by 30 March 2019.
 
   Use the student finance calculator to estimate:
 


### PR DESCRIPTION
This is part of an urgent request from the Home Office to update all callouts about the rights of EU citizens to include the 'no deal' Brexit date. 

For this smart answer, it only involves a change to the text in one callout on the start page.

Trello: https://trello.com/c/5JwvhTGh/297-disclaimers-for-eu-settlement-scheme-and-related-pages-content-change-request-7-jan