### PR TITLE
Add 2019/2020 rates for statutory sick pay

### DIFF
--- a/lib/data/rates/statutory_sick_pay.yml
+++ b/lib/data/rates/statutory_sick_pay.yml
@@ -38,3 +38,8 @@
   end_date: 2019-04-05
   lower_earning_limit_rate: 116
   ssp_weekly_rate: 92.05
+
+- start_date: 2019-04-06
+  end_date: 2020-04-05
+  lower_earning_limit_rate: 118
+  ssp_weekly_rate: 94.25

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/entitled_to_sick_pay.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/entitled_to_sick_pay.govspeak.erb
@@ -18,8 +18,7 @@
   ##What you need to know
 
   <% if calculator.paternity_maternity_warning? %>
-    ^ Your employee will not be able to collect Statutory Paternity Pay or Statutory Adoption Pay while collecting Statutory Sick Pay. ^
-
+    ^ Your employee will not be able to collect Statutory Shared Parental Pay, Statutory Paternity Pay or Statutory Adoption Pay while collecting Statutory Sick Pay. ^
   <% end %>
 
   SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of <%= pattern_days_total %> days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. <% if calculator.enough_notice_of_absence %>They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).<% end %>

--- a/test/unit/calculators/statutory_sick_pay_calculator_test.rb
+++ b/test/unit/calculators/statutory_sick_pay_calculator_test.rb
@@ -794,6 +794,17 @@ module SmartAnswer
           end
         end
 
+        context "in the beginning of 2019/2020" do
+          setup do
+            @date = Date.parse("6 April 2019")
+            @lel = StatutorySickPayCalculator.lower_earning_limit_on(@date)
+          end
+
+          should "be 118" do
+            assert_equal 118.00, @lel
+          end
+        end
+
         context "fallback when no dates are matching" do
           should "not break and use the rate of the latest available fiscal year" do
             date = Date.parse("6 April 2056")
@@ -903,6 +914,19 @@ module SmartAnswer
           )
 
           assert_equal 92.05, calculator.ssp_payment.to_f
+        end
+
+        should "have the correct 2019/2020 value" do
+          calculator = StatutorySickPayCalculator.new(
+            sick_start_date: Date.parse("3 June 2019"),
+            sick_end_date: Date.parse("7 June 2019"),
+            days_of_the_week_worked: %w(1 2 3 4 5),
+            has_linked_sickness: true,
+            linked_sickness_start_date: Date.parse("Fri, 21 Sep 2018"),
+            linked_sickness_end_date: Date.parse("Fri, 28 Dec 2018")
+          )
+
+          assert_equal 94.25, calculator.ssp_payment.to_f
         end
       end
 


### PR DESCRIPTION
This adds the new statutory sick pay rates for 2019/2020.

[Trello Card](https://trello.com/c/gB9Wioj8/830-uprating-calculate-your-employees-statutory-sick-pay)