### PR TITLE
Fix style issues throughout outcomes

### DIFF
--- a/lib/smart_answer_flows/towing-rules/outcomes/apply_for_provisional_bus.govspeak.erb
+++ b/lib/smart_answer_flows/towing-rules/outcomes/apply_for_provisional_bus.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :body do %>
-  You need to apply for provisional category D bus entitlement then pass a category D test. You can then tow trailers up to 750 kg.
+  You need to apply for provisional category D bus entitlement then pass a category D test. You can then tow trailers up to 750kg.
 
   To tow heavier trailers you then need to pass the D+E test.
 <% end %>

--- a/lib/smart_answer_flows/towing-rules/outcomes/apply_for_provisional_lv.govspeak.erb
+++ b/lib/smart_answer_flows/towing-rules/outcomes/apply_for_provisional_lv.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :body do %>
-  If you get provisional category C large vehicle entitlement then pass the category C test you can tow trailers up to 750 kg.
+  If you get provisional category C large vehicle entitlement then pass the category C test you can tow trailers up to 750kg.
 
   If you want to tow heavier trailers you can apply for provisional C+E towing entitlement and pass the C+E test.
 <% end %>

--- a/lib/smart_answer_flows/towing-rules/outcomes/apply_for_provisional_msv.govspeak.erb
+++ b/lib/smart_answer_flows/towing-rules/outcomes/apply_for_provisional_msv.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :body do %>
-  If you apply for a provisional C1 medium-sized vehicle licence then pass the C1 test you can tow trailers up to 750 kg, as long as the combined vehicle and trailer weight isn’t more than 7,500 kg.
+  If you apply for a provisional C1 medium-sized vehicle licence then pass the C1 test you can tow trailers up to 750kg, as long as the combined vehicle and trailer weight is not more than 7,500kg.
 
   If you want to tow heavier trailers you need to apply for provisional C1+E medium-sized vehicle entitlement then pass the C1+E test.
 <% end %>

--- a/lib/smart_answer_flows/towing-rules/outcomes/apply_for_provisional_with_exceptions_msv.govspeak.erb
+++ b/lib/smart_answer_flows/towing-rules/outcomes/apply_for_provisional_with_exceptions_msv.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :body do %>
-  If you apply for a provisional C1 medium-sized vehicle licence then pass the C1 test you can tow trailers up to 750 kg, as long as the combined vehicle and trailer weight isn’t more than 7,500 kg.
+  If you apply for a provisional C1 medium-sized vehicle licence then pass the C1 test you can tow trailers up to 750kg, as long as the combined vehicle and trailer weight is not more than 7,500kg.
 
   If you want to tow heavier trailers you’ll need the C1+E entitlement. You normally have to wait until you’re 21 to get this.
 

--- a/lib/smart_answer_flows/towing-rules/outcomes/full_cat_c_entitlement.govspeak.erb
+++ b/lib/smart_answer_flows/towing-rules/outcomes/full_cat_c_entitlement.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :body do %>
-  You can tow trailers up to 750 kg with a standard category C large vehicle licence.
+  You can tow trailers up to 750kg with a standard category C large vehicle licence.
 
   If you want to tow heavier trailers you need to pass the C+E test.
 <% end %>

--- a/lib/smart_answer_flows/towing-rules/outcomes/full_entitlement_bus.govspeak.erb
+++ b/lib/smart_answer_flows/towing-rules/outcomes/full_entitlement_bus.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :body do %>
-  You can already tow trailers up to 750 kg. To tow heavier trailers you need to apply for provisional D+E towing with a bus entitlement then pass the D+E test.
+  You can already tow trailers up to 750kg. To tow heavier trailers you need to apply for provisional D+E towing with a bus entitlement then pass the D+E test.
 <% end %>
 
 <% content_for :next_steps do %>

--- a/lib/smart_answer_flows/towing-rules/outcomes/full_entitlement_minibus.govspeak.erb
+++ b/lib/smart_answer_flows/towing-rules/outcomes/full_entitlement_minibus.govspeak.erb
@@ -1,7 +1,7 @@
 <% content_for :body do %>
   You can already tow with minibuses, but ‘not for hire or reward’.
 
-  You have the D1+E towing entitlement, which means you can drive minibuses with trailers over 750 kg.
+  You have the D1+E towing entitlement, which means you can drive minibuses with trailers over 750kg.
 <% end %>
 
 <% content_for :next_steps do %>

--- a/lib/smart_answer_flows/towing-rules/outcomes/full_entitlement_msv.govspeak.erb
+++ b/lib/smart_answer_flows/towing-rules/outcomes/full_entitlement_msv.govspeak.erb
@@ -1,7 +1,7 @@
 <% content_for :body do %>
   You already have a restricted C1+E towing with a medium-sized vehicle entitlement on your licence.
 
-  This means you can tow trailers weighing more than 750 kg. The total weight of the vehicle and trailer can’t be more than 8,250 kg and the fully-loaded trailer can’t weigh more than the unladen vehicle weight.
+  This means you can tow trailers weighing more than 750kg. The total weight of the vehicle and trailer cannot be more than 8,250kg and the fully-loaded trailer cannot weigh more than the unladen vehicle weight.
 <% end %>
 
 <% content_for :next_steps do %>

--- a/lib/smart_answer_flows/towing-rules/outcomes/included_entitlement_minibus.govspeak.erb
+++ b/lib/smart_answer_flows/towing-rules/outcomes/included_entitlement_minibus.govspeak.erb
@@ -1,7 +1,7 @@
 <% content_for :body do %>
   You can already tow with minibuses.
 
-  You have the D1+E towing entitlement, which means you can drive minibuses with trailers over 750 kg. The total weight of vehicle and trailer can’t be more than 12,000 kg and the fully loaded trailer can’t weigh more than the unladen vehicle.
+  You have the D1+E towing entitlement, which means you can drive minibuses with trailers over 750kg. The total weight of vehicle and trailer cannot be more than 12,000kg and the fully loaded trailer cannot weigh more than the unladen vehicle.
 <% end %>
 
 <% content_for :next_steps do %>

--- a/lib/smart_answer_flows/towing-rules/outcomes/included_entitlement_msv.govspeak.erb
+++ b/lib/smart_answer_flows/towing-rules/outcomes/included_entitlement_msv.govspeak.erb
@@ -1,7 +1,7 @@
 <% content_for :body do %>
   You already have the C1+E towing with a medium-sized vehicle entitlement on your licence.
 
-  This means you can tow trailers weighing more than 750kg with a C1 medium-sized vehicle. The total weight of the vehicle and trailer can’t be more than 12,000kg and the fully-loaded trailer can’t weigh more than the unladen vehicle weight.
+  This means you can tow trailers weighing more than 750kg with a C1 medium-sized vehicle. The total weight of the vehicle and trailer cannot be more than 12,000kg and the fully-loaded trailer cannot weigh more than the unladen vehicle weight.
 <% end %>
 
 <% content_for :next_steps do %>

--- a/lib/smart_answer_flows/towing-rules/outcomes/limited_conditional_trailer_entitlement_msv.govspeak.erb
+++ b/lib/smart_answer_flows/towing-rules/outcomes/limited_conditional_trailer_entitlement_msv.govspeak.erb
@@ -1,11 +1,11 @@
 <% content_for :body do %>
-  You can tow trailers up to 750 kg with a standard C1 medium-sized vehicle licence as long as the vehicle weight isn’t more than 7,500 kg.
+  You can tow trailers up to 750kg with a standard C1 medium-sized vehicle licence as long as the vehicle weight is not more than 7,500kg.
 
   If you want to tow heavier trailers you’ll need to pass the C1+E test.
 
-  This lets you have a restricted C1+E entitlement because you’re under 21. It lets you tow trailers heavier than 750 kg as long as the combined vehicle and trailer weight isn’t more than 7,500 kg.
+  This lets you have a restricted C1+E entitlement because you’re under 21. It lets you tow trailers heavier than 750kg as long as the combined vehicle and trailer weight is not more than 7,500kg.
 
-  Once you’re 21 you’ll automatically get the full C1+E entitlement and you can tow combinations up to 12,000 kg. The fully-loaded trailer can’t weigh more than the unladen vehicle.
+  Once you’re 21 you’ll automatically get the full C1+E entitlement and you can tow combinations up to 12,000kg. The fully-loaded trailer cannot weigh more than the unladen vehicle.
 <% end %>
 
 <% content_for :next_steps do %>

--- a/lib/smart_answer_flows/towing-rules/outcomes/limited_overall_entitlement_minibus.govspeak.erb
+++ b/lib/smart_answer_flows/towing-rules/outcomes/limited_overall_entitlement_minibus.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :body do %>
-  You need to apply for a provisional D1 minibus licence then pass a D1 minibus test to tow trailers up to 750 kg.
+  You need to apply for a provisional D1 minibus licence then pass a D1 minibus test to tow trailers up to 750kg.
 
   To tow heavier trailers you can then apply for provisional D1+E towing with a minibus entitlement then pass the D1+E test.
 <% end %>

--- a/lib/smart_answer_flows/towing-rules/outcomes/limited_towing_entitlement_minibus.govspeak.erb
+++ b/lib/smart_answer_flows/towing-rules/outcomes/limited_towing_entitlement_minibus.govspeak.erb
@@ -1,7 +1,7 @@
 <% content_for :body do %>
-  You can already tow trailers up to 750 kg with your D1 minibus licence.
+  You can already tow trailers up to 750kg with your D1 minibus licence.
 
-  To tow heavier trailers you need to apply for the provisional D1+E towing with a minibus entitlement and then pass the D1+E test. The total weight of vehicle and trailer can’t be more than 12,000 kg and the fully loaded trailer can’t weigh more than the unladen vehicle.
+  To tow heavier trailers you need to apply for the provisional D1+E towing with a minibus entitlement and then pass the D1+E test. The total weight of vehicle and trailer cannot be more than 12,000kg and the fully loaded trailer cannot weigh more than the unladen vehicle.
 <% end %>
 
 <% content_for :next_steps do %>

--- a/lib/smart_answer_flows/towing-rules/outcomes/limited_trailer_entitlement.govspeak.erb
+++ b/lib/smart_answer_flows/towing-rules/outcomes/limited_trailer_entitlement.govspeak.erb
@@ -5,7 +5,7 @@
 
   You can tow trailers up to 750kg MAM (maximum authorised mass).
 
-  You can also tow larger trailers if the combined trailer and vehicle MAM isn't more than 3,500kg.
+  You can also tow larger trailers if the combined trailer and vehicle MAM is not more than 3,500kg.
 
   ##Category B+E
 

--- a/lib/smart_answer_flows/towing-rules/outcomes/limited_trailer_entitlement_2013.govspeak.erb
+++ b/lib/smart_answer_flows/towing-rules/outcomes/limited_trailer_entitlement_2013.govspeak.erb
@@ -1,7 +1,7 @@
 <% content_for :body do %>
   You can already tow trailers up to 750kg.
 
-  You can also tow heavier trailers if the combined weight of the trailer and vehicle isn’t more than 3,500kg maximum authorised mass (MAM).
+  You can also tow heavier trailers if the combined weight of the trailer and vehicle is not more than 3,500kg maximum authorised mass (MAM).
 
   ##Category BE entitlement
 

--- a/lib/smart_answer_flows/towing-rules/outcomes/limited_trailer_entitlement_msv.govspeak.erb
+++ b/lib/smart_answer_flows/towing-rules/outcomes/limited_trailer_entitlement_msv.govspeak.erb
@@ -1,9 +1,9 @@
 <% content_for :body do %>
-  You can tow trailers up to 750 kg with a standard C1 medium-sized vehicle licence as long as the towing vehicle weight isn’t more than 7,500 kg.
+  You can tow trailers up to 750kg with a standard C1 medium-sized vehicle licence as long as the towing vehicle weight is not more than 7,500kg.
 
   If you want to tow heavier trailers you’ll need to apply for provisional C1+E entitlement then pass the C1+E test.
 
-  This will let you can tow vehicle and trailer combinations up to 12,000 kg. The fully loaded trailer can’t weigh more than the unladen vehicle.
+  This will let you tow vehicle and trailer combinations up to 12,000kg. The fully loaded trailer cannot weigh more than the unladen vehicle.
 <% end %>
 
 <% content_for :next_steps do %>

--- a/lib/smart_answer_flows/towing-rules/outcomes/not_old_enough_bus.govspeak.erb
+++ b/lib/smart_answer_flows/towing-rules/outcomes/not_old_enough_bus.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :body do %>
-  You can’t normally tow with a bus until you’re 21. You’ll then need to pass the category D test to tow trailers up to 750 kg, and then pass the D+E test to tow heavier trailers.
+  You cannot normally tow with a bus until you’re 21. You’ll then need to pass the category D test to tow trailers up to 750kg, and then pass the D+E test to tow heavier trailers.
 
   ##Towing with a bus if you’re under 21
 

--- a/lib/smart_answer_flows/towing-rules/outcomes/not_old_enough_lv.govspeak.erb
+++ b/lib/smart_answer_flows/towing-rules/outcomes/not_old_enough_lv.govspeak.erb
@@ -1,7 +1,7 @@
 <% content_for :body do %>
   In most cases you have to wait until you’re 21 to drive, or tow, with a category C large vehicle.
 
-  When you’ve got a full category C licence you can tow trailers up to 750 kg. If you want to tow heavier trailers you can apply for provisional C+E towing entitlement and pass the C+E test.
+  When you’ve got a full category C licence you can tow trailers up to 750kg. If you want to tow heavier trailers you can apply for provisional C+E towing entitlement and pass the C+E test.
 
   ##Driving and towing with a large vehicle at 18
 

--- a/lib/smart_answer_flows/towing-rules/outcomes/not_old_enough_minibus.govspeak.erb
+++ b/lib/smart_answer_flows/towing-rules/outcomes/not_old_enough_minibus.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :body do %>
-  You can’t normally drive or tow with a minibus until you’re 21. You then need to first take the D1 minibus test to tow trailers up to 750 kg. To tow heavier trailers you’ll then need to take the D1+E towing test.
+  You cannot normally drive or tow with a minibus until you’re 21. You then need to first take the D1 minibus test to tow trailers up to 750kg. To tow heavier trailers you’ll then need to take the D1+E towing test.
 
   ##Driving and towing with a minibus at 18
 

--- a/lib/smart_answer_flows/towing-rules/outcomes/too_young_msv.govspeak.erb
+++ b/lib/smart_answer_flows/towing-rules/outcomes/too_young_msv.govspeak.erb
@@ -1,7 +1,7 @@
 <% content_for :body do %>
   You’re too young to tow with a category C1 medium-sized vehicle.
 
-  You have to wait until you’re 18 to get a C1 licence, which will let you tow trailers up to 750 kg as long as the combined vehicle and trailer weight isn’t more than 7,500 kg.
+  You have to wait until you’re 18 to get a C1 licence, which will let you tow trailers up to 750kg as long as the combined vehicle and trailer weight is not more than 7,500kg.
 
   To tow heavier trailers you’ll then need to get the C1+E towing entitlement. There are restrictions on this until you’re 21.
 


### PR DESCRIPTION
Remove negative contractions and spaces between measurement and kg in most outcomes.

Remove a rogue "can"  in the final paragraph of limited_trailer_entitlement_msv.govspeak.erb