### PR TITLE
Add logic and tests for compressed hours calculations

### DIFF
--- a/lib/smart_answer/calculators/holiday_entitlement.rb
+++ b/lib/smart_answer/calculators/holiday_entitlement.rb
@@ -58,7 +58,7 @@ module SmartAnswer::Calculators
       end
     end
 
-    def formatted_full_time_part_time_hours
+    def formatted_full_time_part_time_compressed_hours
       if left_before_year_end? || worked_partial_year?
         format_number(pro_rated_hours, 2)
       else

--- a/test/unit/calculators/holiday_entitlement_test.rb
+++ b/test/unit/calculators/holiday_entitlement_test.rb
@@ -274,21 +274,21 @@ module SmartAnswer::Calculators
       end
     end
 
-    context "calculate entitlement on hours worked per week" do
+    context "calculate entitlement on hours worked per week and compressed hours" do
       context "for a full leave year" do
         should "for 40 hours over 5 days per week" do
           calc = HolidayEntitlement.new(days_per_week: 5, hours_per_week: 40)
-          assert_equal "224", calc.formatted_full_time_part_time_hours
+          assert_equal "224", calc.formatted_full_time_part_time_compressed_hours
         end
 
         should "for 25 hours over less than 5 days a week" do
           calc = HolidayEntitlement.new(days_per_week: 3, hours_per_week: 25)
-          assert_equal "140", calc.formatted_full_time_part_time_hours
+          assert_equal "140", calc.formatted_full_time_part_time_compressed_hours
         end
 
         should "for 36 hours over more than 5 days a week" do
           calc = HolidayEntitlement.new(days_per_week: 6, hours_per_week: 36)
-          assert_equal "168", calc.formatted_full_time_part_time_hours
+          assert_equal "168", calc.formatted_full_time_part_time_compressed_hours
         end
       end
 
@@ -304,7 +304,7 @@ module SmartAnswer::Calculators
 
             assert_equal BigDecimal("16.3333333333").round(10), calc.full_time_part_time_days.round(10)
             assert_equal BigDecimal("16.5").round(10), calc.rounded_full_time_part_time_days.round(10)
-            assert_equal "132", calc.formatted_full_time_part_time_hours
+            assert_equal "132", calc.formatted_full_time_part_time_compressed_hours
           end
 
           should "for 25 hours less than 5 days a week" do
@@ -317,7 +317,7 @@ module SmartAnswer::Calculators
 
             assert_equal BigDecimal("7").round(10), calc.full_time_part_time_days.round(10)
             assert_equal BigDecimal("7").round(10), calc.rounded_full_time_part_time_days.round(10)
-            assert_equal "58.34", calc.formatted_full_time_part_time_hours
+            assert_equal "58.34", calc.formatted_full_time_part_time_compressed_hours
           end
 
           should "for 36 hours more than 5 days a week" do
@@ -330,7 +330,7 @@ module SmartAnswer::Calculators
 
             assert_equal BigDecimal("4.6666666667").round(10), calc.full_time_part_time_days.round(10)
             assert_equal BigDecimal("5").round(10), calc.rounded_full_time_part_time_days.round(10)
-            assert_equal "30", calc.formatted_full_time_part_time_hours
+            assert_equal "30", calc.formatted_full_time_part_time_compressed_hours
           end
         end
 
@@ -343,7 +343,7 @@ module SmartAnswer::Calculators
               hours_per_week: 40,
             )
 
-            assert_equal "132", calc.formatted_full_time_part_time_hours
+            assert_equal "132", calc.formatted_full_time_part_time_compressed_hours
           end
 
           should "for 25 hours less than 5 days a week" do
@@ -354,7 +354,7 @@ module SmartAnswer::Calculators
               hours_per_week: 25,
             )
 
-            assert_equal "58.34", calc.formatted_full_time_part_time_hours
+            assert_equal "58.34", calc.formatted_full_time_part_time_compressed_hours
           end
 
           should "for 36 hours more than 5 days a week" do
@@ -365,7 +365,7 @@ module SmartAnswer::Calculators
               hours_per_week: 36,
             )
 
-            assert_equal "30", calc.formatted_full_time_part_time_hours
+            assert_equal "30", calc.formatted_full_time_part_time_compressed_hours
           end
         end
       end
@@ -382,7 +382,7 @@ module SmartAnswer::Calculators
 
             assert_equal BigDecimal("224").round(10), calc.full_time_part_time_hours.round(10)
             assert_equal BigDecimal("93.2821917808").round(10), calc.pro_rated_hours.round(10)
-            assert_equal "93.29", calc.formatted_full_time_part_time_hours
+            assert_equal "93.29", calc.formatted_full_time_part_time_compressed_hours
           end
 
           should "for 25 hours less than 5 days a week" do
@@ -395,7 +395,7 @@ module SmartAnswer::Calculators
 
             assert_equal BigDecimal("140").round(10), calc.full_time_part_time_hours.round(10)
             assert_equal BigDecimal("90.9041095890").round(10), calc.pro_rated_hours.round(10)
-            assert_equal "90.91", calc.formatted_full_time_part_time_hours
+            assert_equal "90.91", calc.formatted_full_time_part_time_compressed_hours
           end
 
           should "for 36 hours more than 5 days a week" do
@@ -408,10 +408,9 @@ module SmartAnswer::Calculators
 
             assert_equal BigDecimal("168").round(10), calc.full_time_part_time_hours.round(10)
             assert_equal BigDecimal("107.7041095890").round(10), calc.pro_rated_hours.round(10)
-            assert_equal "107.71", calc.formatted_full_time_part_time_hours
+            assert_equal "107.71", calc.formatted_full_time_part_time_compressed_hours
           end
         end
-        
         context "for a leap year" do
           should "for 40 hours over 5 days a week" do
             calc = HolidayEntitlement.new(
@@ -423,9 +422,8 @@ module SmartAnswer::Calculators
 
             assert_equal BigDecimal("224").round(10), calc.full_time_part_time_hours.round(10)
             assert_equal BigDecimal("93.6393442623").round(10), calc.pro_rated_hours.round(10)
-            assert_equal "93.64", calc.formatted_full_time_part_time_hours
+            assert_equal "93.64", calc.formatted_full_time_part_time_compressed_hours
           end
-          
           should "for 25 hours less than 5 days a week" do
             calc = HolidayEntitlement.new(
               leaving_date: Date.parse("2019-11-23"),
@@ -436,7 +434,7 @@ module SmartAnswer::Calculators
 
             assert_equal BigDecimal("140").round(10), calc.full_time_part_time_hours.round(10)
             assert_equal BigDecimal("90.6557377049").round(10), calc.pro_rated_hours.round(10)
-            assert_equal "90.66", calc.formatted_full_time_part_time_hours
+            assert_equal "90.66", calc.formatted_full_time_part_time_compressed_hours
           end
 
           should "for 36 hours more than 5 days a week" do
@@ -449,7 +447,7 @@ module SmartAnswer::Calculators
 
             assert_equal BigDecimal("168").round(10), calc.full_time_part_time_hours.round(10)
             assert_equal BigDecimal("107.8688524590").round(10), calc.pro_rated_hours.round(10)
-            assert_equal "107.87", calc.formatted_full_time_part_time_hours
+            assert_equal "107.87", calc.formatted_full_time_part_time_compressed_hours
           end
         end
       end
@@ -466,7 +464,7 @@ module SmartAnswer::Calculators
 
             assert_equal BigDecimal("224").round(10), calc.full_time_part_time_hours.round(10)
             assert_equal BigDecimal("110.4657534247").round(10), calc.pro_rated_hours.round(10)
-            assert_equal "110.47", calc.formatted_full_time_part_time_hours
+            assert_equal "110.47", calc.formatted_full_time_part_time_compressed_hours
           end
 
           should "for 25 hours less than 5 days a week" do
@@ -479,7 +477,7 @@ module SmartAnswer::Calculators
 
             assert_equal BigDecimal("140").round(10), calc.full_time_part_time_hours.round(10)
             assert_equal BigDecimal("52.1643835616").round(10), calc.pro_rated_hours.round(10)
-            assert_equal "52.17", calc.formatted_full_time_part_time_hours
+            assert_equal "52.17", calc.formatted_full_time_part_time_compressed_hours
           end
 
           should "for 36 hours more than 5 days a week" do
@@ -492,10 +490,9 @@ module SmartAnswer::Calculators
 
             assert_equal BigDecimal("168").round(10), calc.full_time_part_time_hours.round(10)
             assert_equal BigDecimal("158.3342465753").round(10), calc.pro_rated_hours.round(10)
-            assert_equal "158.34", calc.formatted_full_time_part_time_hours
+            assert_equal "158.34", calc.formatted_full_time_part_time_compressed_hours
           end
         end
-        
         context "for a leap year" do
           should "for 40 hours over 5 days a week" do
             calc = HolidayEntitlement.new(
@@ -507,9 +504,8 @@ module SmartAnswer::Calculators
 
             assert_equal BigDecimal("224").round(10), calc.full_time_part_time_hours.round(10)
             assert_equal BigDecimal("110.7759562842").round(10), calc.pro_rated_hours.round(10)
-            assert_equal "110.78", calc.formatted_full_time_part_time_hours
+            assert_equal "110.78", calc.formatted_full_time_part_time_compressed_hours
           end
-          
           should "for 25 hours less than 5 days a week" do
             calc = HolidayEntitlement.new(
               start_date: Date.parse("2019-11-23"),
@@ -520,7 +516,7 @@ module SmartAnswer::Calculators
 
             assert_equal BigDecimal("140").round(10), calc.full_time_part_time_hours.round(10)
             assert_equal BigDecimal("52.4043715847").round(10), calc.pro_rated_hours.round(10)
-            assert_equal "52.41", calc.formatted_full_time_part_time_hours
+            assert_equal "52.41", calc.formatted_full_time_part_time_compressed_hours
           end
 
           should "for 36 hours more than 5 days a week" do
@@ -533,7 +529,7 @@ module SmartAnswer::Calculators
 
             assert_equal BigDecimal("168").round(10), calc.full_time_part_time_hours.round(10)
             assert_equal BigDecimal("158.3606557377").round(10), calc.pro_rated_hours.round(10)
-            assert_equal "158.37", calc.formatted_full_time_part_time_hours
+            assert_equal "158.37", calc.formatted_full_time_part_time_compressed_hours
           end
         end
       end


### PR DESCRIPTION
This is just to show the diff between `update-holiday-entitlement-calculator` and `update-entitlement-for-compressed-hours-worked-per-week`.
This was already revied in https://github.com/alphagov/smart-answers/pull/4163