### PR TITLE
Revert "Bump govuk_publishing_components from 17.21.0 to 19.0.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "gds-api-adapters", "~> 60.0.0"
 gem 'govspeak', '~> 6.5.0'
 gem 'govuk-content-schema-test-helpers', '~> 1.6.1'
 gem 'govuk_frontend_toolkit', '>= 7.5.0'
-gem 'govuk_publishing_components', '19.0.0'
+gem 'govuk_publishing_components', '17.21.0'
 gem 'htmlentities', '~> 4'
 gem 'json'
 gem 'lrucache', '0.1.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,7 +116,7 @@ GEM
     govuk_frontend_toolkit (8.2.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (19.0.0)
+    govuk_publishing_components (17.21.0)
       gds-api-adapters
       govuk_app_config
       govuk_frontend_toolkit
@@ -174,7 +174,7 @@ GEM
       metaclass (~> 0.0.1)
     multipart-post (2.1.1)
     netrc (0.11.0)
-    nio4r (2.5.1)
+    nio4r (2.4.0)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     nokogumbo (2.0.1)
@@ -273,7 +273,7 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    sassc (2.2.0)
+    sassc (2.1.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
       railties (>= 4.0.0)
@@ -363,7 +363,7 @@ DEPENDENCIES
   govuk-lint
   govuk_app_config
   govuk_frontend_toolkit (>= 7.5.0)
-  govuk_publishing_components (= 19.0.0)
+  govuk_publishing_components (= 17.21.0)
   govuk_test
   htmlentities (~> 4)
   json


### PR DESCRIPTION
Reverts alphagov/smart-answers#4116

Reverts #525

Version 18 and 19 of the govuk_publishing_components are breaking versions, as they introduce GOVUK Frontend Version 3 which in itself is a breaking change. We need to address some styling and mixin issues introduced as a result of this change before we can merge in version 19 of the gem.

Example:
<img width="1020" alt="Screen Shot 2019-09-04 at 10 17 18" src="https://user-images.githubusercontent.com/29889908/64242333-3f909b00-cefd-11e9-97bc-957dfc695d9f.png">

Small font in feedback component