### PR TITLE
Remove the Brexit callout from the student finance calculator start page

### DIFF
--- a/lib/smart_answer_flows/student-finance-calculator/student_finance_calculator.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-calculator/student_finance_calculator.govspeak.erb
@@ -12,12 +12,10 @@
   + 2018 to 2019
   + 2019 to 2020
 
- ^There will be no change to the rights and status of EU citizens currently living in the UK until 30 June 2021, or 31 December 2020 if the UK leaves the EU [without a deal](https://www.gov.uk/government/publications/policy-paper-on-citizens-rights-in-the-event-of-a-no-deal-brexit). You and your family can apply to the [EU Settlement Scheme](https://www.gov.uk/settled-status-eu-citizens-families) to continue living in the UK. 
-
   Use the student finance calculator to estimate:
 
   + student loans
-  + extra student funding, eg if you’re disabled or have children
+  + extra student funding, for example if you’re disabled or have children
 
   Your result will be more accurate if you know your annual household income (your parents’ or partner’s income plus your own).
 <% end %>


### PR DESCRIPTION
- Also correct a recent style guide violation: eg => for example.

https://trello.com/c/VnXFB2zd/1453-3-student-finance-calculator-dynamic-smart-answer