### PR TITLE
Fix lower earnings limits on adoption pay

### DIFF
--- a/lib/smart_answer/calculators/adoption_pay_calculator.rb
+++ b/lib/smart_answer/calculators/adoption_pay_calculator.rb
@@ -13,7 +13,11 @@ module SmartAnswer::Calculators
     end
 
     def lower_earning_limit
-      RatesQuery.from_file('maternity_paternity_adoption').rates(@qualifying_week.last).lower_earning_limit_rate
+      RatesQuery.from_file('maternity_paternity_adoption').rates(relevant_week.last).lower_earning_limit_rate
+    end
+
+    def relevant_week
+      @matched_week
     end
 
     def adoption_placement_date=(date)

--- a/lib/smart_answer/calculators/maternity_pay_calculator.rb
+++ b/lib/smart_answer/calculators/maternity_pay_calculator.rb
@@ -155,7 +155,11 @@ module SmartAnswer::Calculators
     end
 
     def lower_earning_limit
-      RatesQuery.from_file('maternity_paternity_birth').rates(@qualifying_week.last).lower_earning_limit_rate
+      RatesQuery.from_file('maternity_paternity_birth').rates(relevant_week.last).lower_earning_limit_rate
+    end
+
+    def relevant_week
+      @qualifying_week
     end
 
     def employment_end

--- a/lib/smart_answer/calculators/paternity_adoption_pay_calculator.rb
+++ b/lib/smart_answer/calculators/paternity_adoption_pay_calculator.rb
@@ -14,6 +14,12 @@ module SmartAnswer::Calculators
       @adoption_calculator = AdoptionPayCalculator.new(match_date)
 
       super(match_date, 'paternity_adoption')
+
+      @matched_week = @expected_week
+    end
+
+    def relevant_week
+      @matched_week
     end
   end
 end

--- a/test/integration/smart_answer_flows/adoption_calculator_test.rb
+++ b/test/integration/smart_answer_flows/adoption_calculator_test.rb
@@ -519,4 +519,24 @@ class AdoptionCalculatorTest < ActiveSupport::TestCase
       end
     end
   end
+
+  should "show provide the correct lower earnings limit" do
+    # Based on an example provided by HMRC
+    add_response "adoption"
+    add_response "maternity"
+    add_response "no"
+    add_response "2019-04-27"
+    add_response "2019-05-12"
+    add_response "yes"
+    add_response "yes"
+    add_response "yes"
+    add_response "2019-05-12"
+    add_response "2019-04-04"
+    add_response "2019-02-07"
+    add_response "every_4_weeks"
+    add_response "925.0"
+
+    assert_current_node :adoption_leave_and_pay
+    assert_state_variable "lower_earning_limit", sprintf("%.2f", 118)
+  end
 end

--- a/test/integration/smart_answer_flows/paternity_calculator_test.rb
+++ b/test/integration/smart_answer_flows/paternity_calculator_test.rb
@@ -486,6 +486,26 @@ class PaternityCalculatorTest < ActiveSupport::TestCase
           end
         end
 
+        should "show provide the correct lower earnings limit" do
+          # Based on an example provided by HMRC
+          add_response "2019-04-27"
+          add_response "2019-05-12"
+          add_response "yes"
+          add_response "yes"
+          add_response "yes"
+          add_response "yes"
+          add_response "yes"
+          add_response "2019-05-12"
+          add_response "two_weeks"
+          add_response "2019-04-04"
+          add_response "2019-02-07"
+          add_response "every_4_weeks"
+          add_response "925.0"
+
+          assert_current_node :paternity_leave_and_pay
+          assert_state_variable "lower_earning_limit", sprintf("%.2f", 118)
+        end
+
         context "answer no to contract" do
           should "flow through to paternity_leave_and_pay outcome" do
             add_response "2014-01-01"


### PR DESCRIPTION
The legislation says that
> (2)(d)that [their] normal weekly earnings [lower earnings limit] for the period of 8 weeks ending with the relevant week are not less than the lower earnings limit in force under section 5(1)(a) at the end of the relevant week; and
> ...
> (3)The references in subsection (2)(b) and (d) above to the relevant week are to the week in which the person is notified that he has been matched with the child for the purposes of adoption.

In the case of birth this "relevant week" is 16 weeks before the due date.  For adoption it's the match week, analogous to the due week in most cases.

As such we should be using the end of the match week as the point to check the rates file.

https://trello.com/c/SViOJG0s/991-employers-maternity-calculator-change-calculation-in-adoption-paternity-branch