### PR TITLE
[Do not merge] Improving hint text for holiday entitlement calculator

### DIFF
--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/hours_per_week_done.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/hours_per_week_done.govspeak.erb
@@ -1,5 +1,9 @@
 <% content_for :body do %>
   $!The statutory entitlement is <%= "#{holiday_entitlement_hours} #{'hour'.pluralize(holiday_entitlement_hours)}" %> and <%= "#{holiday_entitlement_minutes} #{'minute'.pluralize(holiday_entitlement_minutes)}" %> holiday.$!
 
+  <% if days_per_week > 5 %>
+    Even though more than 5 days a week are worked the maximum statutory holiday entitlement is 28 days.
+  <% end %>
+
   <%= render partial: 'your_employer_with_rounding.govspeak.erb' %>
 <% end %>

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/questions/annualised_hours.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/questions/annualised_hours.govspeak.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :hint do %>
-  This is calculated by excluding statutory entitlement. This calculation isn't suitable for term-time workers.
+  The result will only be accurate if the hours in the worker's contract do not include holiday. Do not use annualised entitlement for term-time workers or zero-hours contracts.
 <% end %>
 
 <% content_for :label do %>

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/questions/how_many_days_per_week_for_hours.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/questions/how_many_days_per_week_for_hours.govspeak.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :hint do %>
-  If you work half-days enter .5 for a half, eg 3.5 for three and a half days.
+  We need this to calculate how many hours are worked in an average day. Include half-days, for example 3.5. 
 <% end %>
 
 <% content_for :error_message do %>

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/questions/how_many_hours_per_week.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/questions/how_many_hours_per_week.govspeak.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :hint do %>
-  If you work half-hours enter .5 for a half, eg 40.5.
+  Include half-hours, for example 40.5.
 <% end %>
 
 <% content_for :error_message do %>


### PR DESCRIPTION
**Trello card**
https://trello.com/c/nLirAxaN/778-text-updates-to-calculate-holiday-entitlement

**Summary**
If you work 40 hours a week over 6 days, you get fewer holiday hours than if you work 40 hours a week over 5 days.

That's correct - holiday allowance is capped at 28 days, so how long a 'day' is makes a difference - but not intuitive. Feedback shows users are struggling to understand this, so we're making minor edits to help.