### PR TITLE
Use JSON instead of Hybrid to serialise cookies

### DIFF
--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -2,4 +2,4 @@
 
 # Specify a serializer for the signed and encrypted cookie jars.
 # Valid options are :json, :marshal, and :hybrid.
-Rails.application.config.action_dispatch.cookies_serializer = :hybrid
+Rails.application.config.action_dispatch.cookies_serializer = :json


### PR DESCRIPTION
Rails 4.1.0 introduced JSON as an option for Cookie Serialisation rather than Marshall. This prevents the opportunity for remote code execution.

SmartAnswers has been using the `:hybrid` strategy since February 2018 to allow any user's cookies currently serialised by Marshall to be exchanged with JSON.

Brakeman 4.6.0 introduced a security check for this, so we should now make the change to `:json`
https://github.com/presidentbeef/brakeman/pull/1364