### PR TITLE
[DO NOT MERGE] Uprating maternity adoption leave

### DIFF
--- a/lib/data/rates/maternity_paternity_adoption.yml
+++ b/lib/data/rates/maternity_paternity_adoption.yml
@@ -21,5 +21,8 @@
   end_date: 2018-04-05
   lower_earning_limit_rate: 113
 - start_date: 2018-04-06
-  end_date: 2100-04-05
+  end_date: 2019-04-05
   lower_earning_limit_rate: 116
+- start_date: 2019-04-06
+  end_date: 2100-04-05
+  lower_earning_limit_rate: 118

--- a/lib/data/rates/maternity_paternity_birth.yml
+++ b/lib/data/rates/maternity_paternity_birth.yml
@@ -24,5 +24,8 @@
   end_date: 2018-04-05
   lower_earning_limit_rate: 113
 - start_date: 2018-04-06
-  end_date: 2100-04-05
+  end_date: 2019-04-05
   lower_earning_limit_rate: 116
+- start_date: 2019-04-06
+  end_date: 2100-04-05
+  lower_earning_limit_rate: 118

--- a/lib/smart_answer/calculators/maternity_pay_calculator.rb
+++ b/lib/smart_answer/calculators/maternity_pay_calculator.rb
@@ -284,7 +284,9 @@ module SmartAnswer::Calculators
         { min: uprating_date(2014), max: uprating_date(2015), amount: 138.18 },
         { min: uprating_date(2014), max: uprating_date(2017), amount: 139.58 },
         { min: uprating_date(2017), max: uprating_date(2018), amount: 140.98 },
-        { min: uprating_date(2018), max: uprating_date(2100), amount: 145.18 } ### Change year in future
+        { min: uprating_date(2018), max: uprating_date(2019), amount: 145.18 },
+        { min: uprating_date(2019), max: uprating_date(2100), amount: 148.68 }
+         ### Change year in future
       ]
       rate = rates.find { |r| r[:min] <= date && date < r[:max] } || rates.last
       rate[:amount]

--- a/lib/smart_answer_flows/maternity-paternity-calculator/questions/how_many_payments_monthly.govspeak.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/questions/how_many_payments_monthly.govspeak.erb
@@ -1,10 +1,10 @@
 <% content_for :title do %>
-  How many payments did the employee receive between <%= relevant_period %>?
+  How many months' pay did the employee get between <%= relevant_period %>?
 <% end %>
 
 <% content_for :hint do %>
-  If you have paid the employee 2 month’s pay in one month, count it as 2 payments. 
-  Don't count bonuses or holiday payments on top of paid annual leave.
+  If you have paid the employee 2 months’ pay in one month, count it as 2 payments.
+  Do not include bonuses or other one-off payments.
 <% end %>
 
 <% options(payment_options_monthly) %>

--- a/lib/smart_answer_flows/maternity-paternity-calculator/questions/how_many_payments_weekly.govspeak.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/questions/how_many_payments_weekly.govspeak.erb
@@ -1,10 +1,10 @@
 <% content_for :title do %>
-  How many payments did the employee receive between <%= relevant_period %>?
+  How many weeks' pay did the employee get between <%= relevant_period %>?
 <% end %>
 
 <% content_for :hint do %>
-  If you have paid the employee 2 weeks’ pay in one week, count it as 2 payments. 
-  Don't count bonuses or holiday payments on top of paid annual leave.
+  If you have paid the employee 2 weeks’ pay in one week, count it as 2 payments.
+  Do not include bonuses or other one-off payments.
 <% end %>
 
 <% options(payment_options_weekly) %>

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_additional_pat_pay.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_additional_pat_pay.govspeak.erb
@@ -39,3 +39,9 @@ Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of their 
 Weekly rate (between 6 April 2018 and 5 April 2019) | £145.18, or 90% of their average weekly earnings (whichever is lower).
 
 <% end %>
+
+<% if calculator.paid_leave_is_in_tax_year?(2019) %>
+
+Weekly rate (between 6 April 2019 and 5 April 2020) | £148.68, or 90% of their average weekly earnings (whichever is lower).
+
+<% end %>

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_both_shared_pay.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_both_shared_pay.govspeak.erb
@@ -34,6 +34,12 @@ Mother’s shared parental pay (between 6 April 2018 and 5 April 2019) | £145.1
 
 <% end %>
 
+<% if calculator.paid_leave_is_in_tax_year?(2019) %>
+
+Mother’s shared parental pay (between 6 April 2019 and 5 April 2020) | £148.68 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+<% end %>
+
 <% if calculator.paid_leave_is_in_tax_year?(2014) %>
 
 Partner's shared parental pay (between 6 April 2014 and 5 April 2015) | £138.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
@@ -61,5 +67,11 @@ Partner's shared parental pay (between 6 April 2017 and 5 April 2018) | £140.98
 <% if calculator.paid_leave_is_in_tax_year?(2018) %>
 
 Partner's shared parental pay (between 6 April 2018 and 5 April 2019) | £145.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+<% end %>
+
+<% if calculator.paid_leave_is_in_tax_year?(2019) %>
+
+Partner's shared parental pay (between 6 April 2019 and 5 April 2020) | £148.68 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_allowance.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_allowance.govspeak.erb
@@ -44,4 +44,10 @@ Weekly rate (between 6 April 2018 and 5 April 2019) | £145.18, or 90% of her av
 
 <% end %>
 
+<% if calculator.paid_leave_is_in_tax_year?(2019) %>
+
+Weekly rate (between 6 April 2019 and 5 April 2020) | £148.68, or 90% of her average weekly earnings (whichever is lower)
+
+<% end %>
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_pay.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_pay.govspeak.erb
@@ -42,6 +42,12 @@ Remaining weeks (between 6 April 2018 and 5 April 2019) | £145.18 per week or 9
 
 <% end %>
 
+<% if calculator.paid_leave_is_in_tax_year?(2019) %>
+
+Remaining weeks (between 6 April 2019 and 5 April 2020) | £148.68 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+<% end %>
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_shared_pay.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_shared_pay.govspeak.erb
@@ -33,3 +33,9 @@ Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week 
 Shared Parental Pay (between 6 April 2018 and 5 April 2019) | £145.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
+
+<% if calculator.paid_leave_is_in_tax_year?(2019) %>
+
+Shared Parental Pay (between 6 April 2019 and 5 April 2020) | £148.68 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+<% end %>

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_pay.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_pay.govspeak.erb
@@ -40,6 +40,12 @@ Weekly rate (between 6 April 2018 and 5 April 2019) | £145.18 per week or 90% o
 
 <% end %>
 
+<% if calculator.paid_leave_is_in_tax_year?(2019) %>
+
+Weekly rate (between 6 April 2019 and 5 April 2020) | £148.68 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+<% end %>
+
 <% if calculator.paid_leave_is_in_tax_year?(2013) %>
 
 Tell the partner’s employer | 28 days before they want to start paternity pay

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_shared_pay.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_shared_pay.govspeak.erb
@@ -33,3 +33,9 @@ Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week 
 Shared Parental Pay (between 6 April 2018 and 5 April 2019) | £145.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
+
+<% if calculator.paid_leave_is_in_tax_year?(2019) %>
+
+Shared Parental Pay (between 6 April 2019 and 5 April 2020) | £148.68 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+<% end %>

--- a/test/integration/smart_answer_flows/maternity_calculator_test.rb
+++ b/test/integration/smart_answer_flows/maternity_calculator_test.rb
@@ -471,6 +471,27 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
       end
     end
 
+    context "check for correct LEL Saturday, 13th 2019 monthly" do
+      setup do
+        add_response Date.parse("2019-07-26")
+        add_response Date.parse("2019-06-29")
+        add_response :yes
+        add_response Date.parse("2019-04-06")
+        add_response Date.parse("2019-02-07")
+        add_response :monthly
+        add_response 956
+        add_response "2"
+        add_response "weekly_starting"
+      end
+
+      should "have LEL of 118" do
+        assert_state_variable :to_saturday_formatted, "Saturday, 13 April 2019"
+        assert_state_variable "lower_earning_limit", sprintf("%.2f", 118)
+        assert_current_node :maternity_leave_and_pay_result
+      end
+    end
+
+
     context "check for correct LEL Saturday, 12 April 2014 monthly" do
       setup do
         add_response Date.parse("2014-07-26")
@@ -666,12 +687,12 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
         "30 January 2019" => "£622.20",
         "27 February 2019" => "£580.72",
         "29 March 2019" => "£622.20",
-        "30 April 2019" => "£663.68",
-        "31 May 2019" => "£642.94",
-        "28 June 2019" => "£311.10",
+        "30 April 2019" => "£675.68",
+        "31 May 2019" => "£658.44",
+        "28 June 2019" => "£318.60",
       )
 
-      assert_state_variable :total_smp, "6224.03"
+      assert_state_variable :total_smp, "6259.03"
     end
   end
 

--- a/test/unit/calculators/maternity_pay_calculator_test.rb
+++ b/test/unit/calculators/maternity_pay_calculator_test.rb
@@ -367,6 +367,7 @@ module SmartAnswer::Calculators
 
       context "statutory pay rate for given year" do
         {
+          2019 => 148.68,
           2018 => 145.18,
           2017 => 140.98,
           2016 => 139.58,


### PR DESCRIPTION
Maternity, paternity, shared and adoption leave rates are rising to £148.68 from April 7th.

Lower Earning Limits are rising from £116 to £118 per week from April 6th.

[Trello](https://trello.com/c/lQgrihjp/763-uprating-maternity-adoption-and-paternity-leave-for-employers-calculator)