### PR TITLE
Add method to show hours/minutes and not decimals

### DIFF
--- a/lib/smart_answer/calculators/holiday_entitlement.rb
+++ b/lib/smart_answer/calculators/holiday_entitlement.rb
@@ -76,6 +76,14 @@ module SmartAnswer::Calculators
       end
     end
 
+    def full_time_part_time_hours_and_minutes
+      time_in_seconds = (BigDecimal(formatted_full_time_part_time_compressed_hours, 10) * 3600).to_i
+      seconds = time_in_seconds % 60
+      minutes = (time_in_seconds / 60) % 60
+      hours = time_in_seconds / 3600
+      [hours, seconds < 30 ? minutes : minutes + 1]
+    end
+
     def pro_rated_hours
       fraction_of_year * rounded_full_time_part_time_hours
     end

--- a/test/unit/calculators/holiday_entitlement_test.rb
+++ b/test/unit/calculators/holiday_entitlement_test.rb
@@ -279,16 +279,19 @@ module SmartAnswer::Calculators
         should "for 40 hours over 5 days per week" do
           calc = HolidayEntitlement.new(working_days_per_week: 5, hours_per_week: 40)
           assert_equal "224", calc.formatted_full_time_part_time_compressed_hours
+          assert_equal [224, 0], calc.full_time_part_time_hours_and_minutes
         end
 
         should "for 25 hours over less than 5 days a week" do
           calc = HolidayEntitlement.new(working_days_per_week: 3, hours_per_week: 25)
           assert_equal "140", calc.formatted_full_time_part_time_compressed_hours
+          assert_equal [140, 0], calc.full_time_part_time_hours_and_minutes
         end
 
         should "for 36 hours over more than 5 days a week" do
           calc = HolidayEntitlement.new(working_days_per_week: 6, hours_per_week: 36)
           assert_equal "168", calc.formatted_full_time_part_time_compressed_hours
+          assert_equal [168, 0], calc.full_time_part_time_hours_and_minutes
         end
       end
 
@@ -305,6 +308,7 @@ module SmartAnswer::Calculators
             assert_equal BigDecimal("16.3333333333").round(10), calc.full_time_part_time_days.round(10)
             assert_equal BigDecimal("16.5").round(10), calc.rounded_full_time_part_time_days.round(10)
             assert_equal "132", calc.formatted_full_time_part_time_compressed_hours
+            assert_equal [132, 0], calc.full_time_part_time_hours_and_minutes
           end
 
           should "for 25 hours less than 5 days a week" do
@@ -318,6 +322,7 @@ module SmartAnswer::Calculators
             assert_equal BigDecimal("7").round(10), calc.full_time_part_time_days.round(10)
             assert_equal BigDecimal("7").round(10), calc.rounded_full_time_part_time_days.round(10)
             assert_equal "58.34", calc.formatted_full_time_part_time_compressed_hours
+            assert_equal [58, 20], calc.full_time_part_time_hours_and_minutes
           end
 
           should "for 36 hours more than 5 days a week" do
@@ -331,6 +336,7 @@ module SmartAnswer::Calculators
             assert_equal BigDecimal("4.6666666667").round(10), calc.full_time_part_time_days.round(10)
             assert_equal BigDecimal("5").round(10), calc.rounded_full_time_part_time_days.round(10)
             assert_equal "30", calc.formatted_full_time_part_time_compressed_hours
+            assert_equal [30, 0], calc.full_time_part_time_hours_and_minutes
           end
         end
 
@@ -344,6 +350,7 @@ module SmartAnswer::Calculators
             )
 
             assert_equal "132", calc.formatted_full_time_part_time_compressed_hours
+            assert_equal [132, 0], calc.full_time_part_time_hours_and_minutes
           end
 
           should "for 25 hours less than 5 days a week" do
@@ -355,6 +362,7 @@ module SmartAnswer::Calculators
             )
 
             assert_equal "58.34", calc.formatted_full_time_part_time_compressed_hours
+            assert_equal [58, 20], calc.full_time_part_time_hours_and_minutes
           end
 
           should "for 36 hours more than 5 days a week" do
@@ -366,6 +374,7 @@ module SmartAnswer::Calculators
             )
 
             assert_equal "30", calc.formatted_full_time_part_time_compressed_hours
+            assert_equal [30, 0], calc.full_time_part_time_hours_and_minutes
           end
         end
       end
@@ -383,6 +392,7 @@ module SmartAnswer::Calculators
             assert_equal BigDecimal("224").round(10), calc.full_time_part_time_hours.round(10)
             assert_equal BigDecimal("93.2821917808").round(10), calc.pro_rated_hours.round(10)
             assert_equal "93.29", calc.formatted_full_time_part_time_compressed_hours
+            assert_equal [93, 17], calc.full_time_part_time_hours_and_minutes
           end
 
           should "for 25 hours less than 5 days a week" do
@@ -396,6 +406,7 @@ module SmartAnswer::Calculators
             assert_equal BigDecimal("140").round(10), calc.full_time_part_time_hours.round(10)
             assert_equal BigDecimal("90.9041095890").round(10), calc.pro_rated_hours.round(10)
             assert_equal "90.91", calc.formatted_full_time_part_time_compressed_hours
+            assert_equal [90, 55], calc.full_time_part_time_hours_and_minutes
           end
 
           should "for 36 hours more than 5 days a week" do
@@ -409,6 +420,7 @@ module SmartAnswer::Calculators
             assert_equal BigDecimal("168").round(10), calc.full_time_part_time_hours.round(10)
             assert_equal BigDecimal("107.7041095890").round(10), calc.pro_rated_hours.round(10)
             assert_equal "107.71", calc.formatted_full_time_part_time_compressed_hours
+            assert_equal [107, 43], calc.full_time_part_time_hours_and_minutes
           end
         end
         context "for a leap year" do
@@ -423,6 +435,7 @@ module SmartAnswer::Calculators
             assert_equal BigDecimal("224").round(10), calc.full_time_part_time_hours.round(10)
             assert_equal BigDecimal("93.6393442623").round(10), calc.pro_rated_hours.round(10)
             assert_equal "93.64", calc.formatted_full_time_part_time_compressed_hours
+            assert_equal [93, 38], calc.full_time_part_time_hours_and_minutes
           end
           should "for 25 hours less than 5 days a week" do
             calc = HolidayEntitlement.new(
@@ -435,6 +448,7 @@ module SmartAnswer::Calculators
             assert_equal BigDecimal("140").round(10), calc.full_time_part_time_hours.round(10)
             assert_equal BigDecimal("90.6557377049").round(10), calc.pro_rated_hours.round(10)
             assert_equal "90.66", calc.formatted_full_time_part_time_compressed_hours
+            assert_equal [90, 40], calc.full_time_part_time_hours_and_minutes
           end
 
           should "for 36 hours more than 5 days a week" do
@@ -448,6 +462,7 @@ module SmartAnswer::Calculators
             assert_equal BigDecimal("168").round(10), calc.full_time_part_time_hours.round(10)
             assert_equal BigDecimal("107.8688524590").round(10), calc.pro_rated_hours.round(10)
             assert_equal "107.87", calc.formatted_full_time_part_time_compressed_hours
+            assert_equal [107, 52], calc.full_time_part_time_hours_and_minutes
           end
         end
       end
@@ -465,6 +480,7 @@ module SmartAnswer::Calculators
             assert_equal BigDecimal("224").round(10), calc.full_time_part_time_hours.round(10)
             assert_equal BigDecimal("110.4657534247").round(10), calc.pro_rated_hours.round(10)
             assert_equal "110.47", calc.formatted_full_time_part_time_compressed_hours
+            assert_equal [110, 28], calc.full_time_part_time_hours_and_minutes
           end
 
           should "for 25 hours less than 5 days a week" do
@@ -478,6 +494,7 @@ module SmartAnswer::Calculators
             assert_equal BigDecimal("140").round(10), calc.full_time_part_time_hours.round(10)
             assert_equal BigDecimal("52.1643835616").round(10), calc.pro_rated_hours.round(10)
             assert_equal "52.17", calc.formatted_full_time_part_time_compressed_hours
+            assert_equal [52, 10], calc.full_time_part_time_hours_and_minutes
           end
 
           should "for 36 hours more than 5 days a week" do
@@ -491,6 +508,7 @@ module SmartAnswer::Calculators
             assert_equal BigDecimal("168").round(10), calc.full_time_part_time_hours.round(10)
             assert_equal BigDecimal("158.3342465753").round(10), calc.pro_rated_hours.round(10)
             assert_equal "158.34", calc.formatted_full_time_part_time_compressed_hours
+            assert_equal [158, 20], calc.full_time_part_time_hours_and_minutes
           end
         end
         context "for a leap year" do
@@ -505,6 +523,7 @@ module SmartAnswer::Calculators
             assert_equal BigDecimal("224").round(10), calc.full_time_part_time_hours.round(10)
             assert_equal BigDecimal("110.7759562842").round(10), calc.pro_rated_hours.round(10)
             assert_equal "110.78", calc.formatted_full_time_part_time_compressed_hours
+            assert_equal [110, 47], calc.full_time_part_time_hours_and_minutes
           end
           should "for 25 hours less than 5 days a week" do
             calc = HolidayEntitlement.new(
@@ -517,6 +536,7 @@ module SmartAnswer::Calculators
             assert_equal BigDecimal("140").round(10), calc.full_time_part_time_hours.round(10)
             assert_equal BigDecimal("52.4043715847").round(10), calc.pro_rated_hours.round(10)
             assert_equal "52.41", calc.formatted_full_time_part_time_compressed_hours
+            assert_equal [52, 25], calc.full_time_part_time_hours_and_minutes
           end
 
           should "for 36 hours more than 5 days a week" do
@@ -530,6 +550,7 @@ module SmartAnswer::Calculators
             assert_equal BigDecimal("168").round(10), calc.full_time_part_time_hours.round(10)
             assert_equal BigDecimal("158.3606557377").round(10), calc.pro_rated_hours.round(10)
             assert_equal "158.37", calc.formatted_full_time_part_time_compressed_hours
+            assert_equal [158, 22], calc.full_time_part_time_hours_and_minutes
           end
         end
       end


### PR DESCRIPTION
The method `full_time_part_time_hours_and_minutes` is used in the flow
and is needed to show the entitlement time in hours and minutes instead
of decimals: `[2, 30]` vs `2.5`.