### PR TITLE
Add Northern Ireland redundancy pay limits

### DIFF
--- a/lib/data/rates/redundancy_pay_northern_ireland.yml
+++ b/lib/data/rates/redundancy_pay_northern_ireland.yml
@@ -27,3 +27,7 @@
   end_date: 2019-04-05
   max: "15,000"
   rate: 530
+- start_date: 2019-04-06
+  end_date: 2020-04-05
+  max: "16,410"
+  rate: 547

--- a/test/integration/smart_answer_flows/calculate_employee_redundancy_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_employee_redundancy_pay_test.rb
@@ -7,7 +7,7 @@ class CalculateEmployeeRedundancyPayTest < ActiveSupport::TestCase
   include FlowTestHelper
 
   setup do
-    Timecop.freeze("2018-08-31")
+    Timecop.freeze("2019-08-31")
     setup_for_testing_flow SmartAnswer::CalculateEmployeeRedundancyPayFlow
   end
 
@@ -309,6 +309,22 @@ class CalculateEmployeeRedundancyPayTest < ActiveSupport::TestCase
       assert_state_variable :ni_max_amount, "15,000"
       assert_state_variable :statutory_redundancy_pay, "1,778"
       assert_state_variable :statutory_redundancy_pay_ni, "1,855"
+    end
+  end
+
+  context "2019/2020" do
+    should "Use the correct rates" do
+      add_response '2019-06-01'
+      add_response '22'
+      add_response '7'
+      add_response '700'
+      assert_current_node :done
+      assert_state_variable :rate, 525
+      assert_state_variable :ni_rate, 547
+      assert_state_variable :max_amount, "15,750"
+      assert_state_variable :ni_max_amount, "16,410"
+      assert_state_variable :statutory_redundancy_pay, "1,837.50"
+      assert_state_variable :statutory_redundancy_pay_ni, "1,914.50"
     end
   end
 

--- a/test/integration/smart_answer_flows/calculate_your_redundancy_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_your_redundancy_pay_test.rb
@@ -7,7 +7,7 @@ class CalculateYourRedundancyPayTest < ActiveSupport::TestCase
   include FlowTestHelper
 
   setup do
-    Timecop.freeze("2018-08-31")
+    Timecop.freeze("2019-08-31")
     setup_for_testing_flow SmartAnswer::CalculateYourRedundancyPayFlow
   end
 
@@ -309,6 +309,22 @@ class CalculateYourRedundancyPayTest < ActiveSupport::TestCase
       assert_state_variable :ni_max_amount, "15,000"
       assert_state_variable :statutory_redundancy_pay, "1,778"
       assert_state_variable :statutory_redundancy_pay_ni, "1,855"
+    end
+  end
+
+  context "2019/2020" do
+    should "Use the correct rates" do
+      add_response '2019-05-01'
+      add_response '22'
+      add_response '7'
+      add_response '700'
+      assert_current_node :done
+      assert_state_variable :rate, 525
+      assert_state_variable :ni_rate, 547
+      assert_state_variable :max_amount, "15,750"
+      assert_state_variable :ni_max_amount, "16,410"
+      assert_state_variable :statutory_redundancy_pay, "1,837.50"
+      assert_state_variable :statutory_redundancy_pay_ni, "1,914.50"
     end
   end
 end


### PR DESCRIPTION
Update Northern Ireland statutory redundancy pay.

The new ‘max’ is £16,410
The new ‘rate’ is £547

[Trello](https://trello.com/c/Ti4V3hvi/941-statutory-redundancy-calculators-northern-ireland-rates-update)