### PR TITLE
Support publishing individual smart answers

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This is a Ruby on Rails application that contains:
 
 ### Changes to the landing page
 
-Changes to landing pages need to be sent to be sent to the `content store` for them to be rendered on the page. The [rake task `publishing_api:publish`](https://github.com/alphagov/smart-answers/blob/master/lib/tasks/publishing_api.rake) needs to be run once you have deployed your changes in each environment and can be done in [Jenkins](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=smartanswers&MACHINE_CLASS=calculators_frontend&RAKE_TASK=publishing_api:publish).
+Changes to landing pages need to be sent to be sent to the `content store` for them to be rendered on the page. The [rake task `publishing_api:publish_all`](https://github.com/alphagov/smart-answers/blob/master/lib/tasks/publishing_api.rake) needs to be run once you have deployed your changes in each environment and can be done in [Jenkins](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=smartanswers&MACHINE_CLASS=calculators_frontend&RAKE_TASK=publishing_api:publish_all).
 
 ### Debugging
 
@@ -87,7 +87,7 @@ Changes to landing pages need to be sent to be sent to the `content store` for t
 
 ### Registering on GOV.UK
 
-- `bundle exec rake publishing_api:publish` will send smart answers to the publishing-api.
+- `bundle exec rake publishing_api:publish_all` will send smart answers to the publishing-api.
 
 ### Search indexing
 

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -1,6 +1,6 @@
 namespace :publishing_api do
   desc "Publish smart answers to the content-store"
-  task publish: [:environment] do
+  task publish_all: [:environment] do
     flow_presenters = RegisterableSmartAnswers.new.flow_presenters
     ContentItemPublisher.new.publish(flow_presenters)
   end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -4,4 +4,13 @@ namespace :publishing_api do
     flow_presenters = RegisterableSmartAnswers.new.flow_presenters
     ContentItemPublisher.new.publish(flow_presenters)
   end
+
+  task :publish_single, %i[slug] => [:environment] do |_, args|
+    flow_presenters = RegisterableSmartAnswers.new.flow_presenters
+    ContentItemPublisher.new.publish(
+      flow_presenters.select do |presenter|
+        presenter.slug == args[:slug]
+      end,
+    )
+  end
 end


### PR DESCRIPTION
Which just publishes a single Smart Answer, by slug. This is generally
neater, but also motivated by avoiding restoring the start page for
the Holiday Entitlement Calculator.