### PR TITLE
Updated Tunisia marriage abroad

### DIFF
--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/ceremony_country/partner_british/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/ceremony_country/partner_british/_opposite_sex.govspeak.erb
@@ -8,10 +8,10 @@ You need to swear an affirmation or affidavit that says you’re legally allowed
 
 This costs <%= format_money calculator.consular_fee(:affidavit_or_affirmation_for_marriage) %>. You can pay:
 
-- in the [local currency](/government/publications/tunisia-consular-fees) in cash
 - in British pounds by Visa or Mastercard
+- in the [local currency](/government/publications/tunisia-consular-fees) in cash
 
-[Make an appointment at the embassy in Tunis](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/notice-of-marriage-or-civil-partnership/slot_picker) to swear your affirmation or affidavit.
+[Make an appointment at the embassy in Tunis](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/exchange-a-certificate-of-no-impediment/slot_picker) to swear your affirmation or affidavit.
 
 You and your partner need to bring your: 
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/ceremony_country/partner_british/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/ceremony_country/partner_british/_opposite_sex.govspeak.erb
@@ -4,55 +4,29 @@ Contact the relevant local authorities in Tunisia to find out about local marria
 
 ##What you need to do
 
-You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
+You need to swear an affirmation or affidavit that says you’re legally allowed to get married.
 
-To get a CNI, you must post notice of your intended marriage in Tunisia. You can do this at the British embassy.
+This costs <%= format_money calculator.consular_fee(:affidavit_or_affirmation_for_marriage) %>. You can pay:
 
-You’ll need to have been living in Tunisia for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
+- in the [local currency](/government/publications/tunisia-consular-fees) in cash
+- in British pounds by Visa or Mastercard
 
-[Make an appointment at the embassy in Tunis.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tunis](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/notice-of-marriage-or-civil-partnership/slot_picker) to swear your affirmation or affidavit.
 
-You’ll need to provide supporting documents, including:
+You and your partner need to bring your: 
 
-- your passport
-- proof of residence, such as a residence certificate - check with the embassy or notary public to find out what you need
-- equivalent documents for your partner
+- birth certificate
+- passport
+- evidence if you’ve changed your name by deed poll
 
-You’ll need to complete a [‘Notice of marriage’](/government/publications/notice-of-marriage-form--2) form and an [‘Affidavit for marriage’](/government/publications/affirmationaffidavit-of-marital-status-form) form.
+If you’ve been married or in a civil partnership before, you’ll also need:
 
-You can download and fill in (but not sign) the forms in advance.
+- your original [decree absolute or final order](/copy-decree-absolute-final-order) (this could be a PDF and covering email from the court) - if you’re divorced
+- your annulment certificate - if your marriage or civil partnership was annulled
+- your civil partnership dissolution - if your civil partnership was dissolved
+- your partner’s [death certificate](/order-copy-birth-death-marriage-certificate) and marriage certificate - if you’ve been widowed
 
-You must take the forms with you to your appointment.
 
 %The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
 
-^Your partner will need to follow the same process and pay the fees to get their own CNI.^
 
-If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
-
-- a [decree absolute or final order](/copy-decree-absolute-final-order)
-- a civil partnership dissolution or annulment certificate
-- your (or your partner’s) former spouse or civil partner’s [death certificate](/order-copy-birth-death-marriage-certificate/)
-
-^You’ll also need to provide evidence of nationality or residence if the divorce or dissolution took place outside the UK. You’ll need to get it [legalised](/get-document-legalised) and [translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English.^
-
-###What happens next
-
-The embassy will charge you for taking the oath, posting notice of your intention to marry and issuing your CNI.
-
-The consulate will display your notice of marriage publicly for 7 days.
-
-^You don't need to stay in the country while your notice is posted.^
-
-## Fees
-
-<%= render partial: 'consular_fees_table_items.govspeak.erb',
-           collection: calculator.services,
-           as: :service,
-           locals: { calculator: calculator } %>
-
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Tunisia](/government/publications/tunisia-consular-fees).
-
-<%=  render partial: 'how_to_pay.govspeak.erb', locals: {calculator: calculator}%>
-
-*[CNI]:certificate of no impediment

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/ceremony_country/partner_local/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/ceremony_country/partner_local/_opposite_sex.govspeak.erb
@@ -4,57 +4,33 @@ Contact the relevant local authorities in Tunisia to find out about local marria
 
 ##What you need to do
 
-You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
+You need to swear an affirmation or affidavit that says you’re legally allowed to get married.
 
-To get a CNI, you must post notice of your intended marriage in Tunisia. You can do this at the British embassy.
+This costs <%= format_money calculator.consular_fee(:affidavit_or_affirmation_for_marriage) %>. You can pay:
 
-You’ll need to have been living in Tunisia for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
+- in the [local currency](/government/publications/tunisia-consular-fees) in cash
+- in British pounds by Visa or Mastercard
 
-[Make an appointment at the embassy in Tunis.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tunis](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/notice-of-marriage-or-civil-partnership/slot_picker) to swear your affirmation or affidavit.
 
-You’ll need to provide supporting documents, including:
+You and your partner need to bring your: 
 
-- your passport
-- proof of residence, such as a residence certificate - check with the embassy or notary public to find out what you need
-- equivalent documents for your partner
+- birth certificate
+- passport
+- evidence if you’ve changed your name by deed poll
 
-You’ll need to complete a [‘Notice of marriage’](/government/publications/notice-of-marriage-form--2) form and an [‘Affidavit for marriage’](/government/publications/affirmationaffidavit-of-marital-status-form) form.
+If you’ve been married or in a civil partnership before, you’ll also need:
 
-You can download and fill in (but not sign) the forms in advance.
+- your original [decree absolute or final order](/copy-decree-absolute-final-order) (this could be a PDF and covering email from the court) - if you’re divorced
+- your annulment certificate - if your marriage or civil partnership was annulled
+- your civil partnership dissolution - if your civil partnership was dissolved
+- your partner’s [death certificate](/order-copy-birth-death-marriage-certificate) and marriage certificate - if you’ve been widowed
 
-You must take the forms with you to your appointment.
 
 %The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
 
-If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
-
-- a [decree absolute or final order](/copy-decree-absolute-final-order)
-- a civil partnership dissolution or annulment certificate
-- your (or your partner’s) former spouse or civil partner’s [death certificate](/order-copy-birth-death-marriage-certificate/)
-
-^You’ll also need to provide evidence of nationality or residence if the divorce or dissolution took place outside the UK. You’ll need to get it [legalised](/get-document-legalised) and [translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English.^
-
-###What happens next
-
-The embassy will charge you for taking the oath, posting notice of your intention to marry and issuing your CNI.
-
-The consulate will display your notice of marriage publicly for 7 days.
-
-^You don't need to stay in the country while your notice is posted.^
 
 ##Naturalisation of your partner if they move to the UK
 
 Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
 
-## Fees
-
-<%= render partial: 'consular_fees_table_items.govspeak.erb',
-           collection: calculator.services,
-           as: :service,
-           locals: { calculator: calculator } %>
-
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Tunisia](/government/publications/tunisia-consular-fees).
-
-<%=  render partial: 'how_to_pay.govspeak.erb', locals: {calculator: calculator}%>
-
-*[CNI]:certificate of no impediment

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/ceremony_country/partner_local/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/ceremony_country/partner_local/_opposite_sex.govspeak.erb
@@ -8,10 +8,10 @@ You need to swear an affirmation or affidavit that says you’re legally allowed
 
 This costs <%= format_money calculator.consular_fee(:affidavit_or_affirmation_for_marriage) %>. You can pay:
 
-- in the [local currency](/government/publications/tunisia-consular-fees) in cash
 - in British pounds by Visa or Mastercard
+- in the [local currency](/government/publications/tunisia-consular-fees) in cash
 
-[Make an appointment at the embassy in Tunis](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/notice-of-marriage-or-civil-partnership/slot_picker) to swear your affirmation or affidavit.
+[Make an appointment at the embassy in Tunis](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/exchange-a-certificate-of-no-impediment/slot_picker) to swear your affirmation or affidavit.
 
 You and your partner need to bring your: 
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/ceremony_country/partner_other/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/ceremony_country/partner_other/_opposite_sex.govspeak.erb
@@ -4,57 +4,34 @@ Contact the relevant local authorities in Tunisia to find out about local marria
 
 ##What you need to do
 
-You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
+You need to swear an affirmation or affidavit that says you’re legally allowed to get married.
 
-To get a CNI, you must post notice of your intended marriage in Tunisia. You can do this at the British embassy.
+This costs <%= format_money calculator.consular_fee(:affidavit_or_affirmation_for_marriage) %>. You can pay:
 
-You’ll need to have been living in Tunisia for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
+- in the [local currency](/government/publications/tunisia-consular-fees) in cash
+- in British pounds by Visa or Mastercard
 
-[Make an appointment at the embassy in Tunis.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tunis](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/notice-of-marriage-or-civil-partnership/slot_picker) to swear your affirmation or affidavit.
 
-You’ll need to provide supporting documents, including:
+You and your partner need to bring your: 
 
-- your passport
-- proof of residence, such as a residence certificate - check with the embassy or notary public to find out what you need
-- equivalent documents for your partner
+- birth certificate
+- passport
+- evidence if you’ve changed your name by deed poll
 
-You’ll need to complete a [‘Notice of marriage’](/government/publications/notice-of-marriage-form--2) form and an [‘Affidavit for marriage’](/government/publications/affirmationaffidavit-of-marital-status-form) form.
+If you’ve been married or in a civil partnership before, you’ll also need:
 
-You can download and fill in (but not sign) the forms in advance.
+- your original [decree absolute or final order](/copy-decree-absolute-final-order) (this could be a PDF and covering email from the court) - if you’re divorced
+- your annulment certificate - if your marriage or civil partnership was annulled
+- your civil partnership dissolution - if your civil partnership was dissolved
+- your partner’s [death certificate](/order-copy-birth-death-marriage-certificate) and marriage certificate - if you’ve been widowed
 
-You must take the forms with you to your appointment.
 
 %The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
 
-If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
-
-- a [decree absolute or final order](/copy-decree-absolute-final-order)
-- a civil partnership dissolution or annulment certificate
-- your (or your partner’s) former spouse or civil partner’s [death certificate](/order-copy-birth-death-marriage-certificate/)
-
-^You’ll also need to provide evidence of nationality or residence if the divorce or dissolution took place outside the UK. You’ll need to get it [legalised](/get-document-legalised) and [translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English.^
-
-###What happens next
-
-The embassy will charge you for taking the oath, posting notice of your intention to marry and issuing your CNI.
-
-The consulate will display your notice of marriage publicly for 7 days.
-
-^You don't need to stay in the country while your notice is posted.^
 
 ##Naturalisation of your partner if they move to the UK
 
 Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
 
-## Fees
 
-<%= render partial: 'consular_fees_table_items.govspeak.erb',
-           collection: calculator.services,
-           as: :service,
-           locals: { calculator: calculator } %>
-
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Tunisia](/government/publications/tunisia-consular-fees).
-
-<%=  render partial: 'how_to_pay.govspeak.erb', locals: {calculator: calculator}%>
-
-*[CNI]:certificate of no impediment

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/ceremony_country/partner_other/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/ceremony_country/partner_other/_opposite_sex.govspeak.erb
@@ -8,10 +8,10 @@ You need to swear an affirmation or affidavit that says you’re legally allowed
 
 This costs <%= format_money calculator.consular_fee(:affidavit_or_affirmation_for_marriage) %>. You can pay:
 
-- in the [local currency](/government/publications/tunisia-consular-fees) in cash
 - in British pounds by Visa or Mastercard
+- in the [local currency](/government/publications/tunisia-consular-fees) in cash
 
-[Make an appointment at the embassy in Tunis](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/notice-of-marriage-or-civil-partnership/slot_picker) to swear your affirmation or affidavit.
+[Make an appointment at the embassy in Tunis](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/exchange-a-certificate-of-no-impediment/slot_picker) to swear your affirmation or affidavit.
 
 You and your partner need to bring your: 
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/third_country/partner_british/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/third_country/partner_british/_opposite_sex.govspeak.erb
@@ -8,10 +8,10 @@ You need to swear an affirmation or affidavit that says you’re legally allowed
 
 This costs <%= format_money calculator.consular_fee(:affidavit_or_affirmation_for_marriage) %>. You can pay:
 
-- in the [local currency](/government/publications/tunisia-consular-fees) in cash
 - in British pounds by Visa or Mastercard
+- in the [local currency](/government/publications/tunisia-consular-fees) in cash
 
-[Make an appointment at the embassy in Tunis](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/notice-of-marriage-or-civil-partnership/slot_picker) to swear your affirmation or affidavit.
+[Make an appointment at the embassy in Tunis](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/exchange-a-certificate-of-no-impediment/slot_picker) to swear your affirmation or affidavit.
 
 You and your partner need to bring your: 
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/third_country/partner_british/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/third_country/partner_british/_opposite_sex.govspeak.erb
@@ -4,13 +4,26 @@ Contact the relevant local authorities in Tunisia to find out about local marria
 
 ##What you need to do
 
-You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
+You need to swear an affirmation or affidavit that says you’re legally allowed to get married.
 
-There are 2 ways you can get a CNI:
+This costs <%= format_money calculator.consular_fee(:affidavit_or_affirmation_for_marriage) %>. You can pay:
 
-- [go to the UK and post notice with a UK registrar](/marriage-abroad/y/tunisia/uk/partner_british/opposite_sex)
-- [go to Tunisia and post notice at the embassy or consulate there](/marriage-abroad/y/tunisia/ceremony_country/partner_british/opposite_sex)
+- in the [local currency](/government/publications/tunisia-consular-fees) in cash
+- in British pounds by Visa or Mastercard
 
-%If you choose to post notice, you’ll normally have to wait at least 13 days for your CNI. It can take longer depending on the local authorities’ processes and the time of year.%
+[Make an appointment at the embassy in Tunis](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/notice-of-marriage-or-civil-partnership/slot_picker) to swear your affirmation or affidavit.
 
-*[CNI]:Certificate of no impediment
+You and your partner need to bring your: 
+
+- birth certificate
+- passport
+- evidence if you’ve changed your name by deed poll
+
+If you’ve been married or in a civil partnership before, you’ll also need:
+
+- your original [decree absolute or final order](/copy-decree-absolute-final-order) (this could be a PDF and covering email from the court) - if you’re divorced
+- your annulment certificate - if your marriage or civil partnership was annulled
+- your civil partnership dissolution - if your civil partnership was dissolved
+- your partner’s [death certificate](/order-copy-birth-death-marriage-certificate) and marriage certificate - if you’ve been widowed
+
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/third_country/partner_local/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/third_country/partner_local/_opposite_sex.govspeak.erb
@@ -4,13 +4,27 @@ Contact the relevant local authorities in Tunisia to find out about local marria
 
 ##What you need to do
 
-You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
+You need to swear an affirmation or affidavit that says you’re legally allowed to get married.
 
-There are 2 ways you can get a CNI:
+This costs <%= format_money calculator.consular_fee(:affidavit_or_affirmation_for_marriage) %>. You can pay:
 
-- [go to the UK and post notice with a UK registrar](/marriage-abroad/y/tunisia/uk/partner_local/opposite_sex)
-- [go to Tunisia and post notice at the embassy or consulate there](/marriage-abroad/y/tunisia/ceremony_country/partner_local/opposite_sex)
+- in the [local currency](/government/publications/tunisia-consular-fees) in cash
+- in British pounds by Visa or Mastercard
 
-%If you choose to post notice, you’ll normally have to wait at least 13 days for your CNI. It can take longer depending on the local authorities’ processes and the time of year.%
+[Make an appointment at the embassy in Tunis](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/notice-of-marriage-or-civil-partnership/slot_picker) to swear your affirmation or affidavit.
 
-*[CNI]:Certificate of no impediment
+You and your partner need to bring your: 
+
+- birth certificate
+- passport
+- evidence if you’ve changed your name by deed poll
+
+If you’ve been married or in a civil partnership before, you’ll also need:
+
+- your original [decree absolute or final order](/copy-decree-absolute-final-order) (this could be a PDF and covering email from the court) - if you’re divorced
+- your annulment certificate - if your marriage or civil partnership was annulled
+- your civil partnership dissolution - if your civil partnership was dissolved
+- your partner’s [death certificate](/order-copy-birth-death-marriage-certificate) and marriage certificate - if you’ve been widowed
+
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
+

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/third_country/partner_local/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/third_country/partner_local/_opposite_sex.govspeak.erb
@@ -8,10 +8,10 @@ You need to swear an affirmation or affidavit that says you’re legally allowed
 
 This costs <%= format_money calculator.consular_fee(:affidavit_or_affirmation_for_marriage) %>. You can pay:
 
-- in the [local currency](/government/publications/tunisia-consular-fees) in cash
 - in British pounds by Visa or Mastercard
+- in the [local currency](/government/publications/tunisia-consular-fees) in cash
 
-[Make an appointment at the embassy in Tunis](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/notice-of-marriage-or-civil-partnership/slot_picker) to swear your affirmation or affidavit.
+[Make an appointment at the embassy in Tunis](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/exchange-a-certificate-of-no-impediment/slot_picker) to swear your affirmation or affidavit.
 
 You and your partner need to bring your: 
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/third_country/partner_other/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/third_country/partner_other/_opposite_sex.govspeak.erb
@@ -8,10 +8,10 @@ You need to swear an affirmation or affidavit that says you’re legally allowed
 
 This costs <%= format_money calculator.consular_fee(:affidavit_or_affirmation_for_marriage) %>. You can pay:
 
-- in the [local currency](/government/publications/tunisia-consular-fees) in cash
 - in British pounds by Visa or Mastercard
+- in the [local currency](/government/publications/tunisia-consular-fees) in cash
 
-[Make an appointment at the embassy in Tunis](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/notice-of-marriage-or-civil-partnership/slot_picker) to swear your affirmation or affidavit.
+[Make an appointment at the embassy in Tunis](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/exchange-a-certificate-of-no-impediment/slot_picker) to swear your affirmation or affidavit.
 
 You and your partner need to bring your: 
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/third_country/partner_other/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/third_country/partner_other/_opposite_sex.govspeak.erb
@@ -4,13 +4,27 @@ Contact the relevant local authorities in Tunisia to find out about local marria
 
 ##What you need to do
 
-You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
+You need to swear an affirmation or affidavit that says you’re legally allowed to get married.
 
-There are 2 ways you can get a CNI:
+This costs <%= format_money calculator.consular_fee(:affidavit_or_affirmation_for_marriage) %>. You can pay:
 
-- [go to the UK and post notice with a UK registrar](/marriage-abroad/y/tunisia/uk/partner_other/opposite_sex)
-- [go to Tunisia and post notice at the embassy or consulate there](/marriage-abroad/y/tunisia/ceremony_country/partner_other/opposite_sex)
+- in the [local currency](/government/publications/tunisia-consular-fees) in cash
+- in British pounds by Visa or Mastercard
 
-%If you choose to post notice, you’ll normally have to wait at least 13 days for your CNI. It can take longer depending on the local authorities’ processes and the time of year.%
+[Make an appointment at the embassy in Tunis](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/notice-of-marriage-or-civil-partnership/slot_picker) to swear your affirmation or affidavit.
 
-*[CNI]:Certificate of no impediment
+You and your partner need to bring your: 
+
+- birth certificate
+- passport
+- evidence if you’ve changed your name by deed poll
+
+If you’ve been married or in a civil partnership before, you’ll also need:
+
+- your original [decree absolute or final order](/copy-decree-absolute-final-order) (this could be a PDF and covering email from the court) - if you’re divorced
+- your annulment certificate - if your marriage or civil partnership was annulled
+- your civil partnership dissolution - if your civil partnership was dissolved
+- your partner’s [death certificate](/order-copy-birth-death-marriage-certificate) and marriage certificate - if you’ve been widowed
+
+%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
+

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/uk/partner_british/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/uk/partner_british/_opposite_sex.govspeak.erb
@@ -4,27 +4,29 @@ Contact the [Embassy of Tunisia](/government/publications/foreign-embassies-in-t
 
 ##What you need to do
 
-You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
+You need to swear an affirmation or affidavit that says you’re legally allowed to get married.
 
-You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
+This costs <%= format_money calculator.consular_fee(:affidavit_or_affirmation_for_marriage) %>. You can pay:
 
-^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Tunisia to find out how long a CNI is valid under local law.^
+- in the [local currency](/government/publications/tunisia-consular-fees) in cash
+- in British pounds by Visa or Mastercard
 
-You’ll need to exchange your UK-issued CNI for one that’s valid in Tunisia at the nearest British embassy to where you’re getting married.
+[Make an appointment at the embassy in Tunis](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/notice-of-marriage-or-civil-partnership/slot_picker) to swear your affirmation or affidavit.
 
-[Make an appointment at the British Embassy in Tunis.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/exchange-a-certificate-of-no-impediment/slot_picker)
+You and your partner need to bring your: 
+
+- birth certificate
+- passport
+- evidence if you’ve changed your name by deed poll
+
+If you’ve been married or in a civil partnership before, you’ll also need:
+
+- your original [decree absolute or final order](/copy-decree-absolute-final-order) (this could be a PDF and covering email from the court) - if you’re divorced
+- your annulment certificate - if your marriage or civil partnership was annulled
+- your civil partnership dissolution - if your civil partnership was dissolved
+- your partner’s [death certificate](/order-copy-birth-death-marriage-certificate) and marriage certificate - if you’ve been widowed
+
 
 %The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
 
-## Fees
 
-<%= render partial: 'consular_fees_table_items.govspeak.erb',
-collection: calculator.services,
-as: :service,
-locals: { calculator: calculator } %>
-
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Tunisia](/government/publications/tunisia-consular-fees).
-
-<%=  render partial: 'how_to_pay.govspeak.erb', locals: {calculator: calculator}%>
-
-*[CNI]:certificate of no impediment

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/uk/partner_british/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/uk/partner_british/_opposite_sex.govspeak.erb
@@ -8,10 +8,10 @@ You need to swear an affirmation or affidavit that says you’re legally allowed
 
 This costs <%= format_money calculator.consular_fee(:affidavit_or_affirmation_for_marriage) %>. You can pay:
 
-- in the [local currency](/government/publications/tunisia-consular-fees) in cash
 - in British pounds by Visa or Mastercard
+- in the [local currency](/government/publications/tunisia-consular-fees) in cash
 
-[Make an appointment at the embassy in Tunis](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/notice-of-marriage-or-civil-partnership/slot_picker) to swear your affirmation or affidavit.
+[Make an appointment at the embassy in Tunis](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/exchange-a-certificate-of-no-impediment/slot_picker) to swear your affirmation or affidavit.
 
 You and your partner need to bring your: 
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/uk/partner_local/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/uk/partner_local/_opposite_sex.govspeak.erb
@@ -4,15 +4,28 @@ Contact the [Embassy of Tunisia](/government/publications/foreign-embassies-in-t
 
 ##What you need to do
 
-You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
+You need to swear an affirmation or affidavit that says you’re legally allowed to get married.
 
-You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
+This costs <%= format_money calculator.consular_fee(:affidavit_or_affirmation_for_marriage) %>. You can pay:
 
-^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Tunisia to find out how long a CNI is valid under local law.^
+- in the [local currency](/government/publications/tunisia-consular-fees) in cash
+- in British pounds by Visa or Mastercard
 
-You’ll need to exchange your UK-issued CNI for one that’s valid in Tunisia at the nearest British embassy to where you’re getting married.
+[Make an appointment at the embassy in Tunis](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/notice-of-marriage-or-civil-partnership/slot_picker) to swear your affirmation or affidavit.
 
-[Make an appointment at the British Embassy in Tunis.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/exchange-a-certificate-of-no-impediment/slot_picker)
+You and your partner need to bring your: 
+
+- birth certificate
+- passport
+- evidence if you’ve changed your name by deed poll
+
+If you’ve been married or in a civil partnership before, you’ll also need:
+
+- your original [decree absolute or final order](/copy-decree-absolute-final-order) (this could be a PDF and covering email from the court) - if you’re divorced
+- your annulment certificate - if your marriage or civil partnership was annulled
+- your civil partnership dissolution - if your civil partnership was dissolved
+- your partner’s [death certificate](/order-copy-birth-death-marriage-certificate) and marriage certificate - if you’ve been widowed
+
 
 %The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
 
@@ -20,15 +33,4 @@ You’ll need to exchange your UK-issued CNI for one that’s valid in Tunisia a
 
 Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
 
-## Fees
 
-<%= render partial: 'consular_fees_table_items.govspeak.erb',
-collection: calculator.services,
-as: :service,
-locals: { calculator: calculator } %>
-
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Tunisia](/government/publications/tunisia-consular-fees).
-
-<%=  render partial: 'how_to_pay.govspeak.erb', locals: {calculator: calculator}%>
-
-*[CNI]:certificate of no impediment

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/uk/partner_local/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/uk/partner_local/_opposite_sex.govspeak.erb
@@ -8,10 +8,10 @@ You need to swear an affirmation or affidavit that says you’re legally allowed
 
 This costs <%= format_money calculator.consular_fee(:affidavit_or_affirmation_for_marriage) %>. You can pay:
 
-- in the [local currency](/government/publications/tunisia-consular-fees) in cash
 - in British pounds by Visa or Mastercard
+- in the [local currency](/government/publications/tunisia-consular-fees) in cash
 
-[Make an appointment at the embassy in Tunis](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/notice-of-marriage-or-civil-partnership/slot_picker) to swear your affirmation or affidavit.
+[Make an appointment at the embassy in Tunis](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/exchange-a-certificate-of-no-impediment/slot_picker) to swear your affirmation or affidavit.
 
 You and your partner need to bring your: 
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/uk/partner_other/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/uk/partner_other/_opposite_sex.govspeak.erb
@@ -8,10 +8,10 @@ You need to swear an affirmation or affidavit that says you’re legally allowed
 
 This costs <%= format_money calculator.consular_fee(:affidavit_or_affirmation_for_marriage) %>. You can pay:
 
-- in the [local currency](/government/publications/tunisia-consular-fees) in cash
 - in British pounds by Visa or Mastercard
+- in the [local currency](/government/publications/tunisia-consular-fees) in cash
 
-[Make an appointment at the embassy in Tunis](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/notice-of-marriage-or-civil-partnership/slot_picker) to swear your affirmation or affidavit.
+[Make an appointment at the embassy in Tunis](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/exchange-a-certificate-of-no-impediment/slot_picker) to swear your affirmation or affidavit.
 
 You and your partner need to bring your: 
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/uk/partner_other/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/uk/partner_other/_opposite_sex.govspeak.erb
@@ -4,15 +4,28 @@ Contact the [Embassy of Tunisia](/government/publications/foreign-embassies-in-t
 
 ##What you need to do
 
-You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re allowed to marry.
+You need to swear an affirmation or affidavit that says you’re legally allowed to get married.
 
-You can normally get a CNI by giving a notice of marriage at your local register office or registrar in the UK. Find your local office or registrar in [England and Wales](https://www.gov.uk/register-offices), [Scotland](http://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](http://www.nidirect.gov.uk/index/information-and-services/government-citizens-and-rights/births-and-registration/district-registrars-in-northern-ireland.htm), [Isle of Man](http://www.gov.im/registries/general/civilregistry), [Jersey](http://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
+This costs <%= format_money calculator.consular_fee(:affidavit_or_affirmation_for_marriage) %>. You can pay:
 
-^A CNI issued in Scotland is valid for 3 months. A CNI issued in England, Wales or Northern Ireland will not expire. Check with your local register office to find out how long a CNI is valid if you live in the Channel Islands or the Isle of Man. You should also check with the local authorities in Tunisia to find out how long a CNI is valid under local law.^
+- in the [local currency](/government/publications/tunisia-consular-fees) in cash
+- in British pounds by Visa or Mastercard
 
-You’ll need to exchange your UK-issued CNI for one that’s valid in Tunisia at the nearest British embassy to where you’re getting married.
+[Make an appointment at the embassy in Tunis](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/notice-of-marriage-or-civil-partnership/slot_picker) to swear your affirmation or affidavit.
 
-[Make an appointment at the British Embassy in Tunis.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/exchange-a-certificate-of-no-impediment/slot_picker)
+You and your partner need to bring your: 
+
+- birth certificate
+- passport
+- evidence if you’ve changed your name by deed poll
+
+If you’ve been married or in a civil partnership before, you’ll also need:
+
+- your original [decree absolute or final order](/copy-decree-absolute-final-order) (this could be a PDF and covering email from the court) - if you’re divorced
+- your annulment certificate - if your marriage or civil partnership was annulled
+- your civil partnership dissolution - if your civil partnership was dissolved
+- your partner’s [death certificate](/order-copy-birth-death-marriage-certificate) and marriage certificate - if you’ve been widowed
+
 
 %The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
 
@@ -20,15 +33,3 @@ You’ll need to exchange your UK-issued CNI for one that’s valid in Tunisia a
 
 Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
 
-## Fees
-
-<%= render partial: 'consular_fees_table_items.govspeak.erb',
-           collection: calculator.services,
-           as: :service,
-           locals: { calculator: calculator } %>
-
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Tunisia](/government/publications/tunisia-consular-fees).
-
-<%=  render partial: 'how_to_pay.govspeak.erb', locals: {calculator: calculator}%>
-
-*[CNI]:certificate of no impediment


### PR DESCRIPTION
https://trello.com/c/e3rcfb6H/2393-12-aug-getting-married-abroad-tunisia-1

Updated the 9 opposite sex outcomes as the way users can prove they're free to get married has changed. Previously they needed a CNI, now they need an affidavit/affirmation. 