### PR TITLE
Rescue 403 errors from content-store

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,11 +2,14 @@ class ApplicationController < ActionController::Base
   include Slimmer::Template
 
   rescue_from GdsApi::TimedOutException, with: :error_503
+  rescue_from GdsApi::HTTPForbidden, with: :error_403
   rescue_from ActionController::UnknownFormat, with: :error_404
 
   slimmer_template "wrapper"
 
 protected
+
+  def error_403; error(403); end
 
   def error_404; error(404); end
 

--- a/test/integration/error_handling_test.rb
+++ b/test/integration/error_handling_test.rb
@@ -53,6 +53,17 @@ class ErrorHandlingTest < ActionDispatch::IntegrationTest
     end
   end
 
+  context "when GdsApi::HTTPForbidden raised before render" do
+    setup do
+      ExampleController.exception_to_raise_before_render = GdsApi::HTTPForbidden.new(403)
+    end
+
+    should "set response status code to 403" do
+      get "/test"
+      assert_response 403
+    end
+  end
+
   context "when GdsApi::TimedOutException raised after render" do
     setup do
       ExampleController.exception_to_raise_after_render = GdsApi::TimedOutException


### PR DESCRIPTION
Trello: https://trello.com/c/BFSkOY22
Follows on from: alphagov/collections#1324

What's changed and why?
At the moment smart-answers are throwing a 500, when it receives an error code it doesn't recognise
from content-store. That means that users are shown a "Problem has occurred" page.

We need to handle this error properly so that in the case of a 403, the user will be properly routed
to signon and asked to login if there is any form of access limiting on the content item (e.g. hosted on draft
stack, access limited to organisation etc)