### PR TITLE
Rename "Macedonia" to "North Macedonia"

### DIFF
--- a/lib/data/marriage_abroad_services.yml
+++ b/lib/data/marriage_abroad_services.yml
@@ -93,6 +93,13 @@ morocco:
       default:
       - :affidavit_or_affirmation_for_marriage
   payment_partial_name: pay_by_cash_or_credit_card_no_cheque
+north-macedonia:
+  opposite_sex:
+    ceremony_country:
+      default:
+      - :receiving_notice_of_marriage
+      - :issuing_cni_or_nulla_osta
+  payment_partial_name: pay_by_cash_or_credit_card_no_cheque
 norway:
   opposite_sex:
     ceremony_country:
@@ -514,13 +521,6 @@ luxembourg:
       default:
       - :issuing_cni_or_nulla_osta
   payment_partial_name: pay_in_cash_visa_or_mastercard
-macedonia:
-  opposite_sex:
-    ceremony_country:
-      default:
-      - :receiving_notice_of_marriage
-      - :issuing_cni_or_nulla_osta
-  payment_partial_name: pay_by_cash_or_credit_card_no_cheque
 mexico:
   opposite_sex:
     ceremony_country:

--- a/lib/data/passport_data.yml
+++ b/lib/data/passport_data.yml
@@ -1182,16 +1182,6 @@ macao:
   applying: 6 weeks
   replacing: 6 weeks
   optimistic_processing_time?: true
-macedonia:
-  type: ips_application_1
-  group: ips_documents_group_2
-  app_form: hmpo_1_application_form
-  online_application: true
-  renewing_new: 4 weeks
-  renewing_old: 6 weeks
-  applying: 6 weeks
-  replacing: 6 weeks
-  optimistic_processing_time?: true
 madagascar:
   type: ips_application_1
   group: ips_documents_group_3
@@ -1491,6 +1481,16 @@ north-korea:
   applying: 6 weeks
   replacing: 6 weeks
   optimistic_processing_time?: false
+north-macedonia:
+  type: ips_application_1
+  group: ips_documents_group_2
+  app_form: hmpo_1_application_form
+  online_application: true
+  renewing_new: 4 weeks
+  renewing_old: 6 weeks
+  applying: 6 weeks
+  replacing: 6 weeks
+  optimistic_processing_time?: true
 norway:
   type: ips_application_1
   group: ips_documents_group_1

--- a/lib/data/prisoner_packs.yml
+++ b/lib/data/prisoner_packs.yml
@@ -303,8 +303,6 @@
   translators: /government/publications/british-embassy-luxembourg-translators
   prison: /government/publications/british-embassy-luxembourg-prisoner-pack
 - slug: macao
-- slug: macedonia
-  pdf: /government/publications/macedonia-prisoner-pack
 - slug: madagascar
   lawyer: /government/publications/madagascar-list-of-lawyers
 - slug: malawi
@@ -368,6 +366,8 @@
   pdf: /government/publications/nigeria-prisoner-pack
   lawyer: /government/publications/nigeria-list-of-lawyers
 - slug: north-korea
+- slug: north-macedonia
+  pdf: /government/publications/north-macedonia-prisoner-pack
 - slug: norway
   pdf: /government/publications/norway-prisoner-pack
   lawyer: /government/publications/norway-list-of-lawyers

--- a/lib/data/translators.yml
+++ b/lib/data/translators.yml
@@ -43,7 +43,6 @@ lebanon: /government/publications/lebanon-list-of-lawyers
 libya: /government/publications/libya-list-of-translators
 lithuania: /government/publications/lithuania-list-of-lawyers
 luxembourg: /government/publications/british-embassy-luxembourg-translators
-macedonia: /government/publications/macedonia-list-of-lawyers
 mexico: /government/publications/mexico-list-of-lawyers
 moldova: /government/publications/moldova-list-of-lawyers
 montenegro: /government/publications/montenegro-list-of-lawyers
@@ -53,6 +52,7 @@ namibia: /government/publications/namibia-list-of-lawyers
 nepal: /government/publications/nepal-list-of-lawyers
 netherlands: /government/publications/netherlands-list-of-lawyers
 nicaragua: /government/publications/nicaragua-list-of-lawyers
+north-macedonia: /government/publications/north-macedonia-lawyers
 paraguay: /government/publications/list-of-english-speaking-lawyers-and-translators-in-paraguay
 portugal: /government/publications/portugal-list-of-translators-and-interpreters
 russia: /government/publications/russia-list-of-lawyers

--- a/lib/smart_answer/calculators/marriage_abroad_data_query.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_data_query.rb
@@ -123,11 +123,11 @@ module SmartAnswer::Calculators
       libya
       lithuania
       luxembourg
-      macedonia
       mexico
       montenegro
       nepal
       netherlands
+      north-macedonia
       oman
       panama
       russia
@@ -358,9 +358,9 @@ module SmartAnswer::Calculators
       kyrgyzstan
       lithuania
       luxembourg
-      macedonia
       mexico
       montenegro
+      north-macedonia
       nepal
       panama
       russia
@@ -424,9 +424,9 @@ module SmartAnswer::Calculators
       libya
       lithuania
       luxembourg
-      macedonia
       mexico
       montenegro
+      north-macedonia
       russia
       serbia
       tajikistan

--- a/lib/smart_answer/calculators/uk_benefits_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/uk_benefits_abroad_calculator.rb
@@ -5,7 +5,7 @@ module SmartAnswer::Calculators
     attr_accessor :country, :benefits, :dispute_criteria, :partner_premiums
     attr_accessor :possible_impairments, :impairment_periods, :tax_credits
 
-    COUNTRIES_OF_FORMER_YUGOSLAVIA = %w(bosnia-and-herzegovina kosovo macedonia montenegro serbia).freeze
+    COUNTRIES_OF_FORMER_YUGOSLAVIA = %w(bosnia-and-herzegovina kosovo montenegro north-macedonia serbia).freeze
     STATE_BENEFITS = {
       bereavement_benefits: "Bereavement benefits",
       severe_disablement_allowance: "Severe Disablement Allowance",

--- a/lib/smart_answer/calculators/uk_visa_calculator.rb
+++ b/lib/smart_answer/calculators/uk_visa_calculator.rb
@@ -339,12 +339,12 @@ module SmartAnswer::Calculators
       lesotho
       liberia
       libya
-      macedonia
       malawi
       moldova
       mongolia
       nepal
       nigeria
+      north-macedonia
       pakistan
       palestinian-territories
       rwanda

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_refugee_not_leaving_airport.govspeak.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_refugee_not_leaving_airport.govspeak.erb
@@ -36,7 +36,7 @@
   * Lesotho
   * Liberia
   * Libya
-  * Macedonia
+  * North Macedonia
   * Malawi
   * Moldova
   * Mongolia

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_opposite_sex_marriage_in_consular_cni_countries_when_residing_in_ceremony_country.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_opposite_sex_marriage_in_consular_cni_countries_when_residing_in_ceremony_country.govspeak.erb
@@ -37,7 +37,7 @@
     If you need a CNI, you must arrange this through the British Embassy in Costa Rica because there aren’t any British consular facilities in Nicaragua.
 
 
-  <% elsif %w(kazakhstan macedonia russia).exclude?(calculator.ceremony_country) %>
+  <% elsif %w(kazakhstan north-macedonia russia).exclude?(calculator.ceremony_country) %>
     To get a CNI, you must post notice of your intended marriage in <%= calculator.country_name_lowercase_prefix %>. You can do this at the British embassy or in front of a notary public.
 
 
@@ -73,11 +73,11 @@
 
 
   <% end %>
-  <% if calculator.ceremony_country == 'macedonia' %>
-    Contact a notary public or British Embassy in Macedonia to get advice:
+  <% if calculator.ceremony_country == 'north-macedonia' %>
+    Contact a notary public or British Embassy in North Macedonia to get advice:
 
     $C
-    British Embassy Macedonia
+    British Embassy North Macedonia
     Telephone: + 389 (2) 3299 299
     <consular.skopje@fco.gov.uk>
     $C
@@ -132,7 +132,7 @@
   <% if calculator.ceremony_country == 'macao' %>
     <%= render partial: 'required_supporting_documents_macao.govspeak.erb' %>
   <% else %>
-    <% if calculator.birth_certificate_required_as_supporting_document? && (calculator.notary_public_ceremony_country? || %w(macedonia).include?(calculator.ceremony_country)) %>
+    <% if calculator.birth_certificate_required_as_supporting_document? && (calculator.notary_public_ceremony_country? || %w(north-macedonia).include?(calculator.ceremony_country)) %>
       You’ll need to provide supporting documents, including:
 
       - your passport
@@ -150,7 +150,7 @@
       - equivalent documents for your partner
 
 
-    <% elsif (calculator.notary_public_ceremony_country? || %w(macedonia).include?(calculator.ceremony_country)) %>
+    <% elsif (calculator.notary_public_ceremony_country? || %w(north-macedonia).include?(calculator.ceremony_country)) %>
       You’ll need to provide supporting documents, including:
 
       - your passport

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_opposite_sex_marriage_in_consular_cni_countries_when_residing_in_uk.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_opposite_sex_marriage_in_consular_cni_countries_when_residing_in_uk.govspeak.erb
@@ -69,7 +69,7 @@
   <% if calculator.partner_is_same_sex? ||
     (
       calculator.document_download_link_if_opposite_sex_resident_of_uk_countries? &&
-      (calculator.notary_public_ceremony_country? || %w(macedonia).include?(calculator.ceremony_country))
+      (calculator.notary_public_ceremony_country? || %w(north-macedonia).include?(calculator.ceremony_country))
     ) %>
     <%= render partial: 'download_and_fill_notice_and_affidavit_but_not_sign.govspeak.erb' %>
 

--- a/lib/smart_answer_flows/shared/births_and_deaths_registration/_document_return_fees.govspeak.erb
+++ b/lib/smart_answer_flows/shared/births_and_deaths_registration/_document_return_fees.govspeak.erb
@@ -3,5 +3,5 @@ You must also pay for your documents to be returned to you.
 Postage destination | Fee
 -|-
 UK address or British Forces Post Office | <%= document_return_fees.post_to_uk %>
-Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | <%= document_return_fees.post_to_europe %>
+Europe (excluding Albania, Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Georgia, Liechtenstein, North Macedonia, Moldova, Montenegro, Russia, Serbia, Turkey and Ukraine) | <%= document_return_fees.post_to_europe %>
 Rest of world | <%= document_return_fees.post_to_rest_of_the_world %>

--- a/script/marriage-abroad-services-updates/opposite_sex_cni.yml
+++ b/script/marriage-abroad-services-updates/opposite_sex_cni.yml
@@ -31,11 +31,11 @@
 - latvia
 - lithuania
 - luxembourg
-- macedonia
 - mexico
 - moldova
 - montenegro
 - nepal
+- north-macedonia
 - panama
 - poland
 - romania

--- a/script/marriage-abroad-services-updates/same_sex_removals.yml
+++ b/script/marriage-abroad-services-updates/same_sex_removals.yml
@@ -86,7 +86,6 @@
 - libya
 - liechtenstein
 - macao
-- macedonia
 - madagascar
 - malawi
 - malaysia
@@ -109,6 +108,7 @@
 - niger
 - nigeria
 - north-korea
+- north-macedonia
 - oman
 - pakistan
 - palau

--- a/test/fixtures/worldwide/north-macedonia_organisations.json
+++ b/test/fixtures/worldwide/north-macedonia_organisations.json
@@ -74,7 +74,7 @@
     "status": "ok",
     "links": [
       {
-        "href": "https://www.gov.uk/api/world-locations/macedonia/organisations?page=1",
+        "href": "https://www.gov.uk/api/world-locations/north-macedonia/organisations?page=1",
         "rel": "self"
       }
     ]

--- a/test/fixtures/worldwide_locations.yml
+++ b/test/fixtures/worldwide_locations.yml
@@ -118,7 +118,6 @@
 - lithuania
 - luxembourg
 - macao
-- macedonia
 - madagascar
 - malawi
 - malaysia
@@ -149,6 +148,7 @@
 - niger
 - nigeria
 - north-korea
+- north-macedonia
 - norway
 - oman
 - pakistan

--- a/test/integration/smart_answer_flows/marriage_abroad_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_test.rb
@@ -11,7 +11,7 @@ class MarriageAbroadTest < ActiveSupport::TestCase
   FLATTEN_COUNTRIES_6_OUTCOMES = %w(greece italy spain poland).freeze
   FLATTEN_COUNTRIES_18_OUTCOMES = %w(algeria austria azerbaijan brazil british-indian-ocean-territory burma cambodia chile colombia denmark el-salvador ethiopia the-gambia germany hungary indonesia iran jordan kenya kuwait latvia malaysia maldives moldova montenegro morocco mozambique nicaragua panama portugal oman qatar romania russia sweden tanzania tunisia uganda vietnam).freeze
   FLATTEN_COUNTRIES = FLATTEN_COUNTRIES_CEREMONY_LOCATION_OUTCOMES + FLATTEN_COUNTRIES_2_OUTCOMES + FLATTEN_COUNTRIES_6_OUTCOMES + FLATTEN_COUNTRIES_18_OUTCOMES
-  NOT_FLATTEN_COUNTRIES = %w(albania american-samoa anguilla argentina armenia aruba bahamas belarus belgium bonaire-st-eustatius-saba burundi canada costa-rica cote-d-ivoire czech-republic democratic-republic-of-the-congo estonia hong-kong kazakhstan kosovo kyrgyzstan laos lebanon lithuania macao macedonia madagascar malawi malta mayotte mexico monaco netherlands north-korea norway guatemala paraguay peru rwanda saint-barthelemy san-marino saudi-arabia serbia seychelles slovakia slovenia somalia st-maarten st-martin south-korea spain switzerland turkmenistan ukraine united-arab-emirates uzbekistan wallis-and-futuna yemen).freeze
+  NOT_FLATTEN_COUNTRIES = %w(albania american-samoa anguilla argentina armenia aruba bahamas belarus belgium bonaire-st-eustatius-saba burundi canada costa-rica cote-d-ivoire czech-republic democratic-republic-of-the-congo estonia hong-kong kazakhstan kosovo kyrgyzstan laos lebanon lithuania macao madagascar malawi malta mayotte mexico monaco netherlands north-korea north-macedonia norway guatemala paraguay peru rwanda saint-barthelemy san-marino saudi-arabia serbia seychelles slovakia slovenia somalia st-maarten st-martin south-korea spain switzerland turkmenistan ukraine united-arab-emirates uzbekistan wallis-and-futuna yemen).freeze
 
   def self.translations
     @translations ||= YAML.load_file("lib/smart_answer_flows/locales/en/marriage-abroad.yml")
@@ -423,9 +423,9 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
   end
 
-  context "user lives in 3rd country, ceremony in macedonia, partner os (any nationality)" do
+  context "user lives in 3rd country, ceremony in north-macedonia, partner os (any nationality)" do
     setup do
-      add_response 'macedonia'
+      add_response 'north-macedonia'
       add_response 'third_country'
       add_response 'partner_other'
       add_response 'opposite_sex'
@@ -435,9 +435,9 @@ class MarriageAbroadTest < ActiveSupport::TestCase
     end
   end
 
-  context "user lives in macedonia, ceremony in macedonia" do
+  context "user lives in north-macedonia, ceremony in north-macedonia" do
     setup do
-      add_response 'macedonia'
+      add_response 'north-macedonia'
       add_response 'ceremony_country'
       add_response 'partner_other'
       add_response 'opposite_sex'


### PR DESCRIPTION
HM Government's FCO has officially recognised the change of Macedonia's
name to North Macedonia: 
https://www.gov.uk/government/news/foreign-secretary-statement-on-the-republic-of-north-macedonia

Trello card: https://trello.com/c/ySMq2bcm/786-slug-and-tag-changes-country-name-change-macedonia-to-north-macedonia

Co-Authored-By: Debrah Chua <deborah.chua@digital.cabinet-office.gov.uk>