### PR TITLE
Removed reference to civil partnership

### DIFF
--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/finland/_title.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/finland/_title.govspeak.erb
@@ -1,3 +1,3 @@
 <% content_for :title do %>
-  Marriage and Civil partnership in Finland
+  Marriage in Finland
 <% end %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/finland/_uk.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/finland/_uk.govspeak.erb
@@ -31,7 +31,7 @@ Your CNI is valid in Finland for 3 months.
 
 ###Legalisation and translation
 
-You’ll need to get your CNI [legalised](/get-document-legalised) (certified as genuine) by the
+You’ll need to get your CNI [legalised](/get-document-legalised) by the
 Foreign and Commonwealth Office (FCO).
 
 You should also check with the local authority in Finland to find out if you need to provide legalised and translated copies of any other documents.

--- a/test/artefacts/marriage-abroad/finland/ceremony_country.txt
+++ b/test/artefacts/marriage-abroad/finland/ceremony_country.txt
@@ -1,4 +1,4 @@
-Marriage and Civil partnership in Finland
+Marriage in Finland
 
 ##Before you start
 

--- a/test/artefacts/marriage-abroad/finland/third_country.txt
+++ b/test/artefacts/marriage-abroad/finland/third_country.txt
@@ -1,4 +1,4 @@
-Marriage and Civil partnership in Finland
+Marriage in Finland
 
 ##Before you start
 

--- a/test/artefacts/marriage-abroad/finland/uk.txt
+++ b/test/artefacts/marriage-abroad/finland/uk.txt
@@ -1,4 +1,4 @@
-Marriage and Civil partnership in Finland
+Marriage in Finland
 
 ##Before you start
 
@@ -33,7 +33,7 @@ Your CNI is valid in Finland for 3 months.
 
 ###Legalisation and translation
 
-You’ll need to get your CNI [legalised](/get-document-legalised) (certified as genuine) by the
+You’ll need to get your CNI [legalised](/get-document-legalised) by the
 Foreign and Commonwealth Office (FCO).
 
 You should also check with the local authority in Finland to find out if you need to provide legalised and translated copies of any other documents.


### PR DESCRIPTION
https://trello.com/c/USToYLTT/1999-marriage-abroad-change-to-cni-content-for-finland
 
I've updated the title file for Finland marriage abroad to remove reference to civil partnership as it's no longer possible to get one.

I've also removed an inaccurate definition of 'legalisation'.