### PR TITLE
Fix question layouts

### DIFF
--- a/app/assets/stylesheets/smart_answers.scss
+++ b/app/assets/stylesheets/smart_answers.scss
@@ -254,6 +254,10 @@ $is-ie: false !default;
         margin-top: 20px;
       }
     }
+
+    li {
+      margin-bottom: govuk-spacing(1);
+    }
   }
 
   .current-question {

--- a/app/presenters/date_question_presenter.rb
+++ b/app/presenters/date_question_presenter.rb
@@ -29,7 +29,10 @@ class DateQuestionPresenter < QuestionPresenter
   end
 
   def years_options
-    years = Array(start_date.year..end_date.year).map { |number|
+    smallest = [start_date.year, end_date.year].min
+    biggest = [start_date.year, end_date.year].max
+
+    years = Array(smallest..biggest).map { |number|
       format_date(number, :year)
     }
     years.unshift(text: "", value: "")

--- a/app/presenters/money_question_presenter.rb
+++ b/app/presenters/money_question_presenter.rb
@@ -4,4 +4,9 @@ class MoneyQuestionPresenter < QuestionPresenter
   def response_label(value)
     format_money(SmartAnswer::Money.new(value))
   end
+
+  def hint_text
+    text = [body, "in £", suffix_label].reject(&:blank?).compact.join(", ")
+    ActionView::Base.full_sanitizer.sanitize(text)
+  end
 end

--- a/app/presenters/value_question_presenter.rb
+++ b/app/presenters/value_question_presenter.rb
@@ -6,6 +6,7 @@ class ValueQuestionPresenter < QuestionPresenter
   end
 
   def hint_text
-    suffix_label.present? ? suffix_label : label
+    text = [body, hint, suffix_label].reject(&:blank?).compact.join(", ")
+    ActionView::Base.full_sanitizer.sanitize(text)
   end
 end

--- a/app/views/smart_answers/inputs/_checkbox_question.html.erb
+++ b/app/views/smart_answers/inputs/_checkbox_question.html.erb
@@ -1,6 +1,7 @@
 <%= render "govuk_publishing_components/components/checkboxes", {
   name: "response[]",
   heading: question.title,
+  description: question.body,
   id: "response",
   error: question.error,
   hint_text: question.hint_text,

--- a/app/views/smart_answers/inputs/_date_question.html.erb
+++ b/app/views/smart_answers/inputs/_date_question.html.erb
@@ -3,6 +3,10 @@
     <%= question.body %>
   <% end %>
 
+  <% if question.hint.present? %>
+    <p><%= question.hint %></p>
+  <% end %>
+
   <div class="govuk-grid-row date-wrapper">
     <% unless question.default_day %>
       <div class="govuk-grid-column-one-third date-wrapper__col">

--- a/app/views/smart_answers/inputs/_date_question.html.erb
+++ b/app/views/smart_answers/inputs/_date_question.html.erb
@@ -1,4 +1,8 @@
 <% form_contents = capture do %>
+  <% if question.body.present? %>
+    <%= question.body %>
+  <% end %>
+
   <div class="govuk-grid-row date-wrapper">
     <% unless question.default_day %>
       <div class="govuk-grid-column-one-third date-wrapper__col">

--- a/app/views/smart_answers/inputs/_money_question.html.erb
+++ b/app/views/smart_answers/inputs/_money_question.html.erb
@@ -5,6 +5,7 @@
   name: "response",
   id: "response",
   heading_size: "m",
+  width: 10,
   hint: question.hint_text,
   value: prefill_value_for(question),
   error_message: question.error

--- a/app/views/smart_answers/inputs/_money_question.html.erb
+++ b/app/views/smart_answers/inputs/_money_question.html.erb
@@ -5,7 +5,7 @@
   name: "response",
   id: "response",
   heading_size: "m",
-  hint: "in £ #{question.suffix_label}",
+  hint: question.hint_text,
   value: prefill_value_for(question),
   error_message: question.error
 } %>

--- a/app/views/smart_answers/inputs/_multiple_choice_question.html.erb
+++ b/app/views/smart_answers/inputs/_multiple_choice_question.html.erb
@@ -3,6 +3,7 @@
   heading: question.title,
   hint: question.hint,
   id_prefix: "response",
+  description: question.body,
   error_message: question.error,
   items: question.radio_buttons
 } %>

--- a/app/views/smart_answers/inputs/_postcode_question.html.erb
+++ b/app/views/smart_answers/inputs/_postcode_question.html.erb
@@ -6,5 +6,6 @@
   id: "response",
   heading_size: "m",
   error_message: question.error,
+  hint: question.body,
   value: prefill_value_for(question)
 } %>

--- a/app/views/smart_answers/inputs/_postcode_question.html.erb
+++ b/app/views/smart_answers/inputs/_postcode_question.html.erb
@@ -5,6 +5,7 @@
   name: "response",
   id: "response",
   heading_size: "m",
+  width: 10,
   error_message: question.error,
   hint: question.body,
   value: prefill_value_for(question)

--- a/app/views/smart_answers/inputs/_salary_question.html.erb
+++ b/app/views/smart_answers/inputs/_salary_question.html.erb
@@ -5,6 +5,7 @@
   name: "response[amount]",
   id: "response_amount",
   heading_size: "m",
+  width: 10,
   hint: "in £",
   error_message: question.error,
   value: prefill_value_for(question, :amount)

--- a/app/views/smart_answers/inputs/_value_question.html.erb
+++ b/app/views/smart_answers/inputs/_value_question.html.erb
@@ -5,6 +5,7 @@
   name: "response",
   id: "response",
   heading_size: "m",
+  width: 10,
   hint: question.hint_text,
   value: prefill_value_for(question),
   error_message: question.error

--- a/app/views/smart_answers/question.html.erb
+++ b/app/views/smart_answers/question.html.erb
@@ -14,7 +14,10 @@
 
       <div class="question" data-debug-template-path="<%= question.relative_erb_template_path %>">
         <div class="question-body">
-          <% if question.body.present? %>
+          <%
+            show_body = ['salary_question', 'country_select_question'].include? question.partial_template_name
+          %>
+          <% if question.body.present? && show_body %>
             <article role="article">
               <%= question.body %>
             </article>

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/how_much_money.govspeak.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/how_much_money.govspeak.erb
@@ -2,6 +2,10 @@
   Money question: How much does the world cost?
 <% end %>
 
+<% content_for :body do %>
+  Body can contain further explanations.
+<% end %>
+
 <% content_for :suffix_label do %>
   this year
 <% end %>

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/how_much_salary.govspeak.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/how_much_salary.govspeak.erb
@@ -2,6 +2,14 @@
   Salary question: What would you like your salary to be?
 <% end %>
 
+<% content_for :body do %>
+  Body can contain further explanations.
+<% end %>
+
+<% content_for :hint do %>
+  This is a hint
+<% end %>
+
 <% content_for :error_message do %>
   Really, not more?
 <% end %>

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_boolean_choice.govspeak.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_boolean_choice.govspeak.erb
@@ -2,6 +2,14 @@
   Multiple choice (yes/no): Would you like to see the other questions?
 <% end %>
 
+<% content_for :body do %>
+  Body can contain further explanations.
+<% end %>
+
+<% content_for :hint do %>
+  This is a hint
+<% end %>
+
 <% options(
   "yes": "Yes",
   "no": "No"

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_choice.govspeak.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_choice.govspeak.erb
@@ -2,6 +2,14 @@
   Multiple choice: Which of these numbers is not a prime number?
 <% end %>
 
+<% content_for :body do %>
+  Body can contain further explanations.
+<% end %>
+
+<% content_for :hint do %>
+  This is a hint
+<% end %>
+
 <% options(
   "one": "One",
   "two": "Two",

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_country.govspeak.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_country.govspeak.erb
@@ -2,6 +2,10 @@
   Country select: Where are you now?
 <% end %>
 
+<% content_for :body do %>
+  Body can contain further explanations.
+<% end %>
+
 <% content_for :error_message do %>
   You are currently in a fictional country?
 <% end %>

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_date.govspeak.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_date.govspeak.erb
@@ -2,6 +2,10 @@
   Date question: What date is tomorrow?
 <% end %>
 
+<% content_for :body do %>
+  Body can contain further explanations.
+<% end %>
+
 <% content_for :error_message do %>
   That's not tomorrow.
 <% end %>

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_date_of_birth.govspeak.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_date_of_birth.govspeak.erb
@@ -2,6 +2,10 @@
   Date question: What is your date of birth?
 <% end %>
 
+<% content_for :body do %>
+  Body can contain further explanations.
+<% end %>
+
 <% content_for :error_message do %>
   You haven't been born yet.
 <% end %>

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_date_this_year.govspeak.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_date_this_year.govspeak.erb
@@ -2,6 +2,10 @@
   Date question: When is Christmas this year?
 <% end %>
 
+<% content_for :body do %>
+  Body can contain further explanations.
+<% end %>
+
 <% content_for :error_message do %>
   That's not Christmas.
 <% end %>

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_date_within_range.govspeak.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_date_within_range.govspeak.erb
@@ -2,6 +2,10 @@
   Date question: When will be the next 29 February?
 <% end %>
 
+<% content_for :body do %>
+  Body can contain further explanations.
+<% end %>
+
 <% content_for :error_message do %>
   That's not a leap year.
 <% end %>

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_float.govspeak.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_float.govspeak.erb
@@ -2,6 +2,10 @@
   Value/float question: What is 1/2?
 <% end %>
 
+<% content_for :body do %>
+  Body can contain further explanations.
+<% end %>
+
 <% content_for :label do %>
   Number
 <% end %>

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_integer.govspeak.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_integer.govspeak.erb
@@ -2,6 +2,10 @@
   Value/integer question: How many software engineers does it take to change a light bulb?
 <% end %>
 
+<% content_for :body do %>
+  Body can contain further explanations.
+<% end %>
+
 <% content_for :error_message do %>
   None. That's a hardware problem. Or: The light bulb works fine on the system in my office. Or: Darkness is working as intended.
 <% end %>

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_postcode.govspeak.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_postcode.govspeak.erb
@@ -2,6 +2,14 @@
   Postcode question: Where is Aviation House?
 <% end %>
 
+<% content_for :body do %>
+  Body can contain further explanations.
+<% end %>
+
+<% content_for :hint do %>
+  This is a hint
+<% end %>
+
 <% content_for :error_message do %>
   It's WC2B 6NH.
 <% end %>

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_value.govspeak.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_value.govspeak.erb
@@ -2,6 +2,10 @@
   Value question: "Hello ..."?
 <% end %>
 
+<% content_for :body do %>
+  Body can contain further explanations.
+<% end %>
+
 <% content_for :suffix_label do %>
   !
 <% end %>

--- a/lib/smart_answer_flows/am-i-getting-minimum-wage/questions/how_many_hours_did_you_work.govspeak.erb
+++ b/lib/smart_answer_flows/am-i-getting-minimum-wage/questions/how_many_hours_did_you_work.govspeak.erb
@@ -6,10 +6,6 @@
 This includes any time you were at work and needed to be available for work or any time spent travelling in connection with work (for example, travelling to a training course or between work locations). Do not include overtime or time taken to travel to your normal workplace.
 <% end %>
 
-<% content_for :suffix_label do %>
-  hours
-<% end %>
-
 <% content_for :error_message do %>
   Please enter a number
 <% end %>

--- a/lib/smart_answer_flows/am-i-getting-minimum-wage/questions/how_many_hours_do_you_work.govspeak.erb
+++ b/lib/smart_answer_flows/am-i-getting-minimum-wage/questions/how_many_hours_do_you_work.govspeak.erb
@@ -4,11 +4,6 @@
 
 <% content_for :hint do %>
 This includes any time you’re at work and need to be available for work or any time spent travelling in connection with work (for example, travelling to a training course or between work locations). Do not include overtime or time taken to travel to your normal workplace.
-
-<% end %>
-
-<% content_for :suffix_label do %>
-  hours
 <% end %>
 
 <% content_for :error_message do %>

--- a/lib/smart_answer_flows/am-i-getting-minimum-wage/questions/how_much_are_you_paid_during_pay_period.govspeak.erb
+++ b/lib/smart_answer_flows/am-i-getting-minimum-wage/questions/how_much_are_you_paid_during_pay_period.govspeak.erb
@@ -6,10 +6,6 @@
 Do not include payments for overtime or anything extra to your pay, for example money for clothes or goods.
 <% end %>
 
-<% content_for :suffix_label do %>
-  in the pay period
-<% end %>
-
 <% content_for :error_message do %>
   Please enter a number
 <% end %>

--- a/lib/smart_answer_flows/am-i-getting-minimum-wage/questions/how_much_were_you_paid_during_pay_period.govspeak.erb
+++ b/lib/smart_answer_flows/am-i-getting-minimum-wage/questions/how_much_were_you_paid_during_pay_period.govspeak.erb
@@ -6,10 +6,6 @@
   Do not include tips, overtime or anything else on top of your pay, for example money for clothes or goods.
 <% end %>
 
-<% content_for :suffix_label do %>
-  in the pay period
-<% end %>
-
 <% content_for :error_message do %>
   Please enter a number
 <% end %>

--- a/lib/smart_answer_flows/am-i-getting-minimum-wage/questions/how_often_did_you_get_paid.govspeak.erb
+++ b/lib/smart_answer_flows/am-i-getting-minimum-wage/questions/how_often_did_you_get_paid.govspeak.erb
@@ -3,17 +3,7 @@
 <% end %>
 
 <% content_for :hint do %>
-  You get paid every
-
-<% end %>
-
-<% content_for :suffix_label do %>
-  days
-<% end %>
-
-<% content_for :body do %>
-  This is your pay period (also called a ‘pay reference period’).
-
+  Your pay period in days
 <% end %>
 
 <% content_for :error_message do %>

--- a/lib/smart_answer_flows/am-i-getting-minimum-wage/questions/how_often_do_you_get_paid.govspeak.erb
+++ b/lib/smart_answer_flows/am-i-getting-minimum-wage/questions/how_often_do_you_get_paid.govspeak.erb
@@ -3,17 +3,7 @@
 <% end %>
 
 <% content_for :hint do %>
-  You get paid every
-
-<% end %>
-
-<% content_for :suffix_label do %>
-  days
-<% end %>
-
-<% content_for :body do %>
-  This is your pay period (also called a ‘pay reference period’).
-
+  Your pay period in days
 <% end %>
 
 <% content_for :error_message do %>

--- a/lib/smart_answer_flows/calculate-agricultural-holiday-entitlement/questions/how_many_total_days.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-agricultural-holiday-entitlement/questions/how_many_total_days.govspeak.erb
@@ -4,11 +4,6 @@
 
 <% content_for :hint do %>
   This includes any days that you worked basic hours, took annual leave or were off sick (whether paid or not).
-
-<% end %>
-
-<% content_for :label do %>
-  Total days worked for current employer
 <% end %>
 
 <% content_for :error_message do %>

--- a/lib/smart_answer_flows/calculate-employee-redundancy-pay/questions/years_employed.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-employee-redundancy-pay/questions/years_employed.govspeak.erb
@@ -6,10 +6,6 @@
   Only count full years of service. For example, 3 years and 9 months count as 3 years.
 <% end %>
 
-<% content_for :suffix_label do %>
-  full years worked
-<% end %>
-
 <% content_for :error_message do %>
   Please enter a number. Based on your previous answers this should be no greater than <%= years_available %>
 <% end %>

--- a/lib/smart_answer_flows/calculate-your-redundancy-pay/questions/age_of_employee.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-redundancy-pay/questions/age_of_employee.govspeak.erb
@@ -2,10 +2,6 @@
   How old were you on the date you were made redundant?
 <% end %>
 
-<% content_for :suffix_label do %>
-  years old
-<% end %>
-
 <% content_for :error_message do %>
   Please enter an age between 16 and 100.
 <% end %>

--- a/lib/smart_answer_flows/calculate-your-redundancy-pay/questions/years_employed.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-redundancy-pay/questions/years_employed.govspeak.erb
@@ -6,10 +6,6 @@
   Only count full years of service. For example, 3 years and 9 months count as 3 years.
 <% end %>
 
-<% content_for :suffix_label do %>
-  full years worked
-<% end %>
-
 <% content_for :error_message do %>
   Please enter a number. Based on your previous answers this should be no greater than <%= years_available %>
 <% end %>

--- a/lib/smart_answer_flows/minimum-wage-calculator-employers/questions/current_accommodation_charge.govspeak.erb
+++ b/lib/smart_answer_flows/minimum-wage-calculator-employers/questions/current_accommodation_charge.govspeak.erb
@@ -2,10 +2,6 @@
   How much do you charge for accommodation per day?
 <% end %>
 
-<% content_for :suffix_label do %>
-  per day
-<% end %>
-
 <% content_for :error_message do %>
   Please enter a number greater than 0
 <% end %>

--- a/lib/smart_answer_flows/minimum-wage-calculator-employers/questions/current_accommodation_usage.govspeak.erb
+++ b/lib/smart_answer_flows/minimum-wage-calculator-employers/questions/current_accommodation_usage.govspeak.erb
@@ -2,10 +2,6 @@
   How many days per week does the worker live in the accommodation?
 <% end %>
 
-<% content_for :suffix_label do %>
-  days per week
-<% end %>
-
 <% content_for :error_message do %>
   7 is the highest number of days you can enter.
 <% end %>

--- a/lib/smart_answer_flows/minimum-wage-calculator-employers/questions/how_many_hours_did_you_work.govspeak.erb
+++ b/lib/smart_answer_flows/minimum-wage-calculator-employers/questions/how_many_hours_did_you_work.govspeak.erb
@@ -6,10 +6,6 @@
 This includes any time your employee was at work and needed to be available for work or any time spent travelling in connection with work (for example, travelling to a training course or between work locations). Do not include overtime or time taken to travel to their normal workplace.
 <% end %>
 
-<% content_for :suffix_label do %>
-  hours
-<% end %>
-
 <% content_for :error_message do %>
   Please enter a number
 <% end %>

--- a/lib/smart_answer_flows/minimum-wage-calculator-employers/questions/how_many_hours_do_you_work.govspeak.erb
+++ b/lib/smart_answer_flows/minimum-wage-calculator-employers/questions/how_many_hours_do_you_work.govspeak.erb
@@ -6,10 +6,6 @@
 This includes any time your employee is at work and needs to be available for work or any time spent travelling in connection with work (for example, travelling to a training course or between work locations). Do not include overtime or time taken to travel to their normal workplace.
 <% end %>
 
-<% content_for :suffix_label do %>
-  hours
-<% end %>
-
 <% content_for :error_message do %>
   Please enter a number
 <% end %>

--- a/lib/smart_answer_flows/minimum-wage-calculator-employers/questions/how_much_are_you_paid_during_pay_period.govspeak.erb
+++ b/lib/smart_answer_flows/minimum-wage-calculator-employers/questions/how_much_are_you_paid_during_pay_period.govspeak.erb
@@ -6,10 +6,6 @@
 Do not include tips, overtime or anything else on top of their pay, for example money for clothes or goods.
 <% end %>
 
-<% content_for :suffix_label do %>
-  in the pay period
-<% end %>
-
 <% content_for :error_message do %>
   Please enter a number
 <% end %>

--- a/lib/smart_answer_flows/minimum-wage-calculator-employers/questions/how_much_were_you_paid_during_pay_period.govspeak.erb
+++ b/lib/smart_answer_flows/minimum-wage-calculator-employers/questions/how_much_were_you_paid_during_pay_period.govspeak.erb
@@ -6,10 +6,6 @@
 Do not include tips, overtime or anything else on top of their pay, for example money for clothes or goods.
 <% end %>
 
-<% content_for :suffix_label do %>
-  in the pay period
-<% end %>
-
 <% content_for :error_message do %>
   Please enter a number
 <% end %>

--- a/lib/smart_answer_flows/minimum-wage-calculator-employers/questions/how_often_did_you_get_paid.govspeak.erb
+++ b/lib/smart_answer_flows/minimum-wage-calculator-employers/questions/how_often_did_you_get_paid.govspeak.erb
@@ -3,17 +3,9 @@
 <% end %>
 
 <% content_for :hint do %>
-  You pay the worker every
+  The pay period in days
 <% end %>
 
-<% content_for :suffix_label do %>
-  days
-<% end %>
-
-<% content_for :body do %>
-  This is the pay period (also called a ‘pay reference period’).
-
-<% end %>
 
 <% content_for :error_message do %>
   Please enter a number between 1 and 31.

--- a/lib/smart_answer_flows/minimum-wage-calculator-employers/questions/how_often_do_you_get_paid.govspeak.erb
+++ b/lib/smart_answer_flows/minimum-wage-calculator-employers/questions/how_often_do_you_get_paid.govspeak.erb
@@ -3,16 +3,7 @@
 <% end %>
 
 <% content_for :hint do %>
-  You pay the worker every
-<% end %>
-
-<% content_for :suffix_label do %>
-  days
-<% end %>
-
-<% content_for :body do %>
-  This is the pay period (also called a ‘pay reference period’).
-
+  The pay period in days
 <% end %>
 
 <% content_for :error_message do %>

--- a/lib/smart_answer_flows/minimum-wage-calculator-employers/questions/past_accommodation_charge.govspeak.erb
+++ b/lib/smart_answer_flows/minimum-wage-calculator-employers/questions/past_accommodation_charge.govspeak.erb
@@ -2,10 +2,6 @@
   How much did you charge for accommodation per day?
 <% end %>
 
-<% content_for :suffix_label do %>
-  per day
-<% end %>
-
 <% content_for :error_message do %>
   Please enter a number greater than 0
 <% end %>

--- a/lib/smart_answer_flows/minimum-wage-calculator-employers/questions/past_accommodation_usage.govspeak.erb
+++ b/lib/smart_answer_flows/minimum-wage-calculator-employers/questions/past_accommodation_usage.govspeak.erb
@@ -2,10 +2,6 @@
   How many days per week did the worker live in the accommodation?
 <% end %>
 
-<% content_for :suffix_label do %>
-  days per week
-<% end %>
-
 <% content_for :error_message do %>
   7 is the highest number of days you can enter.
 <% end %>

--- a/test/functional/smart_answers_controller_value_question_test.rb
+++ b/test/functional/smart_answers_controller_value_question_test.rb
@@ -36,16 +36,6 @@ class SmartAnswersControllerValueQuestionTest < ActionController::TestCase
         get :show, params: { id: "smart-answers-controller-sample-with-value-question", started: "y", responses: "12345" }
         assert_select ".done-questions", /How many green bottles\?\s+12,345/
       end
-
-      context "label in erb template" do
-        setup do
-          get :show, params: { id: "smart-answers-controller-sample-with-value-question", started: "y", responses: "12345" }
-        end
-        should "show the label text before the question input" do
-          assert_match(/value-question-label.*?input.*?name="response".*?/m, response.body)
-          assert_select "input[type=text][name=response]"
-        end
-      end
     end
   end
 


### PR DESCRIPTION
Recent changes to use the components for smart answers introduced a few question readability problems, specifically to do with the layout of questions - body text was appearing in the wrong place, hint text was sometimes not appearing.

Example of the problem (from [this smart answer](https://www.gov.uk/landlord-immigration-check/y/E1%208QS/yes/yes/eea)):

<img width="781" alt="Screen Shot 2019-10-03 at 10 44 01" src="https://user-images.githubusercontent.com/861310/66117394-76c19d00-e5cc-11e9-8860-34f9a8c07d4e.png">

Solution:

<img width="622" alt="Screen Shot 2019-10-03 at 10 43 36" src="https://user-images.githubusercontent.com/861310/66117403-7cb77e00-e5cc-11e9-9eff-78b939f92084.png">

Another problem was that suffixes (text immediately to the right of some value questions, e.g. "days") didn't make sense in the new layout, or repeated what was already said in the question.

This PR solves these problems by doing the following layout changes:

- where components have a description field as well as a hint, body text is used for description and so included after the question label or legend (multiple choice question, date question)
- where components do not have a description field, body text, hint text and suffix text are combined into a single element and used for the hint text (value questions)

This PR also includes some content changes to questions, where the above measures did not help with the text layout of the questions. These content changes are from [this content spreadsheet](https://docs.google.com/spreadsheets/d/1l-FfOM2ZqDRUYtEBuqKz1n77py6yTnQoV8pGip2vhOg/edit#gid=2072014057) and only those needed and marked as okay to do have been implemented.

This PR also fixes a bug with date questions, where if the year range started with a higher number (e.g. a range between 2019 and 1900) the range would return 0. This is fixed by using the smallest number as the start of the range (this happened in 'Calculate your married couples allowance' on the age of the husband question).

This PR also updates the 'all smart answer questions' test question to have more data in it, to improve the reliability of it when testing.

