### PR TITLE
Fix styles of headings and lists in body text

### DIFF
--- a/app/assets/stylesheets/smart_answers.scss
+++ b/app/assets/stylesheets/smart_answers.scss
@@ -11,6 +11,29 @@ $is-ie: false !default;
   .outcome {
     min-height: 0; //overrides a much higher min height from static
   }
+
+  .govspeak-wrapper {
+    h2 {
+      @extend %govuk-heading-l;
+    }
+
+    h3 {
+      @extend %govuk-heading-m;
+    }
+
+    p {
+      @extend %govuk-body-m;
+    }
+
+    ul {
+      @extend %govuk-list;
+      @extend %govuk-list--bullet;
+    }
+  }
+
+  .application-notice {
+    padding-top: govuk-spacing(3);
+  }
 }
 
 //Heroku alert

--- a/app/views/smart_answers/landing.html.erb
+++ b/app/views/smart_answers/landing.html.erb
@@ -13,7 +13,7 @@
     } %>
 
     <div class="article-container group">
-      <article role="article" class="group" data-debug-template-path="<%= start_node.relative_erb_template_path %>">
+      <article role="article" class="group govspeak-wrapper" data-debug-template-path="<%= start_node.relative_erb_template_path %>">
         <div class="inner">
           <section class="intro">
             <div class="descriptive__text">

--- a/app/views/smart_answers/result.html.erb
+++ b/app/views/smart_answers/result.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <div class="govuk-grid-row">
-  <div id="result-info" class="govuk-grid-column-two-thirds outcome">
+  <div id="result-info" class="govuk-grid-column-two-thirds outcome govspeak-wrapper">
     <%= render 'debug' %>
     <%= render "govuk_publishing_components/components/title", {
       title: @presenter.title


### PR DESCRIPTION
- styling was missing for headings and lists in result and intro pages for smart answers
- adds govuk-frontend mixins to provide consistent font sizes etc. as content is rendered in govspeak and can't have specific classes applied
- also adds a fix for 'quote' elements (they look like blockquotes but they're not) as this change originally broke them a little

Before:

<img width="672" alt="Screenshot 2019-10-24 at 15 46 55" src="https://user-images.githubusercontent.com/861310/67497264-a74da180-f675-11e9-89ca-b474c7e5ff52.png">

After:

<img width="687" alt="Screenshot 2019-10-24 at 15 47 14" src="https://user-images.githubusercontent.com/861310/67497284-ad438280-f675-11e9-905e-781c213ff0e7.png">
