### PR TITLE
Austria - Opposite sex civil partnership

### DIFF
--- a/lib/data/marriage_abroad_services.yml
+++ b/lib/data/marriage_abroad_services.yml
@@ -263,12 +263,12 @@ austria:
   opposite_sex:
     ceremony_country:
       default:
-      - :receiving_notice_of_marriage
+      - :receiving_notice_of_marriage_or_civil_partnership
       - :issuing_cni_or_nulla_osta
   same_sex:
     default:
       default:
-      - :receiving_notice_of_marriage
+      - :receiving_notice_of_marriage_or_civil_partnership
       - :issuing_cni_or_nulla_osta
   payment_partial_name: pay_by_visa_masterdcard_sometimes_cash_or_friends_card
 azerbaijan:

--- a/lib/data/rates/marriage_abroad_consular_fees.yml
+++ b/lib/data/rates/marriage_abroad_consular_fees.yml
@@ -23,6 +23,7 @@
   issuing_marriage_certificate: 50
   receiving_notice_of_marriage: 50
   receiving_notice_of_civil_partnership: 50
+  receiving_notice_of_marriage_or_civil_partnership: 50
   receiving_notice_of_registration: 50
   registering_civil_partnership: 150
   registering_civil_partnership_or_marriage: 150

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/_consular_fees_table_items.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/_consular_fees_table_items.govspeak.erb
@@ -9,6 +9,8 @@ Service | Fee
   Receiving a notice of civil partnership | <%= format_money calculator.consular_fee(:receiving_notice_of_civil_partnership) %>
 <% when :receiving_notice_of_marriage %>
   Receiving a notice of marriage | <%= format_money calculator.consular_fee(:receiving_notice_of_marriage) %>
+<% when :receiving_notice_of_marriage_or_civil_partnership %>
+  Receiving a notice of marriage or civil partnership | <%= format_money calculator.consular_fee(:receiving_notice_of_marriage_or_civil_partnership) %>
 <% when :issuing_custom_and_law_certificate %>
   Issuing a certificate of custom and law | <%= format_money calculator.consular_fee(:issuing_custom_and_law_certificate) %>
 <% when :issuing_cni_or_nulla_osta %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/_title.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/_title.govspeak.erb
@@ -1,5 +1,5 @@
 <% if calculator.partner_is_same_sex? %>
   Civil partnership and same-sex marriage in Austria
 <% else %>
-  Marriage in Austria
+  Marriage and civil partnership in Austria
 <% end %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/ceremony_country/partner_british/_opposite_sex.erb
@@ -1,14 +1,18 @@
-Contact the relevant local authorities in Austria to find out about local marriage laws, including what documents you’ll need.
+You can get married or enter into a civil partnership in Austria.
+
+Civil partnerships are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’ in Austria. Opposite-sex civil partnerships aren’t recognised in the UK.
+
+Contact the relevant local authorities in Austria to find out about local civil partnership and marriage laws, including what documents you’ll need.
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
 
 ##What you need to do
 
-You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
+You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry or enter into a civil partnership or equivalent in Austria.
 
-To get a CNI, you must post notice of your intended marriage in Austria. You can do this at the British embassy or in front of a notary public.
+To get a CNI, you must post notice of your intention to get married or enter into a civil partnership in Austria. You can do this at the British embassy or in front of a notary public.
 
-You’ll need to have been living in Austria for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
+You’ll need to have been living in Austria for at least 3 full days before you can post notice. For example, if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 [Make an appointment at the embassy in Vienna.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-vienna/notice-of-marriage-or-civil-partnership/slot_picker)
 
@@ -18,13 +22,15 @@ You’ll need to provide supporting documents, including:
 - proof of residence, such as a residence certificate - check with the embassy or notary public to find out what you need
 - equivalent documents for your partner
 
-You’ll need to complete a [‘Notice of marriage’](/government/publications/notice-of-marriage-form--2) form and an [‘Affidavit for marriage’](/government/publications/affirmationaffidavit-of-marital-status-form) form.
+To post notice for marriage you'll need to complete a ['Notice of marriage'](https://www.gov.uk/government/publications/notice-of-marriage-form--2) and an ['Affidavit for marriage’](https://www.gov.uk/government/publications/affirmationaffidavit-of-marital-status-form) form.
+
+To post notice for a civil partnership you'll need to complete both the ['declaration' and 'notice of registered partnership' forms](https://www.gov.uk/government/publications/getting-married-in-austria-civil-partnership-forms).
 
 You can download and fill in (but not sign) the forms in advance.
 
 You must take the forms with you to your appointment.
 
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage or civil partnership to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
 
 ^Your partner will need to follow the same process and pay the fees to get their own CNI.^
 
@@ -44,9 +50,9 @@ If you give notice at a notary public, you must post the signed forms and any su
 
 ^The embassy or consulate may charge a fee to return your documents to you.^
 
-The consulate will display your notice of marriage publicly for 7 days.
+The consulate will display your notice of marriage or civil partnership publicly for 7 days.
 
-They’ll then send all of your documentation to the British embassy or consulate nearest to where you’re getting married in Austria, who will issue your CNI (as long as nobody has registered an objection).
+They’ll then issue your CNI (as long as nobody has registered an objection) and send it to the British embassy or consulate nearest to where you’re getting married or having a civil partnership ceremony in Austria.
 
 There’s an additional fee for this - the embassy or consulate will contact you to arrange payment.
 
@@ -66,6 +72,3 @@ You normally have to pay fees for consular services in the local currency - thes
 <%= render partial: 'how_to_pay.govspeak.erb', locals: {calculator: calculator} %>
 
 *[CNI]:certificate of no impediment
-
-
-

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/ceremony_country/partner_local/_opposite_sex.erb
@@ -1,14 +1,18 @@
-Contact the relevant local authorities in Austria to find out about local marriage laws, including what documents you’ll need.
+You can get married or enter into a civil partnership in Austria.
+
+Civil partnerships are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’ in Austria. Opposite-sex civil partnerships aren’t recognised in the UK.
+
+Contact the relevant local authorities in Austria to find out about local civil partnership and marriage laws, including what documents you’ll need.
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
 
 ##What you need to do
 
-You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
+You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry or enter into a civil partnership or equivalent in Austria.
 
-To get a CNI, you must post notice of your intended marriage in Austria. You can do this at the British embassy or in front of a notary public.
+To get a CNI, you must post notice of your intention to get married or enter into a civil partnership in Austria. You can do this at the British embassy or in front of a notary public.
 
-You’ll need to have been living in Austria for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
+You’ll need to have been living in Austria for at least 3 full days before you can post notice. For example, if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 [Make an appointment at the embassy in Vienna.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-vienna/notice-of-marriage-or-civil-partnership/slot_picker)
 
@@ -18,13 +22,15 @@ You’ll need to provide supporting documents, including:
 - proof of residence, such as a residence certificate - check with the embassy or notary public to find out what you need
 - equivalent documents for your partner
 
-You’ll need to complete a [‘Notice of marriage’](/government/publications/notice-of-marriage-form--2) form and an [‘Affidavit for marriage’](/government/publications/affirmationaffidavit-of-marital-status-form) form.
+To post notice for marriage you'll need to complete a ['Notice of marriage'](https://www.gov.uk/government/publications/notice-of-marriage-form--2) and an ['Affidavit for marriage’](https://www.gov.uk/government/publications/affirmationaffidavit-of-marital-status-form) form.
+
+To post notice for a civil partnership you'll need to complete both the ['declaration' and 'notice of registered partnership' forms](https://www.gov.uk/government/publications/getting-married-in-austria-civil-partnership-forms).
 
 You can download and fill in (but not sign) the forms in advance.
 
 You must take the forms with you to your appointment.
 
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage or civil partnership to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
 
 If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
 
@@ -42,9 +48,9 @@ If you give notice at a notary public, you must post the signed forms and any su
 
 ^The embassy or consulate may charge a fee to return your documents to you.^
 
-The consulate will display your notice of marriage publicly for 7 days.
+The consulate will display your notice of marriage or civil partnership publicly for 7 days.
 
-They’ll then send all of your documentation to the British embassy or consulate nearest to where you’re getting married in Austria, who will issue your CNI (as long as nobody has registered an objection).
+They’ll then issue your CNI (as long as nobody has registered an objection) and send it to the British embassy or consulate nearest to where you’re getting married or having a civil partnership ceremony in Austria.
 
 There’s an additional fee for this - the embassy or consulate will contact you to arrange payment.
 
@@ -54,7 +60,11 @@ You should check if your CNI needs to be legalised (certified as genuine) by the
 
 ##Naturalisation of your partner if they move to the UK
 
-Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
+Your partner can apply to become a British citizen once they’ve lived in the UK for 3 years after getting married.
+
+Opposite sex civil partnerships are not legally recognised in the UK.
+
+[Check if you can become a British citizen](/british-citizenship).
 
 ## Fees
 
@@ -68,6 +78,3 @@ You normally have to pay fees for consular services in the local currency - thes
 <%= render partial: 'how_to_pay.govspeak.erb', locals: {calculator: calculator} %>
 
 *[CNI]:certificate of no impediment
-
-
-

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/ceremony_country/partner_other/_opposite_sex.erb
@@ -1,14 +1,18 @@
-Contact the relevant local authorities in Austria to find out about local marriage laws, including what documents you’ll need.
+You can get married or enter into a civil partnership in Austria.
+
+Civil partnerships are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’ in Austria. Opposite-sex civil partnerships aren’t recognised in the UK.
+
+Contact the relevant local authorities in Austria to find out about local civil partnership and marriage laws, including what documents you’ll need.
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
 
 ##What you need to do
 
-You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
+You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry or enter into a civil partnership or equivalent in Austria.
 
-To get a CNI, you must post notice of your intended marriage in Austria. You can do this at the British embassy or in front of a notary public.
+To get a CNI, you must post notice of your intention to get married or enter into a civil partnership in Austria. You can do this at the British embassy or in front of a notary public.
 
-You’ll need to have been living in Austria for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
+You’ll need to have been living in Austria for at least 3 full days before you can post notice. For example, if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
 [Make an appointment at the embassy in Vienna.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-vienna/notice-of-marriage-or-civil-partnership/slot_picker)
 
@@ -18,13 +22,15 @@ You’ll need to provide supporting documents, including:
 - proof of residence, such as a residence certificate - check with the embassy or notary public to find out what you need
 - equivalent documents for your partner
 
-You’ll need to complete a [‘Notice of marriage’](/government/publications/notice-of-marriage-form--2) form and an [‘Affidavit for marriage’](/government/publications/affirmationaffidavit-of-marital-status-form) form.
+To post notice for marriage you'll need to complete a ['Notice of marriage'](https://www.gov.uk/government/publications/notice-of-marriage-form--2) and an ['Affidavit for marriage’](https://www.gov.uk/government/publications/affirmationaffidavit-of-marital-status-form) form.
+
+To post notice for a civil partnership you'll need to complete both the ['declaration' and 'notice of registered partnership' forms](https://www.gov.uk/government/publications/getting-married-in-austria-civil-partnership-forms).
 
 You can download and fill in (but not sign) the forms in advance.
 
 You must take the forms with you to your appointment.
 
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage or civil partnership to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
 
 If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
 
@@ -42,9 +48,9 @@ If you give notice at a notary public, you must post the signed forms and any su
 
 ^The embassy or consulate may charge a fee to return your documents to you.^
 
-The consulate will display your notice of marriage publicly for 7 days.
+The consulate will display your notice of marriage or civil partnership publicly for 7 days.
 
-They’ll then send all of your documentation to the British embassy or consulate nearest to where you’re getting married in Austria, who will issue your CNI (as long as nobody has registered an objection).
+They’ll then issue your CNI (as long as nobody has registered an objection) and send it to the British embassy or consulate nearest to where you’re getting married or having a civil partnership ceremony in Austria.
 
 There’s an additional fee for this - the embassy or consulate will contact you to arrange payment.
 
@@ -54,7 +60,11 @@ You should check if your CNI needs to be legalised (certified as genuine) by the
 
 ##Naturalisation of your partner if they move to the UK
 
-Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
+Your partner can apply to become a British citizen once they’ve lived in the UK for 3 years after getting married.
+
+Opposite sex civil partnerships are not legally recognised in the UK.
+
+[Check if you can become a British citizen](/british-citizenship).
 
 ## Fees
 
@@ -68,6 +78,3 @@ You normally have to pay fees for consular services in the local currency - thes
 <%= render partial: 'how_to_pay.govspeak.erb', locals: {calculator: calculator} %>
 
 *[CNI]:certificate of no impediment
-
-
-

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/third_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/third_country/partner_british/_opposite_sex.erb
@@ -1,15 +1,23 @@
-Contact the relevant local authorities in Austria to find out about local marriage laws, including what documents you’ll need.
+You can get married or enter into a civil partnership in Austria. 
+
+Civil partnerships are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’ in Austria. Opposite-sex civil partnerships aren’t recognised in the UK.
+
+Contact the relevant local authorities in Austria to find out about local civil partnership and marriage laws, including what documents you’ll need.
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Austria](/foreign-travel-advice/austria) before making any plans.
 
 ##What you need to do
 
-You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
+You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry or enter into a civil partnership.
 
-There are 2 ways you can get a CNI:
+There are 2 ways you can get a CNI for marriage in Austria:
 
-- [go to the UK and post notice with a UK registrar](/marriage-abroad/y/austria/uk/partner_british/opposite_sex)
-- [go to Austria and post notice at the embassy or consulate there](/marriage-abroad/y/austria/ceremony_country/partner_british/opposite_sex)
++ [go to the UK and post notice with a UK registrar](https://www.gov.uk/marriage-abroad/y/austria/uk/partner_british/opposite_sex)
++ [go to Austria and post notice at the embassy or consulate there](https://www.gov.uk/marriage-abroad/y/austria/ceremony_country/partner_british/opposite_sex)  
+
+To get a CNI for a civil partnership you must:
+
++ [go to Austria and post notice at the embassy or consulate there](https://www.gov.uk/marriage-abroad/y/austria/ceremony_country/partner_british/opposite_sex)
 
 %If you choose to post notice, you’ll normally have to wait at least 13 days for your CNI. It can take longer depending on the local authorities’ processes and the time of year.%
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/third_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/third_country/partner_local/_opposite_sex.erb
@@ -1,17 +1,33 @@
-Contact the relevant local authorities in Austria to find out about local marriage laws, including what documents you’ll need.
+You can get married or enter into a civil partnership in Austria. 
+
+Civil partnerships are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’ in Austria. Opposite-sex civil partnerships aren’t recognised in the UK.
+
+Contact the relevant local authorities in Austria to find out about local civil partnership and marriage laws, including what documents you’ll need.
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Austria](/foreign-travel-advice/austria) before making any plans.
 
 ##What you need to do
 
-You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
+You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry or enter into a civil partnership.
 
-There are 2 ways you can get a CNI:
+There are 2 ways you can get a CNI for marriage in Austria:
 
-- [go to the UK and post notice with a UK registrar](/marriage-abroad/y/austria/uk/partner_local/opposite_sex)
-- [go to Austria and post notice at the embassy or consulate there](/marriage-abroad/y/austria/ceremony_country/partner_local/opposite_sex)
++ [go to the UK and post notice with a UK registrar](https://www.gov.uk/marriage-abroad/y/austria/uk/partner_british/opposite_sex)
++ [go to Austria and post notice at the embassy or consulate there](https://www.gov.uk/marriage-abroad/y/austria/ceremony_country/partner_british/opposite_sex)  
+
+To get a CNI for a civil partnership you must:
+
++ [go to Austria and post notice at the embassy or consulate there](https://www.gov.uk/marriage-abroad/y/austria/ceremony_country/partner_british/opposite_sex)
 
 %If you choose to post notice, you’ll normally have to wait at least 13 days for your CNI. It can take longer depending on the local authorities’ processes and the time of year.%
+
+##Naturalisation of your partner if they move to the UK
+
+Your partner can apply to become a British citizen once they’ve lived in the UK for 3 years after getting married.
+
+Opposite sex civil partnerships are not legally recognised in the UK.
+
+[Check if you can become a British citizen](/british-citizenship). 
 
 *[CNI]:Certificate of no impediment
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/third_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/third_country/partner_other/_opposite_sex.erb
@@ -1,17 +1,33 @@
-Contact the relevant local authorities in Austria to find out about local marriage laws, including what documents you’ll need.
+You can get married or enter into a civil partnership in Austria. 
+
+Civil partnerships are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’ in Austria. Opposite-sex civil partnerships aren’t recognised in the UK.
+
+Contact the relevant local authorities in Austria to find out about local civil partnership and marriage laws, including what documents you’ll need.
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Austria](/foreign-travel-advice/austria) before making any plans.
 
 ##What you need to do
 
-You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
+You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry or enter into a civil partnership.
 
-There are 2 ways you can get a CNI:
+There are 2 ways you can get a CNI for marriage in Austria:
 
-- [go to the UK and post notice with a UK registrar](/marriage-abroad/y/austria/uk/partner_other/opposite_sex)
-- [go to Austria and post notice at the embassy or consulate there](/marriage-abroad/y/austria/ceremony_country/partner_other/opposite_sex)
++ [go to the UK and post notice with a UK registrar](https://www.gov.uk/marriage-abroad/y/austria/uk/partner_british/opposite_sex)
++ [go to Austria and post notice at the embassy or consulate there](https://www.gov.uk/marriage-abroad/y/austria/ceremony_country/partner_british/opposite_sex)  
+
+To get a CNI for a civil partnership you must:
+
++ [go to Austria and post notice at the embassy or consulate there](https://www.gov.uk/marriage-abroad/y/austria/ceremony_country/partner_british/opposite_sex)
 
 %If you choose to post notice, you’ll normally have to wait at least 13 days for your CNI. It can take longer depending on the local authorities’ processes and the time of year.%
+
+##Naturalisation of your partner if they move to the UK
+
+Your partner can apply to become a British citizen once they’ve lived in the UK for 3 years after getting married.
+
+Opposite sex civil partnerships are not legally recognised in the UK.
+
+[Check if you can become a British citizen](/british-citizenship). 
 
 *[CNI]:Certificate of no impediment
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/uk/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/uk/partner_british/_opposite_sex.erb
@@ -1,8 +1,14 @@
-Contact the [Embassy of Austria](/government/publications/foreign-embassies-in-the-uk) before making any plans to find out about local marriage laws, including what documents you’ll need.
+You can get married or enter into a civil partnership in Austria. 
+
+Civil partnerships are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’ in Austria. Opposite-sex civil partnerships aren’t recognised in the UK.
+
+Contact the [Embassy of Austria](https://www.gov.uk/government/publications/foreign-embassies-in-the-uk) before making plans to find out about local marriage and civil partnership laws, including what documents you’ll need. 
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Austria](/foreign-travel-advice/austria) before making any plans.
 
-##What you need to do
+##Getting married
+
+###What you need to do
 
 You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
 
@@ -20,6 +26,12 @@ You should also check if it needs to be:
 - translated - [find a translator abroad](/government/collections/list-of-lawyers), or in the UK through the [Institute of Linguists](http://www.ciol.org.uk)
 
 You should also check with the local authorities in Austria to find out if you need to provide legalised and translated copies of any other documents.
+
+##Getting a civil partnership
+
+###What you need to do
+
+To get a CNI for a civil partnership you must [go to Austria and post notice at the embassy or consulate there](https://www.gov.uk/marriage-abroad/y/austria/ceremony_country/partner_british/opposite_sex).
 
 %The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/uk/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/uk/partner_local/_opposite_sex.erb
@@ -1,8 +1,14 @@
-Contact the [Embassy of Austria](/government/publications/foreign-embassies-in-the-uk) before making any plans to find out about local marriage laws, including what documents you’ll need.
+You can get married or enter into a civil partnership in Austria. 
+
+Civil partnerships are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’ in Austria. Opposite-sex civil partnerships aren’t recognised in the UK.
+
+Contact the [Embassy of Austria](https://www.gov.uk/government/publications/foreign-embassies-in-the-uk) before making plans to find out about local marriage and civil partnership laws, including what documents you’ll need. 
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Austria](/foreign-travel-advice/austria) before making any plans.
 
-##What you need to do
+##Getting married
+
+###What you need to do
 
 You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
 
@@ -21,11 +27,21 @@ You should also check if it needs to be:
 
 You should also check with the local authorities in Austria to find out if you need to provide legalised and translated copies of any other documents.
 
+##Getting a civil partnership
+
+###What you need to do
+
+To get a CNI for a civil partnership you must [go to Austria and post notice at the embassy or consulate there](https://www.gov.uk/marriage-abroad/y/austria/ceremony_country/partner_british/opposite_sex).
+
 %The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
 
 ##Naturalisation of your partner if they move to the UK
 
-Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
+Your partner can apply to become a British citizen once they’ve lived in the UK for 3 years after getting married.
+
+Opposite sex civil partnerships are not legally recognised in the UK.
+
+[Check if you can become a British citizen](/british-citizenship).
 
 *[CNI]:certificate of no impediment
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/uk/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/uk/partner_other/_opposite_sex.erb
@@ -1,8 +1,14 @@
-Contact the [Embassy of Austria](/government/publications/foreign-embassies-in-the-uk) before making any plans to find out about local marriage laws, including what documents you’ll need.
+You can get married or enter into a civil partnership in Austria. 
+
+Civil partnerships are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’ in Austria. Opposite-sex civil partnerships aren’t recognised in the UK.
+
+Contact the [Embassy of Austria](https://www.gov.uk/government/publications/foreign-embassies-in-the-uk) before making plans to find out about local marriage and civil partnership laws, including what documents you’ll need. 
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Austria](/foreign-travel-advice/austria) before making any plans.
 
-##What you need to do
+##Getting married
+
+###What you need to do
 
 You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
 
@@ -23,9 +29,19 @@ You should also check with the local authorities in Austria to find out if you n
 
 %The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
 
+##Getting a civil partnership
+
+###What you need to do
+
+To get a CNI for a civil partnership you must [go to Austria and post notice at the embassy or consulate there](https://www.gov.uk/marriage-abroad/y/austria/ceremony_country/partner_british/opposite_sex).
+
 ##Naturalisation of your partner if they move to the UK
 
-Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
+Your partner can apply to become a British citizen once they’ve lived in the UK for 3 years after getting married.
+
+Opposite sex civil partnerships are not legally recognised in the UK.
+
+[Check if you can become a British citizen](/british-citizenship).
 
 *[CNI]:certificate of no impediment
 


### PR DESCRIPTION
https://trello.com/c/uKmuTan2/2000-getting-married-abroad-opposite-sex-civil-partnership-in-austria

Civil partnerships are now legal in Austria so I updated 9 outcomes to reflect this change. For example, outcomes include civil partnership info, links to 'post notice' civil partnership forms and updates to naturalisation info. 