### PR TITLE
Add content security policy

### DIFF
--- a/config/initializers/csp.rb
+++ b/config/initializers/csp.rb
@@ -1,0 +1,1 @@
+GovukContentSecurityPolicy.configure


### PR DESCRIPTION
This commit adds a content security policy header using `govuk_app_config`.