### PR TITLE
Fix maternity calculator outcome

### DIFF
--- a/lib/smart_answer_flows/maternity-paternity-calculator/outcomes/maternity_leave_and_pay_result.govspeak.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/outcomes/maternity_leave_and_pay_result.govspeak.erb
@@ -14,9 +14,14 @@
   <% else %>
     ##Statutory Maternity Leave
 
-    The employee is not entitled to Statutory Maternity Leave because they don’t have an employment contract with you.
+    The employee is entitled to Statutory Maternity Leave if they:
 
-    Write to them within 28 days of their leave request confirming this.
+    - have an employment contract with you, regardless of when it started
+    - gave you the correct notice
+
+    [Check if they have an employment contract](/employment-contracts-and-conditions) if you’re not sure.
+
+    If they’re not entitled, write and tell them within 28 days of their request.
 
   <% end %>
 


### PR DESCRIPTION
...for workers without a contract.

This outcome seems to be incorrect so, as a temporary fix, HMRC have
provided this text change to implement.

Trello: https://trello.com/c/YbhjkcJL/40-maternity-calculator-incorrect-outcome-for-workers-without-a-contract

# **Before:**
<img width="986" alt="Screen Shot 2019-05-02 at 13 38 15" src="https://user-images.githubusercontent.com/14851208/57075965-4d7ca800-6ce0-11e9-8125-e26f380709d0.png">

# **After:**

<img width="995" alt="Screen Shot 2019-05-02 at 13 37 52" src="https://user-images.githubusercontent.com/14851208/57075983-58cfd380-6ce0-11e9-96da-5359154ce25f.png">