### PR TITLE
Remove redundant GdsApi Adapters option

### DIFF
--- a/config/initializers/gds_api.rb
+++ b/config/initializers/gds_api.rb
@@ -1,6 +1,5 @@
 require 'gds_api/base'
 
 GdsApi::Base.default_options = {
-  logger: Logger.new(Rails.root.join("log/#{Rails.env}.api_client.log")),
-  cache_size: 150
+  logger: Logger.new(Rails.root.join("log/#{Rails.env}.api_client.log"))
 }


### PR DESCRIPTION
The GdsApi Adapters no longer does caching, so the cache_size option
is unused.