### PR TITLE
(1/6) HolidayEntitlementCalculator: Add logic and tests for days-worked-per-week calculations

### DIFF
--- a/lib/smart_answer/calculators/holiday_entitlement.rb
+++ b/lib/smart_answer/calculators/holiday_entitlement.rb
@@ -1,101 +1,90 @@
+require "bigdecimal"
 require "date"
-require "ostruct"
 
 module SmartAnswer::Calculators
-  class HolidayEntitlement < OpenStruct
+  class HolidayEntitlement
     # created for the holiday entitlement calculator
-    STATUTORY_HOLIDAY_ENTITLEMENT_IN_WEEKS = 5.6
-    MAXIMUM_STATUTORY_HOLIDAY_ENTITLEMENT_IN_DAYS = 28.0
+    STATUTORY_HOLIDAY_ENTITLEMENT_IN_WEEKS = BigDecimal(5.6, 10)
+    MAXIMUM_STATUTORY_HOLIDAY_ENTITLEMENT_IN_DAYS = 28.to_d
+    MONTHS_PER_YEAR = 12.to_d
+    DAYS_PER_YEAR = 365.to_d
+    DAYS_PER_LEAP_YEAR = 366.to_d
+    STANDARD_DAYS_PER_WEEK = 5.to_d
+
+    attr_reader :days_per_week, :start_date, :leaving_date, :leave_year_start_date
+
+    def initialize(days_per_week: 0, start_date: nil, leaving_date: nil, leave_year_start_date: Date.today.beginning_of_year)
+      @days_per_week = BigDecimal(days_per_week, 10)
+      @start_date = start_date
+      @leaving_date = leaving_date
+      @leave_year_start_date = leave_year_start_date
+    end
 
     def full_time_part_time_days
       days = STATUTORY_HOLIDAY_ENTITLEMENT_IN_WEEKS * days_per_week
-      days_cap = MAXIMUM_STATUTORY_HOLIDAY_ENTITLEMENT_IN_DAYS
-      actual_days = days > days_cap ? days_cap : days
+      actual_days = if left_before_year_end || (days_per_week < STANDARD_DAYS_PER_WEEK)
+                      days
+                    else
+                      [MAXIMUM_STATUTORY_HOLIDAY_ENTITLEMENT_IN_DAYS, days].min
+                    end
       (actual_days * fraction_of_year).round(10)
     end
 
-    def full_time_part_time_hours
-      hours = STATUTORY_HOLIDAY_ENTITLEMENT_IN_WEEKS * hours_per_week
-      hours_in_day = hours_per_week.to_f / days_per_week
-      hours_cap = MAXIMUM_STATUTORY_HOLIDAY_ENTITLEMENT_IN_DAYS * hours_in_day
-      actual_hours = hours > hours_cap ? hours_cap : hours
-      (actual_hours * fraction_of_year).round(10)
-    end
-
-    def full_time_part_time_hours_and_minutes
-      (full_time_part_time_hours * 60).ceil.divmod(60).map(&:ceil)
-    end
-
-    def compressed_hours_entitlement
-      minutes = STATUTORY_HOLIDAY_ENTITLEMENT_IN_WEEKS * hours_per_week * 60
-      minutes.ceil.divmod(60).map(&:ceil)
-    end
-
-    def compressed_hours_daily_average
-      minutes = hours_per_week.to_f / days_per_week * 60
-      minutes.ceil.divmod(60).map(&:ceil)
-    end
-
-    def shift_entitlement
-      (STATUTORY_HOLIDAY_ENTITLEMENT_IN_WEEKS * fraction_of_year * shifts_per_week).round(10)
-    end
-
-    def fraction_of_year
-      return 1 if self.start_date.nil? && self.leaving_date.nil?
-
-      days_divide = leave_year_range.leap? ? 366 : 365
-
-      if start_date && leaving_date
-        (leaving_date - start_date + 1.0) / days_divide
-      elsif leaving_date
-        (leaving_date - leave_year_range.begins_on + 1.0) / days_divide
+    def formatted_full_time_part_time_days
+      if started_after_year_began || worked_full_year
+        rounded_days = (full_time_part_time_days * 2).ceil / 2.00
+        format_number(rounded_days)
       else
-        (leave_year_range.ends_on - start_date + 1.0) / days_divide
+        format_number(full_time_part_time_days)
       end
     end
 
-    def formatted_fraction_of_year(decimals = 2)
-      format_number(fraction_of_year, decimals)
+    def months_worked
+      year_difference = BigDecimal(leave_year_range.ends_on.year - start_date.year, 10)
+      month_difference = MONTHS_PER_YEAR * year_difference + leave_year_range.ends_on.month - start_date.month
+
+      leave_year_range.ends_on.day > start_date.day ? month_difference + 1 : month_difference
+    end
+
+    def fraction_of_year
+      if started_after_year_began || worked_partial_year
+        months_worked / MONTHS_PER_YEAR
+      elsif left_before_year_end
+        days_in_year = leave_year_range.leap? ? DAYS_PER_LEAP_YEAR : DAYS_PER_YEAR
+        (leaving_date - leave_year_range.begins_on + 1) / days_in_year
+      else
+        MONTHS_PER_YEAR / MONTHS_PER_YEAR
+      end
+    end
+
+    private
+
+    def worked_full_year
+      !start_date && !leaving_date
+    end
+
+    def started_after_year_began
+      start_date && !leaving_date
+    end
+
+    def left_before_year_end
+      !start_date && leaving_date
+    end
+
+    def worked_partial_year
+      start_date && leaving_date
     end
 
     def strip_zeros(number)
       number.to_s.sub(/\.0+$/, "")
     end
 
-    # rubocop:disable Style/MissingRespondToMissing
-    def method_missing(symbol, *args)
-      # formatted_foo calls format_number on foo
-      formatting_method = formatting_method(symbol)
-      if formatting_method
-        format_number(send(formatting_method), args.first || 1)
-      else
-        super
-      end
-    end
-    # rubocop:enable Style/MissingRespondToMissing
-
-    def respond_to?(symbol, include_all = false)
-      formatting_method(symbol).present? || super
-    end
-
-  private
-
-    def formatting_method(symbol)
-      matches = symbol.to_s.match(/\Aformatted_(.*)\z/)
-      matches ? matches[1].to_sym : nil
-    end
-
     def leave_year_range
-      leave_year_start = self.leave_year_start_date || "1 January"
-      SmartAnswer::YearRange.resetting_on(leave_year_start).including(date_calc)
-    end
-
-    def shifts_per_week
-      (shifts_per_shift_pattern.to_f / days_per_shift_pattern * 7).round(10)
+      SmartAnswer::YearRange.resetting_on(leave_year_start_date).including(date_calc)
     end
 
     def date_calc
-      if self.start_date
+      if start_date
         start_date
       else
         leaving_date

--- a/test/unit/calculators/holiday_entitlement_test.rb
+++ b/test/unit/calculators/holiday_entitlement_test.rb
@@ -33,8 +33,8 @@ module SmartAnswer::Calculators
               days_per_week: 5,
             )
 
-            assert_equal BigDecimal(0.5833333333, 10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal(16.3333333333, 12), calc.full_time_part_time_days.round(10)
+            assert_equal BigDecimal("0.5833333333").round(10), calc.fraction_of_year.round(10)
+            assert_equal BigDecimal("16.3333333333").round(10), calc.full_time_part_time_days.round(10)
             assert_equal "16.5", calc.formatted_full_time_part_time_days
           end
 
@@ -46,8 +46,8 @@ module SmartAnswer::Calculators
               days_per_week: 3,
             )
 
-            assert_equal BigDecimal(0.4166666667, 10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal(7.0, 10), calc.full_time_part_time_days.round(10)
+            assert_equal BigDecimal("0.4166666667").round(10), calc.fraction_of_year.round(10)
+            assert_equal BigDecimal("7.0").round(10), calc.full_time_part_time_days.round(10)
             assert_equal "7", calc.formatted_full_time_part_time_days
           end
 
@@ -59,8 +59,8 @@ module SmartAnswer::Calculators
               days_per_week: 6,
             )
 
-            assert_equal BigDecimal(0.1666666667, 10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal(4.6666666667, 11), calc.full_time_part_time_days.round(10)
+            assert_equal BigDecimal("0.1666666667").round(10), calc.fraction_of_year.round(10)
+            assert_equal BigDecimal("4.6666666667").round(10), calc.full_time_part_time_days.round(10)
             assert_equal "5", calc.formatted_full_time_part_time_days
           end
         end
@@ -74,8 +74,8 @@ module SmartAnswer::Calculators
               days_per_week: 5,
             )
 
-            assert_equal BigDecimal(0.5833333333, 10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal(16.3333333333, 12), calc.full_time_part_time_days.round(10)
+            assert_equal BigDecimal("0.5833333333").round(10), calc.fraction_of_year.round(10)
+            assert_equal BigDecimal("16.3333333333").round(10), calc.full_time_part_time_days.round(10)
             assert_equal "16.5", calc.formatted_full_time_part_time_days
           end
 
@@ -87,8 +87,8 @@ module SmartAnswer::Calculators
               days_per_week: 3,
             )
 
-            assert_equal BigDecimal(0.4166666667, 10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal(7.0, 10), calc.full_time_part_time_days.round(10)
+            assert_equal BigDecimal("0.4166666667").round(10), calc.fraction_of_year.round(10)
+            assert_equal BigDecimal("7.0").round(10), calc.full_time_part_time_days.round(10)
             assert_equal "7", calc.formatted_full_time_part_time_days
           end
 
@@ -100,8 +100,8 @@ module SmartAnswer::Calculators
               days_per_week: 6,
             )
 
-            assert_equal BigDecimal(0.1666666667, 10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal(4.6666666667, 11), calc.full_time_part_time_days.round(10)
+            assert_equal BigDecimal("0.1666666667").round(10), calc.fraction_of_year.round(10)
+            assert_equal BigDecimal("4.6666666667").round(10), calc.full_time_part_time_days.round(10)
             assert_equal "5", calc.formatted_full_time_part_time_days
           end
         end
@@ -117,8 +117,8 @@ module SmartAnswer::Calculators
               days_per_week: 5,
             )
 
-            assert_equal BigDecimal(0.4164383562, 10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal(11.6602739726, 12), calc.full_time_part_time_days.round(10)
+            assert_equal BigDecimal("0.4164383562").round(10), calc.fraction_of_year.round(10)
+            assert_equal BigDecimal("11.6602739726").round(10), calc.full_time_part_time_days.round(10)
             assert_equal "11.7", calc.formatted_full_time_part_time_days
           end
 
@@ -129,8 +129,8 @@ module SmartAnswer::Calculators
               leave_year_start_date: Date.parse("2018-04-01"),
               days_per_week: 3,
             )
-            assert_equal BigDecimal(0.6493150685, 10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal(10.9084931507, 12), calc.full_time_part_time_days.round(10)
+            assert_equal BigDecimal("0.6493150685").round(10), calc.fraction_of_year.round(10)
+            assert_equal BigDecimal("10.9084931507").round(10), calc.full_time_part_time_days.round(10)
             assert_equal "11", calc.formatted_full_time_part_time_days
           end
 
@@ -141,8 +141,8 @@ module SmartAnswer::Calculators
               leave_year_start_date: Date.parse("2019-01-01"),
               days_per_week: 6,
             )
-            assert_equal BigDecimal(0.6410958904, 10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal(21.5408219178, 12), calc.full_time_part_time_days.round(10)
+            assert_equal BigDecimal("0.6410958904").round(10), calc.fraction_of_year.round(10)
+            assert_equal BigDecimal("21.5408219178").round(10), calc.full_time_part_time_days.round(10)
             assert_equal "21.6", calc.formatted_full_time_part_time_days
           end
         end
@@ -156,8 +156,8 @@ module SmartAnswer::Calculators
               days_per_week: 5,
             )
 
-            assert_equal BigDecimal(0.4180327869, 10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal(11.7049180328, 12), calc.full_time_part_time_days.round(10)
+            assert_equal BigDecimal("0.4180327869").round(10), calc.fraction_of_year.round(10)
+            assert_equal BigDecimal("11.7049180328").round(10), calc.full_time_part_time_days.round(10)
             assert_equal "11.8", calc.formatted_full_time_part_time_days
           end
 
@@ -169,8 +169,8 @@ module SmartAnswer::Calculators
               days_per_week: 3,
             )
 
-            assert_equal BigDecimal(0.6475409836, 10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal(10.8786885246, 12), calc.full_time_part_time_days.round(10)
+            assert_equal BigDecimal("0.6475409836").round(10), calc.fraction_of_year.round(10)
+            assert_equal BigDecimal("10.8786885246").round(10), calc.full_time_part_time_days.round(10)
             assert_equal "10.9", calc.formatted_full_time_part_time_days
           end
 
@@ -182,9 +182,93 @@ module SmartAnswer::Calculators
               days_per_week: 6,
             )
 
-            assert_equal BigDecimal(0.6420765027, 10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal(21.5737704918, 12), calc.full_time_part_time_days.round(10)
+            assert_equal BigDecimal("0.6420765027").round(10), calc.fraction_of_year.round(10)
+            assert_equal BigDecimal("21.5737704918").round(10), calc.full_time_part_time_days.round(10)
             assert_equal "21.6", calc.formatted_full_time_part_time_days
+          end
+        end
+      end
+
+      context "starting and leaving part way through a leave year" do
+        context "for a standard year" do
+          # /days-worked-per-week/starting/2020-01-20/2020-08-07/5.0
+          should "for 5 days a week" do
+            calc = HolidayEntitlement.new(
+              start_date: Date.parse("2019-01-20"),
+              leaving_date: Date.parse("2019-07-18"),
+              days_per_week: 5,
+            )
+
+            assert_equal BigDecimal("0.4931506849").round(10), calc.fraction_of_year.round(10)
+            assert_equal BigDecimal("13.8082191780822").round(10), calc.full_time_part_time_days.round(10)
+            assert_equal "13.9", calc.formatted_full_time_part_time_days
+          end
+
+          # /days-worked-per-week/starting/2019-11-23/2020-04-07/3.0
+          should "for less than 5 days a week" do
+            calc = HolidayEntitlement.new(
+              start_date: Date.parse("2018-11-23"),
+              leaving_date: Date.parse("2019-04-07"),
+              days_per_week: 3,
+            )
+
+            assert_equal BigDecimal("0.3726027397").round(10), calc.fraction_of_year.round(10)
+            assert_equal BigDecimal("6.2597260274").round(10), calc.full_time_part_time_days.round(10)
+            assert_equal "6.3", calc.formatted_full_time_part_time_days
+          end
+
+          # /days-worked-per-week/starting/2019-08-22/2020-07-31/6.0
+          should "for more than 5 days a week" do
+            calc = HolidayEntitlement.new(
+              start_date: Date.parse("2018-08-22"),
+              leaving_date: Date.parse("2019-07-31"),
+              days_per_week: 6,
+            )
+
+            assert_equal BigDecimal("0.9424657534").round(10), calc.fraction_of_year.round(10)
+            assert_equal BigDecimal("26.3890410959").round(10), calc.full_time_part_time_days.round(10)
+            assert_equal "26.4", calc.formatted_full_time_part_time_days
+          end
+        end
+
+        context "for a leap year" do
+          # /days-worked-per-week/starting/2020-01-20/2020-08-07/5.0
+          should "for 5 days a week" do
+            calc = HolidayEntitlement.new(
+              start_date: Date.parse("2020-01-20"),
+              leaving_date: Date.parse("2020-07-18"),
+              days_per_week: 5,
+            )
+
+            assert_equal BigDecimal("0.4945355191").round(10), calc.fraction_of_year.round(10)
+            assert_equal BigDecimal("13.8469945355").round(10), calc.full_time_part_time_days.round(10)
+            assert_equal "13.9", calc.formatted_full_time_part_time_days
+          end
+
+          # /days-worked-per-week/starting/2019-11-23/2020-04-07/3.0
+          should "for less than 5 days a week" do
+            calc = HolidayEntitlement.new(
+              start_date: Date.parse("2019-11-23"),
+              leaving_date: Date.parse("2020-04-07"),
+              days_per_week: 3,
+            )
+
+            assert_equal BigDecimal("0.3743169399").round(10), calc.fraction_of_year.round(10)
+            assert_equal BigDecimal("6.2885245902").round(10), calc.full_time_part_time_days.round(10)
+            assert_equal "6.3", calc.formatted_full_time_part_time_days
+          end
+
+          # /days-worked-per-week/starting/2019-08-22/2020-07-31/6.0
+          should "for more than 5 days a week" do
+            calc = HolidayEntitlement.new(
+              start_date: Date.parse("2019-08-22"),
+              leaving_date: Date.parse("2020-07-31"),
+              days_per_week: 6,
+            )
+
+            assert_equal BigDecimal("0.9426229508").round(10), calc.fraction_of_year.round(10)
+            assert_equal BigDecimal("26.3934426229508").round(10), calc.full_time_part_time_days.round(10)
+            assert_equal "26.4", calc.formatted_full_time_part_time_days
           end
         end
       end

--- a/test/unit/calculators/holiday_entitlement_test.rb
+++ b/test/unit/calculators/holiday_entitlement_test.rb
@@ -2,377 +2,191 @@ require_relative "../../test_helper"
 
 module SmartAnswer::Calculators
   class HolidayEntitlementTest < ActiveSupport::TestCase
-    context "calculating fraction of year" do
-      should "return 1 with no start date or leaving date" do
-        calc = HolidayEntitlement.new
-        assert_equal 1, calc.fraction_of_year
-      end
-
-      context "with a start_date" do
-        should "return the fraction of a year" do
-          calc = HolidayEntitlement.new(start_date: Date.parse("2011-02-21"))
-          assert_equal "0.8603", sprintf("%.4f", calc.fraction_of_year)
+    context "calculate entitlement on days worked per week" do
+      # /days-worked-per-week/full-year/5.0
+      context "for a full leave year" do
+        should "for 5 days a week" do
+          calc = HolidayEntitlement.new(days_per_week: 5)
+          assert_equal "28", calc.formatted_full_time_part_time_days
         end
 
-        should "return the fraction of a year in a leap year" do
-          calc = HolidayEntitlement.new(start_date: Date.parse("2012-02-21"))
-          assert_equal "0.8607", sprintf("%.4f", calc.fraction_of_year)
+        # /days-worked-per-week/full-year/5.0
+        should "for more than 5 days a week" do
+          calc = HolidayEntitlement.new(days_per_week: 7)
+          assert_equal "28", calc.formatted_full_time_part_time_days
         end
 
-        should "return the fraction of a year in a leap year not covering Feb 29th" do
-          calc = HolidayEntitlement.new(start_date: Date.parse("2012-03-01"))
-          assert_equal "0.8361", sprintf("%.4f", calc.fraction_of_year)
+        # /days-worked-per-week/full-year/3.5
+        should "for less than 5 days a week" do
+          calc = HolidayEntitlement.new(days_per_week: 3)
+          assert_equal "17", calc.formatted_full_time_part_time_days
         end
       end
 
-      context "with a leaving_date" do
-        should "return the fraction of a year" do
-          calc = HolidayEntitlement.new(leaving_date: Date.parse("2011-06-21"))
-          assert_equal "0.4712", sprintf("%.4f", calc.fraction_of_year)
+      context "starting part way through a leave year" do
+        context "for a standard year" do
+          # /days-worked-per-week/starting/2019-06-01/2019-01-01/5.0
+          should "for 5 days a week" do
+            calc = HolidayEntitlement.new(
+              start_date: Date.parse("2019-06-01"),
+              leave_year_start_date: Date.parse("2019-01-01"),
+              days_per_week: 5,
+            )
+
+            assert_equal BigDecimal(0.5833333333, 10), calc.fraction_of_year.round(10)
+            assert_equal BigDecimal(16.3333333333, 12), calc.full_time_part_time_days.round(10)
+            assert_equal "16.5", calc.formatted_full_time_part_time_days
+          end
+
+          # /days-worked-per-week/starting/2019-11-21/2019-04-01/3.0
+          should "for less than 5 days a week" do
+            calc = HolidayEntitlement.new(
+              start_date: Date.parse("2019-11-23"),
+              leave_year_start_date: Date.parse("2019-04-01"),
+              days_per_week: 3,
+            )
+
+            assert_equal BigDecimal(0.4166666667, 10), calc.fraction_of_year.round(10)
+            assert_equal BigDecimal(7.0, 10), calc.full_time_part_time_days.round(10)
+            assert_equal "7", calc.formatted_full_time_part_time_days
+          end
+
+          # /days-worked-per-week/starting/2019-11-14/2019-01-01/6.0
+          should "for more than 5 days a week" do
+            calc = HolidayEntitlement.new(
+              start_date: Date.parse("2019-11-14"),
+              leave_year_start_date: Date.parse("2019-01-01"),
+              days_per_week: 6,
+            )
+
+            assert_equal BigDecimal(0.1666666667, 10), calc.fraction_of_year.round(10)
+            assert_equal BigDecimal(4.6666666667, 11), calc.full_time_part_time_days.round(10)
+            assert_equal "5", calc.formatted_full_time_part_time_days
+          end
         end
 
-        should "return the fraction of a year in a leap year" do
-          calc = HolidayEntitlement.new(leaving_date: Date.parse("2012-06-21"))
-          assert_equal "0.4727", sprintf("%.4f", calc.fraction_of_year)
-        end
+        context "for a leap year" do
+          # /days-worked-per-week/starting/2020-06-01/2020-01-01/5.0
+          should "for 5 days a week" do
+            calc = HolidayEntitlement.new(
+              start_date: Date.parse("2020-06-01"),
+              leave_year_start_date: Date.parse("2020-01-01"),
+              days_per_week: 5,
+            )
 
-        should "return the fraction of a year in a leap year not covering Feb 29th" do
-          calc = HolidayEntitlement.new(leaving_date: Date.parse("2012-01-21"))
-          assert_equal "0.0574", sprintf("%.4f", calc.fraction_of_year)
-        end
-      end
+            assert_equal BigDecimal(0.5833333333, 10), calc.fraction_of_year.round(10)
+            assert_equal BigDecimal(16.3333333333, 12), calc.full_time_part_time_days.round(10)
+            assert_equal "16.5", calc.formatted_full_time_part_time_days
+          end
 
-      context "with a leave_year_start" do
-        context "with a start date" do
-          context "start date before leave_year_start" do
-            should "return the fraction of a year" do
-              calc = HolidayEntitlement.new(start_date: Date.parse("2011-01-21"), leave_year_start_date: Date.parse("2011-02-01"))
-              assert_equal "0.0301", sprintf("%.4f", calc.fraction_of_year)
-            end
+          # /days-worked-per-week/starting/2020-11-21/2020-04-01/3.0
+          should "for less than 5 days a week" do
+            calc = HolidayEntitlement.new(
+              start_date: Date.parse("2020-11-23"),
+              leave_year_start_date: Date.parse("2020-04-01"),
+              days_per_week: 3,
+            )
 
-            should "return the fraction of a year in a leap year" do
-              # 2011-12-31 to 2012-12-30
-              calc = HolidayEntitlement.new(start_date: Date.parse("2012-02-02"), leave_year_start_date: Date.parse("2012-12-31"))
-              assert_equal "0.9098", sprintf("%.4f", calc.fraction_of_year)
-            end
+            assert_equal BigDecimal(0.4166666667, 10), calc.fraction_of_year.round(10)
+            assert_equal BigDecimal(7.0, 10), calc.full_time_part_time_days.round(10)
+            assert_equal "7", calc.formatted_full_time_part_time_days
+          end
 
-            should "return the fraction of a year in a leap year not covering Feb 29th" do
-              calc = HolidayEntitlement.new(start_date: Date.parse("2013-01-21"), leave_year_start_date: Date.parse("2013-02-01"))
-              assert_equal "0.0301", sprintf("%.4f", calc.fraction_of_year)
-            end
-          end # context - start date before leave_year_start
+          # /days-worked-per-week/starting/2020-11-14/2020-01-01/6.0
+          should "for more than 5 days a week" do
+            calc = HolidayEntitlement.new(
+              start_date: Date.parse("2020-11-14"),
+              leave_year_start_date: Date.parse("2020-01-01"),
+              days_per_week: 6,
+            )
 
-          context "start date after leave_year_start" do
-            should "return the fraction of a year" do
-              calc = HolidayEntitlement.new(start_date: Date.parse("2011-04-21"), leave_year_start_date: Date.parse("2011-02-01"))
-              assert_equal "0.7836", sprintf("%.4f", calc.fraction_of_year)
-            end
-
-            should "return the fraction of a year in a leap year" do
-              calc = HolidayEntitlement.new(start_date: Date.parse("2012-02-21"), leave_year_start_date: Date.parse("2012-02-01"))
-              assert_equal "0.9454", sprintf("%.4f", calc.fraction_of_year)
-            end
-
-            should "return the fraction of a year in a leap year not covering Feb 29th" do
-              calc = HolidayEntitlement.new(start_date: Date.parse("2012-04-21"), leave_year_start_date: Date.parse("2012-02-01"))
-              assert_equal "0.7814", sprintf("%.4f", calc.fraction_of_year)
-            end
-          end # context - start date after leave_year_start
-        end # context - with a start date
-
-        context "with a leave date" do
-          context "leaving date before leave_year_start" do
-            should "return the fraction of a year" do
-              calc = HolidayEntitlement.new(leaving_date: Date.parse("2011-01-21"), leave_year_start_date: Date.parse("2011-02-01"))
-              assert_equal "0.9726", sprintf("%.4f", calc.fraction_of_year)
-            end
-
-            should "return the fraction of a year in a leap year" do
-              calc = HolidayEntitlement.new(leaving_date: Date.parse("2013-01-21"), leave_year_start_date: Date.parse("2013-02-01"))
-              assert_equal "0.9727", sprintf("%.4f", calc.fraction_of_year)
-            end
-
-            should "return the fraction of a year in a leap year not covering Feb 29th" do
-              calc = HolidayEntitlement.new(leaving_date: Date.parse("2012-01-21"), leave_year_start_date: Date.parse("2012-03-01"))
-              assert_equal "0.8934", sprintf("%.4f", calc.fraction_of_year)
-            end
-          end # context - leaving date before leave_year_start
-
-          context "leaving date after leave_year_start" do
-            should "return the fraction of a year" do
-              calc = HolidayEntitlement.new(leaving_date: Date.parse("2011-04-21"), leave_year_start_date: Date.parse("2011-02-01"))
-              assert_equal "0.2192", sprintf("%.4f", calc.fraction_of_year)
-            end
-
-            should "return the fraction of a year in a leap year" do
-              calc = HolidayEntitlement.new(leaving_date: Date.parse("2012-04-21"), leave_year_start_date: Date.parse("2012-02-01"))
-              assert_equal "0.2213", sprintf("%.4f", calc.fraction_of_year)
-            end
-
-            should "return the fraction of a year in a leap year not covering Feb 29th" do
-              calc = HolidayEntitlement.new(leaving_date: Date.parse("2012-02-21"), leave_year_start_date: Date.parse("2012-02-01"))
-              assert_equal "0.0574", sprintf("%.4f", calc.fraction_of_year)
-            end
-          end # context - leaving date after leave_year_start
-        end # context - with a leave date
-      end # context - with a leave_year_start
-
-      should "format the result" do
-        calc = HolidayEntitlement.new(start_date: Date.parse("2012-02-21"))
-        assert_equal "0.87", calc.formatted_fraction_of_year
-      end
-    end # context - calculating fraction of year
-
-    context "calculating full-time or part-time holiday entitlement" do
-      context "working for a full year" do
-        should "calculate entitlement for 5 days a week" do
-          calc = HolidayEntitlement.new(
-            days_per_week: 5,
-          )
-
-          assert_equal 28, calc.full_time_part_time_days
-        end
-
-        should "calculate entitlement for more than 5 days a week" do
-          calc = HolidayEntitlement.new(
-            days_per_week: 6,
-          )
-
-          # 28 is the max
-          assert_equal 28, calc.full_time_part_time_days
-        end
-
-        should "calculate entitlement for less than 5 days a week" do
-          calc = HolidayEntitlement.new(
-            days_per_week: 3,
-          )
-
-          assert_equal "16.80", sprintf("%.2f", calc.full_time_part_time_days)
-        end
-      end # full year
-
-      context "starting this year" do
-        should "calculate entitlement for 5 days a week" do
-          calc = HolidayEntitlement.new(
-            start_date: Date.parse("2012-03-12"),
-            days_per_week: 5,
-          )
-          assert_equal "22.57", sprintf("%.2f", calc.full_time_part_time_days)
-        end
-
-        should "calculate entitlement for more than 5 days a week" do
-          calc = HolidayEntitlement.new(
-            start_date: Date.parse("2012-03-12"),
-            days_per_week: 7,
-          )
-          # Capped
-          assert_equal "22.57", sprintf("%.2f", calc.full_time_part_time_days)
-        end
-
-        should "cap entitlement at 28 days if starting on first day" do
-          calc = HolidayEntitlement.new(
-            start_date: Date.parse("2012-01-01"),
-            days_per_week: 7,
-          )
-          assert_equal 28, calc.full_time_part_time_days
-        end
-
-        should "calculate entitlement for less than 5 days per week" do
-          calc = HolidayEntitlement.new(
-            start_date: Date.parse("2012-03-12"),
-            days_per_week: 3,
-          )
-          assert_equal "13.54", sprintf("%.2f", calc.full_time_part_time_days)
-        end
-      end # starting this year
-
-      context "leaving this year" do
-        should "calculate entitlement for 5 days a week" do
-          calc = HolidayEntitlement.new(
-            leaving_date: Date.parse("2012-07-24"),
-            days_per_week: 5,
-          )
-          assert_equal "15.76", sprintf("%.2f", calc.full_time_part_time_days)
-        end
-
-        should "calculate entitlement for more than 5 days a week" do
-          calc = HolidayEntitlement.new(
-            leaving_date: Date.parse("2012-07-24"),
-            days_per_week: 6,
-          )
-          # Capped
-          assert_equal "15.76", sprintf("%.2f", calc.full_time_part_time_days)
-        end
-
-        should "cap entitlement at 28 days if leaving at end of year" do
-          calc = HolidayEntitlement.new(
-            leaving_date: Date.parse("2012-12-31"),
-            days_per_week: 7,
-          )
-          assert_equal 28, calc.full_time_part_time_days
-        end
-
-        should "calculate entitlement for less than 5 days a week" do
-          calc = HolidayEntitlement.new(
-            leaving_date: Date.parse("2012-07-24"),
-            days_per_week: 3,
-          )
-          assert_equal "9.46", sprintf("%.2f", calc.full_time_part_time_days)
-        end
-      end # leaving this year
-
-      should "format the result using format_days" do
-        calc = HolidayEntitlement.new
-        calc.expects(:full_time_part_time_days).returns(18.342452)
-
-        assert_equal "18.4", calc.formatted_full_time_part_time_days
-      end
-    end
-
-    context "calculating full time or part time holiday entitlement by hour" do
-      [{ hours_per_week: 32.5, days_per_week: 5, start_date: Date.parse("2012-03-01"), leave_year_start_date: Date.parse("2011-04-01"), expected: "15.5" },
-       { hours_per_week: 15, days_per_week: 3, expected: "84" },
-       { hours_per_week: 30, days_per_week: 6, expected: "140" }].each do |example|
-        should example.to_s do
-          calc = HolidayEntitlement.new(example.except(:expected))
-          assert_equal example[:expected], calc.formatted_full_time_part_time_hours
-        end
-      end
-    end
-
-    context "calculating compressed hours entitlement" do
-      should "return the hours and minutes of entitlement" do
-        calc = HolidayEntitlement.new(hours_per_week: 20.5, days_per_week: 3)
-        assert_equal [114, 48], calc.compressed_hours_entitlement
-      end
-
-      should "return the hours and minutes of daily entitlement" do
-        calc = HolidayEntitlement.new(hours_per_week: 20.5, days_per_week: 3)
-        assert_equal [6, 50], calc.compressed_hours_daily_average
-      end
-    end
-
-    context "calculating shift worker shifts" do
-      context "full year" do
-        setup do
-          @calc = HolidayEntitlement.new(
-            hours_per_shift: 7.5,
-            shifts_per_shift_pattern: 4,
-            days_per_shift_pattern: 8,
-          )
-        end
-
-        should "return the average shifts per week" do
-          assert_equal 3.5, @calc.send(:shifts_per_week)
-        end
-
-        should "return the holiday entitlement in shifts" do
-          assert_equal "19.600", sprintf("%.3f", @calc.shift_entitlement)
-        end
-      end # full year
-
-      context "starting this year" do
-        setup do
-          @calc = HolidayEntitlement.new(
-            start_date: Date.parse("2012-07-01"),
-            hours_per_shift: 7.5,
-            shifts_per_shift_pattern: 4,
-            days_per_shift_pattern: 8,
-          )
-        end
-
-        should "return the holiday entitlement in shifts" do
-          assert_equal "9.854", sprintf("%.3f", @calc.shift_entitlement)
+            assert_equal BigDecimal(0.1666666667, 10), calc.fraction_of_year.round(10)
+            assert_equal BigDecimal(4.6666666667, 11), calc.full_time_part_time_days.round(10)
+            assert_equal "5", calc.formatted_full_time_part_time_days
+          end
         end
       end
 
-      context "leaving this year" do
-        setup do
-          @calc = HolidayEntitlement.new(
-            leaving_date: Date.parse("2012-09-30"),
-            hours_per_shift: 7.5,
-            shifts_per_shift_pattern: 4,
-            days_per_shift_pattern: 8,
-          )
+      context "leaving part way through a leave year" do
+        context "for a standard year" do
+          # /days-worked-per-week/starting/2019-06-01/2019-01-01/5.0
+          should "for 5 days a week" do
+            calc = HolidayEntitlement.new(
+              leaving_date: Date.parse("2019-06-01"),
+              leave_year_start_date: Date.parse("2019-01-01"),
+              days_per_week: 5,
+            )
+
+            assert_equal BigDecimal(0.4164383562, 10), calc.fraction_of_year.round(10)
+            assert_equal BigDecimal(11.6602739726, 12), calc.full_time_part_time_days.round(10)
+            assert_equal "11.7", calc.formatted_full_time_part_time_days
+          end
+
+          # /days-worked-per-week/starting/2019-11-21/2019-04-01/3.0
+          should "for less than 5 days a week" do
+            calc = HolidayEntitlement.new(
+              leaving_date: Date.parse("2018-11-23"),
+              leave_year_start_date: Date.parse("2018-04-01"),
+              days_per_week: 3,
+            )
+            assert_equal BigDecimal(0.6493150685, 10), calc.fraction_of_year.round(10)
+            assert_equal BigDecimal(10.9084931507, 12), calc.full_time_part_time_days.round(10)
+            assert_equal "11", calc.formatted_full_time_part_time_days
+          end
+
+          # /days-worked-per-week/starting/2019-08-22/2019-01-01/6.0
+          should "for more than 5 days a week" do
+            calc = HolidayEntitlement.new(
+              leaving_date: Date.parse("2019-08-22"),
+              leave_year_start_date: Date.parse("2019-01-01"),
+              days_per_week: 6,
+            )
+            assert_equal BigDecimal(0.6410958904, 10), calc.fraction_of_year.round(10)
+            assert_equal BigDecimal(21.5408219178, 12), calc.full_time_part_time_days.round(10)
+            assert_equal "21.6", calc.formatted_full_time_part_time_days
+          end
         end
 
-        should "return the holiday entitlement in shifts" do
-          assert_equal "14.673", sprintf("%.3f", @calc.shift_entitlement)
+        context "for a leap year" do
+          # /days-worked-per-week/starting/2020-06-01/2020-01-01/5.0
+          should "for 5 days a week" do
+            calc = HolidayEntitlement.new(
+              leaving_date: Date.parse("2020-06-01"),
+              leave_year_start_date: Date.parse("2020-01-01"),
+              days_per_week: 5,
+            )
+
+            assert_equal BigDecimal(0.4180327869, 10), calc.fraction_of_year.round(10)
+            assert_equal BigDecimal(11.7049180328, 12), calc.full_time_part_time_days.round(10)
+            assert_equal "11.8", calc.formatted_full_time_part_time_days
+          end
+
+          # /days-worked-per-week/starting/2020-11-21/2020-04-01/3.0
+          should "for less than 5 days a week" do
+            calc = HolidayEntitlement.new(
+              leaving_date: Date.parse("2019-11-23"),
+              leave_year_start_date: Date.parse("2019-04-01"),
+              days_per_week: 3,
+            )
+
+            assert_equal BigDecimal(0.6475409836, 10), calc.fraction_of_year.round(10)
+            assert_equal BigDecimal(10.8786885246, 12), calc.full_time_part_time_days.round(10)
+            assert_equal "10.9", calc.formatted_full_time_part_time_days
+          end
+
+          # /days-worked-per-week/starting/2020-08-22/2020-01-01/6.0
+          should "for more than 5 days a week" do
+            calc = HolidayEntitlement.new(
+              leaving_date: Date.parse("2020-08-22"),
+              leave_year_start_date: Date.parse("2020-01-01"),
+              days_per_week: 6,
+            )
+
+            assert_equal BigDecimal(0.6420765027, 10), calc.fraction_of_year.round(10)
+            assert_equal BigDecimal(21.5737704918, 12), calc.full_time_part_time_days.round(10)
+            assert_equal "21.6", calc.formatted_full_time_part_time_days
+          end
         end
-      end
-    end
-
-    context "strip_zeros" do
-      setup do
-        @calc = HolidayEntitlement.new
-      end
-
-      should "strip trailing zeroes after the dp from numbers" do
-        assert_equal "123", @calc.strip_zeros(123.0)
-      end
-
-      should "not strip significant zeroes" do
-        assert_equal "120", @calc.strip_zeros(120.0)
-      end
-    end
-
-    context "formatted version of anything" do
-      # implemented with method_missing
-      setup do
-        @calc = HolidayEntitlement.new
-        class << @calc
-          def foo; end
-        end
-      end
-
-      should "return foo to 1 dp by default" do
-        @calc.stubs(:foo).returns(123.6593)
-        assert_equal "123.7", @calc.formatted_foo
-      end
-
-      should "round up in all cases" do
-        @calc.stubs(:foo).returns(123.00001)
-        assert_equal "123.1", @calc.formatted_foo
-      end
-
-      should "allow overriding the dp" do
-        @calc.stubs(:foo).returns(123.6593)
-        assert_equal "123.66", @calc.formatted_foo(2)
-      end
-
-      should "strip .0 from foo" do
-        @calc.stubs(:foo).returns(0.0)
-        assert_equal "0", @calc.formatted_foo
-      end
-
-      should "respond to foo" do
-        assert @calc.respond_to?(:foo)
-      end
-    end
-
-    context "decimal precision in hours and minutes calculations" do
-      setup do
-        @calc = HolidayEntitlement.new(
-          hours_per_week: 28,
-          days_per_week: 5,
-          start_date: nil,
-          leave_year_start_date: nil,
-        )
-      end
-      should "calculate with the correct precision" do
-        assert_equal 156.8, @calc.full_time_part_time_hours
-      end
-    end
-    context "decimal precision in days_per_week calculations" do
-      setup do
-        @calc = HolidayEntitlement.new(
-          days_per_week: 4.5,
-          start_date: nil,
-          leave_year_start_date: nil,
-        )
-      end
-      should "calculate with the correct precision" do
-        assert_equal 25.2, @calc.full_time_part_time_days
       end
     end
   end


### PR DESCRIPTION
**EPIC: HolidayEntitlementCalculator new logic.** We're raising this PR for visibility, then we'll branch off this branch to continue with the other phases in the [parent Trello card](https://trello.com/c/DOulB3Hd/1297-epic-republish-holiday-entitlement-calculator-with-new-logic-%F0%9F%8D%90). Then we'll merge the final PR at the end, after some rebasing. Hence, this is PR 1/6. :scream:

This implements:
- Days worked per week for a full leave year.
- Starting work part-way through a leave year.
- Leaving work part-way through a leave year.
- We even account for leap years.

- We've done a lot of refactoring to help our numbers match the numbers on the spreadsheet we took our test data from. Notably, converting the HolidayEntitlement OpenStruct to a Class to make it easier to work with, and making sure all the necessary methods dealt with BigDecimals instead of Floats, to make sure we're precise enough in the calculations.
- We've deleted a lot of the old calculator code and tests to make our current changes easier to reason about and able to be done hopefully less confusingly. *This means that the Flow tests fail because they call code that doesn't exist any more.* When we've finished the EPIC REFACTOR, we'll tie it all together again.

https://trello.com/c/x7UV13sW/1325-8-implement-revised-logic-for-days-worked-per-week-for-holiday-entitlement-calculator

Co-authored-by: Alan Gabbianelli <alan.gabbianelli@digital.cabinet-office.gov.uk>
Co-authored-by: Ed Kerry <edward.kerry@digital.cabinet-office.gov.uk>
Co-authored-by: Issy Long <isabell.long@digital.cabinet-office.gov.uk>
Co-authored-by: Deborah Chua <deborah.chua@digital.cabinet-office.gov.uk>