### PR TITLE
[8 April] Updated state pension rates with 2019-2020 figures

### DIFF
--- a/lib/data/rates/state_pension.yml
+++ b/lib/data/rates/state_pension.yml
@@ -30,6 +30,11 @@
   lower_weekly_rate: 73.30
 
 - start_date: 2018-04-09
-  end_date: 2019-04-10
+  end_date: 2019-04-07
   weekly_rate: 125.95
   lower_weekly_rate: 75.50
+
+- start_date: 2019-04-08
+  end_date: 2020-04-08
+  weekly_rate: 129.20
+  lower_weekly_rate: 77.45


### PR DESCRIPTION
https://trello.com/c/7vG0azrP/2018-6-april-uprating-state-pension-through-partner

Updated with the new rates that come in to effect on 8 April 2019.