### PR TITLE
 Add new maternity leave question

### DIFF
--- a/lib/smart_answer_flows/maternity-paternity-calculator/maternity_calculator_flow.rb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/maternity_calculator_flow.rb
@@ -63,7 +63,7 @@ module SmartAnswer
           end
         end
 
-        # QM3
+        ## QM3
         multiple_choice :did_the_employee_work_for_you_between? do
           option :yes
           option :no
@@ -78,19 +78,31 @@ module SmartAnswer
             calculator.format_date_day to_saturday
           end
 
-          save_input_as :has_employment_contract
+          save_input_as :has_employment_contract_between_dates
 
           next_node do |response|
             case response
             when 'yes'
               question :last_normal_payday?
             when 'no'
-              outcome :maternity_leave_and_pay_result
+              question :does_the_employee_work_for_you_now?
             end
           end
         end
 
         ## QM4
+        multiple_choice :does_the_employee_work_for_you_now? do
+          option :yes
+          option :no
+
+          save_input_as :has_employment_contract_now
+
+          next_node do
+            outcome :maternity_leave_and_pay_result
+          end
+        end
+
+        ## QM5
         date_question :last_normal_payday? do
           from { 2.years.ago(Date.today) }
           to { 2.years.since(Date.today) }
@@ -105,7 +117,7 @@ module SmartAnswer
           end
         end
 
-        ## QM5
+        ## QM6
         date_question :payday_eight_weeks? do
           from { 2.year.ago(Date.today) }
           to { 2.years.since(Date.today) }
@@ -134,7 +146,7 @@ module SmartAnswer
           end
         end
 
-        ## QM6
+        ## QM7
         multiple_choice :pay_frequency? do
           option :weekly
           option :every_2_weeks
@@ -150,7 +162,7 @@ module SmartAnswer
           end
         end
 
-        ## QM7
+        ## QM8
         money_question :earnings_for_pay_period? do
           on_response do |response|
             calculator.earnings_for_pay_period = response
@@ -171,7 +183,7 @@ module SmartAnswer
           end
         end
 
-        ## QM8
+        ## QM9
         multiple_choice :how_do_you_want_the_smp_calculated? do
           option :weekly_starting
           option :usual_paydates
@@ -191,7 +203,7 @@ module SmartAnswer
           end
         end
 
-        ## QM9
+        ## QM10
         date_question :when_is_your_employees_next_pay_day? do
           calculate :next_pay_day do |response|
             calculator.pay_date = response
@@ -203,7 +215,7 @@ module SmartAnswer
           end
         end
 
-        ## QM10
+        ## QM11
         multiple_choice :when_in_the_month_is_the_employee_paid? do
           option :first_day_of_the_month
           option :last_day_of_the_month
@@ -227,7 +239,7 @@ module SmartAnswer
           end
         end
 
-        ## QM11
+        ## QM12
         value_question :what_specific_date_each_month_is_the_employee_paid?, parse: :to_i do
           calculate :pay_day_in_month do |response|
             day = response
@@ -240,7 +252,7 @@ module SmartAnswer
           end
         end
 
-        ## QM12
+        ## QM13
         checkbox_question :what_days_does_the_employee_work? do
           (0...days_of_the_week.size).each { |i| option i.to_s.to_sym }
 
@@ -253,7 +265,7 @@ module SmartAnswer
           end
         end
 
-        ## QM13
+        ## QM14
         multiple_choice :what_particular_day_of_the_month_is_the_employee_paid? do
           days_of_the_week.each { |d| option d.to_sym }
 
@@ -266,7 +278,7 @@ module SmartAnswer
           end
         end
 
-        ## QM14
+        ## QM15
         multiple_choice :which_week_in_month_is_the_employee_paid? do
           option :first
           option :second

--- a/lib/smart_answer_flows/maternity-paternity-calculator/maternity_paternity_calculator.govspeak.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/maternity_paternity_calculator.govspeak.erb
@@ -9,7 +9,7 @@
 <% content_for :body do %>
   Calculate your employee’s:
 
-  + statutory maternity pay (SMP), paternity pay, adoption pay
+  + Statutory Maternity Pay (SMP), paternity pay, adoption pay
   + relevant employment period and average weekly earnings
   + leave period
 <% end %>

--- a/lib/smart_answer_flows/maternity-paternity-calculator/outcomes/_must_be_on_payroll.govspeak.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/outcomes/_must_be_on_payroll.govspeak.erb
@@ -1,1 +1,1 @@
-you must be liable for their secondary Class 1 National Insurance contributions - ie you will be if they’re on your payroll
+you must be liable for their secondary Class 1 National Insurance contributions - you are if they’re on your payroll

--- a/lib/smart_answer_flows/maternity-paternity-calculator/outcomes/maternity_leave_and_pay_result.govspeak.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/outcomes/maternity_leave_and_pay_result.govspeak.erb
@@ -22,15 +22,15 @@
 
   <% if not_entitled_to_pay_reason.present? %>
     <% if calculator.earnings_for_pay_period %>
-      ##Statutory maternity pay
+      ##Statutory Maternity Pay
 
-      The employee is not entitled to statutory maternity pay.
+      The employee is not entitled to Statutory Maternity Pay.
       Their average weekly earnings are <%= format_money(average_weekly_earnings) %> (you can’t round this figure up or down). To qualify:
 
     <% else %>
-      ##Statutory maternity pay
+      ##Statutory Maternity Pay
 
-      The employee is not entitled to statutory maternity pay. To qualify:
+      The employee is not entitled to Statutory Maternity Pay. To qualify:
 
     <% end %>
     <% case not_entitled_to_pay_reason %>

--- a/lib/smart_answer_flows/maternity-paternity-calculator/outcomes/maternity_leave_and_pay_result.govspeak.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/outcomes/maternity_leave_and_pay_result.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :body do %>
-  <% if has_employment_contract == 'yes' %>
+  <% if has_employment_contract_between_dates == 'yes' || has_employment_contract_now == 'yes' %>
     ##Statutory Maternity Leave
 
     The employee is entitled to up to 52 weeks Statutory Maternity Leave.
@@ -14,14 +14,9 @@
   <% else %>
     ##Statutory Maternity Leave
 
-    The employee is entitled to Statutory Maternity Leave if they:
+    The employee is not entitled to Statutory Maternity Leave because they do not have an employment contract with you.
 
-    - have an employment contract with you, regardless of when it started
-    - gave you the correct notice
-
-    [Check if they have an employment contract](/employment-contracts-and-conditions) if you’re not sure.
-
-    If they’re not entitled, write and tell them within 28 days of their request.
+    Write to them within 28 days of their leave request confirming this.
 
   <% end %>
 

--- a/lib/smart_answer_flows/maternity-paternity-calculator/questions/does_the_employee_work_for_you_now.govspeak.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/questions/does_the_employee_work_for_you_now.govspeak.erb
@@ -1,0 +1,12 @@
+<% content_for :title do %>
+  Does the employee have an employment contract with you now?
+<% end %>
+
+<% content_for :hint do %>
+  This includes written and verbal contracts.
+<% end %>
+
+<% options(
+       "no": "No",
+       "yes": "Yes"
+   ) %>

--- a/lib/smart_answer_flows/maternity-paternity-calculator/shared_adoption_maternity_paternity_flow.rb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/shared_adoption_maternity_paternity_flow.rb
@@ -7,7 +7,7 @@ module SmartAnswer
       payment_options_monthly = Calculators::MaternityPayCalculator.payment_options("monthly")
 
       # This question is being used in:
-      # QM9 in MaternityCalculatorFlow
+      # QM8 in MaternityCalculatorFlow
       # QP13 in PaternityCalculatorFlow
       # QA10 in AdoptionCalculatorFlow
       multiple_choice :how_many_payments_weekly? do
@@ -36,7 +36,7 @@ module SmartAnswer
       end
 
       # This question is being used in:
-      # QM9 in MaternityCalculatorFlow
+      # QM8 in MaternityCalculatorFlow
       # QP13 in PaternityCalculatorFlow
       # QA10 in AdoptionCalculatorFlow
       multiple_choice :how_many_payments_every_2_weeks? do
@@ -65,7 +65,7 @@ module SmartAnswer
       end
 
       # This question is being used in:
-      # QM9 in MaternityCalculatorFlow
+      # QM8 in MaternityCalculatorFlow
       # QP13 in PaternityCalculatorFlow
       # QA10 in AdoptionCalculatorFlow
       multiple_choice :how_many_payments_every_4_weeks? do
@@ -94,7 +94,7 @@ module SmartAnswer
       end
 
       # This question is being used in:
-      # QM9 in MaternityCalculatorFlow
+      # QM8 in MaternityCalculatorFlow
       # QP13 in PaternityCalculatorFlow
       # QA10 in AdoptionCalculatorFlow
       multiple_choice :how_many_payments_monthly? do

--- a/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
@@ -10,7 +10,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
     setup_for_testing_flow SmartAnswer::CalculateStatutorySickPayFlow
   end
 
-  context "Getting statutory maternity pay" do
+  context "Getting Statutory Maternity Pay" do
     should "go to result A1" do
       add_response "statutory_maternity_pay"
       assert_current_node :already_getting_maternity # A1

--- a/test/integration/smart_answer_flows/maternity_calculator_test.rb
+++ b/test/integration/smart_answer_flows/maternity_calculator_test.rb
@@ -146,7 +146,7 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
               add_response :yes
             end
 
-            ## QM4
+            ## QM5
             should "ask when the last normal payday" do
               assert_current_node :last_normal_payday?
             end
@@ -158,7 +158,7 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
               setup do
                 add_response @qw.last - 2
               end
-              ## QM5
+              ## QM6
               should "ask when before lastpayday I was paid" do
                 assert_current_node :payday_eight_weeks?
               end
@@ -168,7 +168,7 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
                   add_response 8.weeks.ago(@qw.last - 2)
                 end
 
-                ## QM6
+                ## QM7
                 should "ask how often you pay the employee" do
                   assert_current_node :pay_frequency?
                 end
@@ -177,7 +177,7 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
                   setup do
                     add_response 'weekly'
                   end
-                  ## QM7
+                  ## QM8
                   should "ask what the employees earnings are for the period" do
                     assert_current_node :earnings_for_pay_period?
                     ##TODO relevant period calculation
@@ -372,10 +372,35 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
             end
           end #answer yes to QM3
           context "answer no" do
-            should "state that you they are not entitled to pay" do
+            setup do
               add_response :no
-              assert_state_variable "not_entitled_to_pay_reason", :not_worked_long_enough_and_not_on_payroll
-              assert_current_node :maternity_leave_and_pay_result
+            end
+
+            ## QM4
+            should "ask if the employee works for you now" do
+              assert_current_node :does_the_employee_work_for_you_now?
+            end
+
+            context "answer yes" do
+              setup do
+                add_response :yes
+              end
+
+              should "state that you are not entitled to pay" do
+                assert_state_variable "not_entitled_to_pay_reason", :not_worked_long_enough_and_not_on_payroll
+                assert_current_node :maternity_leave_and_pay_result
+              end
+            end
+
+            context "answer no" do
+              setup do
+                add_response :no
+              end
+
+              should "state that you are not entitled to pay" do
+                assert_state_variable "not_entitled_to_pay_reason", :not_worked_long_enough_and_not_on_payroll
+                assert_current_node :maternity_leave_and_pay_result
+              end
             end
           end
         end # QM2 ask when the employee wants to start their leave?


### PR DESCRIPTION
This is to give a more accurate outcome.

From Content team:
```
An earlier version of the smart answer assumed you weren't eligible for
Statutory Maternity Leave if you weren't eligible for Statutory
Maternity Pay - that's true in 99% of cases but not all.

We fudged the outcome by adding 'The employee is entitled to Statutory
Maternity Leave if... they have an employment contract with you,
regardless of when it started', but it's better to have proper routing
and make the outcomes easier to understand.
```

Trello card: https://trello.com/c/QUboSszZ/1159-employers-maternity-calculator-new-question-in-maternity-branch