### PR TITLE
Update docs fix links

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This is a Ruby on Rails application that contains:
 * [Next node rules](doc/smart-answers/next-node-rules.md)
 * [Storing data](doc/smart-answers/storing-data.md)
 * [ERB templates](doc/smart-answers/erb-templates.md)
-  * [Landing page template](doc/smart-answers/landing-page-template.md)
+  * [Landing page template](doc/smart-answers/erb-templates/landing-page-template.md)
   * [Question templates](doc/smart-answers/question-templates.md)
   * [Outcome templates](doc/smart-answers/outcome-templates.md)
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ This is a Ruby on Rails application that contains:
 
 * [Development principles](doc/smart-answer-flow-development/development-principles.md)
 * [Deploying changes for Factcheck](doc/smart-answer-flow-development/factcheck.md)
-* [Merging pull requests from the content team](doc/smart-answer-flow-development/merging-content-prs.md)
 * [Flattening outcomes](doc/smart-answer-flow-development/flattening-outcomes.md)
 * [Refactoring existing Smart Answers](doc/smart-answer-flow-development/refactoring.md)
 * Adding [content-ids](doc/smart-answer-flow-development/content-ids.md) to Smart Answers

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ This is a Ruby on Rails application that contains:
 * [Storing data](doc/smart-answers/storing-data.md)
 * [ERB templates](doc/smart-answers/erb-templates.md)
   * [Landing page template](doc/smart-answers/erb-templates/landing-page-template.md)
-  * [Question templates](doc/smart-answers/question-templates.md)
+  * [Question templates](doc/smart-answers/erb-templates/question-templates.md)
   * [Outcome templates](doc/smart-answers/erb-templates/outcome-templates.md)
 
 ### Smart Answer flow development

--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ This is a Ruby on Rails application that contains:
 
 ### Smart Answers app development
 
-* [Development workflow](doc/development-workflow.md)
 * [Common errors you might run into during development](doc/smart-answers-app-development/common-errors.md)
 * [Continuous integration](doc/smart-answers-app-development/continuous-integration.md)
 * [Testing](doc/smart-answers-app-development/testing.md)

--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ This is a Ruby on Rails application that contains:
 * [Common errors you might run into during development](doc/smart-answers-app-development/common-errors.md)
 * [Continuous integration](doc/smart-answers-app-development/continuous-integration.md)
 * [Testing](doc/smart-answers-app-development/testing.md)
-* [Issues and Todo](https://trello.com/b/7HgyU4hy/smart-answers-tasks)
 
 ### Changes to the landing page
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ This is a Ruby on Rails application that contains:
 
 ### Changes to the landing page
 
-As well as following the [development workflow](https://github.com/alphagov/smart-answers/blob/master/doc/development-workflow.md) to make changes, they also need to be sent to the `content store` for them to be rendered on the page. The [rake task `publishing_api:publish`](https://github.com/alphagov/smart-answers/blob/master/lib/tasks/publishing_api.rake) needs to be run once you have deployed your changes in each environment and can be done in [Jenkins](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/).
+Changes to landing pages need to be sent to be sent to the `content store` for them to be rendered on the page. The [rake task `publishing_api:publish`](https://github.com/alphagov/smart-answers/blob/master/lib/tasks/publishing_api.rake) needs to be run once you have deployed your changes in each environment and can be done in [Jenkins](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=smartanswers&amp;MACHINE_CLASS=calculators_frontends&amp;RAKE_TASK=publishing_api:publish).
 
 ### Debugging
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This is a Ruby on Rails application that contains:
 * [ERB templates](doc/smart-answers/erb-templates.md)
   * [Landing page template](doc/smart-answers/erb-templates/landing-page-template.md)
   * [Question templates](doc/smart-answers/question-templates.md)
-  * [Outcome templates](doc/smart-answers/outcome-templates.md)
+  * [Outcome templates](doc/smart-answers/erb-templates/outcome-templates.md)
 
 ### Smart Answer flow development
 

--- a/doc/smart-answer-flow-development/creating-a-new-smart-answer.md
+++ b/doc/smart-answer-flow-development/creating-a-new-smart-answer.md
@@ -61,7 +61,7 @@ Open the new landing page template your editor and copy/paste the following cont
 
 Refresh the Smart Answer in your browser to see this new content.
 
-Read more about [landing page templates](landing-page-template.md).
+Read more about [landing page templates](/doc/smart-answers/erb-templates/landing-page-template.md).
 
 Click "Start now" to visit the first question. You should see an error message indicating that we're now missing an ERB template for our question.
 

--- a/doc/smart-answer-flow-development/creating-a-new-smart-answer.md
+++ b/doc/smart-answer-flow-development/creating-a-new-smart-answer.md
@@ -123,7 +123,7 @@ Open the new outcome page template in your editor and copy/paste the following c
 
 Refresh the Smart Answer in your browser to see this new content.
 
-Read more about [outcome page templates](outcome-templates.md).
+Read more about [outcome page templates](/doc/smart-answers/erb-templates/outcome-templates.md).
 
 And that's all there is to an incredibly simple Smart Answer.
 

--- a/doc/smart-answer-flow-development/creating-a-new-smart-answer.md
+++ b/doc/smart-answer-flow-development/creating-a-new-smart-answer.md
@@ -92,7 +92,7 @@ Open the new question page template in your editor and copy/paste the following 
 
 Refresh the Smart Answer in your browser to see this new content.
 
-Read more about [question page templates](question-templates.md).
+Read more about [question page templates](/doc/smart-answers/erb-templates/question-templates.md).
 
 Enter any value in the text field and click "Next step". You should see an error message indicating that we're now missing an ERB template for the outcome.
 

--- a/doc/smart-answers-app-development/testing.md
+++ b/doc/smart-answers-app-development/testing.md
@@ -42,12 +42,6 @@ When we built the [part-year-profit-tax-credits][3], we adopted the following st
   * This checks that the flow and its component parts are wired up correctly.
   * It doesn't aim for 100% coverage, but just enough to exercise each node at least once.
 
-### Regression tests
-
-* None - we felt that the other tests gave sufficient coverage.
-
-Note: The `part-year-profit-tax-credits` flow was relatively content-light. It remains to be seen how we would go about testing a more content-heavy flow e.g. `marriage-abroad`. However, I still doubt we'll want any tests as brittle or comprehensive as the current regression tests.
-
 ## Old style
 
 We previously had to use nested contexts to write integration tests around Smart Answers. This lead to deeply nested, hard to follow tests. We've removed the code that required this style and should no longer be writing these deeply nested tests.
@@ -55,8 +49,8 @@ We previously had to use nested contexts to write integration tests around Smart
 * Flows that have a calculator also tend to have a unit test for that calculator.
 * When we started doing significant refactoring of the app, we weren't happy that we had sufficient test coverage to support this work.
 * Notably none of the tests actually *rendered* the question or outcome pages.
-* So at this point we introduced the [regression tests](regression-tests.md) as a relatively quick way to improve the test coverage.
-* However, the intention has always been that these regression tests are only a temporary measure.
+* We introduced the regression tests as a relatively quick way to improve the test coverage.
+* The regression tests are only a temporary measure to help with the refactoring and have now been removed.
 
 Here's an example Smart Answer flow and how the two approaches to testing differ:
 
@@ -155,20 +149,6 @@ context "when answering question 1" do
   end
 end
 ```
-
-## Regression tests
-
-See [regression tests documentation](regression-tests.md).
-
-### Adding regression tests to Smart Answers
-
-We're not imagining introducing new regression tests but I think [these instructions](adding-new-regression-tests.md) are still useful while we still have them in the project.
-
-### Removing regression tests
-
-The regression tests were never thought of as a long term part of the project. We added them to give us confidence to make larger changes to the system.
-
-The plan has always been to refactor the existing Smart Answers so that they're easier to test using more traditional techniques. You can hopefully see a good example of this in the way we're testing the `part-year-profit-tax-credits` Smart Answer, where we didn't add any regression tests because we were confident in the unit and integration tests that we created.
 
 [Test Pyramid]: http://martinfowler.com/bliki/TestPyramid.html
 [0]: https://github.com/alphagov/smart-answers/blob/master/lib/smart_answer_flows/calculate-your-child-maintenance.rb

--- a/doc/smart-answers/flow-definition.md
+++ b/doc/smart-answers/flow-definition.md
@@ -81,7 +81,7 @@ Some flows (e.g. [register-a-birth][local-variable-in-flow-definition]) define l
 
 Every flow has an implicit start node which represents the "landing page" i.e. the page which displays the "Start" button. There is no representation of this start node in the flow definition. Clicking the "Start" button on the "landing page" takes you to the page for the first question node (see below).
 
-Also see the documentation for [landing page templates](landing-page-template.md).
+Also see the documentation for [landing page templates](/doc/smart-answers/erb-templates/landing-page-template.md).
 
 ### Question nodes
 

--- a/doc/smart-answers/flow-definition.md
+++ b/doc/smart-answers/flow-definition.md
@@ -278,7 +278,7 @@ Each of these block types and the point at which they are executed is explained 
   1. A `SmartAnswer::InvalidResponse` exception is raised with the `message_key` set as the exception message.
   2. This exception is handled within the app and prevents the transition to the next node.
   3. The `message_key` from the exception message is set on the built-in state variable, `error`.
-  4. When the question template is re-rendered, the `error` state variable is used to lookup the appropriate validation error message in the [question template](question-templates.md#error_messagemessage).
+  4. When the question template is re-rendered, the `error` state variable is used to lookup the appropriate validation error message in the [question template](/doc/smart-answers/erb-templates/question-templates.md#error_messagemessage).
 
 > The use of these blocks is encouraged. However, they should call `valid_xxx?` methods on the `calculator` state variable and not rely on the `response` argument passed into the block.
 
@@ -328,7 +328,7 @@ See the [documentation on storing data](storing-data.md).
 
 #### Templates
 
-See the [documentation for question templates](question-templates.md).
+See the [documentation for question templates](/doc/smart-answers/erb-templates/question-templates.md).
 
 ### Outcome nodes
 

--- a/doc/smart-answers/flow-definition.md
+++ b/doc/smart-answers/flow-definition.md
@@ -346,10 +346,10 @@ If any attempt is made to process a response when the current node is an outcome
 
 See the [documentation for outcome templates](/doc/smart-answers/erb-templates/outcome-templates.md).
 
-[instance-eval]: http://ruby-doc.org/core-2.3.0/BasicObject.html#method-i-instance_eval
-[instance-exec]: http://ruby-doc.org/core-2.3.0/BasicObject.html#method-i-instance_exec
-[method-missing]: http://ruby-doc.org/core-2.3.0/BasicObject.html#method-i-method_missing
-[object-dup]: http://ruby-doc.org/core-2.3.0/Object.html#method-i-dup
+[instance-eval]: http://ruby-doc.org/core-2.6.1/BasicObject.html#method-i-instance_eval
+[instance-exec]: http://ruby-doc.org/core-2.6.1/BasicObject.html#method-i-instance_exec
+[method-missing]: http://ruby-doc.org/core-2.6.1/BasicObject.html#method-i-method_missing
+[object-dup]: http://ruby-doc.org/core-2.6.0/Object.html#method-i-dup
 [local-variable-in-flow-definition]: https://github.com/alphagov/smart-answers/blob/20d2d9f524e912a3edcb9256ce2d790059538641/lib/smart_answer_flows/register-a-birth.rb#L9-L12
 [introduction-of-on-response-blocks]: https://github.com/alphagov/smart-answers/pull/2408
 [flow-registry]: https://github.com/alphagov/smart-answers/blob/cc6c5050bb78d0085cffe0a40630784724aa062a/lib/smart_answer/flow_registry.rb

--- a/doc/smart-answers/flow-definition.md
+++ b/doc/smart-answers/flow-definition.md
@@ -344,7 +344,7 @@ If any attempt is made to process a response when the current node is an outcome
 
 #### Templates
 
-See the [documentation for outcome templates](outcome-templates.md).
+See the [documentation for outcome templates](/doc/smart-answers/erb-templates/outcome-templates.md).
 
 [instance-eval]: http://ruby-doc.org/core-2.3.0/BasicObject.html#method-i-instance_eval
 [instance-exec]: http://ruby-doc.org/core-2.3.0/BasicObject.html#method-i-instance_exec


### PR DESCRIPTION
Remove links to now outdated and deleted documentation as well as retired and archived trello board.
Fix some links that were pointing to the wrong directory.
Update the link to Jenkins run rake task to include params so they are pre-filled in Jenkins.
Delete some references to regression tests.