### PR TITLE
Reorder employers maternity calculator overseas adoption questions

### DIFF
--- a/lib/smart_answer/calculators/adoption_pay_calculator.rb
+++ b/lib/smart_answer/calculators/adoption_pay_calculator.rb
@@ -37,7 +37,7 @@ module SmartAnswer::Calculators
       employee_has_contract_adoption == 'yes' && on_payroll == 'no'
     end
 
-    def a_leave_employment_threshold
+    def overseas_adoption_leave_employment_threshold
       26.weeks.ago(leave_start_date)
     end
 

--- a/lib/smart_answer/calculators/adoption_pay_calculator.rb
+++ b/lib/smart_answer/calculators/adoption_pay_calculator.rb
@@ -37,6 +37,10 @@ module SmartAnswer::Calculators
       employee_has_contract_adoption == 'yes' && on_payroll == 'no'
     end
 
+    def a_leave_employment_threshold
+      26.weeks.ago(leave_start_date)
+    end
+
   private
 
     def rate_for(date)

--- a/lib/smart_answer_flows/maternity-paternity-calculator/adoption_calculator_flow.rb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/adoption_calculator_flow.rb
@@ -83,7 +83,11 @@ module SmartAnswer
           end
 
           next_node do
-            question :adoption_did_the_employee_work_for_you?
+            if adoption_is_from_overseas
+              question :adoption_date_leave_starts?
+            else
+              question :adoption_did_the_employee_work_for_you?
+            end
           end
         end
 
@@ -94,7 +98,11 @@ module SmartAnswer
           next_node do |response|
             case response
             when 'yes'
-              question :adoption_employment_contract?
+              if adoption_is_from_overseas
+                question :adoption_is_the_employee_on_your_payroll?
+              else
+                question :adoption_employment_contract?
+              end
             when 'no'
               outcome :adoption_not_entitled_to_leave_or_pay
             end
@@ -110,7 +118,11 @@ module SmartAnswer
           end
 
           next_node do
-            question :adoption_is_the_employee_on_your_payroll?
+            if adoption_is_from_overseas
+              question :adoption_did_the_employee_work_for_you?
+            else
+              question :adoption_is_the_employee_on_your_payroll?
+            end
           end
         end
 
@@ -133,6 +145,8 @@ module SmartAnswer
           next_node do
             if calculator.no_contract_not_on_payroll?
               outcome :adoption_not_entitled_to_leave_or_pay
+            elsif adoption_is_from_overseas
+              question :last_normal_payday_adoption?
             else
               question :adoption_date_leave_starts?
             end
@@ -172,8 +186,14 @@ module SmartAnswer
             calculator.format_date calculator.a_notice_leave
           end
 
+          calculate :a_leave_employment_threshold do
+            calculator.a_leave_employment_threshold
+          end
+
           next_node do
-            if calculator.has_contract_not_on_payroll?
+            if adoption_is_from_overseas
+              question :adoption_employment_contract?
+            elsif calculator.has_contract_not_on_payroll?
               outcome :adoption_leave_and_pay
             else
               question :last_normal_payday_adoption?

--- a/lib/smart_answer_flows/maternity-paternity-calculator/adoption_calculator_flow.rb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/adoption_calculator_flow.rb
@@ -186,8 +186,8 @@ module SmartAnswer
             calculator.format_date calculator.a_notice_leave
           end
 
-          calculate :a_leave_employment_threshold do
-            calculator.a_leave_employment_threshold
+          calculate :overseas_adoption_leave_employment_threshold do
+            calculator.overseas_adoption_leave_employment_threshold
           end
 
           next_node do

--- a/lib/smart_answer_flows/maternity-paternity-calculator/outcomes/adoption_not_entitled_to_leave_or_pay.govspeak.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/outcomes/adoption_not_entitled_to_leave_or_pay.govspeak.erb
@@ -1,7 +1,11 @@
 <% content_for :body do %>
   ##Not entitled to Statutory Adoption Leave and Pay
 
-  The employee is not entitled to Statutory Adoption Leave or Pay because they must have started working for you on <%= format_date(employment_start) %>
+  <% if adoption_is_from_overseas%>
+    The employee is not entitled to Statutory Adoption Leave or Pay because they must have started working for you on <%= format_date(a_leave_employment_threshold) %>.
+  <% else %>
+    The employee is not entitled to Statutory Adoption Leave or Pay because they must have started working for you on <%= format_date(employment_start) %>.
+  <% end %>
 
   You must write confirming this. Also, send them form SAP1 confirming they’re not entitled to pay within 28 days of their pay request.
 

--- a/lib/smart_answer_flows/maternity-paternity-calculator/questions/adoption_did_the_employee_work_for_you.govspeak.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/questions/adoption_did_the_employee_work_for_you.govspeak.erb
@@ -1,5 +1,9 @@
 <% content_for :title do %>
-  Did the employee work for you on or before <%= format_date(employment_start) %>?
+  <% if adoption_is_from_overseas%>
+    Did the employee work for you on or before <%= format_date(a_leave_employment_threshold) %>?
+  <% else %>
+    Did the employee work for you on or before <%= format_date(employment_start) %>?
+  <% end %>
 <% end %>
 
 <% options(

--- a/lib/smart_answer_flows/maternity-paternity-calculator/questions/adoption_did_the_employee_work_for_you.govspeak.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/questions/adoption_did_the_employee_work_for_you.govspeak.erb
@@ -1,6 +1,6 @@
 <% content_for :title do %>
   <% if adoption_is_from_overseas%>
-    Did the employee work for you on or before <%= format_date(a_leave_employment_threshold) %>?
+    Did the employee work for you on or before <%= format_date(overseas_adoption_leave_employment_threshold) %>?
   <% else %>
     Did the employee work for you on or before <%= format_date(employment_start) %>?
   <% end %>

--- a/lib/smart_answer_flows/maternity-paternity-calculator/questions/date_of_adoption_match.govspeak.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/questions/date_of_adoption_match.govspeak.erb
@@ -1,6 +1,6 @@
 <% content_for :title do %>
   <% if adoption_is_from_overseas %>
-    When did you get permission to adopt?
+    When did the employee get permission to adopt?
   <% else %>
     When was the child matched with the employee?
   <% end %>

--- a/test/unit/calculators/adoption_pay_calculator_test.rb
+++ b/test/unit/calculators/adoption_pay_calculator_test.rb
@@ -191,5 +191,16 @@ module SmartAnswer::Calculators
         assert_equal 25, (Date.parse("2012 Jul 21").julian - Date.parse("2012 Jan 28").julian).to_i / 7
       end
     end
+
+    context "with an overseas adoption" do
+      should "make the latest date of employment 26 weeks before the requested leave start date" do
+        matched_date = Date.parse("2012 Jul 18")
+        calculator = AdoptionPayCalculator.new(matched_date)
+        calculator.adoption_placement_date = Date.parse("2013 Jan 01")
+        calculator.leave_start_date = Date.parse("2013 Jan 01")
+
+        assert_equal Date.parse("2012 Jul 03"), calculator.overseas_adoption_leave_employment_threshold
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR reorders the questions for the employer's maternity calculator in the case of an overseas adoption. The questions have moved from 

```
Q5. When will the child arrive in the UK?_
Q6. Did the employee work for you on or before <date1>?
Q7. Does the employee have an employment contract with you?_
Q8. Was the employee (or will they be) on your payroll on <date2>?
Q9. When does the employee want to start their leave?
```
TO
```
Q5. When will the child arrive in the UK?_ 
Q6. When does the employee want to start their leave?
Q7. Does the employee have an employment contract with you?_ 
Q8. Did the employee work for you on or before <date1>?
Q9. Was the employee (or will they be) on your payroll on <date2>?
```

Currently we are calculating the latest employment date to qualify for maternity pay for overseas adoption at 26 weeks before the mother receives notice that they have permission to adopt.

This has been corrected to now be 26 weeks before they wish to begin their parental leave.

[Trello](https://trello.com/c/mOgUuQ2K/1097-employers-maternity-calculator-reorder-questions-and-logic-in-overseas-adoption-branch)