### PR TITLE
Add self-assement penalty outcomes for 2017-18

### DIFF
--- a/lib/smart_answer/calculators/self_assessment_penalties.rb
+++ b/lib/smart_answer/calculators/self_assessment_penalties.rb
@@ -14,6 +14,7 @@ module SmartAnswer::Calculators
         "2014-15": ONLINE_FILING_DEADLINE_YEAR.starting_in(2016).begins_on,
         "2015-16": ONLINE_FILING_DEADLINE_YEAR.starting_in(2017).begins_on,
         "2016-17": ONLINE_FILING_DEADLINE_YEAR.starting_in(2018).begins_on,
+        "2017-18": ONLINE_FILING_DEADLINE_YEAR.starting_in(2019).begins_on,
       },
       offline_filing_deadline: {
         "2012-13": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2013).begins_on,
@@ -21,6 +22,7 @@ module SmartAnswer::Calculators
         "2014-15": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2015).begins_on,
         "2015-16": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2016).begins_on,
         "2016-17": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2017).begins_on,
+        "2017-18": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2018).begins_on,
       },
       payment_deadline: {
         "2012-13": PAYMENT_DEADLINE_YEAR.starting_in(2014).begins_on,
@@ -28,6 +30,7 @@ module SmartAnswer::Calculators
         "2014-15": PAYMENT_DEADLINE_YEAR.starting_in(2016).begins_on,
         "2015-16": PAYMENT_DEADLINE_YEAR.starting_in(2017).begins_on,
         "2016-17": PAYMENT_DEADLINE_YEAR.starting_in(2018).begins_on,
+        "2017-18": PAYMENT_DEADLINE_YEAR.starting_in(2019).begins_on,
       },
     }.freeze
 
@@ -43,6 +46,8 @@ module SmartAnswer::Calculators
         SmartAnswer::YearRange.tax_year.starting_in(2015)
       when '2016-17'
         SmartAnswer::YearRange.tax_year.starting_in(2016)
+      when '2017-18'
+        SmartAnswer::YearRange.tax_year.starting_in(2017)
       end
     end
 
@@ -62,6 +67,8 @@ module SmartAnswer::Calculators
         PENALTY_YEAR.starting_in(2018).begins_on
       when '2016-17'
         PENALTY_YEAR.starting_in(2019).begins_on
+      when '2017-18'
+        PENALTY_YEAR.starting_in(2020).begins_on
       end
     end
 

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
@@ -13,6 +13,7 @@ module SmartAnswer
         option :"2014-15"
         option :"2015-16"
         option :"2016-17"
+        option :"2017-18"
 
         on_response do |response|
           self.calculator = Calculators::SelfAssessmentPenalties.new

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties/questions/which_year.govspeak.erb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties/questions/which_year.govspeak.erb
@@ -7,5 +7,6 @@
   "2013-14": "6 April 2013 to 5 April 2014",
   "2014-15": "6 April 2014 to 5 April 2015",
   "2015-16": "6 April 2015 to 5 April 2016",
-  "2016-17": "6 April 2016 to 5 April 2017"
+  "2016-17": "6 April 2016 to 5 April 2017",
+  "2017-18": "6 April 2017 to 5 April 2018"
 ) %>

--- a/test/artefacts/estimate-self-assessment-penalties/y.txt
+++ b/test/artefacts/estimate-self-assessment-penalties/y.txt
@@ -9,6 +9,7 @@ For which tax year do you want the estimate?
   * 2014-15: 6 April 2014 to 5 April 2015
   * 2015-16: 6 April 2015 to 5 April 2016
   * 2016-17: 6 April 2016 to 5 April 2017
+  * 2017-18: 6 April 2017 to 5 April 2018
 
 
 

--- a/test/data/estimate-self-assessment-penalties-questions-and-responses.yml
+++ b/test/data/estimate-self-assessment-penalties-questions-and-responses.yml
@@ -5,6 +5,7 @@
 - 2014-15
 - 2015-16
 - 2016-17
+- 2017-18
 :how_submitted?:
 - online
 - paper
@@ -18,6 +19,7 @@
 - 2015-04-07 # 2014-15 - After start of next tax year (2015-04-06)
 - 2016-04-07 # 2015-16 - After start of next tax year (2016-04-06)
 - 2017-04-07 # 2016-17 - After start of next tax year (2017-04-06)
+- 2018-04-07 # 2017-18 - After start of next tax year (2018-04-06)
 :when_paid?:
 - 2013-04-06 # 2012-13 - Paid before submitted (2013-04-07)
 - 2013-04-08 # 2012-13 - Paid after submitted (2013-04-07)
@@ -28,6 +30,7 @@
 - 2015-04-08 # 2014-15 - Paid after submitted
 - 2016-04-08 # 2015-16 - Paid after submitted
 - 2017-04-08 # 2016-17 - Paid after submitted
+- 2018-04-08 # 2017-18 - Paid after submitted
 :how_much_tax?:
 - 500
 - 6003 # Estimated bill value greater than £6002

--- a/test/data/estimate-self-assessment-penalties-responses-and-expected-results.yml
+++ b/test/data/estimate-self-assessment-penalties-responses-and-expected-results.yml
@@ -3934,3 +3934,269 @@
   - '2017-04-08'
   :next_node: :filed_and_paid_on_time
   :outcome_node: true
+
+- :current_node: :which_year?
+  :responses:
+  - 2017-18
+  :next_node: :how_submitted?
+  :outcome_node: false
+- :current_node: :how_submitted?
+  :responses:
+  - 2017-18
+  - online
+  :next_node: :when_submitted?
+  :outcome_node: false
+- :current_node: :when_submitted?
+  :responses:
+  - 2017-18
+  - online
+  - '2014-04-05'
+  :next_node: :when_submitted?
+  :outcome_node: false
+- :current_node: :when_submitted?
+  :responses:
+  - 2017-18
+  - online
+  - '2014-04-07'
+  :next_node: :when_submitted?
+  :outcome_node: false
+- :current_node: :when_submitted?
+  :responses:
+  - 2017-18
+  - online
+  - '2015-01-31'
+  :next_node: :when_submitted?
+  :outcome_node: false
+- :current_node: :when_submitted?
+  :responses:
+  - 2017-18
+  - online
+  - '2015-04-30'
+  :next_node: :when_submitted?
+  :outcome_node: false
+- :current_node: :when_submitted?
+  :responses:
+  - 2017-18
+  - online
+  - '2015-07-31'
+  :next_node: :when_submitted?
+  :outcome_node: false
+- :current_node: :when_submitted?
+  :responses:
+  - 2017-18
+  - online
+  - '2015-04-07'
+  :next_node: :when_submitted?
+  :outcome_node: false
+- :current_node: :when_submitted?
+  :responses:
+  - 2017-18
+  - online
+  - '2016-04-07'
+  :next_node: :when_submitted?
+  :outcome_node: false
+- :current_node: :when_submitted?
+  :responses:
+  - 2017-18
+  - online
+  - '2017-04-07'
+  :next_node: :when_paid?
+  :outcome_node: false
+- :current_node: :when_paid?
+  :responses:
+  - 2017-18
+  - online
+  - '2017-04-07'
+  - '2014-04-06'
+  :next_node: :when_paid?
+  :outcome_node: false
+- :current_node: :when_paid?
+  :responses:
+  - 2017-18
+  - online
+  - '2017-04-07'
+  - '2014-04-08'
+  :next_node: :when_paid?
+  :outcome_node: false
+- :current_node: :when_paid?
+  :responses:
+  - 2017-18
+  - online
+  - '2017-04-07'
+  - '2015-01-31'
+  :next_node: :when_paid?
+  :outcome_node: false
+- :current_node: :when_paid?
+  :responses:
+  - 2017-18
+  - online
+  - '2017-04-07'
+  - '2015-03-02'
+  :next_node: :when_paid?
+  :outcome_node: false
+- :current_node: :when_paid?
+  :responses:
+  - 2017-18
+  - online
+  - '2017-04-07'
+  - '2016-01-31'
+  :next_node: :when_paid?
+  :outcome_node: false
+- :current_node: :when_paid?
+  :responses:
+  - 2017-18
+  - online
+  - '2017-04-07'
+  - '2015-04-08'
+  :next_node: :when_paid?
+  :outcome_node: false
+- :current_node: :when_paid?
+  :responses:
+  - 2017-18
+  - online
+  - '2017-04-07'
+  - '2016-04-08'
+  :next_node: :when_paid?
+  :outcome_node: false
+- :current_node: :when_paid?
+  :responses:
+  - 2017-18
+  - online
+  - '2017-04-07'
+  - '2017-04-08'
+  :next_node: :filed_and_paid_on_time
+  :outcome_node: true
+- :current_node: :how_submitted?
+  :responses:
+  - 2017-18
+  - paper
+  :next_node: :when_submitted?
+  :outcome_node: false
+- :current_node: :when_submitted?
+  :responses:
+  - 2017-18
+  - paper
+  - '2014-04-05'
+  :next_node: :when_submitted?
+  :outcome_node: false
+- :current_node: :when_submitted?
+  :responses:
+  - 2017-18
+  - paper
+  - '2014-04-07'
+  :next_node: :when_submitted?
+  :outcome_node: false
+- :current_node: :when_submitted?
+  :responses:
+  - 2017-18
+  - paper
+  - '2015-01-31'
+  :next_node: :when_submitted?
+  :outcome_node: false
+- :current_node: :when_submitted?
+  :responses:
+  - 2017-18
+  - paper
+  - '2015-04-30'
+  :next_node: :when_submitted?
+  :outcome_node: false
+- :current_node: :when_submitted?
+  :responses:
+  - 2017-18
+  - paper
+  - '2015-07-31'
+  :next_node: :when_submitted?
+  :outcome_node: false
+- :current_node: :when_submitted?
+  :responses:
+  - 2017-18
+  - paper
+  - '2015-04-07'
+  :next_node: :when_submitted?
+  :outcome_node: false
+- :current_node: :when_submitted?
+  :responses:
+  - 2017-18
+  - paper
+  - '2016-04-07'
+  :next_node: :when_submitted?
+  :outcome_node: false
+- :current_node: :when_submitted?
+  :responses:
+  - 2017-18
+  - paper
+  - '2017-04-07'
+  :next_node: :when_paid?
+  :outcome_node: false
+- :current_node: :when_paid?
+  :responses:
+  - 2017-18
+  - paper
+  - '2017-04-07'
+  - '2014-04-06'
+  :next_node: :when_paid?
+  :outcome_node: false
+- :current_node: :when_paid?
+  :responses:
+  - 2017-18
+  - paper
+  - '2017-04-07'
+  - '2014-04-08'
+  :next_node: :when_paid?
+  :outcome_node: false
+- :current_node: :when_paid?
+  :responses:
+  - 2017-18
+  - paper
+  - '2017-04-07'
+  - '2015-01-31'
+  :next_node: :when_paid?
+  :outcome_node: false
+- :current_node: :when_paid?
+  :responses:
+  - 2017-18
+  - paper
+  - '2017-04-07'
+  - '2015-03-02'
+  :next_node: :when_paid?
+  :outcome_node: false
+- :current_node: :when_paid?
+  :responses:
+  - 2017-18
+  - paper
+  - '2017-04-07'
+  - '2016-01-31'
+  :next_node: :when_paid?
+  :outcome_node: false
+- :current_node: :when_paid?
+  :responses:
+  - 2017-18
+  - paper
+  - '2017-04-07'
+  - '2015-04-08'
+  :next_node: :when_paid?
+  :outcome_node: false
+- :current_node: :when_paid?
+  :responses:
+  - 2017-18
+  - paper
+  - '2017-04-07'
+  - '2016-04-08'
+  :next_node: :when_paid?
+  :outcome_node: false
+- :current_node: :when_paid?
+  :responses:
+  - 2017-18
+  - paper
+  - '2017-04-07'
+  - '2017-04-08'
+  :next_node: :when_paid?
+  :outcome_node: false
+- :current_node: :when_paid?
+  :responses:
+  - 2017-18
+  - paper
+  - '2018-04-07'
+  - '2018-04-08'
+  :next_node: :filed_and_paid_on_time
+  :outcome_node: true

--- a/test/unit/calculators/self_assessment_penalties_test.rb
+++ b/test/unit/calculators/self_assessment_penalties_test.rb
@@ -10,6 +10,7 @@ module SmartAnswer::Calculators
           "2014-15": Date.new(2016, 1, 31),
           "2015-16": Date.new(2017, 1, 31),
           "2016-17": Date.new(2018, 1, 31),
+          "2017-18": Date.new(2019, 1, 31),
         },
         offline_filing_deadline: {
           "2012-13": Date.new(2013, 10, 31),
@@ -17,6 +18,7 @@ module SmartAnswer::Calculators
           "2014-15": Date.new(2015, 10, 31),
           "2015-16": Date.new(2016, 10, 31),
           "2016-17": Date.new(2017, 10, 31),
+          "2017-18": Date.new(2018, 10, 31),
         },
         payment_deadline: {
           "2012-13": Date.new(2014, 1, 31),
@@ -24,6 +26,7 @@ module SmartAnswer::Calculators
           "2014-15": Date.new(2016, 1, 31),
           "2015-16": Date.new(2017, 1, 31),
           "2016-17": Date.new(2018, 1, 31),
+          "2017-18": Date.new(2019, 1, 31),
         },
       }
 
@@ -56,10 +59,15 @@ module SmartAnswer::Calculators
 
         assert_equal Date.new(2016, 4, 6), @calculator.start_of_next_tax_year
       end
-      should 'return 2017-04-06 if tax-year is 2017-16' do
+      should 'return 2017-04-06 if tax-year is 2017-17' do
         @calculator.tax_year = '2016-17'
 
         assert_equal Date.new(2017, 4, 6), @calculator.start_of_next_tax_year
+      end
+      should 'return 2018-04-06 if tax-year is 2017-18' do
+        @calculator.tax_year = '2017-18'
+
+        assert_equal Date.new(2018, 4, 6), @calculator.start_of_next_tax_year
       end
     end
 
@@ -88,6 +96,11 @@ module SmartAnswer::Calculators
         @calculator.tax_year = '2016-17'
 
         assert_equal Date.new(2019, 2, 1), @calculator.one_year_after_start_date_for_penalties
+      end
+      should 'return 2020-02-01 if tax-year is 2017-18' do
+        @calculator.tax_year = '2017-18'
+
+        assert_equal Date.new(2020, 2, 1), @calculator.one_year_after_start_date_for_penalties
       end
     end
 


### PR DESCRIPTION
There are no changes to the calculations for these years. Based on 2c76439b0c57ae974769d3996c807ed5a2101f89.

[Trello Card](https://trello.com/c/Uev7dCie/733-adding-new-tax-year-to-the-estimate-your-penalty-for-late-self-assessment-tax-returns-and-payments-calculator)