### PR TITLE
Ignore definite article "the" from country names when alphabetising dropdown

### DIFF
--- a/lib/smart_answer/question/country_select.rb
+++ b/lib/smart_answer/question/country_select.rb
@@ -40,7 +40,7 @@ module SmartAnswer
           countries = countries.reject { |c| @exclude_countries.include?(c.slug) }
         end
         if @additional_countries
-          countries = (countries + @additional_countries).sort { |a, b| a.name <=> b.name }
+          countries = (countries + @additional_countries).sort { |a, b| a.name.sub(/^The /i, '') <=> b.name }
         end
         countries
       end

--- a/test/unit/country_select_question_test.rb
+++ b/test/unit/country_select_question_test.rb
@@ -5,19 +5,20 @@ module SmartAnswer
     context "using the worldwide API data" do
       setup do
         location1 = stub(slug: 'afghanistan', name: 'Afghanistan')
-        location2 = stub(slug: 'denmark', name: 'Denmark')
-        location3 = stub(slug: 'united-kingdom', name: 'United Kingdom')
-        location4 = stub(slug: 'vietnam', name: 'Vietnam')
+        location2 = stub(slug: 'british-antarctic-territory', name: 'British Antartic Territory')
+        location3 = stub(slug: 'denmark', name: 'Denmark')
+        location4 = stub(slug: 'the-gambia', name: 'The Gambia')
         location5 = stub(slug: 'holy-see', name: 'Holy See')
-        location6 = stub(slug: 'british-antarctic-territory', name: 'British Antartic Territory')
-        location7 = stub(slug: 'greenland', name: 'Greenland')
-        WorldLocation.stubs(:all).returns([location1, location2, location3, location4, location5, location6])
-        UkbaCountry.stubs(:all).returns([location7])
+        location6 = stub(slug: 'united-kingdom', name: 'United Kingdom')
+        location7 = stub(slug: 'vietnam', name: 'Vietnam')
+        location8 = stub(slug: 'greenland', name: 'Greenland')
+        WorldLocation.stubs(:all).returns([location1, location2, location3, location4, location5, location6, location7])
+        UkbaCountry.stubs(:all).returns([location8])
       end
 
       should "be able to list options" do
         @question = Question::CountrySelect.new(nil, :example)
-        assert_equal %w(afghanistan denmark vietnam holy-see british-antarctic-territory), @question.options.map(&:slug)
+        assert_equal %w(afghanistan british-antarctic-territory denmark the-gambia holy-see vietnam), @question.options.map(&:slug)
       end
 
       should "validate a provided option" do
@@ -30,22 +31,29 @@ module SmartAnswer
 
       should "include UK when requested" do
         @question = Question::CountrySelect.new(nil, :example, include_uk: true)
-        assert_equal %w(afghanistan denmark united-kingdom vietnam holy-see british-antarctic-territory), @question.options.map(&:slug)
+        assert_equal %w(afghanistan british-antarctic-territory denmark the-gambia holy-see united-kingdom vietnam), @question.options.map(&:slug)
         assert @question.valid_option?('united-kingdom')
       end
 
       should "exclude Holy See and British Antartic Territory when requested" do
         @question = Question::CountrySelect.new(nil, :example, exclude_countries: %w(holy-see british-antarctic-territory))
-        assert_equal %w(afghanistan denmark vietnam), @question.options.map(&:slug)
+        assert_equal %w(afghanistan denmark the-gambia vietnam), @question.options.map(&:slug)
         assert ! @question.valid_option?('holy-see')
         assert ! @question.valid_option?('british-antarctic-territory')
       end
 
-      should "include additional countries" do
-        @question = Question::CountrySelect.new(nil, :example, exclude_countries: %w(afghanistan british-antarctic-territory denmark holy-see vietnam), additional_countries: UkbaCountry.all)
-        assert_equal %w(greenland), @question.options.map(&:slug)
-        assert ! @question.valid_option?("fooey")
-        assert ! @question.valid_option?("united-kingdom")
+      context "when including additional countries" do
+        should "include additional countries" do
+          @question = Question::CountrySelect.new(nil, :example, exclude_countries: %w(afghanistan british-antarctic-territory the-gambia denmark holy-see vietnam), additional_countries: UkbaCountry.all)
+          assert_equal %w(greenland), @question.options.map(&:slug)
+          assert ! @question.valid_option?("fooey")
+          assert ! @question.valid_option?("united-kingdom")
+        end
+
+        should "ignore the definite article when alphabetising country names" do
+          @question = Question::CountrySelect.new(nil, :example, additional_countries: UkbaCountry.all)
+          assert_equal %w(afghanistan british-antarctic-territory denmark the-gambia greenland holy-see vietnam), @question.options.map(&:slug)
+        end
       end
     end
   end


### PR DESCRIPTION
The Worldwide Locations API returns a specific order of country names to display those
starting with `The` in the most convenient position for the user, for example
`The Gambia` appears under `G` rather than `T`. However, the CountrySelect may add some additional countries and then re-order the list.

This PR ensures that SmartAnswers continues to display the user-friendly order by ignoring the definite article `The` at the beginning of any country names when sorting.

[Trello](https://trello.com/c/X2u3t3br/1011-check-if-you-need-a-uk-visa-update-the-gambia-in-dropdown)