### PR TITLE
Married couples allowance 2019/20 uprating

### DIFF
--- a/lib/data/rates/married_couples_allowance.yml
+++ b/lib/data/rates/married_couples_allowance.yml
@@ -26,5 +26,10 @@
 
 - start_date: 2018-04-06
   end_date: 2019-04-05
-  maximum_married_couple_allowance: 8445
+  maximum_married_couple_allowance: 8695
   minimum_married_couple_allowance: 3360
+
+- start_date: 2019-04-06
+  end_date: 2020-04-05
+  maximum_married_couple_allowance: 8915
+  minimum_married_couple_allowance: 3450

--- a/lib/data/rates/personal_allowance.yml
+++ b/lib/data/rates/personal_allowance.yml
@@ -33,3 +33,17 @@
   higher_allowance_1: 11000
   higher_allowance_2: 11000
   income_limit_for_personal_allowances: 28000.0
+
+- start_date: 2018-04-06
+  end_date: 2019-04-05
+  personal_allowance: 11850
+  higher_allowance_1: 11850
+  higher_allowance_2: 11850
+  income_limit_for_personal_allowances: 28900.0
+
+- start_date: 2019-04-06
+  end_date: 2020-04-05
+  personal_allowance: 12500
+  higher_allowance_1: 12500
+  higher_allowance_2: 12500
+  income_limit_for_personal_allowances: 29600.0

--- a/test/unit/calculators/married_couple_allowance_calculator_test.rb
+++ b/test/unit/calculators/married_couple_allowance_calculator_test.rb
@@ -166,5 +166,27 @@ module SmartAnswer::Calculators
         assert_equal 3260, calculator.minimum_mca
       end
     end
+
+    test "rate values for 2018/19" do
+      Timecop.freeze(Date.parse("2018-06-01")) do
+        calculator = MarriedCouplesAllowanceCalculator.new
+
+        assert_equal 11850, calculator.personal_allowance
+        assert_equal 28900.0, calculator.income_limit_for_personal_allowances
+        assert_equal 8695, calculator.maximum_mca
+        assert_equal 3360, calculator.minimum_mca
+      end
+    end
+
+    test "rate values for 2019/20" do
+      Timecop.freeze(Date.parse("2019-06-01")) do
+        calculator = MarriedCouplesAllowanceCalculator.new
+
+        assert_equal 12500, calculator.personal_allowance
+        assert_equal 29600.0, calculator.income_limit_for_personal_allowances
+        assert_equal 8915, calculator.maximum_mca
+        assert_equal 3450, calculator.minimum_mca
+      end
+    end
   end
 end


### PR DESCRIPTION
Includes some missing numbers for 2018/19.

With system clock set to now:
<img width="696" alt="Screen Shot 2019-03-12 at 15 24 38" src="https://user-images.githubusercontent.com/109225/54213459-56b97780-44dc-11e9-8055-5417e67ed02b.png">
<img width="650" alt="Screen Shot 2019-03-12 at 15 25 39" src="https://user-images.githubusercontent.com/109225/54213471-5c16c200-44dc-11e9-8b5c-d1bb2f96d7a8.png">

With system clock set to 6th April:
<img width="655" alt="Screen Shot 2019-04-06 at 15 27 42" src="https://user-images.githubusercontent.com/109225/54213511-6769ed80-44dc-11e9-9a78-117c9c36ed54.png">
<img width="692" alt="Screen Shot 2019-04-06 at 15 27 56" src="https://user-images.githubusercontent.com/109225/54213519-6a64de00-44dc-11e9-9c64-ef4b58698b2a.png">

https://trello.com/c/PjAwUlxD/452-uprating-married-couples-allowance-calculator