### PR TITLE
Changes to all outcomes for marriage abroad in Belgium

### DIFF
--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_british/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_british/_opposite_sex.govspeak.erb
@@ -1,5 +1,3 @@
-##Marriage in Belgium
-
 Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_british/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_british/_opposite_sex.govspeak.erb
@@ -1,5 +1,5 @@
 
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_british/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_british/_opposite_sex.govspeak.erb
@@ -1,55 +1,37 @@
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including what documents you’ll need.
-
-^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
+^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
 
 ##What you need to do
 
-You’ll be asked to provide an affirmation or affidavit document to prove you’re allowed to marry.
+You'll be asked to provide a 'certificate of custom and law for marriage' (‘certificate de coutume’ or ‘certificaat van gewoonterecht’) to prove you’re allowed to marry.
 
-Make an appointment at the British embassy or consulate in Belgium to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
+You need to apply by post. Your certificate will then be posted to you within 10 working days.
 
-[Make an appointment at the British embassy in Brussels.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
+If your partner is British, they also need to get a certificate. You can send both applications in the same envelope. You'll still need to pay 2 application fees, but you'll only be charged once for the postage of your certificates.
 
-You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.
+s1. Download the application for a certificate of custom and law for marriage.
+s2. Fill in and sign the form and payment authorisation slip. You’ll need to get certain documents - these are listed on the form.
+s3. Post your application and supporting documents to the British Consulate General Brussels. Write your own address on the envelope too - this is where you’ll be sent your certificate. 
 
-You can download and fill in (but not sign) the forms in advance.
+$D[Download ‘Application for a certificate of custom/law for marriage in Belgium’](/government/publications/affidavitaffirmation-of-marital-status-form-belgium)$D
 
-$D
-[Download ‘Affidavit for marriage’ and ’Affirmation for marriage’](/government/publications/affidavitaffirmation-of-marital-status-form-belgium)
-$D
+$A
+British Consulate General Brussels (Marriage)
+Ave d’Auderghem 10
+Brussels 1040
+BELGIUM
+$A
 
-^Your partner will need to get an affirmation as well.^
+###Check if your certificate needs to be legalised
 
-You’ll need to provide supporting documents, including:
+You might need to get your certificate of custom and law for marriage ‘legalised’ (certified as genuine) by the local authorities -  [check with the Belgian Ministry of Foreign Affairs](https://diplomatie.belgium.be/en/services/legalisation_of_documents/faq/how_can_foreign_documents_be_legalised_use_belgium).
 
-- your passport
-- proof of residence, such as a residence certificate - check with the embassy to find out what you need
-- equivalent documents for your partner
+##Fees
 
-Read the guidance on the [documents that you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
+Service | Fees
+- | -
+Certificate of custom and law for marriage | £50
+Postage | £5
 
-###Legalisation and translation
-
-You’ll need to get your affirmation or affidavit [translated](/government/collections/lists-of-translators-and-interpreters) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
-
-If you’ve been divorced or widowed, you’ll also need:
-
-- a [decree absolute or final order](/copy-decree-absolute-final-order) or the [death certificate](/order-copy-birth-death-marriage-certificate/)
-
-- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English.
-
-You’ll also need to provide evidence if you’ve changed your name by deed poll.
-
-^Your partner will probably need to get an affirmation or affidavit as well.^
-
-## Fees
-
-<%= render partial: 'consular_fees_table_items.govspeak.erb',
-    collection: calculator.services,
-    as: :service,
-    locals: { calculator: calculator } %>
-
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Belgium](/government/publications/belgium-consular-fees).
-
-You can pay by cash or credit card, but not by personal cheque.
+You can only pay by card and in British Pounds as shown in the [list of consular fees for Belgium](/government/publications/belgium-consular-fees).

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_british/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_british/_opposite_sex.govspeak.erb
@@ -1,3 +1,4 @@
+
 Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_british/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_british/_opposite_sex.govspeak.erb
@@ -1,3 +1,5 @@
+##Marriage in Belgium
+
 Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_british/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_british/_same_sex.govspeak.erb
@@ -1,3 +1,8 @@
+Same-sex relationships in Belgium that are recognised as civil partnerships under British law are known as:
+
+- marriage
+- ’cohabitation légale’, ’wettelijke samenwoning’, or ’gesetzliches zusammenwohnen’ (’statutory cohabitation’)
+
 Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_british/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_british/_same_sex.govspeak.erb
@@ -1,5 +1,3 @@
-##Civil Partnership in Belgium
-
 Same-sex relationships in Belgium that are recognised as civil partnerships under British law are known as:
 
 - marriage

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_british/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_british/_same_sex.govspeak.erb
@@ -3,7 +3,7 @@ Same-sex relationships in Belgium that are recognised as civil partnerships unde
 - marriage
 - ’cohabitation légale’, ’wettelijke samenwoning’, or ’gesetzliches zusammenwohnen’ (’statutory cohabitation’)
 
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_british/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_british/_same_sex.govspeak.erb
@@ -1,3 +1,5 @@
+##Civil Partnership in Belgium
+
 Same-sex relationships in Belgium that are recognised as civil partnerships under British law are known as:
 
 - marriage

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_british/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_british/_same_sex.govspeak.erb
@@ -1,60 +1,37 @@
-Same-sex relationships in Belgium that are recognised as civil partnerships under British law are known as:
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
-- marriage
-- ’cohabitation légale’, ’wettelijke samenwoning’, or ’gesetzliches zusammenwohnen’ (’statutory cohabitation’)
-
-Contact the relevant local authorities in Belgium to find out about local laws, including what documents you’ll need.
-
-^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
+^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
 
 ##What you need to do
 
-You’ll be asked to provide an affirmation or affidavit document to prove you’re allowed to marry.
+You'll be asked to provide a 'certificate of custom and law for marriage' (‘certificate de coutume’ or ‘certificaat van gewoonterecht’) to prove you’re allowed to marry.
 
-Make an appointment at the British embassy or consulate in Belgium to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
+You need to apply by post. Your certificate will then be posted to you within 10 working days.
 
-[Make an appointment at the British embassy in Brussels.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
+If your partner is British, they also need to get a certificate. You can send both applications in the same envelope. You'll still need to pay 2 application fees, but you'll only be charged once for the postage of your certificates.
 
-You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.
+s1. Download the application for a certificate of custom and law for marriage.
+s2. Fill in and sign the form and payment authorisation slip. You’ll need to get certain documents - these are listed on the form.
+s3. Post your application and supporting documents to the British Consulate General Brussels. Write your own address on the envelope too - this is where you’ll be sent your certificate. 
 
-You can download and fill in (but not sign) the forms in advance.
+$D[Download ‘Application for a certificate of custom/law for marriage in Belgium’](/government/publications/affidavitaffirmation-of-marital-status-form-belgium)$D
 
-$D
-[Download ‘Affidavit for marriage’ and ’Affirmation for marriage’](/government/publications/affidavitaffirmation-of-marital-status-form-belgium)
-$D
+$A
+British Consulate General Brussels (Marriage)
+Ave d’Auderghem 10
+Brussels 1040
+BELGIUM
+$A
 
-^Your partner will need to get an affirmation as well.^
+###Check if your certificate needs to be legalised
 
-You’ll need to provide supporting documents, including:
+You might need to get your certificate of custom and law for marriage ‘legalised’ (certified as genuine) by the local authorities -  [check with the Belgian Ministry of Foreign Affairs](https://diplomatie.belgium.be/en/services/legalisation_of_documents/faq/how_can_foreign_documents_be_legalised_use_belgium).
 
-- your passport
-- proof of residence, such as a residence certificate - check with the embassy to find out what you need
-- equivalent documents for your partner
+##Fees
 
-Read the guidance on the [documents that you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
+Service | Fees
+- | -
+Certificate of custom and law for marriage | £50
+Postage | £5
 
-###Legalisation and translation
-
-You’ll need to get your affirmation or affidavit [translated](/government/collections/lists-of-translators-and-interpreters) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
-
-If you’ve been divorced, widowed or previously in a civil partnership, you’ll need to provide:
-
-- a [decree absolute or final order](/copy-decree-absolute-final-order) or [death certificate](/order-copy-birth-death-marriage-certificate)
-- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English
-- a civil partnership dissolution or annulment certificate
-- evidence if you’ve changed your name by deed poll
-
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
-
-^Your partner will probably need to get an affirmation or affidavit as well.^
-
-## Fees
-
-<%= render partial: 'consular_fees_table_items.govspeak.erb',
-    collection: calculator.services,
-    as: :service,
-    locals: { calculator: calculator } %>
-
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Belgium](/government/publications/belgium-consular-fees).
-
-You can pay by cash or credit card, but not by personal cheque.
+You can only pay by card and in British Pounds as shown in the [list of consular fees for Belgium](/government/publications/belgium-consular-fees).

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_local/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_local/_opposite_sex.govspeak.erb
@@ -1,61 +1,37 @@
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including what documents you’ll need.
-
-^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
+^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
 
 ##What you need to do
 
-You’ll be asked to provide an affirmation or affidavit document to prove you’re allowed to marry.
+You'll be asked to provide a 'certificate of custom and law for marriage' (‘certificate de coutume’ or ‘certificaat van gewoonterecht’) to prove you’re allowed to marry.
 
-Make an appointment at the British embassy or consulate in Belgium to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
+You need to apply by post. Your certificate will then be posted to you within 10 working days.
 
-[Make an appointment at the British embassy in Brussels.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
+If your partner is British, they also need to get a certificate. You can send both applications in the same envelope. You'll still need to pay 2 application fees, but you'll only be charged once for the postage of your certificates.
 
-You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.
+s1. Download the application for a certificate of custom and law for marriage.
+s2. Fill in and sign the form and payment authorisation slip. You’ll need to get certain documents - these are listed on the form.
+s3. Post your application and supporting documents to the British Consulate General Brussels. Write your own address on the envelope too - this is where you’ll be sent your certificate. 
 
-You can download and fill in (but not sign) the forms in advance.
+$D[Download ‘Application for a certificate of custom/law for marriage in Belgium’](/government/publications/affidavitaffirmation-of-marital-status-form-belgium)$D
 
-$D
-[Download ‘Affidavit for marriage’ and ’Affirmation for marriage’](/government/publications/affidavitaffirmation-of-marital-status-form-belgium)
-$D
+$A
+British Consulate General Brussels (Marriage)
+Ave d’Auderghem 10
+Brussels 1040
+BELGIUM
+$A
 
-^Your partner will need to get an affirmation as well.^
+###Check if your certificate needs to be legalised
 
-You’ll need to provide supporting documents, including:
+You might need to get your certificate of custom and law for marriage ‘legalised’ (certified as genuine) by the local authorities -  [check with the Belgian Ministry of Foreign Affairs](https://diplomatie.belgium.be/en/services/legalisation_of_documents/faq/how_can_foreign_documents_be_legalised_use_belgium).
 
-- your passport
-- proof of residence, such as a residence certificate - check with the embassy to find out what you need
-- equivalent documents for your partner
+##Fees
 
-Read the guidance on the [documents that you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
+Service | Fees
+- | -
+Certificate of custom and law for marriage | £50
+Postage | £5
 
-###Legalisation and translation
-
-You’ll need to get your affirmation or affidavit [translated](/government/collections/lists-of-translators-and-interpreters) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
-
-If you’ve been divorced or widowed, you’ll also need:
-
-- a [decree absolute or final order](/copy-decree-absolute-final-order) or the [death certificate](/order-copy-birth-death-marriage-certificate/)
-
-- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English.
-
-You’ll also need to provide evidence if you’ve changed your name by deed poll.
-
-^Your partner will probably need to get an equivalent document from their national authorities.^
-
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
-
-##Naturalisation of your partner if they move to the UK
-
-Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
-
-## Fees
-
-<%= render partial: 'consular_fees_table_items.govspeak.erb',
-    collection: calculator.services,
-    as: :service,
-    locals: { calculator: calculator } %>
-
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Belgium](/government/publications/belgium-consular-fees).
-
-You can pay by cash or credit card, but not by personal cheque.
+You can only pay by card and in British Pounds as shown in the [list of consular fees for Belgium](/government/publications/belgium-consular-fees).

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_local/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_local/_opposite_sex.govspeak.erb
@@ -1,5 +1,3 @@
-##Marriage in Belgium
-
 Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_local/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_local/_opposite_sex.govspeak.erb
@@ -1,5 +1,5 @@
 
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_local/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_local/_opposite_sex.govspeak.erb
@@ -1,3 +1,4 @@
+
 Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_local/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_local/_opposite_sex.govspeak.erb
@@ -1,3 +1,5 @@
+##Marriage in Belgium
+
 Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_local/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_local/_same_sex.govspeak.erb
@@ -1,5 +1,3 @@
-##Civil Partnership in Belgium
-
 Same-sex relationships in Belgium that are recognised as civil partnerships under British law are known as:
 
 - marriage

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_local/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_local/_same_sex.govspeak.erb
@@ -3,7 +3,7 @@ Same-sex relationships in Belgium that are recognised as civil partnerships unde
 - marriage
 - ’cohabitation légale’, ’wettelijke samenwoning’, or ’gesetzliches zusammenwohnen’ (’statutory cohabitation’)
 
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_local/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_local/_same_sex.govspeak.erb
@@ -1,3 +1,5 @@
+##Civil Partnership in Belgium
+
 Same-sex relationships in Belgium that are recognised as civil partnerships under British law are known as:
 
 - marriage

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_local/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_local/_same_sex.govspeak.erb
@@ -3,62 +3,40 @@ Same-sex relationships in Belgium that are recognised as civil partnerships unde
 - marriage
 - ’cohabitation légale’, ’wettelijke samenwoning’, or ’gesetzliches zusammenwohnen’ (’statutory cohabitation’)
 
-Contact the relevant local authorities in Belgium to find out about local laws, including what documents you’ll need.
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
-^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
+^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
 
 ##What you need to do
 
-You’ll be asked to provide an affirmation or affidavit document to prove you’re allowed to marry.
+You'll be asked to provide a 'certificate of custom and law for marriage' (‘certificate de coutume’ or ‘certificaat van gewoonterecht’) to prove you’re allowed to marry.
 
-Make an appointment at the British embassy or consulate in Belgium to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
+You need to apply by post. Your certificate will then be posted to you within 10 working days.
 
-[Make an appointment at the British embassy in Brussels.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
+If your partner is British, they also need to get a certificate. You can send both applications in the same envelope. You'll still need to pay 2 application fees, but you'll only be charged once for the postage of your certificates.
 
-You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.
+s1. Download the application for a certificate of custom and law for marriage.
+s2. Fill in and sign the form and payment authorisation slip. You’ll need to get certain documents - these are listed on the form.
+s3. Post your application and supporting documents to the British Consulate General Brussels. Write your own address on the envelope too - this is where you’ll be sent your certificate. 
 
-You can download and fill in (but not sign) the forms in advance.
+$D[Download ‘Application for a certificate of custom/law for marriage in Belgium’](/government/publications/affidavitaffirmation-of-marital-status-form-belgium)$D
 
-$D
-[Download ‘Affidavit for marriage’ and ’Affirmation for marriage’](/government/publications/affidavitaffirmation-of-marital-status-form-belgium)
-$D
+$A
+British Consulate General Brussels (Marriage)
+Ave d’Auderghem 10
+Brussels 1040
+BELGIUM
+$A
 
-^Your partner will need to get an affirmation as well.^
+###Check if your certificate needs to be legalised
 
-You’ll need to provide supporting documents, including:
+You might need to get your certificate of custom and law for marriage ‘legalised’ (certified as genuine) by the local authorities -  [check with the Belgian Ministry of Foreign Affairs](https://diplomatie.belgium.be/en/services/legalisation_of_documents/faq/how_can_foreign_documents_be_legalised_use_belgium).
 
-- your passport
-- proof of residence, such as a residence certificate - check with the embassy to find out what you need
-- equivalent documents for your partner
+##Fees
 
-Read the guidance on the [documents that you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
+Service | Fees
+- | -
+Certificate of custom and law for marriage | £50
+Postage | £5
 
-###Legalisation and translation
-
-You’ll need to get your affirmation or affidavit [translated](/government/collections/lists-of-translators-and-interpreters) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
-
-If you’ve been divorced, widowed or previously in a civil partnership, you’ll need to provide:
-
-- a [decree absolute or final order](/copy-decree-absolute-final-order) or [death certificate](/order-copy-birth-death-marriage-certificate)
-- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English
-- a civil partnership dissolution or annulment certificate
-- evidence if you’ve changed your name by deed poll
-
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
-
-^Your partner will probably need to get an equivalent document from their national authorities.^
-
-##Naturalisation of your partner if they move to the UK
-
-Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
-
-## Fees
-
-<%= render partial: 'consular_fees_table_items.govspeak.erb',
-    collection: calculator.services,
-    as: :service,
-    locals: { calculator: calculator } %>
-
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Belgium](/government/publications/belgium-consular-fees).
-
-You can pay by cash or credit card, but not by personal cheque.
+You can only pay by card and in British Pounds as shown in the [list of consular fees for Belgium](/government/publications/belgium-consular-fees).

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_other/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_other/_opposite_sex.govspeak.erb
@@ -1,61 +1,37 @@
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including what documents you’ll need.
-
-^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
+^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
 
 ##What you need to do
 
-You’ll be asked to provide an affirmation or affidavit document to prove you’re allowed to marry.
+You'll be asked to provide a 'certificate of custom and law for marriage' (‘certificate de coutume’ or ‘certificaat van gewoonterecht’) to prove you’re allowed to marry.
 
-Make an appointment at the British embassy or consulate in Belgium to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
+You need to apply by post. Your certificate will then be posted to you within 10 working days.
 
-[Make an appointment at the British embassy in Brussels.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
+If your partner is British, they also need to get a certificate. You can send both applications in the same envelope. You'll still need to pay 2 application fees, but you'll only be charged once for the postage of your certificates.
 
-You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.
+s1. Download the application for a certificate of custom and law for marriage.
+s2. Fill in and sign the form and payment authorisation slip. You’ll need to get certain documents - these are listed on the form.
+s3. Post your application and supporting documents to the British Consulate General Brussels. Write your own address on the envelope too - this is where you’ll be sent your certificate. 
 
-You can download and fill in (but not sign) the forms in advance.
+$D[Download ‘Application for a certificate of custom/law for marriage in Belgium’](/government/publications/affidavitaffirmation-of-marital-status-form-belgium)$D
 
-$D
-[Download ‘Affidavit for marriage’ and ’Affirmation for marriage’](/government/publications/affidavitaffirmation-of-marital-status-form-belgium)
-$D
+$A
+British Consulate General Brussels (Marriage)
+Ave d’Auderghem 10
+Brussels 1040
+BELGIUM
+$A
 
-^Your partner will need to get an affirmation as well.^
+###Check if your certificate needs to be legalised
 
-You’ll need to provide supporting documents, including:
+You might need to get your certificate of custom and law for marriage ‘legalised’ (certified as genuine) by the local authorities -  [check with the Belgian Ministry of Foreign Affairs](https://diplomatie.belgium.be/en/services/legalisation_of_documents/faq/how_can_foreign_documents_be_legalised_use_belgium).
 
-- your passport
-- proof of residence, such as a residence certificate - check with the embassy to find out what you need
-- equivalent documents for your partner
+##Fees
 
-Read the guidance on the [documents that you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
+Service | Fees
+- | -
+Certificate of custom and law for marriage | £50
+Postage | £5
 
-###Legalisation and translation
-
-You’ll need to get your affirmation or affidavit [translated](/government/collections/lists-of-translators-and-interpreters) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
-
-If you’ve been divorced or widowed, you’ll also need:
-
-- a [decree absolute or final order](/copy-decree-absolute-final-order) or the [death certificate](/order-copy-birth-death-marriage-certificate/)
-
-- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English.
-
-You’ll also need to provide evidence if you’ve changed your name by deed poll.
-
-^Your partner will probably need to get an equivalent document from their national authorities.^
-
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
-
-##Naturalisation of your partner if they move to the UK
-
-Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
-
-## Fees
-
-<%= render partial: 'consular_fees_table_items.govspeak.erb',
-    collection: calculator.services,
-    as: :service,
-    locals: { calculator: calculator } %>
-
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Belgium](/government/publications/belgium-consular-fees).
-
-You can pay by cash or credit card, but not by personal cheque.
+You can only pay by card and in British Pounds as shown in the [list of consular fees for Belgium](/government/publications/belgium-consular-fees).

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_other/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_other/_opposite_sex.govspeak.erb
@@ -1,5 +1,3 @@
-##Marriage in Belgium
-
 Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_other/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_other/_opposite_sex.govspeak.erb
@@ -1,5 +1,5 @@
 
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_other/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_other/_opposite_sex.govspeak.erb
@@ -1,3 +1,4 @@
+
 Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_other/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_other/_opposite_sex.govspeak.erb
@@ -1,3 +1,5 @@
+##Marriage in Belgium
+
 Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_other/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_other/_same_sex.govspeak.erb
@@ -3,7 +3,7 @@ Same-sex relationships in Belgium that are recognised as civil partnerships unde
 - marriage
 - ’cohabitation légale’, ’wettelijke samenwoning’, or ’gesetzliches zusammenwohnen’ (’statutory cohabitation’)
 
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_other/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/ceremony_country/partner_other/_same_sex.govspeak.erb
@@ -3,62 +3,40 @@ Same-sex relationships in Belgium that are recognised as civil partnerships unde
 - marriage
 - ’cohabitation légale’, ’wettelijke samenwoning’, or ’gesetzliches zusammenwohnen’ (’statutory cohabitation’)
 
-Contact the relevant local authorities in Belgium to find out about local laws, including what documents you’ll need.
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
-^You should [get legal advice](/government/collections/list-of-lawyers) before making any plans.^
+^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
 
 ##What you need to do
 
-You’ll be asked to provide an affirmation or affidavit document to prove you’re allowed to marry.
+You'll be asked to provide a 'certificate of custom and law for marriage' (‘certificate de coutume’ or ‘certificaat van gewoonterecht’) to prove you’re allowed to marry.
 
-Make an appointment at the British embassy or consulate in Belgium to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
+You need to apply by post. Your certificate will then be posted to you within 10 working days.
 
-[Make an appointment at the British embassy in Brussels.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
+If your partner is British, they also need to get a certificate. You can send both applications in the same envelope. You'll still need to pay 2 application fees, but you'll only be charged once for the postage of your certificates.
 
-You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.
+s1. Download the application for a certificate of custom and law for marriage.
+s2. Fill in and sign the form and payment authorisation slip. You’ll need to get certain documents - these are listed on the form.
+s3. Post your application and supporting documents to the British Consulate General Brussels. Write your own address on the envelope too - this is where you’ll be sent your certificate. 
 
-You can download and fill in (but not sign) the forms in advance.
+$D[Download ‘Application for a certificate of custom/law for marriage in Belgium’](/government/publications/affidavitaffirmation-of-marital-status-form-belgium)$D
 
-$D
-[Download ‘Affidavit for marriage’ and ’Affirmation for marriage’](/government/publications/affidavitaffirmation-of-marital-status-form-belgium)
-$D
+$A
+British Consulate General Brussels (Marriage)
+Ave d’Auderghem 10
+Brussels 1040
+BELGIUM
+$A
 
-^Your partner will need to get an affirmation as well.^
+###Check if your certificate needs to be legalised
 
-You’ll need to provide supporting documents, including:
+You might need to get your certificate of custom and law for marriage ‘legalised’ (certified as genuine) by the local authorities -  [check with the Belgian Ministry of Foreign Affairs](https://diplomatie.belgium.be/en/services/legalisation_of_documents/faq/how_can_foreign_documents_be_legalised_use_belgium).
 
-- your passport
-- proof of residence, such as a residence certificate - check with the embassy to find out what you need
-- equivalent documents for your partner
+##Fees
 
-Read the guidance on the [documents that you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
+Service | Fees
+- | -
+Certificate of custom and law for marriage | £50
+Postage | £5
 
-###Legalisation and translation
-
-You’ll need to get your affirmation or affidavit [translated](/government/collections/lists-of-translators-and-interpreters) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
-
-If you’ve been divorced, widowed or previously in a civil partnership, you’ll need to provide:
-
-- a [decree absolute or final order](/copy-decree-absolute-final-order) or [death certificate](/order-copy-birth-death-marriage-certificate)
-- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English
-- a civil partnership dissolution or annulment certificate
-- evidence if you’ve changed your name by deed poll
-
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
-
-^Your partner will probably need to get an equivalent document from their national authorities.^
-
-##Naturalisation of your partner if they move to the UK
-
-Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
-
-## Fees
-
-<%= render partial: 'consular_fees_table_items.govspeak.erb',
-    collection: calculator.services,
-    as: :service,
-    locals: { calculator: calculator } %>
-
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Belgium](/government/publications/belgium-consular-fees).
-
-You can pay by cash or credit card, but not by personal cheque.
+You can only pay by card and in British Pounds as shown in the [list of consular fees for Belgium](/government/publications/belgium-consular-fees).

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/third_country/partner_british/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/third_country/partner_british/_opposite_sex.govspeak.erb
@@ -1,5 +1,5 @@
 
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/third_country/partner_british/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/third_country/partner_british/_opposite_sex.govspeak.erb
@@ -1,3 +1,4 @@
+
 Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/third_country/partner_british/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/third_country/partner_british/_opposite_sex.govspeak.erb
@@ -1,55 +1,37 @@
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including what documents you’ll need.
-
-^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Belgium](/foreign-travel-advice/belgium) before making any plans.
+^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
 
 ##What you need to do
 
-You’ll be asked to provide an affirmation or affidavit document to prove you’re allowed to marry.
+You'll be asked to provide a 'certificate of custom and law for marriage' (‘certificate de coutume’ or ‘certificaat van gewoonterecht’) to prove you’re allowed to marry.
 
-Make an appointment at the British embassy or consulate in Belgium to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
+You need to apply by post. Your certificate will then be posted to you within 10 working days.
 
-[Make an appointment at the British embassy in Brussels.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
+If your partner is British, they also need to get a certificate. You can send both applications in the same envelope. You'll still need to pay 2 application fees, but you'll only be charged once for the postage of your certificates.
 
-You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.
+s1. Download the application for a certificate of custom and law for marriage.
+s2. Fill in and sign the form and payment authorisation slip. You’ll need to get certain documents - these are listed on the form.
+s3. Post your application and supporting documents to the British Consulate General Brussels. Write your own address on the envelope too - this is where you’ll be sent your certificate. 
 
-You can download and fill in (but not sign) the forms in advance.
+$D[Download ‘Application for a certificate of custom/law for marriage in Belgium’](/government/publications/affidavitaffirmation-of-marital-status-form-belgium)$D
 
-$D
-[Download ‘Affidavit for marriage’ and ’Affirmation for marriage’](/government/publications/affidavitaffirmation-of-marital-status-form-belgium)
-$D
+$A
+British Consulate General Brussels (Marriage)
+Ave d’Auderghem 10
+Brussels 1040
+BELGIUM
+$A
 
-^Your partner will need to get an affirmation as well.^
+###Check if your certificate needs to be legalised
 
-You’ll need to provide supporting documents, including:
+You might need to get your certificate of custom and law for marriage ‘legalised’ (certified as genuine) by the local authorities -  [check with the Belgian Ministry of Foreign Affairs](https://diplomatie.belgium.be/en/services/legalisation_of_documents/faq/how_can_foreign_documents_be_legalised_use_belgium).
 
-- your passport
-- proof of residence, such as a residence certificate - check with the embassy to find out what you need
-- equivalent documents for your partner
+##Fees
 
-Read the guidance on the [documents that you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
+Service | Fees
+- | -
+Certificate of custom and law for marriage | £50
+Postage | £5
 
-###Legalisation and translation
-
-You’ll need to get your affirmation or affidavit [translated](/government/collections/lists-of-translators-and-interpreters) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
-
-If you’ve been divorced or widowed, you’ll also need:
-
-- a [decree absolute or final order](/copy-decree-absolute-final-order) or the [death certificate](/order-copy-birth-death-marriage-certificate/)
-
-- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English.
-
-You’ll also need to provide evidence if you’ve changed your name by deed poll.
-
-^Your partner will probably need to get an affirmation or affidavit as well.^
-
-## Fees
-
-<%= render partial: 'consular_fees_table_items.govspeak.erb',
-    collection: calculator.services,
-    as: :service,
-    locals: { calculator: calculator } %>
-
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Belgium](/government/publications/belgium-consular-fees).
-
-You can pay by cash or credit card, but not by personal cheque.
+You can only pay by card and in British Pounds as shown in the [list of consular fees for Belgium](/government/publications/belgium-consular-fees).

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/third_country/partner_british/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/third_country/partner_british/_same_sex.govspeak.erb
@@ -3,58 +3,40 @@ Same-sex relationships in Belgium that are recognised as civil partnerships unde
 - marriage
 - ’cohabitation légale’, ’wettelijke samenwoning’, or ’gesetzliches zusammenwohnen’ (’statutory cohabitation’)
 
-Contact the relevant local authorities in Belgium to find out about local laws, including what documents you’ll need.
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
-^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Belgium](/foreign-travel-advice/belgium) before making any plans.
+^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
 
 ##What you need to do
 
-You’ll be asked to provide an affirmation or affidavit document to prove you’re allowed to marry.
+You'll be asked to provide a 'certificate of custom and law for marriage' (‘certificate de coutume’ or ‘certificaat van gewoonterecht’) to prove you’re allowed to marry.
 
-Make an appointment at the British embassy or consulate in Belgium to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
+You need to apply by post. Your certificate will then be posted to you within 10 working days.
 
-[Make an appointment at the British embassy in Brussels.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
+If your partner is British, they also need to get a certificate. You can send both applications in the same envelope. You'll still need to pay 2 application fees, but you'll only be charged once for the postage of your certificates.
 
-You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.
+s1. Download the application for a certificate of custom and law for marriage.
+s2. Fill in and sign the form and payment authorisation slip. You’ll need to get certain documents - these are listed on the form.
+s3. Post your application and supporting documents to the British Consulate General Brussels. Write your own address on the envelope too - this is where you’ll be sent your certificate. 
 
-You can download and fill in (but not sign) the forms in advance.
+$D[Download ‘Application for a certificate of custom/law for marriage in Belgium’](/government/publications/affidavitaffirmation-of-marital-status-form-belgium)$D
 
-$D
-[Download ‘Affidavit for marriage’ and ’Affirmation for marriage’](/government/publications/affidavitaffirmation-of-marital-status-form-belgium)
-$D
+$A
+British Consulate General Brussels (Marriage)
+Ave d’Auderghem 10
+Brussels 1040
+BELGIUM
+$A
 
-^Your partner will need to get an affirmation as well.^
+###Check if your certificate needs to be legalised
 
-You’ll need to provide supporting documents, including:
+You might need to get your certificate of custom and law for marriage ‘legalised’ (certified as genuine) by the local authorities -  [check with the Belgian Ministry of Foreign Affairs](https://diplomatie.belgium.be/en/services/legalisation_of_documents/faq/how_can_foreign_documents_be_legalised_use_belgium).
 
-- your passport
-- proof of residence, such as a residence certificate - check with the embassy to find out what you need
-- equivalent documents for your partner
+##Fees
 
-Read the guidance on the [documents that you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
+Service | Fees
+- | -
+Certificate of custom and law for marriage | £50
+Postage | £5
 
-###Legalisation and translation
-
-You’ll need to get your affirmation or affidavit [translated](/government/collections/lists-of-translators-and-interpreters) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
-
-If you’ve been divorced, widowed or previously in a civil partnership, you’ll need to provide:
-
-- a [decree absolute or final order](/copy-decree-absolute-final-order) or [death certificate](/order-copy-birth-death-marriage-certificate)
-- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English
-- a civil partnership dissolution or annulment certificate
-- evidence if you’ve changed your name by deed poll
-
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
-
-^Your partner will probably need to get an affirmation or affidavit as well.^
-
-## Fees
-
-<%= render partial: 'consular_fees_table_items.govspeak.erb',
-    collection: calculator.services,
-    as: :service,
-    locals: { calculator: calculator } %>
-
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Belgium](/government/publications/belgium-consular-fees).
-
-You can pay by cash or credit card, but not by personal cheque.
+You can only pay by card and in British Pounds as shown in the [list of consular fees for Belgium](/government/publications/belgium-consular-fees).

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/third_country/partner_british/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/third_country/partner_british/_same_sex.govspeak.erb
@@ -3,7 +3,7 @@ Same-sex relationships in Belgium that are recognised as civil partnerships unde
 - marriage
 - ’cohabitation légale’, ’wettelijke samenwoning’, or ’gesetzliches zusammenwohnen’ (’statutory cohabitation’)
 
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/third_country/partner_local/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/third_country/partner_local/_opposite_sex.govspeak.erb
@@ -1,5 +1,5 @@
 
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/third_country/partner_local/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/third_country/partner_local/_opposite_sex.govspeak.erb
@@ -1,61 +1,38 @@
 
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including what documents you’ll need.
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
-^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Belgium](/foreign-travel-advice/belgium) before making any plans.
+^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
 
 ##What you need to do
 
-You’ll be asked to provide an affirmation or affidavit document to prove you’re allowed to marry.
+You'll be asked to provide a 'certificate of custom and law for marriage' (‘certificate de coutume’ or ‘certificaat van gewoonterecht’) to prove you’re allowed to marry.
 
-Make an appointment at the British embassy or consulate in Belgium to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
+You need to apply by post. Your certificate will then be posted to you within 10 working days.
 
-[Make an appointment at the British embassy in Brussels.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
+If your partner is British, they also need to get a certificate. You can send both applications in the same envelope. You'll still need to pay 2 application fees, but you'll only be charged once for the postage of your certificates.
 
-You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.
+s1. Download the application for a certificate of custom and law for marriage.
+s2. Fill in and sign the form and payment authorisation slip. You’ll need to get certain documents - these are listed on the form.
+s3. Post your application and supporting documents to the British Consulate General Brussels. Write your own address on the envelope too - this is where you’ll be sent your certificate. 
 
-You can download and fill in (but not sign) the forms in advance.
+$D[Download ‘Application for a certificate of custom/law for marriage in Belgium’](/government/publications/affidavitaffirmation-of-marital-status-form-belgium)$D
 
-$D
-[Download ‘Affidavit for marriage’ and ’Affirmation for marriage’](/government/publications/affidavitaffirmation-of-marital-status-form-belgium)
-$D
+$A
+British Consulate General Brussels (Marriage)
+Ave d’Auderghem 10
+Brussels 1040
+BELGIUM
+$A
 
-^Your partner will need to get an affirmation as well.^
+###Check if your certificate needs to be legalised
 
-You’ll need to provide supporting documents, including:
+You might need to get your certificate of custom and law for marriage ‘legalised’ (certified as genuine) by the local authorities -  [check with the Belgian Ministry of Foreign Affairs](https://diplomatie.belgium.be/en/services/legalisation_of_documents/faq/how_can_foreign_documents_be_legalised_use_belgium).
 
-- your passport
-- proof of residence, such as a residence certificate - check with the embassy to find out what you need
-- equivalent documents for your partner
+##Fees
 
-Read the guidance on the [documents that you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
+Service | Fees
+- | -
+Certificate of custom and law for marriage | £50
+Postage | £5
 
-###Legalisation and translation
-
-You’ll need to get your affirmation or affidavit [translated](/government/collections/lists-of-translators-and-interpreters) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
-
-If you’ve been divorced or widowed, you’ll also need:
-
-- a [decree absolute or final order](/copy-decree-absolute-final-order) or the [death certificate](/order-copy-birth-death-marriage-certificate/)
-
-- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English.
-
-You’ll also need to provide evidence if you’ve changed your name by deed poll.
-
-^Your partner will probably need to get an equivalent document from their national authorities.^
-
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
-
-##Naturalisation of your partner if they move to the UK
-
-Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
-
-## Fees
-
-<%= render partial: 'consular_fees_table_items.govspeak.erb',
-    collection: calculator.services,
-    as: :service,
-    locals: { calculator: calculator } %>
-
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Belgium](/government/publications/belgium-consular-fees).
-
-You can pay by cash or credit card, but not by personal cheque.
+You can only pay by card and in British Pounds as shown in the [list of consular fees for Belgium](/government/publications/belgium-consular-fees).

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/third_country/partner_local/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/third_country/partner_local/_same_sex.govspeak.erb
@@ -3,62 +3,40 @@ Same-sex relationships in Belgium that are recognised as civil partnerships unde
 - marriage
 - ’cohabitation légale’, ’wettelijke samenwoning’, or ’gesetzliches zusammenwohnen’ (’statutory cohabitation’)
 
-Contact the relevant local authorities in Belgium to find out about local laws, including what documents you’ll need.
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
-^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Belgium](/foreign-travel-advice/belgium) before making any plans.
+^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
 
 ##What you need to do
 
-You’ll be asked to provide an affirmation or affidavit document to prove you’re allowed to marry.
+You'll be asked to provide a 'certificate of custom and law for marriage' (‘certificate de coutume’ or ‘certificaat van gewoonterecht’) to prove you’re allowed to marry.
 
-Make an appointment at the British embassy or consulate in Belgium to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
+You need to apply by post. Your certificate will then be posted to you within 10 working days.
 
-[Make an appointment at the British embassy in Brussels.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
+If your partner is British, they also need to get a certificate. You can send both applications in the same envelope. You'll still need to pay 2 application fees, but you'll only be charged once for the postage of your certificates.
 
-You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.
+s1. Download the application for a certificate of custom and law for marriage.
+s2. Fill in and sign the form and payment authorisation slip. You’ll need to get certain documents - these are listed on the form.
+s3. Post your application and supporting documents to the British Consulate General Brussels. Write your own address on the envelope too - this is where you’ll be sent your certificate. 
 
-You can download and fill in (but not sign) the forms in advance.
+$D[Download ‘Application for a certificate of custom/law for marriage in Belgium’](/government/publications/affidavitaffirmation-of-marital-status-form-belgium)$D
 
-$D
-[Download ‘Affidavit for marriage’ and ’Affirmation for marriage’](/government/publications/affidavitaffirmation-of-marital-status-form-belgium)
-$D
+$A
+British Consulate General Brussels (Marriage)
+Ave d’Auderghem 10
+Brussels 1040
+BELGIUM
+$A
 
-^Your partner will need to get an affirmation as well.^
+###Check if your certificate needs to be legalised
 
-You’ll need to provide supporting documents, including:
+You might need to get your certificate of custom and law for marriage ‘legalised’ (certified as genuine) by the local authorities -  [check with the Belgian Ministry of Foreign Affairs](https://diplomatie.belgium.be/en/services/legalisation_of_documents/faq/how_can_foreign_documents_be_legalised_use_belgium).
 
-- your passport
-- proof of residence, such as a residence certificate - check with the embassy to find out what you need
-- equivalent documents for your partner
+##Fees
 
-Read the guidance on the [documents that you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
+Service | Fees
+- | -
+Certificate of custom and law for marriage | £50
+Postage | £5
 
-###Legalisation and translation
-
-You’ll need to get your affirmation or affidavit [translated](/government/collections/lists-of-translators-and-interpreters) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
-
-If you’ve been divorced, widowed or previously in a civil partnership, you’ll need to provide:
-
-- a [decree absolute or final order](/copy-decree-absolute-final-order) or [death certificate](/order-copy-birth-death-marriage-certificate)
-- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English
-- a civil partnership dissolution or annulment certificate
-- evidence if you’ve changed your name by deed poll
-
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
-
-^Your partner will probably need to get an equivalent document from their national authorities.^
-
-##Naturalisation of your partner if they move to the UK
-
-Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
-
-## Fees
-
-<%= render partial: 'consular_fees_table_items.govspeak.erb',
-    collection: calculator.services,
-    as: :service,
-    locals: { calculator: calculator } %>
-
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Belgium](/government/publications/belgium-consular-fees).
-
-You can pay by cash or credit card, but not by personal cheque.
+You can only pay by card and in British Pounds as shown in the [list of consular fees for Belgium](/government/publications/belgium-consular-fees).

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/third_country/partner_local/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/third_country/partner_local/_same_sex.govspeak.erb
@@ -3,7 +3,7 @@ Same-sex relationships in Belgium that are recognised as civil partnerships unde
 - marriage
 - ’cohabitation légale’, ’wettelijke samenwoning’, or ’gesetzliches zusammenwohnen’ (’statutory cohabitation’)
 
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/third_country/partner_other/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/third_country/partner_other/_opposite_sex.govspeak.erb
@@ -1,5 +1,5 @@
 
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/third_country/partner_other/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/third_country/partner_other/_opposite_sex.govspeak.erb
@@ -1,61 +1,38 @@
 
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including what documents you’ll need.
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
-^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Belgium](/foreign-travel-advice/belgium) before making any plans.
+^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
 
 ##What you need to do
 
-You’ll be asked to provide an affirmation or affidavit document to prove you’re allowed to marry.
+You'll be asked to provide a 'certificate of custom and law for marriage' (‘certificate de coutume’ or ‘certificaat van gewoonterecht’) to prove you’re allowed to marry.
 
-Make an appointment at the British embassy or consulate in Belgium to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
+You need to apply by post. Your certificate will then be posted to you within 10 working days.
 
-[Make an appointment at the British embassy in Brussels.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
+If your partner is British, they also need to get a certificate. You can send both applications in the same envelope. You'll still need to pay 2 application fees, but you'll only be charged once for the postage of your certificates.
 
-You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.
+s1. Download the application for a certificate of custom and law for marriage.
+s2. Fill in and sign the form and payment authorisation slip. You’ll need to get certain documents - these are listed on the form.
+s3. Post your application and supporting documents to the British Consulate General Brussels. Write your own address on the envelope too - this is where you’ll be sent your certificate. 
 
-You can download and fill in (but not sign) the forms in advance.
+$D[Download ‘Application for a certificate of custom/law for marriage in Belgium’](/government/publications/affidavitaffirmation-of-marital-status-form-belgium)$D
 
-$D
-[Download ‘Affidavit for marriage’ and ’Affirmation for marriage’](/government/publications/affidavitaffirmation-of-marital-status-form-belgium)
-$D
+$A
+British Consulate General Brussels (Marriage)
+Ave d’Auderghem 10
+Brussels 1040
+BELGIUM
+$A
 
-^Your partner will need to get an affirmation as well.^
+###Check if your certificate needs to be legalised
 
-You’ll need to provide supporting documents, including:
+You might need to get your certificate of custom and law for marriage ‘legalised’ (certified as genuine) by the local authorities -  [check with the Belgian Ministry of Foreign Affairs](https://diplomatie.belgium.be/en/services/legalisation_of_documents/faq/how_can_foreign_documents_be_legalised_use_belgium).
 
-- your passport
-- proof of residence, such as a residence certificate - check with the embassy to find out what you need
-- equivalent documents for your partner
+##Fees
 
-Read the guidance on the [documents that you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
+Service | Fees
+- | -
+Certificate of custom and law for marriage | £50
+Postage | £5
 
-###Legalisation and translation
-
-You’ll need to get your affirmation or affidavit [translated](/government/collections/lists-of-translators-and-interpreters) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
-
-If you’ve been divorced or widowed, you’ll also need:
-
-- a [decree absolute or final order](/copy-decree-absolute-final-order) or the [death certificate](/order-copy-birth-death-marriage-certificate/)
-
-- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English.
-
-You’ll also need to provide evidence if you’ve changed your name by deed poll.
-
-^Your partner will probably need to get an equivalent document from their national authorities.^
-
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
-
-##Naturalisation of your partner if they move to the UK
-
-Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
-
-## Fees
-
-<%= render partial: 'consular_fees_table_items.govspeak.erb',
-    collection: calculator.services,
-    as: :service,
-    locals: { calculator: calculator } %>
-
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Belgium](/government/publications/belgium-consular-fees).
-
-You can pay by cash or credit card, but not by personal cheque.
+You can only pay by card and in British Pounds as shown in the [list of consular fees for Belgium](/government/publications/belgium-consular-fees).

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/third_country/partner_other/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/third_country/partner_other/_same_sex.govspeak.erb
@@ -3,62 +3,40 @@ Same-sex relationships in Belgium that are recognised as civil partnerships unde
 - marriage
 - ’cohabitation légale’, ’wettelijke samenwoning’, or ’gesetzliches zusammenwohnen’ (’statutory cohabitation’)
 
-Contact the relevant local authorities in Belgium to find out about local laws, including what documents you’ll need.
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
-^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Belgium](/foreign-travel-advice/belgium) before making any plans.
+^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
 
 ##What you need to do
 
-You’ll be asked to provide an affirmation or affidavit document to prove you’re allowed to marry.
+You'll be asked to provide a 'certificate of custom and law for marriage' (‘certificate de coutume’ or ‘certificaat van gewoonterecht’) to prove you’re allowed to marry.
 
-Make an appointment at the British embassy or consulate in Belgium to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
+You need to apply by post. Your certificate will then be posted to you within 10 working days.
 
-[Make an appointment at the British embassy in Brussels.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
+If your partner is British, they also need to get a certificate. You can send both applications in the same envelope. You'll still need to pay 2 application fees, but you'll only be charged once for the postage of your certificates.
 
-You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.
+s1. Download the application for a certificate of custom and law for marriage.
+s2. Fill in and sign the form and payment authorisation slip. You’ll need to get certain documents - these are listed on the form.
+s3. Post your application and supporting documents to the British Consulate General Brussels. Write your own address on the envelope too - this is where you’ll be sent your certificate. 
 
-You can download and fill in (but not sign) the forms in advance.
+$D[Download ‘Application for a certificate of custom/law for marriage in Belgium’](/government/publications/affidavitaffirmation-of-marital-status-form-belgium)$D
 
-$D
-[Download ‘Affidavit for marriage’ and ’Affirmation for marriage’](/government/publications/affidavitaffirmation-of-marital-status-form-belgium)
-$D
+$A
+British Consulate General Brussels (Marriage)
+Ave d’Auderghem 10
+Brussels 1040
+BELGIUM
+$A
 
-^Your partner will need to get an affirmation as well.^
+###Check if your certificate needs to be legalised
 
-You’ll need to provide supporting documents, including:
+You might need to get your certificate of custom and law for marriage ‘legalised’ (certified as genuine) by the local authorities -  [check with the Belgian Ministry of Foreign Affairs](https://diplomatie.belgium.be/en/services/legalisation_of_documents/faq/how_can_foreign_documents_be_legalised_use_belgium).
 
-- your passport
-- proof of residence, such as a residence certificate - check with the embassy to find out what you need
-- equivalent documents for your partner
+##Fees
 
-Read the guidance on the [documents that you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
+Service | Fees
+- | -
+Certificate of custom and law for marriage | £50
+Postage | £5
 
-###Legalisation and translation
-
-You’ll need to get your affirmation or affidavit [translated](/government/collections/lists-of-translators-and-interpreters) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
-
-If you’ve been divorced, widowed or previously in a civil partnership, you’ll need to provide:
-
-- a [decree absolute or final order](/copy-decree-absolute-final-order) or [death certificate](/order-copy-birth-death-marriage-certificate)
-- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English
-- a civil partnership dissolution or annulment certificate
-- evidence if you’ve changed your name by deed poll
-
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
-
-^Your partner will probably need to get an equivalent document from their national authorities.^
-
-##Naturalisation of your partner if they move to the UK
-
-Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
-
-## Fees
-
-<%= render partial: 'consular_fees_table_items.govspeak.erb',
-    collection: calculator.services,
-    as: :service,
-    locals: { calculator: calculator } %>
-
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Belgium](/government/publications/belgium-consular-fees).
-
-You can pay by cash or credit card, but not by personal cheque.
+You can only pay by card and in British Pounds as shown in the [list of consular fees for Belgium](/government/publications/belgium-consular-fees).

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/third_country/partner_other/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/third_country/partner_other/_same_sex.govspeak.erb
@@ -3,7 +3,7 @@ Same-sex relationships in Belgium that are recognised as civil partnerships unde
 - marriage
 - ’cohabitation légale’, ’wettelijke samenwoning’, or ’gesetzliches zusammenwohnen’ (’statutory cohabitation’)
 
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/uk/partner_british/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/uk/partner_british/_opposite_sex.govspeak.erb
@@ -1,5 +1,5 @@
 
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/uk/partner_british/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/uk/partner_british/_opposite_sex.govspeak.erb
@@ -1,55 +1,38 @@
 
-Contact the [Embassy of Belgium](/government/publications/foreign-embassies-in-the-uk) before making any plans to find out about local marriage laws, including what documents you’ll need.
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
-^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Belgium](/foreign-travel-advice/belgium) before making any plans.
+^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
 
 ##What you need to do
 
-You’ll be asked to provide an affirmation or affidavit document to prove you’re allowed to marry.
+You'll be asked to provide a 'certificate of custom and law for marriage' (‘certificate de coutume’ or ‘certificaat van gewoonterecht’) to prove you’re allowed to marry.
 
-Make an appointment at the British embassy or consulate in Belgium to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
+You need to apply by post. Your certificate will then be posted to you within 10 working days.
 
-[Make an appointment at the British embassy in Brussels.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
+If your partner is British, they also need to get a certificate. You can send both applications in the same envelope. You'll still need to pay 2 application fees, but you'll only be charged once for the postage of your certificates.
 
-You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.
+s1. Download the application for a certificate of custom and law for marriage.
+s2. Fill in and sign the form and payment authorisation slip. You’ll need to get certain documents - these are listed on the form.
+s3. Post your application and supporting documents to the British Consulate General Brussels. Write your own address on the envelope too - this is where you’ll be sent your certificate. 
 
-You can download and fill in (but not sign) the forms in advance.
+$D[Download ‘Application for a certificate of custom/law for marriage in Belgium’](/government/publications/affidavitaffirmation-of-marital-status-form-belgium)$D
 
-$D
-[Download ‘Affidavit for marriage’ and ’Affirmation for marriage’](/government/publications/affidavitaffirmation-of-marital-status-form-belgium)
-$D
+$A
+British Consulate General Brussels (Marriage)
+Ave d’Auderghem 10
+Brussels 1040
+BELGIUM
+$A
 
-^Your partner will need to get an affirmation as well.^
+###Check if your certificate needs to be legalised
 
-You’ll need to provide supporting documents, including:
+You might need to get your certificate of custom and law for marriage ‘legalised’ (certified as genuine) by the local authorities -  [check with the Belgian Ministry of Foreign Affairs](https://diplomatie.belgium.be/en/services/legalisation_of_documents/faq/how_can_foreign_documents_be_legalised_use_belgium).
 
-- your passport
-- proof of residence, such as a residence certificate - check with the embassy to find out what you need
-- equivalent documents for your partner
+##Fees
 
-Read the guidance on the [documents that you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
+Service | Fees
+- | -
+Certificate of custom and law for marriage | £50
+Postage | £5
 
-###Legalisation and translation
-
-You’ll need to get your affirmation or affidavit [translated](/government/collections/lists-of-translators-and-interpreters) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
-
-If you’ve been divorced or widowed, you’ll also need:
-
-- a [decree absolute or final order](/copy-decree-absolute-final-order) or the [death certificate](/order-copy-birth-death-marriage-certificate/)
-
-- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English.
-
-You’ll also need to provide evidence if you’ve changed your name by deed poll.
-
-^Your partner will probably need to get an affirmation or affidavit as well.^
-
-## Fees
-
-<%= render partial: 'consular_fees_table_items.govspeak.erb',
-    collection: calculator.services,
-    as: :service,
-    locals: { calculator: calculator } %>
-
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Belgium](/government/publications/belgium-consular-fees).
-
-You can pay by cash or credit card, but not by personal cheque.
+You can only pay by card and in British Pounds as shown in the [list of consular fees for Belgium](/government/publications/belgium-consular-fees).

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/uk/partner_british/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/uk/partner_british/_same_sex.govspeak.erb
@@ -3,58 +3,40 @@ Same-sex relationships in Belgium that are recognised as civil partnerships unde
 - marriage
 - ’cohabitation légale’, ’wettelijke samenwoning’, or ’gesetzliches zusammenwohnen’ (’statutory cohabitation’)
 
-Contact the [Embassy of Belgium](/government/publications/foreign-embassies-in-the-uk) before making any plans to find out about local laws, including what documents you’ll need.
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
-^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Belgium](/foreign-travel-advice/belgium) before making any plans.
+^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
 
 ##What you need to do
 
-You’ll be asked to provide an affirmation or affidavit document to prove you’re allowed to marry.
+You'll be asked to provide a 'certificate of custom and law for marriage' (‘certificate de coutume’ or ‘certificaat van gewoonterecht’) to prove you’re allowed to marry.
 
-Make an appointment at the British embassy or consulate in Belgium to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
+You need to apply by post. Your certificate will then be posted to you within 10 working days.
 
-[Make an appointment at the British embassy in Brussels.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
+If your partner is British, they also need to get a certificate. You can send both applications in the same envelope. You'll still need to pay 2 application fees, but you'll only be charged once for the postage of your certificates.
 
-You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.
+s1. Download the application for a certificate of custom and law for marriage.
+s2. Fill in and sign the form and payment authorisation slip. You’ll need to get certain documents - these are listed on the form.
+s3. Post your application and supporting documents to the British Consulate General Brussels. Write your own address on the envelope too - this is where you’ll be sent your certificate. 
 
-You can download and fill in (but not sign) the forms in advance.
+$D[Download ‘Application for a certificate of custom/law for marriage in Belgium’](/government/publications/affidavitaffirmation-of-marital-status-form-belgium)$D
 
-$D
-[Download ‘Affidavit for marriage’ and ’Affirmation for marriage’](/government/publications/affidavitaffirmation-of-marital-status-form-belgium)
-$D
+$A
+British Consulate General Brussels (Marriage)
+Ave d’Auderghem 10
+Brussels 1040
+BELGIUM
+$A
 
-^Your partner will need to get an affirmation as well.^
+###Check if your certificate needs to be legalised
 
-You’ll need to provide supporting documents, including:
+You might need to get your certificate of custom and law for marriage ‘legalised’ (certified as genuine) by the local authorities -  [check with the Belgian Ministry of Foreign Affairs](https://diplomatie.belgium.be/en/services/legalisation_of_documents/faq/how_can_foreign_documents_be_legalised_use_belgium).
 
-- your passport
-- proof of residence, such as a residence certificate - check with the embassy to find out what you need
-- equivalent documents for your partner
+##Fees
 
-Read the guidance on the [documents that you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
+Service | Fees
+- | -
+Certificate of custom and law for marriage | £50
+Postage | £5
 
-###Legalisation and translation
-
-You’ll need to get your affirmation or affidavit [translated](/government/collections/lists-of-translators-and-interpreters) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
-
-If you’ve been divorced, widowed or previously in a civil partnership, you’ll need to provide:
-
-- a [decree absolute or final order](/copy-decree-absolute-final-order) or [death certificate](/order-copy-birth-death-marriage-certificate)
-- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English
-- a civil partnership dissolution or annulment certificate
-- evidence if you’ve changed your name by deed poll
-
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
-
-^Your partner will probably need to get an affirmation or affidavit as well.^
-
-## Fees
-
-<%= render partial: 'consular_fees_table_items.govspeak.erb',
-    collection: calculator.services,
-    as: :service,
-    locals: { calculator: calculator } %>
-
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Belgium](/government/publications/belgium-consular-fees).
-
-You can pay by cash or credit card, but not by personal cheque.
+You can only pay by card and in British Pounds as shown in the [list of consular fees for Belgium](/government/publications/belgium-consular-fees).

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/uk/partner_british/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/uk/partner_british/_same_sex.govspeak.erb
@@ -3,7 +3,7 @@ Same-sex relationships in Belgium that are recognised as civil partnerships unde
 - marriage
 - ’cohabitation légale’, ’wettelijke samenwoning’, or ’gesetzliches zusammenwohnen’ (’statutory cohabitation’)
 
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/uk/partner_local/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/uk/partner_local/_opposite_sex.govspeak.erb
@@ -1,61 +1,38 @@
 
-Contact the [Embassy of Belgium](/government/publications/foreign-embassies-in-the-uk) before making any plans to find out about local marriage laws, including what documents you’ll need.
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
-^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Belgium](/foreign-travel-advice/belgium) before making any plans.
+^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
 
 ##What you need to do
 
-You’ll be asked to provide an affirmation or affidavit document to prove you’re allowed to marry.
+You'll be asked to provide a 'certificate of custom and law for marriage' (‘certificate de coutume’ or ‘certificaat van gewoonterecht’) to prove you’re allowed to marry.
 
-Make an appointment at the British embassy or consulate in Belgium to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
+You need to apply by post. Your certificate will then be posted to you within 10 working days.
 
-[Make an appointment at the British embassy in Brussels.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
+If your partner is British, they also need to get a certificate. You can send both applications in the same envelope. You'll still need to pay 2 application fees, but you'll only be charged once for the postage of your certificates.
 
-You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.
+s1. Download the application for a certificate of custom and law for marriage.
+s2. Fill in and sign the form and payment authorisation slip. You’ll need to get certain documents - these are listed on the form.
+s3. Post your application and supporting documents to the British Consulate General Brussels. Write your own address on the envelope too - this is where you’ll be sent your certificate. 
 
-You can download and fill in (but not sign) the forms in advance.
+$D[Download ‘Application for a certificate of custom/law for marriage in Belgium’](/government/publications/affidavitaffirmation-of-marital-status-form-belgium)$D
 
-$D
-[Download ‘Affidavit for marriage’ and ’Affirmation for marriage’](/government/publications/affidavitaffirmation-of-marital-status-form-belgium)
-$D
+$A
+British Consulate General Brussels (Marriage)
+Ave d’Auderghem 10
+Brussels 1040
+BELGIUM
+$A
 
-^Your partner will need to get an affirmation as well.^
+###Check if your certificate needs to be legalised
 
-You’ll need to provide supporting documents, including:
+You might need to get your certificate of custom and law for marriage ‘legalised’ (certified as genuine) by the local authorities -  [check with the Belgian Ministry of Foreign Affairs](https://diplomatie.belgium.be/en/services/legalisation_of_documents/faq/how_can_foreign_documents_be_legalised_use_belgium).
 
-- your passport
-- proof of residence, such as a residence certificate - check with the embassy to find out what you need
-- equivalent documents for your partner
+##Fees
 
-Read the guidance on the [documents that you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
+Service | Fees
+- | -
+Certificate of custom and law for marriage | £50
+Postage | £5
 
-###Legalisation and translation
-
-You’ll need to get your affirmation or affidavit [translated](/government/collections/lists-of-translators-and-interpreters) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
-
-If you’ve been divorced or widowed, you’ll also need:
-
-- a [decree absolute or final order](/copy-decree-absolute-final-order) or the [death certificate](/order-copy-birth-death-marriage-certificate/)
-
-- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English.
-
-You’ll also need to provide evidence if you’ve changed your name by deed poll.
-
-^Your partner will probably need to get an equivalent document from their national authorities.^
-
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
-
-##Naturalisation of your partner if they move to the UK
-
-Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
-
-## Fees
-
-<%= render partial: 'consular_fees_table_items.govspeak.erb',
-    collection: calculator.services,
-    as: :service,
-    locals: { calculator: calculator } %>
-
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Belgium](/government/publications/belgium-consular-fees).
-
-You can pay by cash or credit card, but not by personal cheque.
+You can only pay by card and in British Pounds as shown in the [list of consular fees for Belgium](/government/publications/belgium-consular-fees).

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/uk/partner_local/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/uk/partner_local/_opposite_sex.govspeak.erb
@@ -1,5 +1,5 @@
 
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/uk/partner_local/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/uk/partner_local/_same_sex.govspeak.erb
@@ -3,7 +3,7 @@ Same-sex relationships in Belgium that are recognised as civil partnerships unde
 - marriage
 - ’cohabitation légale’, ’wettelijke samenwoning’, or ’gesetzliches zusammenwohnen’ (’statutory cohabitation’)
 
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/uk/partner_local/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/uk/partner_local/_same_sex.govspeak.erb
@@ -3,62 +3,40 @@ Same-sex relationships in Belgium that are recognised as civil partnerships unde
 - marriage
 - ’cohabitation légale’, ’wettelijke samenwoning’, or ’gesetzliches zusammenwohnen’ (’statutory cohabitation’)
 
-Contact the [Embassy of Belgium](/government/publications/foreign-embassies-in-the-uk) before making any plans to find out about local laws, including what documents you’ll need.
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
-^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Belgium](/foreign-travel-advice/belgium) before making any plans.
+^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
 
 ##What you need to do
 
-You’ll be asked to provide an affirmation or affidavit document to prove you’re allowed to marry.
+You'll be asked to provide a 'certificate of custom and law for marriage' (‘certificate de coutume’ or ‘certificaat van gewoonterecht’) to prove you’re allowed to marry.
 
-Make an appointment at the British embassy or consulate in Belgium to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
+You need to apply by post. Your certificate will then be posted to you within 10 working days.
 
-[Make an appointment at the British embassy in Brussels.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
+If your partner is British, they also need to get a certificate. You can send both applications in the same envelope. You'll still need to pay 2 application fees, but you'll only be charged once for the postage of your certificates.
 
-You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.
+s1. Download the application for a certificate of custom and law for marriage.
+s2. Fill in and sign the form and payment authorisation slip. You’ll need to get certain documents - these are listed on the form.
+s3. Post your application and supporting documents to the British Consulate General Brussels. Write your own address on the envelope too - this is where you’ll be sent your certificate. 
 
-You can download and fill in (but not sign) the forms in advance.
+$D[Download ‘Application for a certificate of custom/law for marriage in Belgium’](/government/publications/affidavitaffirmation-of-marital-status-form-belgium)$D
 
-$D
-[Download ‘Affidavit for marriage’ and ’Affirmation for marriage’](/government/publications/affidavitaffirmation-of-marital-status-form-belgium)
-$D
+$A
+British Consulate General Brussels (Marriage)
+Ave d’Auderghem 10
+Brussels 1040
+BELGIUM
+$A
 
-^Your partner will need to get an affirmation as well.^
+###Check if your certificate needs to be legalised
 
-You’ll need to provide supporting documents, including:
+You might need to get your certificate of custom and law for marriage ‘legalised’ (certified as genuine) by the local authorities -  [check with the Belgian Ministry of Foreign Affairs](https://diplomatie.belgium.be/en/services/legalisation_of_documents/faq/how_can_foreign_documents_be_legalised_use_belgium).
 
-- your passport
-- proof of residence, such as a residence certificate - check with the embassy to find out what you need
-- equivalent documents for your partner
+##Fees
 
-Read the guidance on the [documents that you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
+Service | Fees
+- | -
+Certificate of custom and law for marriage | £50
+Postage | £5
 
-###Legalisation and translation
-
-You’ll need to get your affirmation or affidavit [translated](/government/collections/lists-of-translators-and-interpreters) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
-
-If you’ve been divorced, widowed or previously in a civil partnership, you’ll need to provide:
-
-- a [decree absolute or final order](/copy-decree-absolute-final-order) or [death certificate](/order-copy-birth-death-marriage-certificate)
-- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English
-- a civil partnership dissolution or annulment certificate
-- evidence if you’ve changed your name by deed poll
-
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
-
-^Your partner will probably need to get an equivalent document from their national authorities.^
-
-##Naturalisation of your partner if they move to the UK
-
-Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
-
-## Fees
-
-<%= render partial: 'consular_fees_table_items.govspeak.erb',
-    collection: calculator.services,
-    as: :service,
-    locals: { calculator: calculator } %>
-
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Belgium](/government/publications/belgium-consular-fees).
-
-You can pay by cash or credit card, but not by personal cheque.
+You can only pay by card and in British Pounds as shown in the [list of consular fees for Belgium](/government/publications/belgium-consular-fees).

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/uk/partner_other/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/uk/partner_other/_opposite_sex.govspeak.erb
@@ -1,61 +1,38 @@
 
-Contact the [Embassy of Belgium](/government/publications/foreign-embassies-in-the-uk) before making any plans to find out about local marriage laws, including what documents you’ll need.
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
-^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Belgium](/foreign-travel-advice/belgium) before making any plans.
+^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
 
 ##What you need to do
 
-You’ll be asked to provide an affirmation or affidavit document to prove you’re allowed to marry.
+You'll be asked to provide a 'certificate of custom and law for marriage' (‘certificate de coutume’ or ‘certificaat van gewoonterecht’) to prove you’re allowed to marry.
 
-Make an appointment at the British embassy or consulate in Belgium to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
+You need to apply by post. Your certificate will then be posted to you within 10 working days.
 
-[Make an appointment at the British embassy in Brussels.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
+If your partner is British, they also need to get a certificate. You can send both applications in the same envelope. You'll still need to pay 2 application fees, but you'll only be charged once for the postage of your certificates.
 
-You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.
+s1. Download the application for a certificate of custom and law for marriage.
+s2. Fill in and sign the form and payment authorisation slip. You’ll need to get certain documents - these are listed on the form.
+s3. Post your application and supporting documents to the British Consulate General Brussels. Write your own address on the envelope too - this is where you’ll be sent your certificate. 
 
-You can download and fill in (but not sign) the forms in advance.
+$D[Download ‘Application for a certificate of custom/law for marriage in Belgium’](/government/publications/affidavitaffirmation-of-marital-status-form-belgium)$D
 
-$D
-[Download ‘Affidavit for marriage’ and ’Affirmation for marriage’](/government/publications/affidavitaffirmation-of-marital-status-form-belgium)
-$D
+$A
+British Consulate General Brussels (Marriage)
+Ave d’Auderghem 10
+Brussels 1040
+BELGIUM
+$A
 
-^Your partner will need to get an affirmation as well.^
+###Check if your certificate needs to be legalised
 
-You’ll need to provide supporting documents, including:
+You might need to get your certificate of custom and law for marriage ‘legalised’ (certified as genuine) by the local authorities -  [check with the Belgian Ministry of Foreign Affairs](https://diplomatie.belgium.be/en/services/legalisation_of_documents/faq/how_can_foreign_documents_be_legalised_use_belgium).
 
-- your passport
-- proof of residence, such as a residence certificate - check with the embassy to find out what you need
-- equivalent documents for your partner
+##Fees
 
-Read the guidance on the [documents that you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
+Service | Fees
+- | -
+Certificate of custom and law for marriage | £50
+Postage | £5
 
-###Legalisation and translation
-
-You’ll need to get your affirmation or affidavit [translated](/government/collections/lists-of-translators-and-interpreters) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
-
-If you’ve been divorced or widowed, you’ll also need:
-
-- a [decree absolute or final order](/copy-decree-absolute-final-order) or the [death certificate](/order-copy-birth-death-marriage-certificate/)
-
-- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English.
-
-You’ll also need to provide evidence if you’ve changed your name by deed poll.
-
-^Your partner will probably need to get an equivalent document from their national authorities.^
-
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
-
-##Naturalisation of your partner if they move to the UK
-
-Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
-
-## Fees
-
-<%= render partial: 'consular_fees_table_items.govspeak.erb',
-    collection: calculator.services,
-    as: :service,
-    locals: { calculator: calculator } %>
-
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Belgium](/government/publications/belgium-consular-fees).
-
-You can pay by cash or credit card, but not by personal cheque.
+You can only pay by card and in British Pounds as shown in the [list of consular fees for Belgium](/government/publications/belgium-consular-fees).

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/uk/partner_other/_opposite_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/uk/partner_other/_opposite_sex.govspeak.erb
@@ -1,5 +1,5 @@
 
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/uk/partner_other/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/uk/partner_other/_same_sex.govspeak.erb
@@ -3,7 +3,7 @@ Same-sex relationships in Belgium that are recognised as civil partnerships unde
 - marriage
 - ’cohabitation légale’, ’wettelijke samenwoning’, or ’gesetzliches zusammenwohnen’ (’statutory cohabitation’)
 
-Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/uk/partner_other/_same_sex.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belgium/uk/partner_other/_same_sex.govspeak.erb
@@ -3,62 +3,40 @@ Same-sex relationships in Belgium that are recognised as civil partnerships unde
 - marriage
 - ’cohabitation légale’, ’wettelijke samenwoning’, or ’gesetzliches zusammenwohnen’ (’statutory cohabitation’)
 
-Contact the [Embassy of Belgium](/government/publications/foreign-embassies-in-the-uk) before making any plans to find out about local laws, including what documents you’ll need.
+Contact the relevant local authorities in Belgium to find out about local marriage laws, including [what documents you’ll need](notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
 
-^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Belgium](/foreign-travel-advice/belgium) before making any plans.
+^You should [get legal advice](/government/collections/list-of-lawyers) and check the travel advice for Belgium before making any plans.^
 
 ##What you need to do
 
-You’ll be asked to provide an affirmation or affidavit document to prove you’re allowed to marry.
+You'll be asked to provide a 'certificate of custom and law for marriage' (‘certificate de coutume’ or ‘certificaat van gewoonterecht’) to prove you’re allowed to marry.
 
-Make an appointment at the British embassy or consulate in Belgium to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
+You need to apply by post. Your certificate will then be posted to you within 10 working days.
 
-[Make an appointment at the British embassy in Brussels.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
+If your partner is British, they also need to get a certificate. You can send both applications in the same envelope. You'll still need to pay 2 application fees, but you'll only be charged once for the postage of your certificates.
 
-You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.
+s1. Download the application for a certificate of custom and law for marriage.
+s2. Fill in and sign the form and payment authorisation slip. You’ll need to get certain documents - these are listed on the form.
+s3. Post your application and supporting documents to the British Consulate General Brussels. Write your own address on the envelope too - this is where you’ll be sent your certificate. 
 
-You can download and fill in (but not sign) the forms in advance.
+$D[Download ‘Application for a certificate of custom/law for marriage in Belgium’](/government/publications/affidavitaffirmation-of-marital-status-form-belgium)$D
 
-$D
-[Download ‘Affidavit for marriage’ and ’Affirmation for marriage’](/government/publications/affidavitaffirmation-of-marital-status-form-belgium)
-$D
+$A
+British Consulate General Brussels (Marriage)
+Ave d’Auderghem 10
+Brussels 1040
+BELGIUM
+$A
 
-^Your partner will need to get an affirmation as well.^
+###Check if your certificate needs to be legalised
 
-You’ll need to provide supporting documents, including:
+You might need to get your certificate of custom and law for marriage ‘legalised’ (certified as genuine) by the local authorities -  [check with the Belgian Ministry of Foreign Affairs](https://diplomatie.belgium.be/en/services/legalisation_of_documents/faq/how_can_foreign_documents_be_legalised_use_belgium).
 
-- your passport
-- proof of residence, such as a residence certificate - check with the embassy to find out what you need
-- equivalent documents for your partner
+##Fees
 
-Read the guidance on the [documents that you’ll need](/notarial-and-documentary-services-guide-for-belgium#proof-of-address-and-identity).
+Service | Fees
+- | -
+Certificate of custom and law for marriage | £50
+Postage | £5
 
-###Legalisation and translation
-
-You’ll need to get your affirmation or affidavit [translated](/government/collections/lists-of-translators-and-interpreters) into the local language and ‘[legalised](/get-document-legalised)’ (certified as genuine) by the local authorities - the embassy or consulate should be able to give you advice.
-
-If you’ve been divorced, widowed or previously in a civil partnership, you’ll need to provide:
-
-- a [decree absolute or final order](/copy-decree-absolute-final-order) or [death certificate](/order-copy-birth-death-marriage-certificate)
-- evidence of nationality or residence where your divorce took place if it was outside the UK. You’ll need to get it [translated](/government/collections/lists-of-translators-and-interpreters) if it’s not in English
-- a civil partnership dissolution or annulment certificate
-- evidence if you’ve changed your name by deed poll
-
-%The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
-
-^Your partner will probably need to get an equivalent document from their national authorities.^
-
-##Naturalisation of your partner if they move to the UK
-
-Your partner can apply to [become a British citizen](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
-
-## Fees
-
-<%= render partial: 'consular_fees_table_items.govspeak.erb',
-    collection: calculator.services,
-    as: :service,
-    locals: { calculator: calculator } %>
-
-You normally have to pay fees for consular services in the local currency - these are shown in the list of [consular fees for Belgium](/government/publications/belgium-consular-fees).
-
-You can pay by cash or credit card, but not by personal cheque.
+You can only pay by card and in British Pounds as shown in the [list of consular fees for Belgium](/government/publications/belgium-consular-fees).


### PR DESCRIPTION
TRELLO: https://trello.com/c/qvjz12na/2357-getting-married-abroad-belgium

There is a new application process for marriage abroad in Belgium, including a new downloadable form. These changes:

- explain the new process in all outcomes, including a new download link to the application 
- remove the automatic fees table so that postage fees can be included
 - keep the introduction in all same-sex outcomes