### PR TITLE
Benefits abroad content corrections

### DIFF
--- a/lib/smart_answer_flows/uk-benefits-abroad/outcomes/db_already_abroad_eea_outcome.govspeak.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/outcomes/db_already_abroad_eea_outcome.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :body do %>
-  You may get [Attendance Allowance](/attendance-allowance), [Carer's Allowance](/carers-allowance), [PIP](/pip) (daily living component) or the care component of Disability Living Allowance if you have a genuine link to the UK.
+  You may get [Attendance Allowance](/attendance-allowance), [Carer's Allowance](/carers-allowance), [PIP](/pip) (daily living component) or the care component of Disability Living Allowance.
 
   [Contact the Exportability Team](/exportability-team) at the Department for Work and Pensions to claim these.
 

--- a/lib/smart_answer_flows/uk-benefits-abroad/outcomes/db_going_abroad_eea_outcome.govspeak.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/outcomes/db_going_abroad_eea_outcome.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :body do %>
-  You can carry on getting [Attendance Allowance](/attendance-allowance), [Carer's Allowance](/carers-allowance), [PIP](/pip) (daily living component) or Disability Living Allowance (care component) if you have a genuine link to the UK.
+  You can carry on getting [Attendance Allowance](/attendance-allowance), [Carer's Allowance](/carers-allowance), [PIP](/pip) (daily living component) or Disability Living Allowance (care component).
 
   The mobility portion of PIP and DLA are not exportable.
 

--- a/lib/smart_answer_flows/uk-benefits-abroad/uk_benefits_abroad.govspeak.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/uk_benefits_abroad.govspeak.erb
@@ -11,7 +11,7 @@
 
   The UK has social security agreements with some countries that:
 
-  - allow you to claim UK contribution-based benefits while you're there
+  - allow you to claim some benefits while you're there
   - mean that your National Insurance contributions can count towards your eligibility for that country's benefits
 
   It's easier to organise benefits before you leave.


### PR DESCRIPTION
https://trello.com/c/FG2wtS0I/2233-asap-share-smart-answer-logic-and-fix-3-errors

I've made a couple of small content changes to correct some inaccuracies:

- removed reference to 'contribution-based benefits' on the start page
- removed reference to needing a genuine link to the UK on the EEA carers benefits pages

