### PR TITLE
patch 1

### DIFF
--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/hours_per_week_done.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/hours_per_week_done.govspeak.erb
@@ -1,5 +1,9 @@
 <% content_for :body do %>
   $!The statutory entitlement is <%= "#{holiday_entitlement_hours} #{'hour'.pluralize(holiday_entitlement_hours)}" %> and <%= "#{holiday_entitlement_minutes} #{'minute'.pluralize(holiday_entitlement_minutes)}" %> holiday.$!
 
+<% if days_per_week > 5 %>
+  Even though more than 5 days a week are worked the maximum statutory holiday entitlement is 28 days.
+<% end %>
+
   <%= render partial: 'your_employer_with_rounding.govspeak.erb' %>
 <% end %>

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/questions/basis_of_calculation.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/questions/basis_of_calculation.govspeak.erb
@@ -12,5 +12,6 @@
 ) %>
 
 <% content_for :hint do %>
-  Check the employment contract if you’re not sure about the holiday entitlement.
+  Check the employment contract if you’re not sure. Choose ‘casual or irregular hours’ 
+  for workers who do different hours each week, for example workers on zero-hours contracts.
 <% end %>

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/questions/how_many_days_per_week_for_hours.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/questions/how_many_days_per_week_for_hours.govspeak.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :hint do %>
-  If you work half-days enter .5 for a half, eg 3.5 for three and a half days.
+  We need this to work out how many hours are worked in an average day. Include any half-days, for example 3.5. 
 <% end %>
 
 <% content_for :error_message do %>

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/questions/how_many_hours_per_week.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/questions/how_many_hours_per_week.govspeak.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :hint do %>
-  If you work half-hours enter .5 for a half, eg 40.5.
+  Include any half-hours, for example 37.5.
 <% end %>
 
 <% content_for :error_message do %>


### PR DESCRIPTION
**Trello card**
https://trello.com/c/nLirAxaN/778-text-updates-to-calculate-holiday-entitlement

**Summary**
If you work 40 hours a week over 6 days, you get fewer holiday hours than if you work 40 hours a week over 5 days.

That's correct - holiday allowance is capped at 28 days, so how long a 'day' is makes a difference - but not intuitive. Feedback shows users are struggling to understand this, so we're making minor edits to help. 