### PR TITLE
Update plek service static uri

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,7 +6,7 @@
   "env": {
     "GOVUK_APP_DOMAIN": "integration.publishing.service.gov.uk",
     "PLEK_SERVICE_CONTENT_STORE_URI": "https://www.gov.uk/api" ,
-    "PLEK_SERVICE_STATIC_URI": "https://assets-origin.integration.publishing.service.gov.uk/",
+    "PLEK_SERVICE_STATIC_URI": "https://assets.integration.publishing.service.gov.uk/",
     "RUNNING_ON_HEROKU": "true",
     "EXPOSE_GOVSPEAK": "true",
     "ERRBIT_ENV": "integration"


### PR DESCRIPTION
Assets CDN has been added to integration, where before we used origin
directly. It also seem that external access to origin has been blocked
because review links now return `Application error` from Heroku.

The edited url goes through the CDN and is publicly accessible, so it
should solve the problem.