### PR TITLE
Update entitlement for hours worked per week

### DIFF
--- a/lib/smart_answer/calculators/holiday_entitlement.rb
+++ b/lib/smart_answer/calculators/holiday_entitlement.rb
@@ -11,10 +11,11 @@ module SmartAnswer::Calculators
     DAYS_PER_LEAP_YEAR = 366.to_d
     STANDARD_DAYS_PER_WEEK = 5.to_d
 
-    attr_reader :days_per_week, :start_date, :leaving_date, :leave_year_start_date
+    attr_reader :days_per_week, :hours_per_week, :start_date, :leaving_date, :leave_year_start_date
 
-    def initialize(days_per_week: 0, start_date: nil, leaving_date: nil, leave_year_start_date: nil)
+    def initialize(days_per_week: 0, hours_per_week: 0, start_date: nil, leaving_date: nil, leave_year_start_date: nil)
       @days_per_week = BigDecimal(days_per_week, 10)
+      @hours_per_week = BigDecimal(hours_per_week, 10)
       @start_date = start_date
       @leaving_date = leaving_date
       @leave_year_start_date = leave_year_start_date || calculate_leave_year_start_date
@@ -28,6 +29,17 @@ module SmartAnswer::Calculators
                       [MAXIMUM_STATUTORY_HOLIDAY_ENTITLEMENT_IN_DAYS, days].min
                     end
       (actual_days * fraction_of_year).round(10)
+    end
+
+    def full_time_part_time_hours
+      hours = STATUTORY_HOLIDAY_ENTITLEMENT_IN_WEEKS * hours_per_week
+      max_hours = MAXIMUM_STATUTORY_HOLIDAY_ENTITLEMENT_IN_DAYS * (hours_per_week / days_per_week)
+      actual_hours = [max_hours, hours].min
+      (actual_hours * fraction_of_year).round(10)
+    end
+
+    def formatted_full_time_part_time_hours
+      format_number(full_time_part_time_hours)
     end
 
     def formatted_full_time_part_time_days

--- a/lib/smart_answer/calculators/holiday_entitlement.rb
+++ b/lib/smart_answer/calculators/holiday_entitlement.rb
@@ -59,7 +59,7 @@ module SmartAnswer::Calculators
     end
 
     def formatted_full_time_part_time_hours
-      if left_before_year_end?
+      if left_before_year_end? || worked_partial_year?
         format_number(pro_rated_hours, 2)
       else
         format_number(rounded_full_time_part_time_hours, 2)

--- a/lib/smart_answer/calculators/holiday_entitlement.rb
+++ b/lib/smart_answer/calculators/holiday_entitlement.rb
@@ -24,7 +24,7 @@ module SmartAnswer::Calculators
 
     def full_time_part_time_days
       days = STATUTORY_HOLIDAY_ENTITLEMENT_IN_WEEKS * days_per_week
-      actual_days = if left_before_year_end || (days_per_week < STANDARD_DAYS_PER_WEEK)
+      actual_days = if left_before_year_end? || (days_per_week < STANDARD_DAYS_PER_WEEK)
                       days
                     else
                       [MAXIMUM_STATUTORY_HOLIDAY_ENTITLEMENT_IN_DAYS, days].min
@@ -33,7 +33,7 @@ module SmartAnswer::Calculators
     end
 
     def rounded_full_time_part_time_days
-      if started_after_year_began || worked_full_year
+      if started_after_year_began? || worked_full_year?
         (full_time_part_time_days * 2).ceil / 2.00
       else
         full_time_part_time_days
@@ -51,7 +51,7 @@ module SmartAnswer::Calculators
     end
 
     def rounded_full_time_part_time_hours
-      if started_after_year_began
+      if started_after_year_began?
         (rounded_full_time_part_time_days * hours_per_week) / days_per_week
       else
         full_time_part_time_hours
@@ -65,11 +65,11 @@ module SmartAnswer::Calculators
     def fraction_of_year
       days_in_year = leave_year_range.leap? ? DAYS_PER_LEAP_YEAR : DAYS_PER_YEAR
 
-      if started_after_year_began
+      if started_after_year_began?
         months_worked / MONTHS_PER_YEAR
-      elsif worked_partial_year
+      elsif worked_partial_year?
         BigDecimal(leaving_date - start_date + 1.0, 10) / days_in_year
-      elsif left_before_year_end
+      elsif left_before_year_end?
         BigDecimal(leaving_date - leave_year_range.begins_on + 1, 10) / days_in_year
       else
         MONTHS_PER_YEAR / MONTHS_PER_YEAR
@@ -82,19 +82,19 @@ module SmartAnswer::Calculators
       leaving_date ? leaving_date.beginning_of_year : Date.today.beginning_of_year
     end
 
-    def worked_full_year
+    def worked_full_year?
       start_date.nil? && leaving_date.nil?
     end
 
-    def started_after_year_began
+    def started_after_year_began?
       start_date.present? && leaving_date.nil?
     end
 
-    def left_before_year_end
+    def left_before_year_end?
       start_date.nil? && leaving_date.present?
     end
 
-    def worked_partial_year
+    def worked_partial_year?
       start_date.present? && leaving_date.present?
     end
 
@@ -109,7 +109,7 @@ module SmartAnswer::Calculators
     end
 
     def date_calc
-      return leave_year_start_date if worked_full_year
+      return leave_year_start_date if worked_full_year?
 
       return leaving_date if leaving_date
 

--- a/lib/smart_answer/calculators/holiday_entitlement.rb
+++ b/lib/smart_answer/calculators/holiday_entitlement.rb
@@ -59,7 +59,15 @@ module SmartAnswer::Calculators
     end
 
     def formatted_full_time_part_time_hours
-      format_number(rounded_full_time_part_time_hours, 2)
+      if left_before_year_end?
+        format_number(pro_rated_hours, 2)
+      else
+        format_number(rounded_full_time_part_time_hours, 2)
+      end
+    end
+
+    def pro_rated_hours
+      fraction_of_year * rounded_full_time_part_time_hours
     end
 
     def fraction_of_year

--- a/lib/smart_answer/calculators/holiday_entitlement.rb
+++ b/lib/smart_answer/calculators/holiday_entitlement.rb
@@ -5,6 +5,7 @@ module SmartAnswer::Calculators
   class HolidayEntitlement
     # created for the holiday entitlement calculator
     STATUTORY_HOLIDAY_ENTITLEMENT_IN_WEEKS = BigDecimal(5.6, 10)
+    MAXIMUM_STATUTORY_DAYS_PER_WEEK = 5.to_d
     MAXIMUM_STATUTORY_HOLIDAY_ENTITLEMENT_IN_DAYS = 28.to_d
     MONTHS_PER_YEAR = 12.to_d
     DAYS_PER_YEAR = 365.to_d
@@ -31,24 +32,34 @@ module SmartAnswer::Calculators
       (actual_days * fraction_of_year).round(10)
     end
 
-    def full_time_part_time_hours
-      hours = STATUTORY_HOLIDAY_ENTITLEMENT_IN_WEEKS * hours_per_week
-      max_hours = MAXIMUM_STATUTORY_HOLIDAY_ENTITLEMENT_IN_DAYS * (hours_per_week / days_per_week)
-      actual_hours = [max_hours, hours].min
-      (actual_hours * fraction_of_year).round(10)
-    end
-
-    def formatted_full_time_part_time_hours
-      format_number(full_time_part_time_hours)
+    def rounded_full_time_part_time_days
+      if started_after_year_began || worked_full_year
+        (full_time_part_time_days * 2).ceil / 2.00
+      else
+        full_time_part_time_days
+      end
     end
 
     def formatted_full_time_part_time_days
-      if started_after_year_began || worked_full_year
-        rounded_days = (full_time_part_time_days * 2).ceil / 2.00
-        format_number(rounded_days)
+      format_number(rounded_full_time_part_time_days)
+    end
+
+    def full_time_part_time_hours
+      minimum_days_per_week = [days_per_week, MAXIMUM_STATUTORY_DAYS_PER_WEEK].min
+
+      STATUTORY_HOLIDAY_ENTITLEMENT_IN_WEEKS * minimum_days_per_week * (hours_per_week / days_per_week)
+    end
+
+    def rounded_full_time_part_time_hours
+      if started_after_year_began
+        (rounded_full_time_part_time_days * hours_per_week) / days_per_week
       else
-        format_number(full_time_part_time_days)
+        full_time_part_time_hours
       end
+    end
+
+    def formatted_full_time_part_time_hours
+      format_number(rounded_full_time_part_time_hours, 2)
     end
 
     def fraction_of_year

--- a/test/unit/calculators/holiday_entitlement_test.rb
+++ b/test/unit/calculators/holiday_entitlement_test.rb
@@ -274,7 +274,7 @@ module SmartAnswer::Calculators
       end
     end
 
-    context "calculate entitltment on hours worked per week" do
+    context "calculate entitlement on hours worked per week" do
       context "for a full leave year" do
         should "for 40 hours over 5 days per week" do
           calc = HolidayEntitlement.new(days_per_week: 5, hours_per_week: 40)

--- a/test/unit/calculators/holiday_entitlement_test.rb
+++ b/test/unit/calculators/holiday_entitlement_test.rb
@@ -273,5 +273,24 @@ module SmartAnswer::Calculators
         end
       end
     end
+
+    context "calculate entitltment on hours worked per week" do
+      context "for a full leave year" do
+        should "for 4 hours over 5 days per week" do
+          calc = HolidayEntitlement.new(days_per_week: 5, hours_per_week: 40)
+          assert_equal "224", calc.formatted_full_time_part_time_hours
+        end
+
+        should "for 25 hours over less than 5 days a week" do
+          calc = HolidayEntitlement.new(days_per_week: 3, hours_per_week: 25)
+          assert_equal "140", calc.formatted_full_time_part_time_hours
+        end
+
+        should "for 36 hours over more than 5 days a week" do
+          calc = HolidayEntitlement.new(days_per_week: 6, hours_per_week: 36)
+          assert_equal "168", calc.formatted_full_time_part_time_hours
+        end
+      end
+    end
   end
 end

--- a/test/unit/calculators/holiday_entitlement_test.rb
+++ b/test/unit/calculators/holiday_entitlement_test.rb
@@ -453,6 +453,90 @@ module SmartAnswer::Calculators
           end
         end
       end
+
+      context "starting and leaving part way through a leave year" do
+        context "for a standard year" do
+          should "for 40 hours over 5 days a week" do
+            calc = HolidayEntitlement.new(
+              start_date: Date.parse("2019-01-20"),
+              leaving_date: Date.parse("2019-07-18"),
+              days_per_week: 5,
+              hours_per_week: 40,
+            )
+
+            assert_equal BigDecimal("224").round(10), calc.full_time_part_time_hours.round(10)
+            assert_equal BigDecimal("110.4657534247").round(10), calc.pro_rated_hours.round(10)
+            assert_equal "110.47", calc.formatted_full_time_part_time_hours
+          end
+
+          should "for 25 hours less than 5 days a week" do
+            calc = HolidayEntitlement.new(
+              start_date: Date.parse("2018-11-23"),
+              leaving_date: Date.parse("2019-04-07"),
+              days_per_week: 3,
+              hours_per_week: 25,
+            )
+
+            assert_equal BigDecimal("140").round(10), calc.full_time_part_time_hours.round(10)
+            assert_equal BigDecimal("52.1643835616").round(10), calc.pro_rated_hours.round(10)
+            assert_equal "52.17", calc.formatted_full_time_part_time_hours
+          end
+
+          should "for 36 hours more than 5 days a week" do
+            calc = HolidayEntitlement.new(
+              start_date: Date.parse("2018-08-22"),
+              leaving_date: Date.parse("2019-07-31"),
+              days_per_week: 6,
+              hours_per_week: 36,
+            )
+
+            assert_equal BigDecimal("168").round(10), calc.full_time_part_time_hours.round(10)
+            assert_equal BigDecimal("158.3342465753").round(10), calc.pro_rated_hours.round(10)
+            assert_equal "158.34", calc.formatted_full_time_part_time_hours
+          end
+        end
+        
+        context "for a leap year" do
+          should "for 40 hours over 5 days a week" do
+            calc = HolidayEntitlement.new(
+              start_date: Date.parse("2020-01-20"),
+              leaving_date: Date.parse("2020-07-18"),
+              days_per_week: 5,
+              hours_per_week: 40,
+            )
+
+            assert_equal BigDecimal("224").round(10), calc.full_time_part_time_hours.round(10)
+            assert_equal BigDecimal("110.7759562842").round(10), calc.pro_rated_hours.round(10)
+            assert_equal "110.78", calc.formatted_full_time_part_time_hours
+          end
+          
+          should "for 25 hours less than 5 days a week" do
+            calc = HolidayEntitlement.new(
+              start_date: Date.parse("2019-11-23"),
+              leaving_date: Date.parse("2020-04-07"),
+              days_per_week: 3,
+              hours_per_week: 25,
+            )
+
+            assert_equal BigDecimal("140").round(10), calc.full_time_part_time_hours.round(10)
+            assert_equal BigDecimal("52.4043715847").round(10), calc.pro_rated_hours.round(10)
+            assert_equal "52.41", calc.formatted_full_time_part_time_hours
+          end
+
+          should "for 36 hours more than 5 days a week" do
+            calc = HolidayEntitlement.new(
+              start_date: Date.parse("2019-08-22"),
+              leaving_date: Date.parse("2020-07-31"),
+              days_per_week: 6,
+              hours_per_week: 36,
+            )
+
+            assert_equal BigDecimal("168").round(10), calc.full_time_part_time_hours.round(10)
+            assert_equal BigDecimal("158.3606557377").round(10), calc.pro_rated_hours.round(10)
+            assert_equal "158.37", calc.formatted_full_time_part_time_hours
+          end
+        end
+      end
     end
   end
 end

--- a/test/unit/calculators/holiday_entitlement_test.rb
+++ b/test/unit/calculators/holiday_entitlement_test.rb
@@ -276,7 +276,7 @@ module SmartAnswer::Calculators
 
     context "calculate entitltment on hours worked per week" do
       context "for a full leave year" do
-        should "for 4 hours over 5 days per week" do
+        should "for 40 hours over 5 days per week" do
           calc = HolidayEntitlement.new(days_per_week: 5, hours_per_week: 40)
           assert_equal "224", calc.formatted_full_time_part_time_hours
         end
@@ -289,6 +289,84 @@ module SmartAnswer::Calculators
         should "for 36 hours over more than 5 days a week" do
           calc = HolidayEntitlement.new(days_per_week: 6, hours_per_week: 36)
           assert_equal "168", calc.formatted_full_time_part_time_hours
+        end
+      end
+
+      context "starting part way through a leave year" do
+        context "for a standard year" do
+          should "for 40 hours over 5 days a week" do
+            calc = HolidayEntitlement.new(
+              start_date: Date.parse("2019-06-01"),
+              leave_year_start_date: Date.parse("2019-01-01"),
+              days_per_week: 5,
+              hours_per_week: 40,
+            )
+
+            assert_equal BigDecimal("16.3333333333").round(10), calc.full_time_part_time_days.round(10)
+            assert_equal BigDecimal("16.5").round(10), calc.rounded_full_time_part_time_days.round(10)
+            assert_equal "132", calc.formatted_full_time_part_time_hours
+          end
+
+          should "for 25 hours less than 5 days a week" do
+            calc = HolidayEntitlement.new(
+              start_date: Date.parse("2020-11-23"),
+              leave_year_start_date: Date.parse("2020-04-01"),
+              days_per_week: 3,
+              hours_per_week: 25,
+            )
+
+            assert_equal BigDecimal("7").round(10), calc.full_time_part_time_days.round(10)
+            assert_equal BigDecimal("7").round(10), calc.rounded_full_time_part_time_days.round(10)
+            assert_equal "58.34", calc.formatted_full_time_part_time_hours
+          end
+
+          should "for 36 hours more than 5 days a week" do
+            calc = HolidayEntitlement.new(
+              start_date: Date.parse("2019-11-14"),
+              leave_year_start_date: Date.parse("2019-01-01"),
+              days_per_week: 6,
+              hours_per_week: 36,
+            )
+
+            assert_equal BigDecimal("4.6666666667").round(10), calc.full_time_part_time_days.round(10)
+            assert_equal BigDecimal("5").round(10), calc.rounded_full_time_part_time_days.round(10)
+            assert_equal "30", calc.formatted_full_time_part_time_hours
+          end
+        end
+
+        context "for a leap year" do
+          should "for 40 hours over 5 days a week" do
+            calc = HolidayEntitlement.new(
+              start_date: Date.parse("2020-06-01"),
+              leave_year_start_date: Date.parse("2020-01-01"),
+              days_per_week: 5,
+              hours_per_week: 40,
+            )
+
+            assert_equal "132", calc.formatted_full_time_part_time_hours
+          end
+
+          should "for 25 hours less than 5 days a week" do
+            calc = HolidayEntitlement.new(
+              start_date: Date.parse("2019-11-23"),
+              leave_year_start_date: Date.parse("2019-04-01"),
+              days_per_week: 3,
+              hours_per_week: 25,
+            )
+
+            assert_equal "58.34", calc.formatted_full_time_part_time_hours
+          end
+
+          should "for 36 hours more than 5 days a week" do
+            calc = HolidayEntitlement.new(
+              start_date: Date.parse("2020-11-14"),
+              leave_year_start_date: Date.parse("2020-01-01"),
+              days_per_week: 6,
+              hours_per_week: 36,
+            )
+
+            assert_equal "30", calc.formatted_full_time_part_time_hours
+          end
         end
       end
     end

--- a/test/unit/calculators/holiday_entitlement_test.rb
+++ b/test/unit/calculators/holiday_entitlement_test.rb
@@ -369,6 +369,90 @@ module SmartAnswer::Calculators
           end
         end
       end
+
+      context "leaving part way through a leave year" do
+        context "for a standard year" do
+          should "for 40 hours over 5 days a week" do
+            calc = HolidayEntitlement.new(
+              leaving_date: Date.parse("2019-06-01"),
+              leave_year_start_date: Date.parse("2019-01-01"),
+              days_per_week: 5,
+              hours_per_week: 40,
+            )
+
+            assert_equal BigDecimal("224").round(10), calc.full_time_part_time_hours.round(10)
+            assert_equal BigDecimal("93.2821917808").round(10), calc.pro_rated_hours.round(10)
+            assert_equal "93.29", calc.formatted_full_time_part_time_hours
+          end
+
+          should "for 25 hours less than 5 days a week" do
+            calc = HolidayEntitlement.new(
+              leaving_date: Date.parse("2020-11-23"),
+              leave_year_start_date: Date.parse("2020-04-01"),
+              days_per_week: 3,
+              hours_per_week: 25,
+            )
+
+            assert_equal BigDecimal("140").round(10), calc.full_time_part_time_hours.round(10)
+            assert_equal BigDecimal("90.9041095890").round(10), calc.pro_rated_hours.round(10)
+            assert_equal "90.91", calc.formatted_full_time_part_time_hours
+          end
+
+          should "for 36 hours more than 5 days a week" do
+            calc = HolidayEntitlement.new(
+              leaving_date: Date.parse("2019-08-22"),
+              leave_year_start_date: Date.parse("2019-01-01"),
+              days_per_week: 6,
+              hours_per_week: 36,
+            )
+
+            assert_equal BigDecimal("168").round(10), calc.full_time_part_time_hours.round(10)
+            assert_equal BigDecimal("107.7041095890").round(10), calc.pro_rated_hours.round(10)
+            assert_equal "107.71", calc.formatted_full_time_part_time_hours
+          end
+        end
+        
+        context "for a leap year" do
+          should "for 40 hours over 5 days a week" do
+            calc = HolidayEntitlement.new(
+              leaving_date: Date.parse("2020-06-01"),
+              leave_year_start_date: Date.parse("2020-01-01"),
+              days_per_week: 5,
+              hours_per_week: 40,
+            )
+
+            assert_equal BigDecimal("224").round(10), calc.full_time_part_time_hours.round(10)
+            assert_equal BigDecimal("93.6393442623").round(10), calc.pro_rated_hours.round(10)
+            assert_equal "93.64", calc.formatted_full_time_part_time_hours
+          end
+          
+          should "for 25 hours less than 5 days a week" do
+            calc = HolidayEntitlement.new(
+              leaving_date: Date.parse("2019-11-23"),
+              leave_year_start_date: Date.parse("2019-04-01"),
+              days_per_week: 3,
+              hours_per_week: 25,
+            )
+
+            assert_equal BigDecimal("140").round(10), calc.full_time_part_time_hours.round(10)
+            assert_equal BigDecimal("90.6557377049").round(10), calc.pro_rated_hours.round(10)
+            assert_equal "90.66", calc.formatted_full_time_part_time_hours
+          end
+
+          should "for 36 hours more than 5 days a week" do
+            calc = HolidayEntitlement.new(
+              leaving_date: Date.parse("2020-08-22"),
+              leave_year_start_date: Date.parse("2020-01-01"),
+              days_per_week: 6,
+              hours_per_week: 36,
+            )
+
+            assert_equal BigDecimal("168").round(10), calc.full_time_part_time_hours.round(10)
+            assert_equal BigDecimal("107.8688524590").round(10), calc.pro_rated_hours.round(10)
+            assert_equal "107.87", calc.formatted_full_time_part_time_hours
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This is just to show the diff between `update-holiday-entitlement-calculator` and `update-entitlement-for-hours-worked-per-week`. 
This was already revied in https://github.com/alphagov/smart-answers/pull/4157