### PR TITLE
Implement new EEA travel rules

### DIFF
--- a/lib/smart_answer/calculators/uk_visa_calculator.rb
+++ b/lib/smart_answer/calculators/uk_visa_calculator.rb
@@ -41,6 +41,10 @@ module SmartAnswer::Calculators
       @passport_country == 'syria'
     end
 
+    def passport_country_is_ireland?
+      @passport_country == 'ireland'
+    end
+
     def passport_country_is_israel?
       @passport_country == 'israel'
     end

--- a/lib/smart_answer_flows/check-uk-visa.rb
+++ b/lib/smart_answer_flows/check-uk-visa.rb
@@ -292,19 +292,20 @@ module SmartAnswer
         end
       end
 
+      outcome :outcome_apply_for_european_temporary_leave_to_remain
       outcome :outcome_diplomatic_business
       outcome :outcome_joining_family_m
       outcome :outcome_joining_family_nvn
+      outcome :outcome_marriage_electronic_visa_waiver
       outcome :outcome_marriage_nvn_ukot
       outcome :outcome_marriage_taiwan
       outcome :outcome_marriage_visa_nat_datv
-      outcome :outcome_marriage_electronic_visa_waiver
       outcome :outcome_medical_n
       outcome :outcome_medical_y
       outcome :outcome_no_visa_needed
       outcome :outcome_partner_family_british_citizen_y
-      outcome :outcome_partner_family_eea_y
       outcome :outcome_partner_family_eea_n
+      outcome :outcome_partner_family_eea_y
       outcome :outcome_school_n
       outcome :outcome_school_waiver
       outcome :outcome_school_y
@@ -313,6 +314,7 @@ module SmartAnswer
       outcome :outcome_study_waiver
       outcome :outcome_study_waiver_taiwan
       outcome :outcome_study_y
+      outcome :outcome_tourism_visa_partner
       outcome :outcome_transit_leaving_airport
       outcome :outcome_transit_leaving_airport_datv
       outcome :outcome_transit_not_leaving_airport
@@ -321,7 +323,6 @@ module SmartAnswer
       outcome :outcome_transit_taiwan_through_border_control
       outcome :outcome_transit_to_the_republic_of_ireland
       outcome :outcome_transit_venezuela
-      outcome :outcome_tourism_visa_partner
       outcome :outcome_visit_waiver
       outcome :outcome_visit_waiver_taiwan
       outcome :outcome_work_m

--- a/lib/smart_answer_flows/check-uk-visa.rb
+++ b/lib/smart_answer_flows/check-uk-visa.rb
@@ -31,7 +31,11 @@ module SmartAnswer
           elsif calculator.passport_country_is_macao?
             question :what_sort_of_travel_document?
           elsif calculator.passport_country_in_eea?
-            outcome :outcome_no_visa_needed
+            if calculator.passport_country_is_ireland?
+              outcome :outcome_no_visa_needed
+            else
+              question :length_of_planned_stay?
+            end
           else
             question :purpose_of_visit?
           end
@@ -60,7 +64,7 @@ module SmartAnswer
         next_node do |response|
           case response
           when 'citizen'
-            outcome :outcome_no_visa_needed
+            question :length_of_planned_stay?
           when 'alien'
             if calculator.passport_country_is_estonia?
               calculator.passport_country = 'estonia-alien-passport'
@@ -83,6 +87,20 @@ module SmartAnswer
 
         next_node do |_|
           question :purpose_of_visit?
+        end
+      end
+
+      multiple_choice :length_of_planned_stay? do
+        option :three_months_or_less
+        option :longer_than_three_months
+
+        next_node do |response|
+          case response
+          when "three_months_or_less"
+            outcome :outcome_no_visa_needed_for_eea_citizens
+          when "longer_than_three_months"
+            outcome :outcome_apply_for_european_temporary_leave_to_remain
+          end
         end
       end
 
@@ -303,6 +321,7 @@ module SmartAnswer
       outcome :outcome_medical_n
       outcome :outcome_medical_y
       outcome :outcome_no_visa_needed
+      outcome :outcome_no_visa_needed_for_eea_citizens
       outcome :outcome_partner_family_british_citizen_y
       outcome :outcome_partner_family_eea_n
       outcome :outcome_partner_family_eea_y

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_apply_for_european_temporary_leave_to_remain.govspeak.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_apply_for_european_temporary_leave_to_remain.govspeak.erb
@@ -1,0 +1,10 @@
+<% content_for :title do %>
+  Within 3 months of arriving in the UK you must apply for European temporary leave to remain
+<% end %>
+
+<% content_for :body do %>
+  You cannot apply yet. You’ll be able to apply from 30 April 2019.
+
+  You can stay in the UK for 3 years if you have European temporary leave to remain.
+  You can work and study in the UK too.
+<% end %>

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_no_visa_needed.govspeak.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_no_visa_needed.govspeak.erb
@@ -3,11 +3,7 @@
 <% end %>
 
 <% content_for :body do %>
-
-  ^When the UK leaves the EU, the rules for how long you can stay without a visa may change. [Check if you need to act now](/guidance/visiting-the-uk-after-brexit) so you can travel as planned.
-
   <% if calculator.study_visit? %>
-
     However, you should bring documents with you to show at the border that you:
 
       - have been accepted on a course by an [accredited institution](/eligibility) or by a UK Higher Education Institution, for example, a letter of acceptance from the institution

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_no_visa_needed_for_eea_citizens.govspeak.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_no_visa_needed_for_eea_citizens.govspeak.erb
@@ -1,0 +1,10 @@
+<% content_for :title do %>
+  You do not need a visa to come to the UK
+<% end %>
+
+<% content_for :body do %>
+  You can stay in the UK for 3 months or less. You can work or study.
+
+  To stay for longer than 3 months you will need to apply for European temporary
+  leave to remain. You cannot apply yet. You’ll be able to apply from 30 April 2019.
+<% end %>

--- a/lib/smart_answer_flows/check-uk-visa/questions/length_of_planned_stay.govspeak.erb
+++ b/lib/smart_answer_flows/check-uk-visa/questions/length_of_planned_stay.govspeak.erb
@@ -1,0 +1,8 @@
+<% content_for :title do %>
+  How long are you planning to stay in the UK?
+<% end %>
+
+<% options(
+  "three_months_or_less": "3 months or less",
+  "longer_than_three_months": "longer than 3 months"
+) %>

--- a/test/integration/smart_answer_flows/check_uk_visa_test.rb
+++ b/test/integration/smart_answer_flows/check_uk_visa_test.rb
@@ -7,7 +7,34 @@ class CheckUkVisaTest < ActiveSupport::TestCase
   include FlowTestHelper
 
   setup do
-    @location_slugs = %w(andorra anguilla armenia bolivia canada china colombia croatia estonia hong-kong latvia macao mexico south-africa stateless-or-refugee syria turkey democratic-republic-of-the-congo oman united-arab-emirates qatar taiwan venezuela afghanistan yemen)
+    @location_slugs = %w(
+      afghanistan
+      andorra
+      anguilla
+      armenia
+      bolivia
+      canada
+      china
+      colombia
+      croatia
+      democratic-republic-of-the-congo
+      estonia
+      hong-kong
+      latvia
+      macao
+      mexico
+      oman
+      qatar
+      south-africa
+      stateless-or-refugee
+      syria
+      taiwan
+      turkey
+      united-arab-emirates
+      venezuela
+      yemen
+    )
+
     stub_world_locations(@location_slugs)
     setup_for_testing_flow SmartAnswer::CheckUkVisaFlow
   end


### PR DESCRIPTION
As per published guidance, these are the rules for travel to the UK from an EEA country if the UK is outside the EU at the time.

https://www.gov.uk/guidance/european-temporary-leave-to-remain-in-the-uk#who-will-need-to-apply

All EEA citizens can stay in the UK for up to and including 3 months without a visa.  Beyond that they will need a European Temporary Leave to Remain.

Republic of Ireland citizens do not need a visa even if staying in the UK longer than 3 months.

https://trello.com/c/VIhHyhO6/913-for-12-april-only-if-no-deal-check-if-you-need-a-visa-content-requests