### PR TITLE
Guard against incorrect contractual_days_covered_by_earnings values

### DIFF
--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -120,6 +120,14 @@ module SmartAnswer
         relevant_period_from <= pay_day_offset + 1.day
       end
 
+      def valid_contractual_days_covered_by_earnings?
+        BigDecimal(contractual_days_covered_by_earnings)
+
+        true
+      rescue ArgumentError
+        false
+      end
+
       def sick_start_date_for_awe
         linked_sickness_start_date || sick_start_date
       end

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -306,6 +306,10 @@ module SmartAnswer
           calculator.contractual_days_covered_by_earnings = response
         end
 
+        validate :must_be_a_number_of_days do
+          calculator.valid_contractual_days_covered_by_earnings?
+        end
+
         next_node do
           question :usual_work_days?
         end

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/questions/contractual_days_covered_by_earnings.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/questions/contractual_days_covered_by_earnings.govspeak.erb
@@ -5,3 +5,7 @@
 <% content_for :hint do %>
   If it’s 2 weeks and 3 days enter ‘17’.
 <% end %>
+
+<% content_for :must_be_a_number_of_days do %>
+  You need to enter a number of days.
+<% end %>

--- a/test/unit/calculators/statutory_sick_pay_calculator_test.rb
+++ b/test/unit/calculators/statutory_sick_pay_calculator_test.rb
@@ -170,6 +170,23 @@ module SmartAnswer
         end
       end
 
+      context "valid_contractual_days_covered_by_earnings?" do
+        setup do
+          @date = Date.parse("2015-01-01")
+          @calculator = StatutorySickPayCalculator.new(sick_start_date: @date)
+        end
+
+        should "be valid if a number" do
+          @calculator.contractual_days_covered_by_earnings = '4'
+          assert @calculator.valid_contractual_days_covered_by_earnings?
+        end
+
+        should "not be valid if it includes letters" do
+          @calculator.contractual_days_covered_by_earnings = '4 weeks'
+          refute @calculator.valid_contractual_days_covered_by_earnings?
+        end
+      end
+
       context ".months_between" do
         should "calculate number of months between dates" do
           months = StatutorySickPayCalculator.months_between(Date.parse("04/02/2012"), Date.parse("17/05/2012"))


### PR DESCRIPTION
In the statutory sick pay calculator. Previously with Ruby 2.5,
`BigDecimal('4 weeks')` would be 4, but with Ruby 2.6, it raises an
exception.

With the previous behaviour, users were getting incorrect answers, as
the calculator was interpreting '4 weeks' as 4 days, so add validation
to prompt the user to enter a number of days.