### PR TITLE
Fix incorrectly named rubocop predicates

### DIFF
--- a/lib/smart_answer/calculators/married_couples_allowance_calculator.rb
+++ b/lib/smart_answer/calculators/married_couples_allowance_calculator.rb
@@ -26,7 +26,7 @@ module SmartAnswer::Calculators
     end
 
     def valid_income?
-      income > 0 # rubocop:disable Styles/NumericPredicate
+      income > 0 # rubocop:disable Style/NumericPredicate
     end
 
     def paying_into_a_pension?
@@ -53,7 +53,7 @@ module SmartAnswer::Calculators
         maximum_reduction_of_allowances = age_related_allowance(birth_date) - personal_allowance
         remaining_reduction = attempted_reduction - maximum_reduction_of_allowances
 
-        if remaining_reduction > 0 # rubocop:disable Styles/NumericPredicate
+        if remaining_reduction > 0 # rubocop:disable Style/NumericPredicate
           reduced_mca = maximum_mca - remaining_reduction
           mca_entitlement = if reduced_mca > minimum_mca
                               reduced_mca

--- a/lib/smart_answer/calculators/maternity_pay_calculator.rb
+++ b/lib/smart_answer/calculators/maternity_pay_calculator.rb
@@ -188,7 +188,7 @@ module SmartAnswer::Calculators
         paydates.each do |paydate|
           # Pay period includes the date of payment hence the range starts the day after.
           pay = pay_for_period(last_paydate, paydate)
-          if pay > 0 # rubocop:disable Styles/NumericPredicate
+          if pay > 0 # rubocop:disable Style/NumericPredicate
             ary << { date: paydate, pay: pay.round(2) }
             last_paydate = paydate + 1
           end


### PR DESCRIPTION
This clears up some rubocop warnings.