### PR TITLE
(4/6) HolidayEntitlementCalculator: Update entitlement for shifts

### DIFF
--- a/lib/smart_answer/calculators/holiday_entitlement.rb
+++ b/lib/smart_answer/calculators/holiday_entitlement.rb
@@ -9,33 +9,32 @@ module SmartAnswer::Calculators
     MAXIMUM_STATUTORY_HOLIDAY_ENTITLEMENT_IN_DAYS = 28.to_d
     MONTHS_PER_YEAR = 12.to_d
     DAYS_PER_YEAR = 365.to_d
+    DAYS_PER_WEEK = 7.to_d
     DAYS_PER_LEAP_YEAR = 366.to_d
-    STANDARD_DAYS_PER_WEEK = 5.to_d
+    STANDARD_WORKING_DAYS_PER_WEEK = 5.to_d
 
-    attr_reader :days_per_week, :hours_per_week, :start_date, :leaving_date, :leave_year_start_date,
-                :hours_per_shift, :shifts_per_shift_pattern, :days_per_shift_pattern
+    attr_reader :working_days_per_week, :hours_per_week, :start_date, :leaving_date, :leave_year_start_date,
+                :shifts_per_shift_pattern, :days_per_shift_pattern
 
-    def initialize(days_per_week: 0,
+    def initialize(working_days_per_week: 0,
                    hours_per_week: 0,
                    start_date: nil,
                    leaving_date: nil,
                    leave_year_start_date: nil,
-                   hours_per_shift: 0,
                    shifts_per_shift_pattern: 0,
                    days_per_shift_pattern: 0)
-      @days_per_week = BigDecimal(days_per_week, 10)
+      @working_days_per_week = BigDecimal(working_days_per_week, 10)
       @hours_per_week = BigDecimal(hours_per_week, 10)
       @start_date = start_date
       @leaving_date = leaving_date
       @leave_year_start_date = leave_year_start_date || calculate_leave_year_start_date
-      @hours_per_shift = BigDecimal(hours_per_shift, 10)
       @shifts_per_shift_pattern = BigDecimal(shifts_per_shift_pattern, 10)
       @days_per_shift_pattern = BigDecimal(days_per_shift_pattern, 10)
     end
 
     def full_time_part_time_days
-      days = STATUTORY_HOLIDAY_ENTITLEMENT_IN_WEEKS * days_per_week
-      actual_days = if left_before_year_end? || (days_per_week < STANDARD_DAYS_PER_WEEK)
+      days = STATUTORY_HOLIDAY_ENTITLEMENT_IN_WEEKS * working_days_per_week
+      actual_days = if left_before_year_end? || (working_days_per_week < STANDARD_WORKING_DAYS_PER_WEEK)
                       days
                     else
                       [MAXIMUM_STATUTORY_HOLIDAY_ENTITLEMENT_IN_DAYS, days].min
@@ -45,7 +44,7 @@ module SmartAnswer::Calculators
 
     def rounded_full_time_part_time_days
       if started_after_year_began? || worked_full_year?
-        (full_time_part_time_days * 2).ceil / 2.00
+        (full_time_part_time_days * 2).ceil / 2.0
       else
         full_time_part_time_days
       end
@@ -56,14 +55,14 @@ module SmartAnswer::Calculators
     end
 
     def full_time_part_time_hours
-      minimum_days_per_week = [days_per_week, MAXIMUM_STATUTORY_DAYS_PER_WEEK].min
+      minimum_days_per_week = [working_days_per_week, MAXIMUM_STATUTORY_DAYS_PER_WEEK].min
 
-      STATUTORY_HOLIDAY_ENTITLEMENT_IN_WEEKS * minimum_days_per_week * (hours_per_week / days_per_week)
+      STATUTORY_HOLIDAY_ENTITLEMENT_IN_WEEKS * minimum_days_per_week * (hours_per_week / working_days_per_week)
     end
 
     def rounded_full_time_part_time_hours
       if started_after_year_began?
-        (rounded_full_time_part_time_days * hours_per_week) / days_per_week
+        (rounded_full_time_part_time_days * hours_per_week) / working_days_per_week
       else
         full_time_part_time_hours
       end
@@ -96,25 +95,26 @@ module SmartAnswer::Calculators
     end
 
     def shift_entitlement
-      minimum_days_per_week = [shifts_per_week, MAXIMUM_STATUTORY_DAYS_PER_WEEK].min
-
       if left_before_year_end? || worked_partial_year?
-        format_number(calculate_holiday * minimum_days_per_week, 2)
-      elsif start_date.present? && leave_year_start_date.present?
-        ((calculate_holiday * minimum_days_per_week * 2).ceil / 2.00).to_s
+        format_number(rounded_shift_entitlement, 2)
+      elsif started_after_year_began?
+        format_number(rounded_shift_entitlement)
       else
-        format_number((calculate_holiday * shifts_per_week))
+        format_number(STATUTORY_HOLIDAY_ENTITLEMENT_IN_WEEKS * shifts_per_week)
       end
+    end
+
+    def rounded_shift_entitlement
+      minimum_days_per_week = [shifts_per_week, MAXIMUM_STATUTORY_DAYS_PER_WEEK].min
+      pro_rated_shifts = STATUTORY_HOLIDAY_ENTITLEMENT_IN_WEEKS * fraction_of_year * minimum_days_per_week
+
+      started_after_year_began? ? (pro_rated_shifts * 2).ceil / 2.0 : pro_rated_shifts
     end
 
   private
 
-    def calculate_holiday
-      STATUTORY_HOLIDAY_ENTITLEMENT_IN_WEEKS * fraction_of_year
-    end
-
     def shifts_per_week
-      (shifts_per_shift_pattern / days_per_shift_pattern * 7).round(10)
+      (shifts_per_shift_pattern / days_per_shift_pattern * DAYS_PER_WEEK).round(10)
     end
 
     def calculate_leave_year_start_date

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
@@ -57,11 +57,11 @@ module SmartAnswer
 
       # Q3
       value_question :how_many_days_per_week?, parse: Float do
-        calculate :days_per_week do |response|
-          days_per_week = response
-          raise InvalidResponse if days_per_week <= 0 || days_per_week > 7
+        calculate :working_days_per_week do |response|
+          working_days_per_week = response
+          raise InvalidResponse if working_days_per_week <= 0 || working_days_per_week > 7
 
-          days_per_week
+          working_days_per_week
         end
         next_node do
           outcome :days_per_week_done
@@ -133,11 +133,11 @@ module SmartAnswer
       end
 
       value_question :how_many_days_per_week_for_hours?, parse: Float do
-        calculate :days_per_week do |response|
-          days_per_week = response
-          raise InvalidResponse if days_per_week <= 0 || days_per_week > 7
+        calculate :working_days_per_week do |response|
+          working_days_per_week = response
+          raise InvalidResponse if working_days_per_week <= 0 || working_days_per_week > 7
 
-          days_per_week
+          working_days_per_week
         end
         next_node do
           outcome :hours_per_week_done
@@ -157,7 +157,7 @@ module SmartAnswer
       end
 
       value_question :compressed_hours_how_many_days_per_week?, parse: Float do
-        calculate :days_per_week do |response|
+        calculate :working_days_per_week do |response|
           days = response
           raise InvalidResponse if days <= 0 || days > 7
 
@@ -246,11 +246,11 @@ module SmartAnswer
 
       outcome :days_per_week_done do
         precalculate :days_per_week_calculated do
-          (days_per_week < 5 ? days_per_week : 5)
+          (working_days_per_week < 5 ? working_days_per_week : 5)
         end
         precalculate :calculator do
           Calculators::HolidayEntitlement.new(
-            days_per_week: (leave_year_start_date.nil? ? days_per_week : days_per_week_calculated),
+            working_days_per_week: (leave_year_start_date.nil? ? working_days_per_week : days_per_week_calculated),
             start_date: start_date,
             leaving_date: leaving_date,
             leave_year_start_date: leave_year_start_date,
@@ -265,7 +265,7 @@ module SmartAnswer
         precalculate :calculator do
           Calculators::HolidayEntitlement.new(
             hours_per_week: hours_per_week,
-            days_per_week: days_per_week,
+            working_days_per_week: working_days_per_week,
             start_date: start_date,
             leaving_date: leaving_date,
             leave_year_start_date: leave_year_start_date,
@@ -286,7 +286,7 @@ module SmartAnswer
         precalculate :calculator do
           Calculators::HolidayEntitlement.new(
             hours_per_week: hours_per_week,
-            days_per_week: days_per_week,
+            working_days_per_week: working_days_per_week,
           )
         end
         precalculate :holiday_entitlement_hours do

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/days_per_week_done.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/days_per_week_done.govspeak.erb
@@ -1,7 +1,7 @@
 <% content_for :body do %>
   $!The statutory holiday entitlement is <%= "#{holiday_entitlement_days} #{'day'.pluralize(holiday_entitlement_days)}" %> holiday.$!
 
-  <% if days_per_week > 5 and calculator.full_time_part_time_days >= 28 %>
+  <% if working_days_per_week > 5 and calculator.full_time_part_time_days >= 28 %>
     Even though more than 5 days a week are worked the maximum statutory holiday entitlement is 28 days.
   <% end %>
 

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/hours_per_week_done.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/hours_per_week_done.govspeak.erb
@@ -1,7 +1,7 @@
 <% content_for :body do %>
   $!The statutory entitlement is <%= "#{holiday_entitlement_hours} #{'hour'.pluralize(holiday_entitlement_hours)}" %> and <%= "#{holiday_entitlement_minutes} #{'minute'.pluralize(holiday_entitlement_minutes)}" %> holiday.$!
 
-  <% if days_per_week > 5 %>
+  <% if working_days_per_week > 5 %>
     Even though more than 5 days a week are worked the maximum statutory holiday entitlement is 28 days.
   <% end %>
 

--- a/test/integration/smart_answer_flows/calculate_your_holiday_entitlement_test.rb
+++ b/test/integration/smart_answer_flows/calculate_your_holiday_entitlement_test.rb
@@ -37,7 +37,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
         SmartAnswer::Calculators::HolidayEntitlement
           .expects(:new)
           .with(
-            days_per_week: 5,
+            working_days_per_week: 5,
             start_date: nil,
             leaving_date: nil,
             leave_year_start_date: nil,
@@ -53,7 +53,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
         SmartAnswer::Calculators::HolidayEntitlement
           .expects(:new)
           .with(
-            days_per_week: 6,
+            working_days_per_week: 6,
             start_date: nil,
             leaving_date: nil,
             leave_year_start_date: nil,
@@ -97,7 +97,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
             SmartAnswer::Calculators::HolidayEntitlement
               .expects(:new)
               .with(
-                days_per_week: 5,
+                working_days_per_week: 5,
                 start_date: Date.parse("#{Date.today.year}-03-14"),
                 leaving_date: nil,
                 leave_year_start_date: Date.parse("#{Date.today.year}-05-02"),
@@ -107,14 +107,14 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
             add_response "5"
             assert_current_node :days_per_week_done
             assert_state_variable :holiday_entitlement_days, "formatted days"
-            assert_state_variable :days_per_week, 5
+            assert_state_variable :working_days_per_week, 5
           end
 
           should "calculate and be done part year when 6 or 7 days" do
             SmartAnswer::Calculators::HolidayEntitlement
               .expects(:new)
               .with(
-                days_per_week: 5,
+                working_days_per_week: 5,
                 start_date: Date.parse("#{Date.today.year}-03-14"),
                 leaving_date: nil,
                 leave_year_start_date: Date.parse("#{Date.today.year}-05-02"),
@@ -124,7 +124,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
             add_response "6"
             assert_current_node :days_per_week_done
             assert_state_variable :holiday_entitlement_days, "formatted days"
-            assert_state_variable :days_per_week, 6
+            assert_state_variable :working_days_per_week, 6
             assert_state_variable :days_per_week_calculated, 5
           end
         end # with a leave year start date
@@ -162,7 +162,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
             SmartAnswer::Calculators::HolidayEntitlement
               .expects(:new)
               .with(
-                days_per_week: 5,
+                working_days_per_week: 5,
                 start_date: nil,
                 leaving_date: Date.parse("#{Date.today.year}-07-14"),
                 leave_year_start_date: Date.parse("#{Date.today.year}-01-01"),
@@ -172,14 +172,14 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
             add_response "5"
             assert_current_node :days_per_week_done
             assert_state_variable :holiday_entitlement_days, "formatted days"
-            assert_state_variable :days_per_week, 5
+            assert_state_variable :working_days_per_week, 5
           end
 
           should "calculate and be done part year when 6 days" do
             SmartAnswer::Calculators::HolidayEntitlement
               .expects(:new)
               .with(
-                days_per_week: 5,
+                working_days_per_week: 5,
                 start_date: nil,
                 leaving_date: Date.parse("#{Date.today.year}-07-14"),
                 leave_year_start_date: Date.parse("#{Date.today.year}-01-01"),
@@ -189,7 +189,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
             add_response "6"
             assert_current_node :days_per_week_done
             assert_state_variable :holiday_entitlement_days, "formatted days"
-            assert_state_variable :days_per_week, 6
+            assert_state_variable :working_days_per_week, 6
           end
         end # with a leave year start date
       end # with a start date
@@ -220,7 +220,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
             SmartAnswer::Calculators::HolidayEntitlement
               .expects(:new)
               .with(
-                days_per_week: 5,
+                working_days_per_week: 5,
                 start_date: Date.parse("#{Date.today.year}-07-14"),
                 leaving_date: Date.parse("#{Date.today.year}-10-14"),
                 leave_year_start_date: nil,
@@ -230,7 +230,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
             add_response "5"
             assert_current_node :days_per_week_done
             assert_state_variable :holiday_entitlement_days, "formatted days"
-            assert_state_variable :days_per_week, 5
+            assert_state_variable :working_days_per_week, 5
           end
         end
       end
@@ -267,7 +267,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
               .expects(:new)
               .with(
                 hours_per_week: 32.0,
-                days_per_week: 5.0,
+                working_days_per_week: 5.0,
                 start_date: nil,
                 leaving_date: nil,
                 leave_year_start_date: nil,
@@ -316,7 +316,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
                   expects(:new).
                   with(
                     hours_per_week: 37.0,
-                    days_per_week: 5,
+                    working_days_per_week: 5,
                     start_date: Date.parse("#{Date.today.year}-06-15"),
                     leaving_date: nil,
                     leave_year_start_date: Date.parse("#{Date.today.year}-01-01"),
@@ -368,7 +368,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
                   expects(:new).
                   with(
                     hours_per_week: 26.5,
-                    days_per_week: 5,
+                    working_days_per_week: 5,
                     start_date: nil,
                     leaving_date: Date.parse("#{Date.today.year}-06-15"),
                     leave_year_start_date: Date.parse("#{Date.today.year}-01-01"),
@@ -419,7 +419,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
                 .expects(:new)
                 .with(
                   hours_per_week: 37,
-                  days_per_week: 5,
+                  working_days_per_week: 5,
                   start_date: Date.parse("#{Date.today.year}-07-14"),
                   leaving_date: Date.parse("#{Date.today.year}-10-14"),
                   leave_year_start_date: nil,
@@ -476,7 +476,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
     should "calculate and be done with hours and days entered" do
       SmartAnswer::Calculators::HolidayEntitlement
         .expects(:new)
-        .with(hours_per_week: 20.5, days_per_week: 3)
+        .with(hours_per_week: 20.5, working_days_per_week: 3)
         .returns(@stubbed_calculator)
       @stubbed_calculator.expects(:compressed_hours_entitlement).at_least_once.returns(["formatted hours", "formatted minutes"])
       @stubbed_calculator.expects(:compressed_hours_daily_average).at_least_once.returns(["formatted daily hours", "formatted daily minutes"])
@@ -485,7 +485,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
       add_response "3"
       assert_current_node :compressed_hours_done
       assert_state_variable :hours_per_week, 20.5
-      assert_state_variable :days_per_week, 3
+      assert_state_variable :working_days_per_week, 3
       assert_state_variable :holiday_entitlement_hours, "formatted hours"
       assert_state_variable :holiday_entitlement_minutes, "formatted minutes"
       assert_state_variable :hours_daily, "formatted daily hours"

--- a/test/unit/calculators/holiday_entitlement_test.rb
+++ b/test/unit/calculators/holiday_entitlement_test.rb
@@ -554,42 +554,83 @@ module SmartAnswer::Calculators
       end
 
       context "for starting part way through a leave year" do
-        should "for 4 shifts per week" do
-          calc = HolidayEntitlement.new(
-            start_date: Date.parse("2019-06-01"),
-            leave_year_start_date: Date.parse("2019-01-01"),
-            hours_per_shift: 6,
-            shifts_per_shift_pattern: 8,
-            days_per_shift_pattern: 14,
-            )
+        context "for a standard year" do
+          should "for 4 shifts per week" do
+            calc = HolidayEntitlement.new(
+              start_date: Date.parse("2019-06-01"),
+              leave_year_start_date: Date.parse("2019-01-01"),
+              hours_per_shift: 6,
+              shifts_per_shift_pattern: 8,
+              days_per_shift_pattern: 14,
+              )
 
-          assert_equal "13.5", calc.shift_entitlement
+            assert_equal "13.5", calc.shift_entitlement
+          end
+
+          should "for 4.9 shifts per week" do
+            calc = HolidayEntitlement.new(
+              start_date: Date.parse("2020-11-23"),
+              leave_year_start_date: Date.parse("2020-04-01"),
+              hours_per_shift: 25,
+              shifts_per_shift_pattern: 7,
+              days_per_shift_pattern: 10,
+              )
+
+            assert_equal "11.5", calc.shift_entitlement
+          end
+
+          should "for 6 shifts per week" do
+            calc = HolidayEntitlement.new(
+              start_date: Date.parse("2019-11-14"),
+              leave_year_start_date: Date.parse("2019-01-01"),
+              hours_per_shift: 36,
+              shifts_per_shift_pattern: 12,
+              days_per_shift_pattern: 14,
+              )
+
+            assert_equal "5.0", calc.shift_entitlement
+          end
         end
 
-        should "for 4.9 shifts per week" do
-          calc = HolidayEntitlement.new(
-            start_date: Date.parse("2020-11-23"),
-            leave_year_start_date: Date.parse("2020-04-01"),
-            hours_per_shift: 25,
-            shifts_per_shift_pattern: 7,
-            days_per_shift_pattern: 10,
-            )
+        context "for a leap year" do
+          should "for 4 shifts per week" do
+            calc = HolidayEntitlement.new(
+              start_date: Date.parse("2020-06-01"),
+              leave_year_start_date: Date.parse("2020-01-01"),
+              hours_per_shift: 6,
+              shifts_per_shift_pattern: 8,
+              days_per_shift_pattern: 14,
+              )
 
-          assert_equal "11.5", calc.shift_entitlement
-        end
+            assert_equal "13.5", calc.shift_entitlement
+          end
 
-        should "for 6 shifts per week" do
-          calc = HolidayEntitlement.new(
-            start_date: Date.parse("2019-11-14"),
-            leave_year_start_date: Date.parse("2019-01-01"),
-            hours_per_shift: 36,
-            shifts_per_shift_pattern: 12,
-            days_per_shift_pattern: 14,
-            )
+          should "for 4.9 shifts per week" do
+            calc = HolidayEntitlement.new(
+              start_date: Date.parse("2019-11-23"),
+              leave_year_start_date: Date.parse("2019-04-01"),
+              hours_per_shift: 25,
+              shifts_per_shift_pattern: 7,
+              days_per_shift_pattern: 10,
+              )
 
-          assert_equal "5.0", calc.shift_entitlement
+            assert_equal "11.5", calc.shift_entitlement
+          end
+
+          should "for 6 shifts per week" do
+            calc = HolidayEntitlement.new(
+              start_date: Date.parse("2020-11-14"),
+              leave_year_start_date: Date.parse("2020-01-01"),
+              hours_per_shift: 36,
+              shifts_per_shift_pattern: 12,
+              days_per_shift_pattern: 14,
+              )
+
+            assert_equal "5.0", calc.shift_entitlement
+          end
         end
       end
+
       context "leaving part way through a leave year" do
         context "for a standard year" do
           should "for 6 hours over 4 days a week" do
@@ -640,6 +681,30 @@ module SmartAnswer::Calculators
 
             assert_equal "9.37", calc.shift_entitlement
           end
+
+          should "for 25 hours over 4.9 days a week" do
+            calc = HolidayEntitlement.new(
+              leaving_date: Date.parse("2019-11-23"),
+              leave_year_start_date: Date.parse("2019-04-01"),
+              hours_per_shift: 25,
+              shifts_per_shift_pattern: 7,
+              days_per_shift_pattern: 10,
+            )
+
+            assert_equal "17.77", calc.shift_entitlement
+          end
+
+          should "for 36 hours over 6 days a week" do
+            calc = HolidayEntitlement.new(
+              leaving_date: Date.parse("2020-11-14"),
+              leave_year_start_date: Date.parse("2020-01-01"),
+              hours_per_shift: 36,
+              shifts_per_shift_pattern: 12,
+              days_per_shift_pattern: 14,
+            )
+
+            assert_equal "24.41", calc.shift_entitlement
+          end
         end
       end
 
@@ -655,6 +720,68 @@ module SmartAnswer::Calculators
             )
 
             assert_equal "11.05", calc.shift_entitlement
+          end
+
+          should "for 25 hours over 4.9 days a week" do
+            calc = HolidayEntitlement.new(
+              start_date: Date.parse("2020-11-23"),
+              leaving_date: Date.parse("2021-04-07"),
+              hours_per_shift: 25,
+              shifts_per_shift_pattern: 7,
+              days_per_shift_pattern: 10,
+            )
+
+            assert_equal "10.23", calc.shift_entitlement
+          end
+
+          should "for 36 hours over 6 days a week" do
+            calc = HolidayEntitlement.new(
+              start_date: Date.parse("2020-08-22"),
+              leaving_date: Date.parse("2021-07-31"),
+              hours_per_shift: 36,
+              shifts_per_shift_pattern: 12,
+              days_per_shift_pattern: 14,
+            )
+
+            assert_equal "26.39", calc.shift_entitlement
+          end
+        end
+
+        context "for a leap year" do
+          should "for 6 hours over 4 days a week" do
+            calc = HolidayEntitlement.new(
+              start_date: Date.parse("2020-01-20"),
+              leaving_date: Date.parse("2020-07-18"),
+              hours_per_shift: 6,
+              shifts_per_shift_pattern: 8,
+              days_per_shift_pattern: 14,
+            )
+
+            assert_equal "11.08", calc.shift_entitlement
+          end
+
+          should "for 25 hours over 4.9 days a week" do
+            calc = HolidayEntitlement.new(
+              start_date: Date.parse("2019-11-23"),
+              leaving_date: Date.parse("2020-04-07"),
+              hours_per_shift: 25,
+              shifts_per_shift_pattern: 7,
+              days_per_shift_pattern: 10,
+            )
+
+            assert_equal "10.28", calc.shift_entitlement
+          end
+
+          should "for 36 hours over 6 days a week" do
+            calc = HolidayEntitlement.new(
+              start_date: Date.parse("2019-08-22"),
+              leaving_date: Date.parse("2020-07-31"),
+              hours_per_shift: 36,
+              shifts_per_shift_pattern: 12,
+              days_per_shift_pattern: 14,
+            )
+
+            assert_equal "26.40", calc.shift_entitlement
           end
         end
       end

--- a/test/unit/calculators/holiday_entitlement_test.rb
+++ b/test/unit/calculators/holiday_entitlement_test.rb
@@ -534,5 +534,130 @@ module SmartAnswer::Calculators
         end
       end
     end
+
+    context "calculate entitlement on shifts worked" do
+      context "for a full leave year" do
+        should "for 6 hours over 14 days with 4 days per week" do
+          calc = HolidayEntitlement.new(hours_per_shift: 6,
+                                        shifts_per_shift_pattern: 8,
+                                        days_per_shift_pattern: 14)
+          assert_equal "22.4", calc.shift_entitlement
+        end
+        should "for 25 hours over less than 5 days a week" do
+          calc = HolidayEntitlement.new(hours_per_shift: 25, shifts_per_shift_pattern: 7, days_per_shift_pattern: 10)
+          assert_equal "27.5", calc.shift_entitlement
+        end
+        should "for 36 hours over more than 5 days a week" do
+          calc = HolidayEntitlement.new(hours_per_shift: 36, shifts_per_shift_pattern: 12, days_per_shift_pattern: 14)
+          assert_equal "33.6", calc.shift_entitlement
+        end
+      end
+
+      context "for starting part way through a leave year" do
+        should "for 4 shifts per week" do
+          calc = HolidayEntitlement.new(
+            start_date: Date.parse("2019-06-01"),
+            leave_year_start_date: Date.parse("2019-01-01"),
+            hours_per_shift: 6,
+            shifts_per_shift_pattern: 8,
+            days_per_shift_pattern: 14,
+            )
+
+          assert_equal "13.5", calc.shift_entitlement
+        end
+
+        should "for 4.9 shifts per week" do
+          calc = HolidayEntitlement.new(
+            start_date: Date.parse("2020-11-23"),
+            leave_year_start_date: Date.parse("2020-04-01"),
+            hours_per_shift: 25,
+            shifts_per_shift_pattern: 7,
+            days_per_shift_pattern: 10,
+            )
+
+          assert_equal "11.5", calc.shift_entitlement
+        end
+
+        should "for 6 shifts per week" do
+          calc = HolidayEntitlement.new(
+            start_date: Date.parse("2019-11-14"),
+            leave_year_start_date: Date.parse("2019-01-01"),
+            hours_per_shift: 36,
+            shifts_per_shift_pattern: 12,
+            days_per_shift_pattern: 14,
+            )
+
+          assert_equal "5.0", calc.shift_entitlement
+        end
+      end
+      context "leaving part way through a leave year" do
+        context "for a standard year" do
+          should "for 6 hours over 4 days a week" do
+            calc = HolidayEntitlement.new(
+              leaving_date: Date.parse("2019-06-01"),
+              leave_year_start_date: Date.parse("2019-01-01"),
+              hours_per_shift: 6,
+              shifts_per_shift_pattern: 8,
+              days_per_shift_pattern: 14,
+              )
+
+            assert_equal "9.33", calc.shift_entitlement
+          end
+
+          should "for 25 hours over 4.9 days a week" do
+            calc = HolidayEntitlement.new(
+              leaving_date: Date.parse("2020-11-23"),
+              leave_year_start_date: Date.parse("2020-04-01"),
+              hours_per_shift: 25,
+              shifts_per_shift_pattern: 7,
+              days_per_shift_pattern: 10,
+            )
+
+            assert_equal "17.82", calc.shift_entitlement
+          end
+
+          should "for 36 hours over 6 days a week" do
+            calc = HolidayEntitlement.new(
+              leaving_date: Date.parse("2019-11-14"),
+              leave_year_start_date: Date.parse("2019-01-01"),
+              hours_per_shift: 36,
+              shifts_per_shift_pattern: 12,
+              days_per_shift_pattern: 14,
+            )
+
+            assert_equal "24.40", calc.shift_entitlement
+          end
+        end
+        context "for a leap year" do
+          should "for 6 hours over 4 days a week" do
+            calc = HolidayEntitlement.new(
+              leaving_date: Date.parse("2020-06-01"),
+              leave_year_start_date: Date.parse("2020-01-01"),
+              hours_per_shift: 6,
+              shifts_per_shift_pattern: 8,
+              days_per_shift_pattern: 14,
+            )
+
+            assert_equal "9.37", calc.shift_entitlement
+          end
+        end
+      end
+
+      context "starting and leaving part way through a leave year" do
+        context "for a standard year" do
+          should "for 6 hours over 4 days a week" do
+            calc = HolidayEntitlement.new(
+              start_date: Date.parse("2019-01-20"),
+              leaving_date: Date.parse("2019-07-18"),
+              hours_per_shift: 6,
+              shifts_per_shift_pattern: 8,
+              days_per_shift_pattern: 14,
+            )
+
+            assert_equal "11.05", calc.shift_entitlement
+          end
+        end
+      end
+    end
   end
 end

--- a/test/unit/calculators/holiday_entitlement_test.rb
+++ b/test/unit/calculators/holiday_entitlement_test.rb
@@ -6,19 +6,19 @@ module SmartAnswer::Calculators
       # /days-worked-per-week/full-year/5.0
       context "for a full leave year" do
         should "for 5 days a week" do
-          calc = HolidayEntitlement.new(days_per_week: 5)
+          calc = HolidayEntitlement.new(working_days_per_week: 5)
           assert_equal "28", calc.formatted_full_time_part_time_days
         end
 
         # /days-worked-per-week/full-year/5.0
         should "for more than 5 days a week" do
-          calc = HolidayEntitlement.new(days_per_week: 7)
+          calc = HolidayEntitlement.new(working_days_per_week: 7)
           assert_equal "28", calc.formatted_full_time_part_time_days
         end
 
         # /days-worked-per-week/full-year/3.5
         should "for less than 5 days a week" do
-          calc = HolidayEntitlement.new(days_per_week: 3)
+          calc = HolidayEntitlement.new(working_days_per_week: 3)
           assert_equal "17", calc.formatted_full_time_part_time_days
         end
       end
@@ -30,7 +30,7 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               start_date: Date.parse("2019-06-01"),
               leave_year_start_date: Date.parse("2019-01-01"),
-              days_per_week: 5,
+              working_days_per_week: 5,
             )
 
             assert_equal BigDecimal("0.5833333333").round(10), calc.fraction_of_year.round(10)
@@ -43,7 +43,7 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               start_date: Date.parse("2019-11-23"),
               leave_year_start_date: Date.parse("2019-04-01"),
-              days_per_week: 3,
+              working_days_per_week: 3,
             )
 
             assert_equal BigDecimal("0.4166666667").round(10), calc.fraction_of_year.round(10)
@@ -56,7 +56,7 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               start_date: Date.parse("2019-11-14"),
               leave_year_start_date: Date.parse("2019-01-01"),
-              days_per_week: 6,
+              working_days_per_week: 6,
             )
 
             assert_equal BigDecimal("0.1666666667").round(10), calc.fraction_of_year.round(10)
@@ -71,7 +71,7 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               start_date: Date.parse("2020-06-01"),
               leave_year_start_date: Date.parse("2020-01-01"),
-              days_per_week: 5,
+              working_days_per_week: 5,
             )
 
             assert_equal BigDecimal("0.5833333333").round(10), calc.fraction_of_year.round(10)
@@ -84,7 +84,7 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               start_date: Date.parse("2020-11-23"),
               leave_year_start_date: Date.parse("2020-04-01"),
-              days_per_week: 3,
+              working_days_per_week: 3,
             )
 
             assert_equal BigDecimal("0.4166666667").round(10), calc.fraction_of_year.round(10)
@@ -97,7 +97,7 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               start_date: Date.parse("2020-11-14"),
               leave_year_start_date: Date.parse("2020-01-01"),
-              days_per_week: 6,
+              working_days_per_week: 6,
             )
 
             assert_equal BigDecimal("0.1666666667").round(10), calc.fraction_of_year.round(10)
@@ -114,7 +114,7 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               leaving_date: Date.parse("2019-06-01"),
               leave_year_start_date: Date.parse("2019-01-01"),
-              days_per_week: 5,
+              working_days_per_week: 5,
             )
 
             assert_equal BigDecimal("0.4164383562").round(10), calc.fraction_of_year.round(10)
@@ -127,7 +127,7 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               leaving_date: Date.parse("2018-11-23"),
               leave_year_start_date: Date.parse("2018-04-01"),
-              days_per_week: 3,
+              working_days_per_week: 3,
             )
             assert_equal BigDecimal("0.6493150685").round(10), calc.fraction_of_year.round(10)
             assert_equal BigDecimal("10.9084931507").round(10), calc.full_time_part_time_days.round(10)
@@ -139,7 +139,7 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               leaving_date: Date.parse("2019-08-22"),
               leave_year_start_date: Date.parse("2019-01-01"),
-              days_per_week: 6,
+              working_days_per_week: 6,
             )
             assert_equal BigDecimal("0.6410958904").round(10), calc.fraction_of_year.round(10)
             assert_equal BigDecimal("21.5408219178").round(10), calc.full_time_part_time_days.round(10)
@@ -153,7 +153,7 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               leaving_date: Date.parse("2020-06-01"),
               leave_year_start_date: Date.parse("2020-01-01"),
-              days_per_week: 5,
+              working_days_per_week: 5,
             )
 
             assert_equal BigDecimal("0.4180327869").round(10), calc.fraction_of_year.round(10)
@@ -166,7 +166,7 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               leaving_date: Date.parse("2019-11-23"),
               leave_year_start_date: Date.parse("2019-04-01"),
-              days_per_week: 3,
+              working_days_per_week: 3,
             )
 
             assert_equal BigDecimal("0.6475409836").round(10), calc.fraction_of_year.round(10)
@@ -179,7 +179,7 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               leaving_date: Date.parse("2020-08-22"),
               leave_year_start_date: Date.parse("2020-01-01"),
-              days_per_week: 6,
+              working_days_per_week: 6,
             )
 
             assert_equal BigDecimal("0.6420765027").round(10), calc.fraction_of_year.round(10)
@@ -196,7 +196,7 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               start_date: Date.parse("2019-01-20"),
               leaving_date: Date.parse("2019-07-18"),
-              days_per_week: 5,
+              working_days_per_week: 5,
             )
 
             assert_equal BigDecimal("0.4931506849").round(10), calc.fraction_of_year.round(10)
@@ -209,7 +209,7 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               start_date: Date.parse("2018-11-23"),
               leaving_date: Date.parse("2019-04-07"),
-              days_per_week: 3,
+              working_days_per_week: 3,
             )
 
             assert_equal BigDecimal("0.3726027397").round(10), calc.fraction_of_year.round(10)
@@ -222,7 +222,7 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               start_date: Date.parse("2018-08-22"),
               leaving_date: Date.parse("2019-07-31"),
-              days_per_week: 6,
+              working_days_per_week: 6,
             )
 
             assert_equal BigDecimal("0.9424657534").round(10), calc.fraction_of_year.round(10)
@@ -237,7 +237,7 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               start_date: Date.parse("2020-01-20"),
               leaving_date: Date.parse("2020-07-18"),
-              days_per_week: 5,
+              working_days_per_week: 5,
             )
 
             assert_equal BigDecimal("0.4945355191").round(10), calc.fraction_of_year.round(10)
@@ -250,7 +250,7 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               start_date: Date.parse("2019-11-23"),
               leaving_date: Date.parse("2020-04-07"),
-              days_per_week: 3,
+              working_days_per_week: 3,
             )
 
             assert_equal BigDecimal("0.3743169399").round(10), calc.fraction_of_year.round(10)
@@ -263,7 +263,7 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               start_date: Date.parse("2019-08-22"),
               leaving_date: Date.parse("2020-07-31"),
-              days_per_week: 6,
+              working_days_per_week: 6,
             )
 
             assert_equal BigDecimal("0.9426229508").round(10), calc.fraction_of_year.round(10)
@@ -277,17 +277,17 @@ module SmartAnswer::Calculators
     context "calculate entitlement on hours worked per week and compressed hours" do
       context "for a full leave year" do
         should "for 40 hours over 5 days per week" do
-          calc = HolidayEntitlement.new(days_per_week: 5, hours_per_week: 40)
+          calc = HolidayEntitlement.new(working_days_per_week: 5, hours_per_week: 40)
           assert_equal "224", calc.formatted_full_time_part_time_compressed_hours
         end
 
         should "for 25 hours over less than 5 days a week" do
-          calc = HolidayEntitlement.new(days_per_week: 3, hours_per_week: 25)
+          calc = HolidayEntitlement.new(working_days_per_week: 3, hours_per_week: 25)
           assert_equal "140", calc.formatted_full_time_part_time_compressed_hours
         end
 
         should "for 36 hours over more than 5 days a week" do
-          calc = HolidayEntitlement.new(days_per_week: 6, hours_per_week: 36)
+          calc = HolidayEntitlement.new(working_days_per_week: 6, hours_per_week: 36)
           assert_equal "168", calc.formatted_full_time_part_time_compressed_hours
         end
       end
@@ -298,7 +298,7 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               start_date: Date.parse("2019-06-01"),
               leave_year_start_date: Date.parse("2019-01-01"),
-              days_per_week: 5,
+              working_days_per_week: 5,
               hours_per_week: 40,
             )
 
@@ -311,7 +311,7 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               start_date: Date.parse("2020-11-23"),
               leave_year_start_date: Date.parse("2020-04-01"),
-              days_per_week: 3,
+              working_days_per_week: 3,
               hours_per_week: 25,
             )
 
@@ -324,7 +324,7 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               start_date: Date.parse("2019-11-14"),
               leave_year_start_date: Date.parse("2019-01-01"),
-              days_per_week: 6,
+              working_days_per_week: 6,
               hours_per_week: 36,
             )
 
@@ -339,7 +339,7 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               start_date: Date.parse("2020-06-01"),
               leave_year_start_date: Date.parse("2020-01-01"),
-              days_per_week: 5,
+              working_days_per_week: 5,
               hours_per_week: 40,
             )
 
@@ -350,7 +350,7 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               start_date: Date.parse("2019-11-23"),
               leave_year_start_date: Date.parse("2019-04-01"),
-              days_per_week: 3,
+              working_days_per_week: 3,
               hours_per_week: 25,
             )
 
@@ -361,7 +361,7 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               start_date: Date.parse("2020-11-14"),
               leave_year_start_date: Date.parse("2020-01-01"),
-              days_per_week: 6,
+              working_days_per_week: 6,
               hours_per_week: 36,
             )
 
@@ -376,7 +376,7 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               leaving_date: Date.parse("2019-06-01"),
               leave_year_start_date: Date.parse("2019-01-01"),
-              days_per_week: 5,
+              working_days_per_week: 5,
               hours_per_week: 40,
             )
 
@@ -389,7 +389,7 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               leaving_date: Date.parse("2020-11-23"),
               leave_year_start_date: Date.parse("2020-04-01"),
-              days_per_week: 3,
+              working_days_per_week: 3,
               hours_per_week: 25,
             )
 
@@ -402,7 +402,7 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               leaving_date: Date.parse("2019-08-22"),
               leave_year_start_date: Date.parse("2019-01-01"),
-              days_per_week: 6,
+              working_days_per_week: 6,
               hours_per_week: 36,
             )
 
@@ -416,7 +416,7 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               leaving_date: Date.parse("2020-06-01"),
               leave_year_start_date: Date.parse("2020-01-01"),
-              days_per_week: 5,
+              working_days_per_week: 5,
               hours_per_week: 40,
             )
 
@@ -428,7 +428,7 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               leaving_date: Date.parse("2019-11-23"),
               leave_year_start_date: Date.parse("2019-04-01"),
-              days_per_week: 3,
+              working_days_per_week: 3,
               hours_per_week: 25,
             )
 
@@ -441,7 +441,7 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               leaving_date: Date.parse("2020-08-22"),
               leave_year_start_date: Date.parse("2020-01-01"),
-              days_per_week: 6,
+              working_days_per_week: 6,
               hours_per_week: 36,
             )
 
@@ -458,7 +458,7 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               start_date: Date.parse("2019-01-20"),
               leaving_date: Date.parse("2019-07-18"),
-              days_per_week: 5,
+              working_days_per_week: 5,
               hours_per_week: 40,
             )
 
@@ -471,7 +471,7 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               start_date: Date.parse("2018-11-23"),
               leaving_date: Date.parse("2019-04-07"),
-              days_per_week: 3,
+              working_days_per_week: 3,
               hours_per_week: 25,
             )
 
@@ -484,7 +484,7 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               start_date: Date.parse("2018-08-22"),
               leaving_date: Date.parse("2019-07-31"),
-              days_per_week: 6,
+              working_days_per_week: 6,
               hours_per_week: 36,
             )
 
@@ -498,7 +498,7 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               start_date: Date.parse("2020-01-20"),
               leaving_date: Date.parse("2020-07-18"),
-              days_per_week: 5,
+              working_days_per_week: 5,
               hours_per_week: 40,
             )
 
@@ -510,7 +510,7 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               start_date: Date.parse("2019-11-23"),
               leaving_date: Date.parse("2020-04-07"),
-              days_per_week: 3,
+              working_days_per_week: 3,
               hours_per_week: 25,
             )
 
@@ -523,7 +523,7 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               start_date: Date.parse("2019-08-22"),
               leaving_date: Date.parse("2020-07-31"),
-              days_per_week: 6,
+              working_days_per_week: 6,
               hours_per_week: 36,
             )
 
@@ -538,17 +538,16 @@ module SmartAnswer::Calculators
     context "calculate entitlement on shifts worked" do
       context "for a full leave year" do
         should "for 6 hours over 14 days with 4 days per week" do
-          calc = HolidayEntitlement.new(hours_per_shift: 6,
-                                        shifts_per_shift_pattern: 8,
+          calc = HolidayEntitlement.new(shifts_per_shift_pattern: 8,
                                         days_per_shift_pattern: 14)
           assert_equal "22.4", calc.shift_entitlement
         end
         should "for 25 hours over less than 5 days a week" do
-          calc = HolidayEntitlement.new(hours_per_shift: 25, shifts_per_shift_pattern: 7, days_per_shift_pattern: 10)
+          calc = HolidayEntitlement.new(shifts_per_shift_pattern: 7, days_per_shift_pattern: 10)
           assert_equal "27.5", calc.shift_entitlement
         end
         should "for 36 hours over more than 5 days a week" do
-          calc = HolidayEntitlement.new(hours_per_shift: 36, shifts_per_shift_pattern: 12, days_per_shift_pattern: 14)
+          calc = HolidayEntitlement.new(shifts_per_shift_pattern: 12, days_per_shift_pattern: 14)
           assert_equal "33.6", calc.shift_entitlement
         end
       end
@@ -559,7 +558,6 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               start_date: Date.parse("2019-06-01"),
               leave_year_start_date: Date.parse("2019-01-01"),
-              hours_per_shift: 6,
               shifts_per_shift_pattern: 8,
               days_per_shift_pattern: 14,
               )
@@ -571,7 +569,6 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               start_date: Date.parse("2020-11-23"),
               leave_year_start_date: Date.parse("2020-04-01"),
-              hours_per_shift: 25,
               shifts_per_shift_pattern: 7,
               days_per_shift_pattern: 10,
               )
@@ -583,12 +580,11 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               start_date: Date.parse("2019-11-14"),
               leave_year_start_date: Date.parse("2019-01-01"),
-              hours_per_shift: 36,
               shifts_per_shift_pattern: 12,
               days_per_shift_pattern: 14,
               )
 
-            assert_equal "5.0", calc.shift_entitlement
+            assert_equal "5", calc.shift_entitlement
           end
         end
 
@@ -597,7 +593,6 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               start_date: Date.parse("2020-06-01"),
               leave_year_start_date: Date.parse("2020-01-01"),
-              hours_per_shift: 6,
               shifts_per_shift_pattern: 8,
               days_per_shift_pattern: 14,
               )
@@ -609,7 +604,6 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               start_date: Date.parse("2019-11-23"),
               leave_year_start_date: Date.parse("2019-04-01"),
-              hours_per_shift: 25,
               shifts_per_shift_pattern: 7,
               days_per_shift_pattern: 10,
               )
@@ -621,12 +615,11 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               start_date: Date.parse("2020-11-14"),
               leave_year_start_date: Date.parse("2020-01-01"),
-              hours_per_shift: 36,
               shifts_per_shift_pattern: 12,
               days_per_shift_pattern: 14,
               )
 
-            assert_equal "5.0", calc.shift_entitlement
+            assert_equal "5", calc.shift_entitlement
           end
         end
       end
@@ -637,7 +630,6 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               leaving_date: Date.parse("2019-06-01"),
               leave_year_start_date: Date.parse("2019-01-01"),
-              hours_per_shift: 6,
               shifts_per_shift_pattern: 8,
               days_per_shift_pattern: 14,
               )
@@ -649,7 +641,6 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               leaving_date: Date.parse("2020-11-23"),
               leave_year_start_date: Date.parse("2020-04-01"),
-              hours_per_shift: 25,
               shifts_per_shift_pattern: 7,
               days_per_shift_pattern: 10,
             )
@@ -661,7 +652,6 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               leaving_date: Date.parse("2019-11-14"),
               leave_year_start_date: Date.parse("2019-01-01"),
-              hours_per_shift: 36,
               shifts_per_shift_pattern: 12,
               days_per_shift_pattern: 14,
             )
@@ -674,7 +664,6 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               leaving_date: Date.parse("2020-06-01"),
               leave_year_start_date: Date.parse("2020-01-01"),
-              hours_per_shift: 6,
               shifts_per_shift_pattern: 8,
               days_per_shift_pattern: 14,
             )
@@ -686,7 +675,6 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               leaving_date: Date.parse("2019-11-23"),
               leave_year_start_date: Date.parse("2019-04-01"),
-              hours_per_shift: 25,
               shifts_per_shift_pattern: 7,
               days_per_shift_pattern: 10,
             )
@@ -698,7 +686,6 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               leaving_date: Date.parse("2020-11-14"),
               leave_year_start_date: Date.parse("2020-01-01"),
-              hours_per_shift: 36,
               shifts_per_shift_pattern: 12,
               days_per_shift_pattern: 14,
             )
@@ -714,7 +701,6 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               start_date: Date.parse("2019-01-20"),
               leaving_date: Date.parse("2019-07-18"),
-              hours_per_shift: 6,
               shifts_per_shift_pattern: 8,
               days_per_shift_pattern: 14,
             )
@@ -726,7 +712,6 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               start_date: Date.parse("2020-11-23"),
               leaving_date: Date.parse("2021-04-07"),
-              hours_per_shift: 25,
               shifts_per_shift_pattern: 7,
               days_per_shift_pattern: 10,
             )
@@ -738,7 +723,6 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               start_date: Date.parse("2020-08-22"),
               leaving_date: Date.parse("2021-07-31"),
-              hours_per_shift: 36,
               shifts_per_shift_pattern: 12,
               days_per_shift_pattern: 14,
             )
@@ -752,7 +736,6 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               start_date: Date.parse("2020-01-20"),
               leaving_date: Date.parse("2020-07-18"),
-              hours_per_shift: 6,
               shifts_per_shift_pattern: 8,
               days_per_shift_pattern: 14,
             )
@@ -764,7 +747,6 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               start_date: Date.parse("2019-11-23"),
               leaving_date: Date.parse("2020-04-07"),
-              hours_per_shift: 25,
               shifts_per_shift_pattern: 7,
               days_per_shift_pattern: 10,
             )
@@ -776,7 +758,6 @@ module SmartAnswer::Calculators
             calc = HolidayEntitlement.new(
               start_date: Date.parse("2019-08-22"),
               leaving_date: Date.parse("2020-07-31"),
-              hours_per_shift: 36,
               shifts_per_shift_pattern: 12,
               days_per_shift_pattern: 14,
             )


### PR DESCRIPTION
Add logic and tests for shifts work calculations

-Added hours_per_shift, shifts_per_shift_pattern and days_per_shift_pattern to the constructor, this will be stored from user input from the flow.
-Added shift_entitlement function to work out holiday entitlement for shift workers
-Added shifts_per_week calculation as it is required by shift_entitlement

Trello: https://trello.com/c/WTpAoNYb

Co-Authored-By: Murilo Dalri <Murilo.Dalri@digital.cabinet-office.gov.uk> 