### PR TITLE
Update no visa outcome for ePassport gate users

### DIFF
--- a/lib/smart_answer/calculators/uk_visa_calculator.rb
+++ b/lib/smart_answer/calculators/uk_visa_calculator.rb
@@ -37,6 +37,10 @@ module SmartAnswer::Calculators
       COUNTRY_GROUP_ELECTRONIC_VISA_WAIVER.include?(@passport_country)
     end
 
+    def passport_country_in_epassport_gate_list?
+      COUNTRY_GROUP_EPASSPORT_GATES.include?(@passport_country)
+    end
+
     def passport_country_in_b1_b2_visa_exception_list?
       @passport_country == 'syria'
     end
@@ -419,6 +423,16 @@ module SmartAnswer::Calculators
       oman
       qatar
       united-arab-emirates
+    ).freeze
+
+    COUNTRY_GROUP_EPASSPORT_GATES = %w(
+      australia
+      canada
+      japan
+      new-zealand
+      singapore
+      south-korea
+      usa
     ).freeze
   end
 end

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_no_visa_needed.govspeak.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_no_visa_needed.govspeak.erb
@@ -7,10 +7,15 @@
   ^When the UK leaves the EU, the rules for how long you can stay without a visa may change. [Check if you need to act now](/guidance/visiting-the-uk-after-brexit) so you can travel as planned.
 
   <% if calculator.study_visit? %>
+    <% if calculator.passport_country_in_epassport_gate_list? %>
+      You must go to a border control officer when you arrive in the UK to get a stamp in your passport. This will allow you to study in the UK.
 
-    However, you should bring documents with you to show at the border that you:
+      ^You cannot get a stamp if you use the ePassport gates.
+    <% end %>
 
-      - have been accepted on a course by an [accredited institution](/eligibility) or by a UK Higher Education Institution, for example, a letter of acceptance from the institution
+    You should bring documents with you that show you:
+
+      - have been accepted on a course by an [accredited institution](/study-visit-visa/eligibility) or by a UK Higher Education Institution, for example, a letter of acceptance from the institution
       - are able to fund your stay in the UK and return journey
       - intend to leave the UK at the end of your course
 

--- a/test/unit/calculators/uk_visa_calculator_test.rb
+++ b/test/unit/calculators/uk_visa_calculator_test.rb
@@ -227,6 +227,20 @@ module SmartAnswer
         end
       end
 
+      context '#passport_country_in_epassport_gate_list?' do
+        should 'return true if passport_country is in list of countries that can use ePassport Gates' do
+          calculator = UkVisaCalculator.new
+          calculator.passport_country = 'usa'
+          assert calculator.passport_country_in_epassport_gate_list?
+        end
+
+        should 'return false if passport_country is not in list of countries that can use ePassport Gates' do
+          calculator = UkVisaCalculator.new
+          calculator.passport_country = 'made-up-country'
+          refute calculator.passport_country_in_epassport_gate_list?
+        end
+      end
+
       context '#passport_country_in_b1_b2_visa_exception_list?' do
         should 'return true if passport_country is in list of countries to which the b1/b2 visa exception applies' do
           calculator = UkVisaCalculator.new


### PR DESCRIPTION
Certain countries can now use ePassport gates at airports. However, certain users must still receive a stamp in their passport. 
```
Australia + study + six months or less
Canada + study + six months or less
Japan + study + six months or less
New Zealand + study + six months or less
Singapore + study + six months or less
South Korea + study + six months or less
United States of America + study + six months or less
```

This updates the outcome to advise user accordingly.

It also corrects a non-working link.

Before:

![Screen Shot 2019-05-21 at 12 09 30](https://user-images.githubusercontent.com/13475227/58091391-61ba1380-7bc1-11e9-9ffa-e0c116603534.png)

After:

![Screen Shot 2019-05-21 at 12 09 16](https://user-images.githubusercontent.com/13475227/58091401-67175e00-7bc1-11e9-8f1e-15099175664c.png)

[Trello](https://trello.com/c/ysT9FTwi/1009-change-check-if-you-need-a-visa-outcomenovisa)