### PR TITLE
Improve "employment and earnings test" question on Pay leave for parents

### DIFF
--- a/lib/smart_answer_flows/pay-leave-for-parents/questions/mother_worked_at_least_26_weeks.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/questions/mother_worked_at_least_26_weeks.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :title do %>
-  Did the mother work (or will she have worked) for at least 26 weeks in this job between <%= format_date(calculator.earnings_employment_start_date) %> and <%= format_date(calculator.earnings_employment_end_date) %>?
+  Did the mother work (or will she have worked) for at least 26 weeks between <%= format_date(calculator.earnings_employment_start_date) %> and <%= format_date(calculator.earnings_employment_end_date) %>?
 <% end %>
 
 <% options(


### PR DESCRIPTION
This question is not well phrased as it implies that the mother must have worked for 26 weeks in the same job (with same employer) when the criteria is actually have worked for 26 weeks (regardless of number of jobs or employers). See http://www.acas.org.uk/index.aspx?articleid=4911.

This pull request removes the qualifier "in this job" as the 26 weeks can be in different jobs.

It might be worth clarifying this in the `post_body` content but I have not done that as part of this PR.