### PR TITLE
[WIP] Add contextual breadcrumbs to smart answers

### DIFF
--- a/app/views/layouts/smart_answers.html.erb
+++ b/app/views/layouts/smart_answers.html.erb
@@ -6,6 +6,12 @@
   <%= javascript_include_tag "application", defer: true %>
 <% end %>
 
+<% if defined?(@presenter.finished?) and @presenter.finished? %>
+  <div class="govuk-width-container">
+    <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: @content_item %>
+  </div>
+<% end %>
+
 <div class="grid-row">
   <%= render partial: "smart_answers/heroku_alert" if heroku? %>
 


### PR DESCRIPTION
## What
Add contextual breadcrumbs to smart answer done pages.

## Why
While investigating a bug we discovered that there are no breadcrumbs on the done pages for smart answers. It should be consistent with start pages.

### Before

#### How it currently looks:
[Screen Shot 2019-06-24 at 16.46.17.png](https://trello-attachments.s3.amazonaws.com/5cac893199b32e890758c311/5d0bae99248c9903ab202014/2916fe6730901f5a3164b87993bf14d2/Screen_Shot_2019-06-24_at_16.46.17.png) 

#### How it currently looks (with step by step tagged):
[Screen Shot 2019-06-24 at 16.46.46.png](https://trello-attachments.s3.amazonaws.com/5cac893199b32e890758c311/5d0bae99248c9903ab202014/8217924cc3e70e6b3c39a52cb1fe941b/Screen_Shot_2019-06-24_at_16.46.46.png) 

### After

#### How it will look without a step by step tagged:
[Screen Shot 2019-06-24 at 16.45.41.png](https://trello-attachments.s3.amazonaws.com/5cac893199b32e890758c311/5d0bae99248c9903ab202014/62f4a20dca8d0b77e58b87b20c5cf21e/Screen_Shot_2019-06-24_at_16.45.41.png) 

#### How it will look with a step by step tagged:
 [Screen Shot 2019-06-24 at 16.45.26.png](https://trello-attachments.s3.amazonaws.com/5cac893199b32e890758c311/5d0bae99248c9903ab202014/cc16f482a60537eeb099da8c7d45f09d/Screen_Shot_2019-06-24_at_16.45.26.png) 

https://trello.com/c/vjnZp0yY/174-secondary-content-doesnt-render-on-smart-answer-pages