### PR TITLE
Changed 'the Tax Credit Office' to 'HMRC'

### DIFF
--- a/lib/smart_answer_flows/childcare-costs-for-tax-credits/childcare_costs_for_tax_credits.govspeak.erb
+++ b/lib/smart_answer_flows/childcare-costs-for-tax-credits/childcare_costs_for_tax_credits.govspeak.erb
@@ -9,7 +9,7 @@
 <% content_for :body do %>
   You can claim extra tax credits to help with your childcare costs if you’re eligible. Use this tool to work out what childcare costs you should claim. You can make your claim 7 days before you start paying for childcare.
 
-  If you already claim tax credits for childcare costs and your costs have changed, you can use this tool to work out if you need to report the change to the Tax Credit Office.
+  If you already claim tax credits for childcare costs and your costs have changed, you can use this tool to work out if you need to report the change to HM Revenue and Customs (HMRC).
 
   ^When calculating your childcare costs, you can only include costs you pay yourself. You may not receive the correct credits if you provide the wrong amount.^
 


### PR DESCRIPTION
Trello: https://trello.com/c/i3kcve2q/2205-tax-credits-change-tax-credit-office-references-to-hmrc

Reason: Users contact HMRC not the Tax Credit Office in this case.
