### PR TITLE
Fix layout issue on question result page

### DIFF
--- a/app/views/layouts/smart_answers.html.erb
+++ b/app/views/layouts/smart_answers.html.erb
@@ -14,10 +14,4 @@
   <%= render 'smartanswer_metadata' %>
 </main>
 
-<% if defined?(@presenter.finished?) and @presenter.finished? %>
-  <div class="related-container">
-    <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: @content_item %>
-  </div>
-<% end %>
-
 <% parent_layout 'application' %>

--- a/app/views/smart_answers/question.html.erb
+++ b/app/views/smart_answers/question.html.erb
@@ -35,8 +35,9 @@
         } %>
       </div>
     </form>
+
+    <%= render 'previous_answers' %>
   </div>
 </div>
 
-<%= render 'previous_answers' %>
 

--- a/app/views/smart_answers/result.html.erb
+++ b/app/views/smart_answers/result.html.erb
@@ -41,7 +41,15 @@
         GOVUK.analytics.trackEvent('Smart Answer', 'Completed', options);
       });
     </script>
+
+    <%= render 'previous_answers' %>
   </div>
+
+  <% if defined?(@presenter.finished?) and @presenter.finished? %>
+    <div class="govuk-grid-column-one-third govuk-!-margin-top-9">
+      <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: @content_item %>
+    </div>
+  <% end %>
 </div>
 
-<%= render 'previous_answers' %>
+


### PR DESCRIPTION
- sidebar related content had been left in a position such that it fell out of the main layout and corrupted the feedback footer component
- this moves it back inside the main flow of the question so that it appears top right on the page
- this change also moves the 'previous answers' section inside the same 2/3 column as the current question, and final result, in order that the related content can appear beneath it in the mobile view. Otherwise the page order is result, related content, previous answers, when it should be result, previous answers, related content

Before:

<img width="557" alt="Screen Shot 2019-10-17 at 12 53 34" src="https://user-images.githubusercontent.com/861310/67006687-b06ec980-f0dd-11e9-8565-0a9403e0e2cd.png">

After (note the width change for the previous answers section):

<img width="520" alt="Screen Shot 2019-10-17 at 12 55 47" src="https://user-images.githubusercontent.com/861310/67006697-b664aa80-f0dd-11e9-9708-4ff55f7739a8.png">
