### PR TITLE
Use govuk components in smart answers

### DIFF
--- a/app/assets/javascripts/helpers.js
+++ b/app/assets/javascripts/helpers.js
@@ -27,7 +27,7 @@ function linkToTemplatesOnGithub() {
  * is deselected.
  */
 SmartAnswer.toggleCheckboxes = function() {
-  var checkboxSel = ".selectable input[type='checkbox']";
+  var checkboxSel = ".govuk-checkboxes__input[type='checkbox']";
   var noneCheckboxSel = checkboxSel + "[value='none']";
   var $checkboxes = $(checkboxSel).not(noneCheckboxSel);
   var $noneCheckbox = $(noneCheckboxSel);
@@ -35,7 +35,6 @@ SmartAnswer.toggleCheckboxes = function() {
     var $checkbox = this.value === 'none' ? $checkboxes : $noneCheckbox;
     if (this.checked) {
       $checkbox.prop('checked', false);
-      $checkbox.parent().removeClass('selected'); // parent label class.
     }
   };
   $checkboxes.change(deselectOptions);

--- a/app/assets/stylesheets/smart_answers.scss
+++ b/app/assets/stylesheets/smart_answers.scss
@@ -407,3 +407,10 @@ $is-ie: false !default;
       color: #FFF3CF;
     }
 }
+
+.date-wrapper {
+  .date-wrapper__col {
+    width: auto;
+    margin-bottom: govuk-spacing(3);
+  }
+}

--- a/app/assets/stylesheets/smart_answers.scss
+++ b/app/assets/stylesheets/smart_answers.scss
@@ -367,11 +367,6 @@ $is-ie: false !default;
     }
   }
 
-  .error-message {
-    margin-top: 0;
-    color:#B01117;
-  }
-
   /*
    * calculators
    */

--- a/app/presenters/checkbox_question_presenter.rb
+++ b/app/presenters/checkbox_question_presenter.rb
@@ -1,4 +1,6 @@
 class CheckboxQuestionPresenter < QuestionWithOptionsPresenter
+  include CurrentQuestionHelper
+
   def response_labels(values)
     values.split(",").map do |value|
       if value == SmartAnswer::Question::Checkbox::NONE_OPTION
@@ -9,15 +11,43 @@ class CheckboxQuestionPresenter < QuestionWithOptionsPresenter
     end
   end
 
+  def multiple_responses?
+    true
+  end
+
+  def hint_text
+    none_option_prefix.present? ? none_option_prefix : hint
+  end
+
+  def checkboxes
+    checkboxes = []
+
+    options.each do |option|
+      checkboxes << {
+        label: option.label,
+        value: option.value,
+        checked: prefill_value_includes?(self, option.value),
+      }
+    end
+
+    if none_option_label.present?
+      checkboxes << {
+        label: none_option_label,
+        value: "none",
+        checked: prefill_value_is?("none"),
+      }
+    end
+
+    checkboxes
+  end
+
+private
+
   def none_option_label
     @node.none_option_label
   end
 
   def none_option_prefix
     @node.none_option_prefix
-  end
-
-  def multiple_responses?
-    true
   end
 end

--- a/app/presenters/country_select_question_presenter.rb
+++ b/app/presenters/country_select_question_presenter.rb
@@ -1,11 +1,17 @@
 class CountrySelectQuestionPresenter < QuestionPresenter
-  def response_label(value)
-    options.find { |option| option.value == value }.label
+  include CurrentQuestionHelper
+
+  def select_options
+    @node.options.map do |option|
+      {
+        text: option.name,
+        value: option.slug,
+        selected: option.slug == prefill_value_for(self),
+      }
+    end
   end
 
-  def options
-    @node.options.map do |option|
-      OpenStruct.new(label: option.name, value: option.slug)
-    end
+  def response_label(value)
+    select_options.find { |option| option[:value] == value }[:text]
   end
 end

--- a/app/presenters/date_question_presenter.rb
+++ b/app/presenters/date_question_presenter.rb
@@ -1,4 +1,5 @@
 class DateQuestionPresenter < QuestionPresenter
+  include CurrentQuestionHelper
   delegate %i[default_day default_month default_year] => :@node
 
   def response_label(value)
@@ -9,6 +10,37 @@ class DateQuestionPresenter < QuestionPresenter
     end
   end
 
+  def error_id
+    "error_id" if error
+  end
+
+  def days_options
+    days = Array(1..31).map { |number|
+      format_date(number, :day)
+    }
+    days.unshift(text: "", value: "")
+  end
+
+  def months_options
+    months = Array(1..12).map { |number|
+      format_date(number, :month)
+    }
+    months.unshift(text: "", value: "")
+  end
+
+  def years_options
+    years = Array(start_date.year..end_date.year).map { |number|
+      format_date(number, :year)
+    }
+    years.unshift(text: "", value: "")
+  end
+
+private
+
+  def only_display_day_and_month?(value)
+    value.year.zero?
+  end
+
   def start_date
     @node.range == false ? 1.year.ago : @node.range.begin
   end
@@ -17,9 +49,11 @@ class DateQuestionPresenter < QuestionPresenter
     @node.range == false ? 3.years.from_now : @node.range.end
   end
 
-private
-
-  def only_display_day_and_month?(value)
-    value.year.zero?
+  def format_date(number, type)
+    {
+      text: type.eql?(:month) ? Date::MONTHNAMES[number] : number,
+      value: number,
+      selected: default_for_date(prefill_value_for(self, type)) == number,
+    }
   end
 end

--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -64,7 +64,7 @@ class FlowPresenter
                       else
                         NodePresenter
                       end
-    @node_presenters[node.name] ||= presenter_class.new(node, current_state)
+    @node_presenters[node.name] ||= presenter_class.new(node, current_state, {}, params)
   end
 
   def current_question_number

--- a/app/presenters/multiple_choice_question_presenter.rb
+++ b/app/presenters/multiple_choice_question_presenter.rb
@@ -1,5 +1,17 @@
 class MultipleChoiceQuestionPresenter < QuestionWithOptionsPresenter
+  include CurrentQuestionHelper
+
   def response_label(value)
-    options.find { |option| option.value == value }.label
+    options.find { |option| option[:value] == value }.label
+  end
+
+  def radio_buttons
+    options.map do |option|
+      {
+        text: option.label,
+        value: option.value,
+        checked: prefill_value_is?(option.value),
+      }
+    end
   end
 end

--- a/app/presenters/node_presenter.rb
+++ b/app/presenters/node_presenter.rb
@@ -2,7 +2,7 @@ class NodePresenter
   extend Forwardable
   delegate [:outcome?] => :@node
 
-  def initialize(node, state = nil)
+  def initialize(node, state = nil, _options = {}, _params = {})
     @node = node
     @state = state || SmartAnswer::State.new(nil)
   end

--- a/app/presenters/outcome_presenter.rb
+++ b/app/presenters/outcome_presenter.rb
@@ -1,6 +1,7 @@
 class OutcomePresenter < NodePresenter
-  def initialize(node, state = nil, options = {})
+  def initialize(node, state = nil, options = {}, params = {})
     super(node, state)
+    @params = params
     helpers = options[:helpers] || []
     @renderer = options[:renderer] || SmartAnswer::ErbRenderer.new(
       template_directory: @node.template_directory.join("outcomes"),

--- a/app/presenters/question_presenter.rb
+++ b/app/presenters/question_presenter.rb
@@ -1,6 +1,9 @@
 class QuestionPresenter < NodePresenter
-  def initialize(node, state = nil, options = {})
+  attr_reader :params
+
+  def initialize(node, state = nil, options = {}, params = {})
     super(node, state)
+    @params = params
     @renderer = options[:renderer]
     helpers = options[:helpers] || []
     @renderer ||= SmartAnswer::ErbRenderer.new(

--- a/app/presenters/value_question_presenter.rb
+++ b/app/presenters/value_question_presenter.rb
@@ -4,4 +4,8 @@ class ValueQuestionPresenter < QuestionPresenter
   def response_label(value)
     number_with_delimiter(value)
   end
+
+  def hint_text
+    suffix_label.present? ? suffix_label : label
+  end
 end

--- a/app/views/smart_answers/inputs/_checkbox_question.html.erb
+++ b/app/views/smart_answers/inputs/_checkbox_question.html.erb
@@ -1,21 +1,8 @@
-<ul class="options">
-  <% question.options.each.with_index do |option, i| %>
-    <li>
-      <label for="response_<%= i %>" class="selectable">
-        <%= check_box_tag "response[]", option.value, prefill_value_includes?(question, option.value), id: "response_#{i}" %>
-        <%= option.label %>
-      </label>
-    </li>
-  <% end %>
-  <% if question.none_option_label.present? %>
-    <li class="none-option">
-      <% if question.none_option_prefix.present? %>
-        <p><%= question.none_option_prefix %></p>
-      <% end %>
-      <label for="response_<%= question.options.size %>" class="selectable">
-        <%= check_box_tag "response[]", "none", prefill_value_is?("none"), id: "response_#{question.options.size}" %>
-        <%= question.none_option_label %>
-      </label>
-    </li>
-  <% end %>
-</ul>
+<%= render "govuk_publishing_components/components/checkboxes", {
+  name: "response[]",
+  heading: question.title,
+  id: "response",
+  error: question.error,
+  hint_text: question.hint_text,
+  items: question.checkboxes
+} %>

--- a/app/views/smart_answers/inputs/_country_select_question.html.erb
+++ b/app/views/smart_answers/inputs/_country_select_question.html.erb
@@ -1,1 +1,7 @@
-<%= select_tag "response", options_from_collection_for_select(question.options, :value, :label, prefill_value_for(question)) %>
+<%= render "govuk_publishing_components/components/select", {
+  id: "response",
+  label: question.title,
+  heading_size: 'm',
+  error_message: question.error,
+  options: question.select_options
+} %>

--- a/app/views/smart_answers/inputs/_date_question.html.erb
+++ b/app/views/smart_answers/inputs/_date_question.html.erb
@@ -1,17 +1,45 @@
-<fieldset>
-  <% unless question.default_day %>
-    <label for="response_day">Day
-      <%= select_day default_for_date(prefill_value_for(question, :day)), prefix: "response", :prompt => '' %>
-    </label>
-  <% end %>
-  <% unless question.default_month %>
-    <label for="response_month">Month
-      <%= select_month default_for_date(prefill_value_for(question, :month)), prefix: "response", prompt: '' %>
-    </label>
-  <% end %>
-  <% unless question.default_year %>
-    <label for="response_year">Year
-      <%= select_year default_for_date(prefill_value_for(question, :year)), prefix: "response", prompt: '', :start_year => question.start_date.year, :end_year => question.end_date.year %>
-    </label>
-  <% end %>
-</fieldset>
+<% form_contents = capture do %>
+  <div class="govuk-grid-row date-wrapper">
+    <% unless question.default_day %>
+      <div class="govuk-grid-column-one-third date-wrapper__col">
+        <%= render "govuk_publishing_components/components/select", {
+          id: "response_day",
+          name: "response[day]",
+          label: "Day",
+          error_id: question.error_id,
+          options: question.days_options
+        } %>
+      </div>
+    <% end %>
+    <% unless question.default_month %>
+      <div class="govuk-grid-column-one-third date-wrapper__col">
+        <%= render "govuk_publishing_components/components/select", {
+          id: "response_month",
+          name: "response[month]",
+          label: "Month",
+          error_id: question.error_id,
+          options: question.months_options
+        } %>
+      </div>
+    <% end %>
+    <% unless question.default_year %>
+      <div class="govuk-grid-column-one-third date-wrapper__col">
+        <%= render "govuk_publishing_components/components/select", {
+          id: "response_year",
+          name: "response[year]",
+          label: "Year",
+          error_id: question.error_id,
+          options: question.years_options
+        } %>
+      </div>
+    <% end %>
+  </div>
+<% end %>
+
+<%= render "govuk_publishing_components/components/fieldset", {
+  legend_text: question.title,
+  heading_size: 'm',
+  error_message: question.error,
+  error_id: question.error_id,
+  text: form_contents
+} %>

--- a/app/views/smart_answers/inputs/_money_question.html.erb
+++ b/app/views/smart_answers/inputs/_money_question.html.erb
@@ -1,1 +1,11 @@
-<label for="response">&pound; <%= text_field_tag('response', nil, size: 5, value: prefill_value_for(question)) %><%= question.suffix_label %></label>
+<%= render "govuk_publishing_components/components/input", {
+  label: {
+    text: question.title
+  },
+  name: "response",
+  id: "response",
+  heading_size: "m",
+  hint: "in £ #{question.suffix_label}",
+  value: prefill_value_for(question),
+  error_message: question.error
+} %>

--- a/app/views/smart_answers/inputs/_multiple_choice_question.html.erb
+++ b/app/views/smart_answers/inputs/_multiple_choice_question.html.erb
@@ -1,12 +1,8 @@
-<% yes_no = question.options.map(&:label).sort == ['No','Yes'] %>
-<% style = yes_no ? 'options inline' : 'options' %>
-<ul class="<%= style %>">
-  <% question.options.each.with_index do |option, i| %>
-    <li>
-      <label for="response_<%= i %>" class="selectable">
-        <%= radio_button_tag "response", option.value, prefill_value_is?(option.value), id: "response_#{i}" %>
-        <%= option.label %>
-      </label>
-    </li>
- <% end %>
-</ul>
+<%= render "govuk_publishing_components/components/radio", {
+  name: "response",
+  heading: question.title,
+  hint: question.hint,
+  id_prefix: "response",
+  error_message: question.error,
+  items: question.radio_buttons
+} %>

--- a/app/views/smart_answers/inputs/_postcode_question.html.erb
+++ b/app/views/smart_answers/inputs/_postcode_question.html.erb
@@ -1,3 +1,10 @@
-<label for="response">
-  <%= text_field_tag("response", prefill_value_for(question)) %>
-</label>
+<%= render "govuk_publishing_components/components/input", {
+  label: {
+    text: question.title
+  },
+  name: "response",
+  id: "response",
+  heading_size: "m",
+  error_message: question.error,
+  value: prefill_value_for(question)
+} %>

--- a/app/views/smart_answers/inputs/_salary_question.html.erb
+++ b/app/views/smart_answers/inputs/_salary_question.html.erb
@@ -1,10 +1,34 @@
-<fieldset>
-  <label for="response_amount">
-    &pound; <%= text_field_tag("response[amount]", nil, size: 5, value: prefill_value_for(question, :amount)) %>
-  </label>
-  <label for="response_period">
-  per <select name="response[period]">
-    <%= options_for_select %w{week month year}, prefill_value_for(question, :period) %>
-  </select>
-  </label>
-</fieldset>
+<%= render "govuk_publishing_components/components/input", {
+  label: {
+    text: question.title
+  },
+  name: "response[amount]",
+  id: "response_amount",
+  heading_size: "m",
+  hint: "in £",
+  error_message: question.error,
+  value: prefill_value_for(question, :amount)
+} %>
+<%= render "govuk_publishing_components/components/select", {
+  id: "response_month",
+  name: "response[period]",
+  heading_size: "m",
+  label: "How often?",
+  options: [
+    {
+      text: "per week",
+      value: "week",
+      selected: prefill_value_for(question, :period) == "week"
+    },
+    {
+      text: "per month",
+      value: "month",
+      selected: prefill_value_for(question, :period) == "month"
+    },
+    {
+      text: "per year",
+      value: "year",
+      selected: prefill_value_for(question, :period) == "year"
+    }
+  ]
+} %>

--- a/app/views/smart_answers/inputs/_value_question.html.erb
+++ b/app/views/smart_answers/inputs/_value_question.html.erb
@@ -1,4 +1,11 @@
-<% if question.has_labels? %><label for="response"><%
-  unless question.suffix_label.present? %><%= question.label %><% end %><% end
-%><%= text_field_tag('response', prefill_value_for(question)) %><%
-  if question.has_labels? %><%= question.suffix_label %></label><% end %>
+<%= render "govuk_publishing_components/components/input", {
+  label: {
+    text: question.title
+  },
+  name: "response",
+  id: "response",
+  heading_size: "m",
+  hint: question.hint_text,
+  value: prefill_value_for(question),
+  error_message: question.error
+} %>

--- a/app/views/smart_answers/landing.html.erb
+++ b/app/views/smart_answers/landing.html.erb
@@ -18,7 +18,12 @@
           </div>
 
           <p class="get-started">
-            <a rel="nofollow" href="<%= smart_answer_path(@name.to_s, started: "y") %>" class="big button" role="button"><%= start_node.start_button_text %></a>
+            <%= render "govuk_publishing_components/components/button", {
+              text: start_node.start_button_text,
+              href: smart_answer_path(@name.to_s, started: "y"),
+              rel: "nofollow",
+              start: true
+            } %>
           </p>
         </section>
         <section class="more">

--- a/app/views/smart_answers/question.html.erb
+++ b/app/views/smart_answers/question.html.erb
@@ -14,7 +14,7 @@
 
       <div class="question" data-debug-template-path="<%= question.relative_erb_template_path %>">
         <% t = question.partial_template_name %>
-        <% if t != 'multiple_choice_question' && t != 'checkbox_question' && t != 'country_select_question' %>
+        <% if t != 'multiple_choice_question' && t != 'checkbox_question' && t != 'country_select_question' && t != 'date_question' %>
           <h2 data-test="question">
             <%= question.title %>
           </h2>

--- a/app/views/smart_answers/question.html.erb
+++ b/app/views/smart_answers/question.html.erb
@@ -14,7 +14,7 @@
 
       <div class="question" data-debug-template-path="<%= question.relative_erb_template_path %>">
         <% t = question.partial_template_name %>
-        <% if t != 'multiple_choice_question' && t != 'checkbox_question' %>
+        <% if t != 'multiple_choice_question' && t != 'checkbox_question' && t != 'country_select_question' %>
           <h2 data-test="question">
             <%= question.title %>
           </h2>

--- a/app/views/smart_answers/question.html.erb
+++ b/app/views/smart_answers/question.html.erb
@@ -13,18 +13,17 @@
     <div class="current-question" id="current-question">
 
       <div class="question" data-debug-template-path="<%= question.relative_erb_template_path %>">
-        <h2 data-test="question">
-          <%= question.title %>
-        </h2>
+        <% if question.partial_template_name != 'multiple_choice_question' %>
+          <h2 data-test="question">
+            <%= question.title %>
+          </h2>
+        <% end %>
+
         <div class="question-body">
           <% if question.body.present? %>
             <article role="article">
               <%= question.body %>
             </article>
-          <% end %>
-
-          <% if question.hint.present? %>
-            <p class="hint"><%= question.hint %></p>
           <% end %>
 
           <div class="<%= question.error && 'error' %>">

--- a/app/views/smart_answers/question.html.erb
+++ b/app/views/smart_answers/question.html.erb
@@ -13,7 +13,8 @@
     <div class="current-question" id="current-question">
 
       <div class="question" data-debug-template-path="<%= question.relative_erb_template_path %>">
-        <% if question.partial_template_name != 'multiple_choice_question' %>
+        <% t = question.partial_template_name %>
+        <% if t != 'multiple_choice_question' && t != 'checkbox_question' %>
           <h2 data-test="question">
             <%= question.title %>
           </h2>

--- a/app/views/smart_answers/question.html.erb
+++ b/app/views/smart_answers/question.html.erb
@@ -13,13 +13,6 @@
     <div class="current-question" id="current-question">
 
       <div class="question" data-debug-template-path="<%= question.relative_erb_template_path %>">
-        <% t = question.partial_template_name %>
-        <% if t != 'multiple_choice_question' && t != 'checkbox_question' && t != 'country_select_question' && t != 'date_question' %>
-          <h2 data-test="question">
-            <%= question.title %>
-          </h2>
-        <% end %>
-
         <div class="question-body">
           <% if question.body.present? %>
             <article role="article">
@@ -28,12 +21,6 @@
           <% end %>
 
           <div class="<%= question.error && 'error' %>">
-            <% if question.error %>
-              <p class="error-message" id="current-error" role="alert">
-                <%= question.error %>
-              </p>
-            <% end %>
-
             <%= render partial: "smart_answers/inputs/#{question.partial_template_name}", locals: { question: question } %>
 
             <%= question.post_body %>

--- a/app/views/smart_answers/question.html.erb
+++ b/app/views/smart_answers/question.html.erb
@@ -43,7 +43,9 @@
 
       <div class="next-question">
         <input type="hidden" name="next" value="1" />
-        <button type="submit" class="medium button">Next step</button>
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Next step"
+        } %>
       </div>
     </div>
   </form>

--- a/test/functional/smart_answers_controller_date_question_test.rb
+++ b/test/functional/smart_answers_controller_date_question_test.rb
@@ -23,7 +23,7 @@ class SmartAnswersControllerDateQuestionTest < ActionController::TestCase
     context "date question" do
       should "display question" do
         get :show, params: { id: "smart-answers-controller-sample-with-date-question", started: "y" }
-        assert_select ".step.current [data-test=question]", /When\?/
+        assert_select ".step.current .govuk-fieldset__legend", /When\?/
         assert_select "select[name='response[day]']"
         assert_select "select[name='response[month]']"
         assert_select "select[name='response[year]']"
@@ -47,7 +47,7 @@ class SmartAnswersControllerDateQuestionTest < ActionController::TestCase
       context "no response given" do
         should "redisplay question" do
           submit_response(day: "", month: "", year: "")
-          assert_select ".step.current [data-test=question]", /When\?/
+          assert_select ".step.current .govuk-fieldset__legend", /When\?/
         end
 
         should "show an error message" do

--- a/test/functional/smart_answers_controller_money_question_test.rb
+++ b/test/functional/smart_answers_controller_money_question_test.rb
@@ -23,13 +23,13 @@ class SmartAnswersControllerMoneyQuestionTest < ActionController::TestCase
     context "money question" do
       should "display question" do
         get :show, params: { id: "smart-answers-controller-sample-with-money-question", started: "y" }
-        assert_select ".step.current [data-test=question]", /How much\?/
+        assert_select ".step.current .govuk-label", /How much\?/
         assert_select "input[type=text][name=response]"
       end
 
       should "show a validation error if invalid input" do
         submit_response "bad_number"
-        assert_select ".step.current [data-test=question]", /How much\?/
+        assert_select ".step.current .govuk-label", /How much\?/
         assert_select "body", /Please answer this question/
       end
 
@@ -40,7 +40,6 @@ class SmartAnswersControllerMoneyQuestionTest < ActionController::TestCase
 
         should "show the label after the question input" do
           assert_select "input[type=text][name=response]"
-          assert_match(/input.*?name="response".*?money-question-suffix-label/m, response.body)
         end
       end
     end

--- a/test/functional/smart_answers_controller_salary_question_test.rb
+++ b/test/functional/smart_answers_controller_salary_question_test.rb
@@ -23,7 +23,7 @@ class SmartAnswersControllerSalaryQuestionTest < ActionController::TestCase
     context "salary question" do
       should "display question" do
         get :show, params: { id: "smart-answers-controller-sample-with-salary-question", started: "y" }
-        assert_select ".step.current [data-test=question]", /How much\?/
+        assert_select ".step.current .govuk-label", /How much\?/
         assert_select "input[type=text][name='response[amount]']"
         assert_select "select[name='response[period]']"
       end
@@ -34,7 +34,7 @@ class SmartAnswersControllerSalaryQuestionTest < ActionController::TestCase
         end
 
         should "show a validation error if invalid amount" do
-          assert_select ".step.current [data-test=question]", /Salary question with error message/
+          assert_select ".step.current .govuk-label", /Salary question with error message/
           assert_select ".error", /salary-question-error-message/
         end
       end
@@ -42,14 +42,14 @@ class SmartAnswersControllerSalaryQuestionTest < ActionController::TestCase
       context "no error message set in erb template" do
         should "show a generic message" do
           submit_response amount: "bad_number"
-          assert_select ".step.current [data-test=question]", /How much\?/
+          assert_select ".step.current .govuk-label", /How much\?/
           assert_select ".error", /Please answer this question/
         end
       end
 
       should "show a validation error if invalid period" do
         submit_response amount: "1", period: "bad_period"
-        assert_select ".step.current [data-test=question]", /How much\?/
+        assert_select ".step.current .govuk-label", /How much\?/
         assert_select ".error", /Please answer this question/
       end
 

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -116,7 +116,7 @@ class SmartAnswersControllerTest < ActionController::TestCase
 
     should "display first question after starting" do
       get :show, params: { id: "smart-answers-controller-sample", started: "y" }
-      assert_select ".step.current [data-test=question]", /Do you like chocolate\?/
+      assert_select ".step.current .govuk-fieldset__legend", /Do you like chocolate\?/
       assert_select "input[name=response][value=yes]"
       assert_select "input[name=response][value=no]"
     end

--- a/test/functional/smart_answers_controller_value_question_test.rb
+++ b/test/functional/smart_answers_controller_value_question_test.rb
@@ -23,7 +23,7 @@ class SmartAnswersControllerValueQuestionTest < ActionController::TestCase
     context "value question" do
       should "display question" do
         get :show, params: { id: "smart-answers-controller-sample-with-value-question", started: "y" }
-        assert_select ".step.current [data-test=question]", /How many green bottles\?/
+        assert_select ".step.current .govuk-label", /How many green bottles\?/
         assert_select "input[type=text][name=response]"
       end
 
@@ -43,17 +43,6 @@ class SmartAnswersControllerValueQuestionTest < ActionController::TestCase
         end
         should "show the label text before the question input" do
           assert_match(/value-question-label.*?input.*?name="response".*?/m, response.body)
-          assert_select "input[type=text][name=response]"
-        end
-      end
-
-      context "suffix_label in erb template" do
-        setup do
-          get :show, params: { id: "smart-answers-controller-sample-with-value-question", started: "y", responses: "123/456" }
-        end
-
-        should "show the label text after the question input" do
-          assert_match(/input.*?name="response".*?value-question-suffix-label/m, response.body)
           assert_select "input[type=text][name=response]"
         end
       end

--- a/test/integration/engine/changing_answer_test.rb
+++ b/test/integration/engine/changing_answer_test.rb
@@ -71,7 +71,7 @@ class ChangingAnswerTest < EngineIntegrationTest
 
       within ".current-question .question-body" do
         assert page.has_field? "response[amount]", with: "5000.0"
-        assert page.has_select? "response[period]", selected: "month"
+        assert page.has_select? "response[period]", selected: "per month"
       end
 
       fill_in "response[amount]", with: "2000"
@@ -101,11 +101,11 @@ class ChangingAnswerTest < EngineIntegrationTest
       fill_in "response", with: "Lancelot"
       click_on "Next step"
 
-      within('.current-question') { assert_page_has_content "What...is your quest?" }
+      within(".current-question") { assert_page_has_content "What...is your quest?" }
       choose("To seek the Holy Grail", visible: false)
       click_on "Next step"
 
-      within('.current-question') { assert_page_has_content "What...is your favorite colour?" }
+      within(".current-question") { assert_page_has_content "What...is your favorite colour?" }
       choose("Blue", visible: false)
       click_on "Next step"
 
@@ -119,18 +119,18 @@ class ChangingAnswerTest < EngineIntegrationTest
 
       assert_current_url "/bridge-of-death/y/Bors"
 
-      within('.current-question') { assert_page_has_content "What...is your quest?" }
+      within(".current-question") { assert_page_has_content "What...is your quest?" }
       choose("To seek the Holy Grail", visible: false)
       click_on "Next step"
 
-      within('.current-question') { assert_page_has_content "What...is your favorite colour?" }
+      within(".current-question") { assert_page_has_content "What...is your favorite colour?" }
       choose("Blue", visible: false)
       click_on "Next step"
 
       within(".result-info") { assert_page_has_content "Right, off you go." }
       within("tr.section:nth-child(2)") { click_on "Change" }
 
-      within '.current-question .question-body' do
+      within ".current-question .question-body" do
         assert page.has_checked_field?("To seek the Holy Grail", visible: false)
         assert page.has_unchecked_field?("To rescue the princess", visible: false)
         assert page.has_unchecked_field?("I dunno", visible: false)
@@ -147,7 +147,7 @@ class ChangingAnswerTest < EngineIntegrationTest
       within(".result-info") { assert_page_has_content "Right, off you go." }
       within("tr.section:nth-child(3)") { click_on "Change" }
 
-      within '.current-question .question-body' do
+      within ".current-question .question-body" do
         assert page.has_checked_field?("Blue", visible: false)
         assert page.has_unchecked_field?("Blue... NO! YELLOOOOOOOOOOOOOOOOWWW!!!!", visible: false)
         assert page.has_unchecked_field?("Red", visible: false)
@@ -172,7 +172,7 @@ class ChangingAnswerTest < EngineIntegrationTest
 
       within("tr.section:nth-child(1)") { click_on "Change" }
 
-      within '.current-question .question-body' do
+      within ".current-question .question-body" do
         assert page.has_unchecked_field?("Ham", visible: false)
         assert page.has_checked_field?("Peppers", visible: false)
         assert page.has_unchecked_field?("Ice Cream!!!", visible: false)

--- a/test/integration/engine/changing_answer_test.rb
+++ b/test/integration/engine/changing_answer_test.rb
@@ -164,22 +164,22 @@ class ChangingAnswerTest < EngineIntegrationTest
 
       visit "/checkbox-sample/y"
 
-      check "Peppers"
-      check "Pepperoni"
+      check("Peppers", visible: false)
+      check("Pepperoni", visible: false)
       click_on "Next step"
 
       assert_current_url "/checkbox-sample/y/pepperoni,peppers"
 
       within("tr.section:nth-child(1)") { click_on "Change" }
 
-      within ".current-question .question-body" do
-        assert page.has_unchecked_field?("Ham")
-        assert page.has_checked_field?("Peppers")
-        assert page.has_unchecked_field?("Ice Cream!!!")
-        assert page.has_checked_field?("Pepperoni")
+      within '.current-question .question-body' do
+        assert page.has_unchecked_field?("Ham", visible: false)
+        assert page.has_checked_field?("Peppers", visible: false)
+        assert page.has_unchecked_field?("Ice Cream!!!", visible: false)
+        assert page.has_checked_field?("Pepperoni", visible: false)
       end
 
-      check "Ham"
+      check("Ham", visible: false)
       click_on "Next step"
 
       assert_current_url "/checkbox-sample/y/ham,pepperoni,peppers"

--- a/test/integration/engine/changing_answer_test.rb
+++ b/test/integration/engine/changing_answer_test.rb
@@ -101,12 +101,12 @@ class ChangingAnswerTest < EngineIntegrationTest
       fill_in "response", with: "Lancelot"
       click_on "Next step"
 
-      within(".current-question") { assert_page_has_content "What...is your quest?" }
-      choose "To seek the Holy Grail"
+      within('.current-question') { assert_page_has_content "What...is your quest?" }
+      choose("To seek the Holy Grail", visible: false)
       click_on "Next step"
 
-      within(".current-question") { assert_page_has_content "What...is your favorite colour?" }
-      choose "Blue"
+      within('.current-question') { assert_page_has_content "What...is your favorite colour?" }
+      choose("Blue", visible: false)
       click_on "Next step"
 
       within(".result-info") { assert_page_has_content "Right, off you go." }
@@ -119,41 +119,41 @@ class ChangingAnswerTest < EngineIntegrationTest
 
       assert_current_url "/bridge-of-death/y/Bors"
 
-      within(".current-question") { assert_page_has_content "What...is your quest?" }
-      choose "To seek the Holy Grail"
+      within('.current-question') { assert_page_has_content "What...is your quest?" }
+      choose("To seek the Holy Grail", visible: false)
       click_on "Next step"
 
-      within(".current-question") { assert_page_has_content "What...is your favorite colour?" }
-      choose "Blue"
+      within('.current-question') { assert_page_has_content "What...is your favorite colour?" }
+      choose("Blue", visible: false)
       click_on "Next step"
 
       within(".result-info") { assert_page_has_content "Right, off you go." }
       within("tr.section:nth-child(2)") { click_on "Change" }
 
-      within ".current-question .question-body" do
-        assert page.has_checked_field? "To seek the Holy Grail"
-        assert page.has_unchecked_field? "To rescue the princess"
-        assert page.has_unchecked_field? "I dunno"
+      within '.current-question .question-body' do
+        assert page.has_checked_field?("To seek the Holy Grail", visible: false)
+        assert page.has_unchecked_field?("To rescue the princess", visible: false)
+        assert page.has_unchecked_field?("I dunno", visible: false)
       end
 
-      choose "To rescue the princess"
+      choose("To rescue the princess", visible: false)
       click_on "Next step"
 
       assert_current_url "/bridge-of-death/y/Bors/to_rescue_the_princess"
 
-      choose "Blue"
+      choose("Blue", visible: false)
       click_on "Next step"
 
       within(".result-info") { assert_page_has_content "Right, off you go." }
       within("tr.section:nth-child(3)") { click_on "Change" }
 
-      within ".current-question .question-body" do
-        assert page.has_checked_field? "Blue"
-        assert page.has_unchecked_field? "Blue... NO! YELLOOOOOOOOOOOOOOOOWWW!!!!"
-        assert page.has_unchecked_field? "Red"
+      within '.current-question .question-body' do
+        assert page.has_checked_field?("Blue", visible: false)
+        assert page.has_unchecked_field?("Blue... NO! YELLOOOOOOOOOOOOOOOOWWW!!!!", visible: false)
+        assert page.has_unchecked_field?("Red", visible: false)
       end
 
-      choose "Red"
+      choose("Red", visible: false)
       click_on "Next step"
 
       assert_current_url "/bridge-of-death/y/Bors/to_rescue_the_princess/red"

--- a/test/integration/engine/checkbox_questions_test.rb
+++ b/test/integration/engine/checkbox_questions_test.rb
@@ -10,22 +10,22 @@ class CheckboxQuestionsTest < EngineIntegrationTest
       visit "/checkbox-sample/y"
 
       within ".current-question" do
-        within "[data-test=question]" do
+        within ".govuk-fieldset__legend" do
           assert_page_has_content "What do you want on your pizza?"
         end
         within ".question-body" do
-          assert page.has_field?("Ham", type: "checkbox", with: "ham")
-          assert page.has_field?("Peppers", type: "checkbox", with: "peppers")
-          assert page.has_field?("Ice Cream!!!", type: "checkbox", with: "ice_cream")
-          assert page.has_field?("Pepperoni", type: "checkbox", with: "pepperoni")
+          assert page.has_field?("Ham", type: "checkbox", with: "ham", visible: false)
+          assert page.has_field?("Peppers", type: "checkbox", with: "peppers", visible: false)
+          assert page.has_field?("Ice Cream!!!", type: "checkbox", with: "ice_cream", visible: false)
+          assert page.has_field?("Pepperoni", type: "checkbox", with: "pepperoni", visible: false)
           # Assert they're in the correct order
           options = page.all(:xpath, ".//label").map(&:text).map(&:strip)
           assert_equal ["Ham", "Peppers", "Ice Cream!!!", "Pepperoni"], options
         end
       end
 
-      check "Ham"
-      check "Pepperoni"
+      check("Ham", visible: false)
+      check("Pepperoni", visible: false)
       click_on "Next step"
 
       assert_current_url "/checkbox-sample/y/ham,pepperoni"
@@ -71,7 +71,7 @@ class CheckboxQuestionsTest < EngineIntegrationTest
         assert_page_has_content "Are you sure you don't want any toppings?"
       end
 
-      check "Definitely no toppings"
+      check("Definitely no toppings", visible: false)
 
       click_on "Next step"
 
@@ -93,7 +93,7 @@ class CheckboxQuestionsTest < EngineIntegrationTest
 
       assert_equal current_path, "/checkbox-sample/y/none"
 
-      within(".error-message") do
+      within(".govuk-error-message") do
         assert_page_has_content "Please answer this question"
       end
     end
@@ -103,11 +103,11 @@ class CheckboxQuestionsTest < EngineIntegrationTest
     should "toggle options when none option is present" do
       visit "/checkbox-sample/y/none"
 
-      check "Definitely no toppings"
-      check "Hmm I'm not sure, ask me again please"
+      check("Definitely no toppings", visible: false)
+      check("Hmm I'm not sure, ask me again please", visible: false)
       refute page.has_checked_field?("Definitely no toppings")
 
-      check "Definitely no toppings"
+      check("Definitely no toppings", visible: false)
       refute page.has_checked_field?("Hmm I'm not sure, ask me again please")
       click_on "Next step"
 
@@ -118,9 +118,9 @@ class CheckboxQuestionsTest < EngineIntegrationTest
   should "calculate next_node correctly" do
     visit "/checkbox-sample/y"
 
-    check "Ham"
-    check "Ice Cream!!!"
-    click_on "Next step"
+    check("Ham", visible: false)
+    check("Ice Cream!!!", visible: false)
+    click_on("Next step", visible: false)
 
     assert_current_url "/checkbox-sample/y/ham,ice_cream"
     within ".outcome:nth-child(1)" do

--- a/test/integration/engine/country_and_date_questions_test.rb
+++ b/test/integration/engine/country_and_date_questions_test.rb
@@ -19,8 +19,8 @@ class CountryAndDateQuestionsTest < EngineIntegrationTest
     should "handle country and date questions" do
       visit "/country-and-date-sample/y"
 
-      within ".current-question" do
-        within "[data-test=question]" do
+      within '.current-question' do
+        within '.govuk-fieldset__legend' do
           assert_page_has_content "Which country do you live in?"
         end
       end
@@ -46,8 +46,8 @@ class CountryAndDateQuestionsTest < EngineIntegrationTest
         end
       end
 
-      within ".current-question" do
-        within "[data-test=question]" do
+      within '.current-question' do
+        within '.govuk-fieldset__legend' do
           assert_page_has_content "What date did you move there?"
         end
       end
@@ -86,8 +86,8 @@ class CountryAndDateQuestionsTest < EngineIntegrationTest
         end
       end
 
-      within ".current-question" do
-        within "[data-test=question]" do
+      within '.current-question' do
+        within '.govuk-fieldset__legend' do
           assert_page_has_content "Which country were you born in?"
         end
       end

--- a/test/integration/engine/country_and_date_questions_test.rb
+++ b/test/integration/engine/country_and_date_questions_test.rb
@@ -19,10 +19,8 @@ class CountryAndDateQuestionsTest < EngineIntegrationTest
     should "handle country and date questions" do
       visit "/country-and-date-sample/y"
 
-      within '.current-question' do
-        within '.govuk-fieldset__legend' do
-          assert_page_has_content "Which country do you live in?"
-        end
+      within ".current-question" do
+        assert_page_has_content "Which country do you live in?"
       end
       within ".question-body" do
         assert page.has_select?("response")
@@ -46,10 +44,8 @@ class CountryAndDateQuestionsTest < EngineIntegrationTest
         end
       end
 
-      within '.current-question' do
-        within '.govuk-fieldset__legend' do
-          assert_page_has_content "What date did you move there?"
-        end
+      within ".current-question" do
+        assert_page_has_content "What date did you move there?"
       end
 
       within ".question-body" do
@@ -86,10 +82,8 @@ class CountryAndDateQuestionsTest < EngineIntegrationTest
         end
       end
 
-      within '.current-question' do
-        within '.govuk-fieldset__legend' do
-          assert_page_has_content "Which country were you born in?"
-        end
+      within ".current-question" do
+        assert_page_has_content "Which country were you born in?"
       end
       within ".question-body" do
         assert page.has_select?("response")

--- a/test/integration/engine/money_and_salary_questions_test.rb
+++ b/test/integration/engine/money_and_salary_questions_test.rb
@@ -10,12 +10,12 @@ class MoneyAndSalaryQuestionsTest < EngineIntegrationTest
       visit "/money-and-salary-sample/y"
 
       within ".current-question" do
-        within "[data-test=question]" do
+        within '.govuk-label[for="response_amount"]' do
           assert_page_has_content "How much do you earn?"
         end
         within ".question-body" do
           assert page.has_field?("response[amount]", type: "text")
-          assert page.has_select?("response[period]", options: %w(week month year))
+          assert page.has_select?("response[period]", options: ["per week", "per month", "per year"])
         end
       end
 
@@ -37,7 +37,7 @@ class MoneyAndSalaryQuestionsTest < EngineIntegrationTest
       end
 
       within ".current-question" do
-        within "[data-test=question]" do
+        within '.govuk-label[for="response"]' do
           assert_page_has_content "What size bonus do you want?"
         end
         within ".question-body" do

--- a/test/integration/engine/multiple_choice_and_value_questions_test.rb
+++ b/test/integration/engine/multiple_choice_and_value_questions_test.rb
@@ -62,8 +62,8 @@ class MultipleChoiceAndValueQuestionsTest < EngineIntegrationTest
         end
       end
 
-      within ".current-question" do
-        within "[data-test=question]" do
+      within '.current-question' do
+        within '.govuk-fieldset__legend' do
           assert_page_has_content "What...is your quest?"
         end
         within ".question-body" do
@@ -99,8 +99,8 @@ class MultipleChoiceAndValueQuestionsTest < EngineIntegrationTest
         end
       end
 
-      within ".current-question" do
-        within "[data-test=question]" do
+      within '.current-question' do
+        within '.govuk-fieldset__legend' do
           assert_page_has_content "What...is your favorite colour?"
         end
         within ".question-body" do

--- a/test/integration/engine/multiple_choice_and_value_questions_test.rb
+++ b/test/integration/engine/multiple_choice_and_value_questions_test.rb
@@ -62,21 +62,21 @@ class MultipleChoiceAndValueQuestionsTest < EngineIntegrationTest
         end
       end
 
-      within '.current-question' do
-        within '.govuk-fieldset__legend' do
+      within ".current-question" do
+        within ".govuk-fieldset__legend" do
           assert_page_has_content "What...is your quest?"
         end
         within ".question-body" do
-          assert page.has_field?("To seek the Holy Grail", type: "radio", with: "to_seek_the_holy_grail")
-          assert page.has_field?("To rescue the princess", type: "radio", with: "to_rescue_the_princess")
-          assert page.has_field?("I dunno", type: "radio", with: "dunno")
+          assert page.has_field?("To seek the Holy Grail", type: "radio", with: "to_seek_the_holy_grail", visible: false)
+          assert page.has_field?("To rescue the princess", type: "radio", with: "to_rescue_the_princess", visible: false)
+          assert page.has_field?("I dunno", type: "radio", with: "dunno", visible: false)
           # Assert they're in the correct order
           options = page.all(:xpath, ".//label").map(&:text).map(&:strip)
           assert_equal ["To seek the Holy Grail", "To rescue the princess", "I dunno"], options
         end
       end
 
-      choose "To seek the Holy Grail"
+      choose("To seek the Holy Grail", visible: false)
       click_on "Next step"
 
       assert_current_url "/bridge-of-death/y/Lancelot/to_seek_the_holy_grail"
@@ -99,21 +99,21 @@ class MultipleChoiceAndValueQuestionsTest < EngineIntegrationTest
         end
       end
 
-      within '.current-question' do
-        within '.govuk-fieldset__legend' do
+      within ".current-question" do
+        within ".govuk-fieldset__legend" do
           assert_page_has_content "What...is your favorite colour?"
         end
         within ".question-body" do
-          assert page.has_field?("Blue", type: "radio", with: "blue")
-          assert page.has_field?("Blue... NO! YELLOOOOOOOOOOOOOOOOWWW!!!!", type: "radio", with: "blue_no_yellow")
-          assert page.has_field?("Red", type: "radio", with: "red")
+          assert page.has_field?("Blue", type: "radio", with: "blue", visible: false)
+          assert page.has_field?("Blue... NO! YELLOOOOOOOOOOOOOOOOWWW!!!!", type: "radio", with: "blue_no_yellow", visible: false)
+          assert page.has_field?("Red", type: "radio", with: "red", visible: false)
           # Assert they're in the correct order
           options = page.all(:xpath, ".//label").map(&:text).map(&:strip)
           assert_equal ["Blue", "Blue... NO! YELLOOOOOOOOOOOOOOOOWWW!!!!", "Red"], options
         end
       end
 
-      choose "Blue"
+      choose("Blue", visible: false)
       click_on "Next step"
 
       assert_current_url "/bridge-of-death/y/Lancelot/to_seek_the_holy_grail/blue"
@@ -158,7 +158,7 @@ class MultipleChoiceAndValueQuestionsTest < EngineIntegrationTest
     fill_in "response", with: "Robin"
     click_on "Next step"
 
-    choose "To seek the Holy Grail"
+    choose("To seek the Holy Grail", visible: false)
     click_on "Next step"
 
     assert_current_url "/bridge-of-death/y/Robin/to_seek_the_holy_grail"

--- a/test/integration/engine/multiple_choice_and_value_questions_test.rb
+++ b/test/integration/engine/multiple_choice_and_value_questions_test.rb
@@ -38,7 +38,7 @@ class MultipleChoiceAndValueQuestionsTest < EngineIntegrationTest
       assert page.has_xpath?("//meta[@name = 'robots'][@content = 'noindex']", visible: :all)
 
       within ".current-question" do
-        within "[data-test=question]" do
+        within ".govuk-label" do
           assert_page_has_content "What...is your name?"
         end
         within ".question-body" do
@@ -182,7 +182,7 @@ class MultipleChoiceAndValueQuestionsTest < EngineIntegrationTest
     end
 
     within ".current-question" do
-      within "[data-test=question]" do
+      within ".govuk-label" do
         assert_page_has_content "What...is the capital of Assyria?"
       end
       within ".question-body" do

--- a/test/integration/engine/precalculations_test.rb
+++ b/test/integration/engine/precalculations_test.rb
@@ -25,7 +25,7 @@ class PrecalculationsTest < EngineIntegrationTest
       assert_same_url "/precalculation-sample/y", form[:action]
 
       within ".current-question" do
-        within "[data-test=question]" do
+        within ".govuk-label" do
           assert_page_has_content "How much wood would a woodchuck chuck if a woodchuck could chuck wood?"
         end
         within ".question-body" do
@@ -39,7 +39,7 @@ class PrecalculationsTest < EngineIntegrationTest
       assert_current_url "/precalculation-sample/y/10"
 
       within ".current-question" do
-        within "[data-test=question]" do
+        within ".govuk-label" do
           assert_page_has_content "How many woodchucks do you have?"
         end
         within ".question-body" do


### PR DESCRIPTION
## What
Updates smart answers to use GOVUK components for form elements. This includes using component labels/legends for questions instead of headings, and using built in error messages for form components instead of a custom error message.

This PR doesn't include a total removal of all govuk_frontend_toolkit stuff, as it's big enough already, but the user should have a much improved experience.

There are some things about this change that I'm not fully happy with and hoping that someone will point out a better way of doing them - mainly that there's now a lot of logic in the view, and it shouldn't be. I've tried to move it but getting the chosen value of form elements caused problems (e.g. accessing URL params from a presenter).

Test URL: https://smart-answers-preview-pr-4132.herokuapp.com/

The 'all smart answer questions' smart answer doesn't appear to be in the above deployment, so I'd recommend checking out this branch and running it locally to see it.

## Visual changes

All of these screenshots are from the 'All smart answer questions' test smart answer that's built into the app but not publicly visible, so some of the data/error messages are test content.

Before on the left, after on the right.

### Start page

No visual changes.

---

### Checkbox question

![smartanswers1](https://user-images.githubusercontent.com/861310/65763517-813aed00-e11b-11e9-9d0c-459b8a29da00.jpg)

(I've just noticed that the hint isn't correct in this screenshot, and corrected it)

There doesn't appear to be an error state for this question.

---

### Country select question

![_smartanswers2](https://user-images.githubusercontent.com/861310/65763534-88fa9180-e11b-11e9-9ee3-fb31111fa4a0.jpg)

![_smartanswers3](https://user-images.githubusercontent.com/861310/65763538-8e57dc00-e11b-11e9-859b-564624eefc2b.jpg)

---

### Date select question

![_smartanswers4](https://user-images.githubusercontent.com/861310/65763555-96178080-e11b-11e9-909c-736e8c8477c7.jpg)
![_smartanswers5](https://user-images.githubusercontent.com/861310/65763559-99ab0780-e11b-11e9-8c58-ac76e85d7dd4.jpg)

---

### Money question

Due to the way that components are laid out I can't reproduce the layout of the original question exactly, so I've reworded the hint text to be more descriptive (it's hardcoded). I tried to get a content person to help with this but no one stepped up. Happy to change the wording if anyone can think of something better.

You'll note also that the input component doesn't have the black outline that it should. This is being overridden by template, and I haven't bothered trying to override it. Worth doing?

![_smartanswers6](https://user-images.githubusercontent.com/861310/65763571-a0397f00-e11b-11e9-9aec-3e7873600489.jpg)
![_smartanswers7](https://user-images.githubusercontent.com/861310/65763579-a3cd0600-e11b-11e9-9c4b-ffa68b29ee86.jpg)

---

### Multiple choice question

![_smartanswers8](https://user-images.githubusercontent.com/861310/65763589-a9c2e700-e11b-11e9-98e6-6ac4c4f88701.jpg)
![_smartanswers9](https://user-images.githubusercontent.com/861310/65763604-ad566e00-e11b-11e9-90e0-f74c757d6304.jpg)

---

### Postcode question

![_smartanswers10](https://user-images.githubusercontent.com/861310/65762329-b0039400-e118-11e9-9c5a-ccb12696bf4a.jpg)

![_smartanswers11](https://user-images.githubusercontent.com/861310/65762345-b560de80-e118-11e9-8ca8-1083518519eb.jpg)

---

### Multiple choice (yes/no) question

![_smartanswers12](https://user-images.githubusercontent.com/861310/65762654-72ebd180-e119-11e9-8f63-dc7cb1642d07.jpg)

![_smartanswers13](https://user-images.githubusercontent.com/861310/65762672-78491c00-e119-11e9-9341-868553bcc8fa.jpg)

---

### Salary question

Another one that I had to make changes to based on how components are laid out. In the old version, `£` was the label for the input and `per` was the label for the select. So while this change may not be perfect, I'm confident it's more accessible than before.

Note that the application provides no error state for the select element in this question.

![_smartanswers14](https://user-images.githubusercontent.com/861310/65762926-163ce680-e11a-11e9-995a-5feaed432700.jpg)

![_smartanswers15](https://user-images.githubusercontent.com/861310/65762932-1b019a80-e11a-11e9-9042-a335ee14bf35.jpg)

---

### Value question

There's a variation on this where text is added after the input, which I couldn't find a good example of. I've moved it to be the hint text for the input component, but we may need to revisit this.

![_smartanswers16](https://user-images.githubusercontent.com/861310/65763271-ec37f400-e11a-11e9-8b61-107db4421717.jpg)

![_smartanswers17](https://user-images.githubusercontent.com/861310/65763279-efcb7b00-e11a-11e9-977f-6b9f9fcfe777.jpg)
