### PR TITLE
Use correctly named strip-dates param

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,7 +9,7 @@
     <% if @content_item %>
       <%= render "govuk_publishing_components/components/meta_tags",
         content_item: @content_item,
-        strip_date_pii: true,
+        strip_dates_pii: true,
         strip_postcode_pii: true %>
     <% end %>
   </head>


### PR DESCRIPTION
The [correct spelling is plural, with an `s`](https://github.com/alphagov/govuk_publishing_components/blob/e5f17e9c33019116b5d73257ce69b07f7bca4a77/lib/govuk_publishing_components/presenters/meta_tags.rb#L130).

This was accidentally added in https://github.com/alphagov/smart-answers/pull/3508.

[Trello Card](https://trello.com/c/MU1CZN78/1005-pii-not-being-stripped-from-state-pension-smart-answer-urls)