### PR TITLE
Upgrade components gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "gds-api-adapters", "~> 60.0.0"
 gem 'govspeak', '~> 6.5.0'
 gem 'govuk-content-schema-test-helpers', '~> 1.6.1'
 gem 'govuk_frontend_toolkit', '>= 7.5.0'
-gem 'govuk_publishing_components', '17.21.0'
+gem 'govuk_publishing_components', '20.2.2'
 gem 'htmlentities', '~> 4'
 gem 'json'
 gem 'lrucache', '0.1.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,10 +113,10 @@ GEM
       sentry-raven (>= 2.7.1, < 2.12.0)
       statsd-ruby (~> 1.4.0)
       unicorn (>= 5.4, < 5.6)
-    govuk_frontend_toolkit (8.2.0)
+    govuk_frontend_toolkit (9.0.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (17.21.0)
+    govuk_publishing_components (20.2.2)
       gds-api-adapters
       govuk_app_config
       govuk_frontend_toolkit
@@ -161,9 +161,9 @@ GEM
       mimemagic (~> 0.3.2)
     metaclass (0.0.4)
     method_source (0.9.2)
-    mime-types (3.2.2)
+    mime-types (3.3)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2019.0331)
+    mime-types-data (3.2019.0904)
     mimemagic (0.3.3)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
@@ -174,7 +174,7 @@ GEM
       metaclass (~> 0.0.1)
     multipart-post (2.1.1)
     netrc (0.11.0)
-    nio4r (2.4.0)
+    nio4r (2.5.1)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     nokogumbo (2.0.1)
@@ -242,7 +242,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     rinku (2.0.6)
-    rouge (3.9.0)
+    rouge (3.10.0)
     rubocop (0.72.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
@@ -273,7 +273,7 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    sassc (2.1.0)
+    sassc (2.2.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
       railties (>= 4.0.0)
@@ -363,7 +363,7 @@ DEPENDENCIES
   govuk-lint
   govuk_app_config
   govuk_frontend_toolkit (>= 7.5.0)
-  govuk_publishing_components (= 17.21.0)
+  govuk_publishing_components (= 20.2.2)
   govuk_test
   htmlentities (~> 4)
   json

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,3 +1,6 @@
+$govuk-compatibility-govukfrontendtoolkit: true;
+$govuk-compatibility-govuktemplate: true;
+
 // frontend_toolkit
 @import "conditionals";
 @import "typography";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,6 +7,6 @@ $govuk-compatibility-govuktemplate: true;
 @import "colours";
 @import "shims";
 
-@import "smart_answers";
-
 @import "govuk_publishing_components/all_components";
+
+@import "smart_answers";

--- a/app/assets/stylesheets/smart_answers.scss
+++ b/app/assets/stylesheets/smart_answers.scss
@@ -41,6 +41,10 @@ $is-ie: false !default;
     min-height: 0px;
   }
 
+  .descriptive__text a:focus {
+    @include govuk-focused-text;
+  }
+
   .previous-answers-top {
     margin-bottom: 1.5em;
   }

--- a/app/views/smart_answers/_previous_answer.html.erb
+++ b/app/views/smart_answers/_previous_answer.html.erb
@@ -12,7 +12,7 @@
   <% end %>
 
   <td class="link-right">
-    <%= link_to @presenter.change_collapsed_question_link(number_questions_so_far + 1) do %>
+    <%= link_to @presenter.change_collapsed_question_link(number_questions_so_far + 1), class: "govuk-link" do %>
       Change<span class="visuallyhidden"> answer to "<%= question.title %>"</span>
     <% end %>
   </td>

--- a/app/views/smart_answers/_previous_answers.html.erb
+++ b/app/views/smart_answers/_previous_answers.html.erb
@@ -5,7 +5,7 @@
           <h3 class="previous-answers-title">
             Previous answers
           </h3>
-          <%= link_to "Start again", smart_answer_path(params[:id]), :class => "start-right" %>
+          <%= link_to "Start again", smart_answer_path(params[:id]), :class => "start-right govuk-link" %>
         <table>
           <tbody>
             <% @presenter.collapsed_questions.each_with_index do |question, number_questions_so_far| %>

--- a/app/views/smart_answers/landing.html.erb
+++ b/app/views/smart_answers/landing.html.erb
@@ -13,7 +13,9 @@
     <article role="article" class="group" data-debug-template-path="<%= start_node.relative_erb_template_path %>">
       <div class="inner">
         <section class="intro">
-          <%= start_node.body %>
+          <div class="descriptive__text">
+            <%= start_node.body %>
+          </div>
 
           <p class="get-started">
             <a rel="nofollow" href="<%= smart_answer_path(@name.to_s, started: "y") %>" class="big button" role="button"><%= start_node.start_button_text %></a>
@@ -21,7 +23,7 @@
         </section>
         <section class="more">
           <% unless start_node.post_body.blank? %>
-            <div id="before-you-start">
+            <div id="before-you-start" class="descriptive__text">
               <h2>Before you start</h2>
               <%= start_node.post_body %>
             </div>

--- a/app/views/smart_answers/result.html.erb
+++ b/app/views/smart_answers/result.html.erb
@@ -16,7 +16,9 @@
           <div class="summary"><h2 class="result-title"><%= outcome.title %></h2></div>
         <% end %>
 
-        <%= outcome.body %>
+        <div class="descriptive__text">
+          <%= outcome.body %>
+        </div>
       </div>
     </div>
 


### PR DESCRIPTION
Upgrade smart answers to the new components gem. Not much needed doing, although I've had to apply a workaround to get `govuk-link` styles into most of the text, by wrapping the text in a new class and giving that the required link styles.

There are a lot of elements in this application that would benefit from components but this is not a small change so I'm attempting it in a [separate PR](https://github.com/alphagov/smart-answers/pull/4132).
