### PR TITLE
Add redundancy pay rates for 2019/2020

### DIFF
--- a/lib/data/rates/redundancy_pay.yml
+++ b/lib/data/rates/redundancy_pay.yml
@@ -27,3 +27,7 @@
   end_date: 2019-04-05
   max: "15,240"
   rate: 508
+- start_date: 2019-04-06
+  end_date: 2020-04-05
+  max: "15,750"
+  rate: 525

--- a/test/unit/calculators/redundancy_calculator_test.rb
+++ b/test/unit/calculators/redundancy_calculator_test.rb
@@ -29,6 +29,7 @@ module SmartAnswer::Calculators
         assert_equal 479, RedundancyCalculator.redundancy_rates(Date.new(2016, 4, 6)).rate
         assert_equal 489, RedundancyCalculator.redundancy_rates(Date.new(2017, 4, 6)).rate
         assert_equal 508, RedundancyCalculator.redundancy_rates(Date.new(2018, 4, 6)).rate
+        assert_equal 525, RedundancyCalculator.redundancy_rates(Date.new(2019, 4, 6)).rate
       end
 
       should "vary the max amount per year" do
@@ -41,7 +42,8 @@ module SmartAnswer::Calculators
         assert_equal "14,250", RedundancyCalculator.redundancy_rates(Date.new(2015, 4, 6)).max
         assert_equal "14,370", RedundancyCalculator.redundancy_rates(Date.new(2016, 4, 6)).max
         assert_equal "14,670", RedundancyCalculator.redundancy_rates(Date.new(2017, 4, 6)).max
-        assert_equal "15,240", RedundancyCalculator.redundancy_rates(Date.new(Date.today.year, 12, 31)).max
+        assert_equal "15,240", RedundancyCalculator.redundancy_rates(Date.new(2018, 4, 6)).max
+        assert_equal "15,750", RedundancyCalculator.redundancy_rates(Date.new(Date.today.year, 12, 31)).max
       end
 
       should "use the most recent rate for far future dates" do


### PR DESCRIPTION
This adds the new redundancy pay rates for 2019/2020.
<img width="979" alt="Screen Shot 2019-03-20 at 15 06 09" src="https://user-images.githubusercontent.com/38078064/54912450-92930a80-4ee8-11e9-8199-2b709170c5fc.png">
<img width="974" alt="Screen Shot 2019-03-20 at 15 07 09" src="https://user-images.githubusercontent.com/38078064/54912483-9e7ecc80-4ee8-11e9-823a-7ec2962f1dc0.png">

[Trello card](https://trello.com/c/ZL7TINmg/874-6-april-changes-to-2-redundancy-pay-calculators)