### PR TITLE
Update flow for "hours-worked-per-week" and "compressed-hours"

### DIFF
--- a/lib/smart_answer/calculators/holiday_entitlement.rb
+++ b/lib/smart_answer/calculators/holiday_entitlement.rb
@@ -32,6 +32,11 @@ module SmartAnswer::Calculators
       @days_per_shift_pattern = BigDecimal(days_per_shift_pattern, 10)
     end
 
+    def compressed_hours_daily_average
+      minutes = hours_per_week.to_f / working_days_per_week * 60
+      minutes.ceil.divmod(60).map(&:ceil)
+    end
+
     def full_time_part_time_days
       days = STATUTORY_HOLIDAY_ENTITLEMENT_IN_WEEKS * working_days_per_week
       actual_days = if left_before_year_end? || (working_days_per_week < STANDARD_WORKING_DAYS_PER_WEEK)

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
@@ -113,7 +113,7 @@ module SmartAnswer
           case calculation_basis
           when "days-worked-per-week"
             question :how_many_days_per_week?
-          when "hours-worked-per-week"
+          when "hours-worked-per-week", "compressed-hours"
             question :how_many_hours_per_week?
           when "shift-worker"
             question :shift_worker_hours_per_shift?
@@ -259,6 +259,9 @@ module SmartAnswer
           Calculators::HolidayEntitlement.new(
             hours_per_week: hours_per_week,
             working_days_per_week: working_days_per_week,
+            start_date: start_date,
+            leaving_date: leaving_date,
+            leave_year_start_date: leave_year_start_date,
           )
         end
         precalculate :holiday_entitlement_hours do

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
@@ -123,7 +123,7 @@ module SmartAnswer
         end
       end
 
-      # Q10
+      # Q10 - Q15
       value_question :how_many_hours_per_week?, parse: Float do
         save_input_as :hours_per_week
 

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
@@ -21,10 +21,8 @@ module SmartAnswer
 
         next_node do |response|
           case response
-          when "days-worked-per-week", "hours-worked-per-week"
+          when "days-worked-per-week", "hours-worked-per-week", "compressed-hours"
             question :calculation_period?
-          when "compressed-hours"
-            question :compressed_hours_how_many_hours_per_week?
           when "shift-worker"
             question :shift_worker_basis?
           end
@@ -68,7 +66,7 @@ module SmartAnswer
         end
       end
 
-      # Q4 - Q12
+      # Q4 - Q12 - Q20
       date_question :what_is_your_starting_date? do
         from { Date.civil(1.year.ago.year, 1, 1) }
         to { Date.civil(1.year.since(Date.today).year, 12, 31) }
@@ -83,7 +81,7 @@ module SmartAnswer
         end
       end
 
-      # Q5 - Q13
+      # Q5 - Q13 - Q21
       date_question :what_is_your_leaving_date? do
         from { Date.civil(1.year.ago.year, 1, 1) }
         to { Date.civil(1.year.since(Date.today).year, 12, 31) }
@@ -105,7 +103,7 @@ module SmartAnswer
         end
       end
 
-      # Q6 - Q14
+      # Q6 - Q14 - Q22
       date_question :when_does_your_leave_year_start? do
         from { Date.civil(1.year.ago.year, 1, 1) }
         to { Date.civil(1.year.since(Date.today).year, 12, 31) }
@@ -123,7 +121,7 @@ module SmartAnswer
         end
       end
 
-      # Q10 - Q15
+      # Q10 - Q15 - Q18
       value_question :how_many_hours_per_week?, parse: Float do
         save_input_as :hours_per_week
 
@@ -132,7 +130,7 @@ module SmartAnswer
         end
       end
 
-      # Q11 - Q16
+      # Q11 - Q16 - Q19
       value_question :how_many_days_per_week_for_hours?, parse: Float do
         calculate :working_days_per_week do |response|
           working_days_per_week = response
@@ -141,32 +139,11 @@ module SmartAnswer
           working_days_per_week
         end
         next_node do
-          outcome :hours_per_week_done
-        end
-      end
-
-      value_question :compressed_hours_how_many_hours_per_week?, parse: Float do
-        calculate :hours_per_week do |response|
-          hours = response
-          raise InvalidResponse if hours <= 0 || hours > 168
-
-          hours
-        end
-        next_node do
-          question :compressed_hours_how_many_days_per_week?
-        end
-      end
-
-      value_question :compressed_hours_how_many_days_per_week?, parse: Float do
-        calculate :working_days_per_week do |response|
-          days = response
-          raise InvalidResponse if days <= 0 || days > 7
-
-          days
-        end
-
-        next_node do
-          outcome :compressed_hours_done
+          if calculation_basis == "compressed-hours"
+            outcome :compressed_hours_done
+          else
+            outcome :hours_per_week_done
+          end
         end
       end
 
@@ -285,10 +262,10 @@ module SmartAnswer
           )
         end
         precalculate :holiday_entitlement_hours do
-          calculator.compressed_hours_entitlement.first
+          calculator.full_time_part_time_hours_and_minutes.first
         end
         precalculate :holiday_entitlement_minutes do
-          calculator.compressed_hours_entitlement.last
+          calculator.full_time_part_time_hours_and_minutes.last
         end
         precalculate :hours_daily do
           calculator.compressed_hours_daily_average.first

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
@@ -68,7 +68,7 @@ module SmartAnswer
         end
       end
 
-      # Q4
+      # Q4 - Q12
       date_question :what_is_your_starting_date? do
         from { Date.civil(1.year.ago.year, 1, 1) }
         to { Date.civil(1.year.since(Date.today).year, 12, 31) }
@@ -83,7 +83,7 @@ module SmartAnswer
         end
       end
 
-      # Q5
+      # Q5 - Q13
       date_question :what_is_your_leaving_date? do
         from { Date.civil(1.year.ago.year, 1, 1) }
         to { Date.civil(1.year.since(Date.today).year, 12, 31) }
@@ -105,7 +105,7 @@ module SmartAnswer
         end
       end
 
-      # Q6
+      # Q6 - Q14
       date_question :when_does_your_leave_year_start? do
         from { Date.civil(1.year.ago.year, 1, 1) }
         to { Date.civil(1.year.since(Date.today).year, 12, 31) }
@@ -132,6 +132,7 @@ module SmartAnswer
         end
       end
 
+      # Q11 - Q16
       value_question :how_many_days_per_week_for_hours?, parse: Float do
         calculate :working_days_per_week do |response|
           working_days_per_week = response
@@ -273,9 +274,6 @@ module SmartAnswer
         end
         precalculate :holiday_entitlement_hours do
           holiday_entitlement_hours_and_minutes.first
-        end
-        precalculate :holiday_entitlement_minutes do
-          holiday_entitlement_hours_and_minutes.last
         end
       end
 

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
@@ -92,7 +92,7 @@ module SmartAnswer
             case calculation_basis
             when "days-worked-per-week"
               question :how_many_days_per_week?
-            when "hours-worked-per-week"
+            when "hours-worked-per-week", "compressed-hours"
               question :how_many_hours_per_week?
             when "shift-worker"
               question :shift_worker_hours_per_shift?

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/compressed_hours_done.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/compressed_hours_done.govspeak.erb
@@ -2,4 +2,7 @@
   $!The statutory holiday entitlement is <%= "#{holiday_entitlement_hours} #{'hour'.pluralize(holiday_entitlement_hours)}" %> and <%= "#{holiday_entitlement_minutes} #{'minute'.pluralize(holiday_entitlement_minutes)}" %> holiday for the year. Rather than taking a day’s holiday it’s <%= "#{hours_daily} #{'hour'.pluralize(hours_daily)}" %> and <%= "#{minutes_daily} #{'minute'.pluralize(minutes_daily)}" %> holiday for each day otherwise worked.$!
 
   <%= render partial: 'your_employer_with_rounding.govspeak.erb' %>
+  <% if holiday_period == "starting" %>
+    <%= render partial: "the_user_should_be_aware.govspeak.erb" %>
+  <% end %>
 <% end %>

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/hours_per_week_done.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/hours_per_week_done.govspeak.erb
@@ -6,4 +6,8 @@
   <% end %>
 
   <%= render partial: 'your_employer_with_rounding.govspeak.erb' %>
+
+  <% if holiday_period == "starting" %>
+    <%= render partial: "the_user_should_be_aware.govspeak.erb" %>
+  <% end %>
 <% end %>

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/hours_per_week_done.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/hours_per_week_done.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :body do %>
-  $!The statutory entitlement is <%= "#{holiday_entitlement_hours} #{'hour'.pluralize(holiday_entitlement_hours)}" %> and <%= "#{holiday_entitlement_minutes} #{'minute'.pluralize(holiday_entitlement_minutes)}" %> holiday.$!
+  $!The statutory entitlement is <%= "#{holiday_entitlement_hours} #{'hour'.pluralize(holiday_entitlement_hours)}" %> holiday.$!
 
   <% if working_days_per_week > 5 %>
     Even though more than 5 days a week are worked the maximum statutory holiday entitlement is 28 days.

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/questions/basis_of_calculation.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/questions/basis_of_calculation.govspeak.erb
@@ -5,7 +5,7 @@
 <% options(
   "days-worked-per-week": "days worked per week",
   "hours-worked-per-week": "hours worked per week",
-  "compressed-hours": "compressed hours (full-time hours over fewer days)",
+  "compressed-hours": "compressed hours",
   "shift-worker": "shifts"
 ) %>
 

--- a/test/integration/smart_answer_flows/calculate_your_holiday_entitlement_test.rb
+++ b/test/integration/smart_answer_flows/calculate_your_holiday_entitlement_test.rb
@@ -345,6 +345,51 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
         end
       end
     end
+
+    context "starting and leaving within a leave year" do
+      setup do
+        add_response "starting-and-leaving"
+      end
+      should "ask for the employment start date" do
+        assert_current_node :what_is_your_starting_date?
+      end
+      context "answer 'Jan 20th 2019'" do
+        setup do
+          add_response "2019-01-20"
+        end
+        should "ask for the employment end date" do
+          assert_current_node :what_is_your_leaving_date?
+        end
+        context "answer 'July 18th 2019'" do
+          setup do
+            add_response "2019-07-18"
+          end
+          should "ask the number of hours worked per week" do
+            assert_current_node :how_many_hours_per_week?
+          end
+          context "answer 40 hours" do
+            setup do
+              add_response "40"
+            end
+            should "ask the number of days worked per week" do
+              assert_current_node :how_many_days_per_week_for_hours?
+            end
+            context "answer 5 days" do
+              setup do
+                add_response "5"
+              end
+              should "calculate the holiday entitlement" do
+                assert_current_node :compressed_hours_done
+                assert_state_variable "holiday_entitlement_hours", 110
+                assert_state_variable "holiday_entitlement_minutes", 28
+                assert_state_variable "hours_daily", 8
+                assert_state_variable "minutes_daily", 0
+              end
+            end
+          end
+        end
+      end
+    end
   end # compressed-hours
 
   context "shift worker" do

--- a/test/integration/smart_answer_flows/calculate_your_holiday_entitlement_test.rb
+++ b/test/integration/smart_answer_flows/calculate_your_holiday_entitlement_test.rb
@@ -29,9 +29,9 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
       should "ask the number of hours worked per week" do
         assert_current_node :how_many_hours_per_week?
       end
-      context "answer 32 hours" do
+      context "answer 40 hours" do
         setup do
-          add_response "32"
+          add_response "40"
         end
         should "ask the number of days worked per week" do
           assert_current_node :how_many_days_per_week_for_hours?
@@ -44,18 +44,16 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
             SmartAnswer::Calculators::HolidayEntitlement
               .expects(:new)
               .with(
-                hours_per_week: 32.0,
+                hours_per_week: 40.0,
                 working_days_per_week: 5.0,
                 start_date: nil,
                 leaving_date: nil,
                 leave_year_start_date: nil,
               ).returns(@stubbed_calculator)
-            @stubbed_calculator.expects(:full_time_part_time_hours).returns(179.2)
+            @stubbed_calculator.expects(:full_time_part_time_hours).returns(224.0)
 
             assert_current_node :hours_per_week_done
-            assert_state_variable "holiday_entitlement_hours", 179
-            assert_state_variable "holiday_entitlement_minutes", 12
-            assert_current_node :hours_per_week_done
+            assert_state_variable "holiday_entitlement_hours", 224
           end
         end
       end

--- a/test/integration/smart_answer_flows/calculate_your_holiday_entitlement_test.rb
+++ b/test/integration/smart_answer_flows/calculate_your_holiday_entitlement_test.rb
@@ -119,23 +119,26 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
       should "ask for the employment end date" do
         assert_current_node :what_is_your_leaving_date?
       end
-      context "answer 06-15" do
+      context "answer 'June 1st 2019'" do
         setup do
-          add_response "#{Date.today.year}-06-15"
+          add_response "2019-06-01"
         end
         should "ask when the leave year started" do
           assert_current_node :when_does_your_leave_year_start?
         end
-        context "answer 01-01" do
+        context "answer Jan 1st 2019" do
           setup do
-            add_response "#{Date.today.year}-01-01"
+            add_response "2019-01-01"
           end
           should "ask the number of hours worked per week" do
             assert_current_node :how_many_hours_per_week?
           end
-          context "answer 26.5 hours" do
+          context "answer 40 hours" do
             setup do
-              add_response "26.5"
+              add_response "40"
+            end
+            should "ask the number of days worked per week" do
+              assert_current_node :how_many_days_per_week_for_hours?
             end
             context "answer 5 days" do
               setup do
@@ -145,18 +148,17 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
                 SmartAnswer::Calculators::HolidayEntitlement.
                   expects(:new).
                   with(
-                    hours_per_week: 26.5,
+                    hours_per_week: 40,
                     working_days_per_week: 5,
                     start_date: nil,
-                    leaving_date: Date.parse("#{Date.today.year}-06-15"),
-                    leave_year_start_date: Date.parse("#{Date.today.year}-01-01"),
+                    leaving_date: Date.parse("2019-06-01"),
+                    leave_year_start_date: Date.parse("2019-01-01"),
                   ).
                   returns(@stubbed_calculator)
-                @stubbed_calculator.expects(:full_time_part_time_hours).returns(19.75)
+                @stubbed_calculator.expects(:full_time_part_time_hours).returns(93.29)
 
                 assert_current_node :hours_per_week_done
-                assert_state_variable "holiday_entitlement_hours", 19
-                assert_state_variable "holiday_entitlement_minutes", 45
+                assert_state_variable "holiday_entitlement_hours", 93
               end
             end
           end

--- a/test/integration/smart_answer_flows/calculate_your_holiday_entitlement_test.rb
+++ b/test/integration/smart_answer_flows/calculate_your_holiday_entitlement_test.rb
@@ -119,7 +119,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
       should "ask for the employment end date" do
         assert_current_node :what_is_your_leaving_date?
       end
-      context "answer 'June 1st 2019'" do
+      context "answer June 1st 2019" do
         setup do
           add_response "2019-06-01"
         end
@@ -170,46 +170,49 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
       setup do
         add_response "starting-and-leaving"
       end
-      should "ask what was the employment start date" do
+      should "ask for the employment start date" do
         assert_current_node :what_is_your_starting_date?
       end
-      context "add employment start date" do
+      context "answer 'Jan 20th 2019'" do
         setup do
-          add_response "#{Date.today.year}-07-14"
+          add_response "2019-01-20"
         end
-        should "ask what date employment finished" do
+        should "ask for the employment end date" do
           assert_current_node :what_is_your_leaving_date?
         end
-        context "add employment end date" do
+        context "answer 'July 18th 2019'" do
           setup do
-            add_response "#{Date.today.year}-10-14"
+            add_response "2019-07-18"
           end
-          should "ask you how many hours worked per week" do
+          should "ask the number of hours worked per week" do
             assert_current_node :how_many_hours_per_week?
           end
-          context "add hours worker per week" do
+          context "answer 40 hours" do
             setup do
-              add_response "37"
+              add_response "40"
             end
-            should "ask you how many days worked per week" do
+            should "ask the number of days worked per week" do
               assert_current_node :how_many_days_per_week_for_hours?
             end
-            should "calculate and be done part year when 5 days" do
-              SmartAnswer::Calculators::HolidayEntitlement
-                .expects(:new)
-                .with(
-                  hours_per_week: 37,
-                  working_days_per_week: 5,
-                  start_date: Date.parse("#{Date.today.year}-07-14"),
-                  leaving_date: Date.parse("#{Date.today.year}-10-14"),
-                  leave_year_start_date: nil,
-                ).returns(@stubbed_calculator)
-              @stubbed_calculator.expects(:full_time_part_time_hours).returns(79.5)
+            context "answer 5 days" do
+              setup do
+                add_response "5"
+              end
+              should "calculate the holiday entitlement" do
+                SmartAnswer::Calculators::HolidayEntitlement
+                  .expects(:new)
+                  .with(
+                    hours_per_week: 40,
+                    working_days_per_week: 5,
+                    start_date: Date.parse("2019-01-20"),
+                    leaving_date: Date.parse("2019-07-18"),
+                    leave_year_start_date: nil,
+                  ).returns(@stubbed_calculator)
+                @stubbed_calculator.expects(:full_time_part_time_hours).returns(110.47)
 
-              add_response "5"
-              assert_current_node :hours_per_week_done
-              assert_state_variable "holiday_entitlement_hours", 79
-              assert_state_variable "holiday_entitlement_minutes", 30
+                assert_current_node :hours_per_week_done
+                assert_state_variable "holiday_entitlement_hours", 110
+              end
             end
           end
         end

--- a/test/integration/smart_answer_flows/calculate_your_holiday_entitlement_test.rb
+++ b/test/integration/smart_answer_flows/calculate_your_holiday_entitlement_test.rb
@@ -255,6 +255,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
         end
       end
     end
+
     context "answer starting part way through the leave year" do
       setup do
         add_response "starting"
@@ -291,6 +292,51 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
                 assert_current_node :compressed_hours_done
                 assert_state_variable "holiday_entitlement_hours", 132
                 assert_state_variable "holiday_entitlement_minutes", 0
+                assert_state_variable "hours_daily", 8
+                assert_state_variable "minutes_daily", 0
+              end
+            end
+          end
+        end
+      end
+    end
+
+    context "answer leaving part way through the leave year" do
+      setup do
+        add_response "leaving"
+      end
+      should "ask for the employment end date" do
+        assert_current_node :what_is_your_leaving_date?
+      end
+      context "answer June 1st 2019" do
+        setup do
+          add_response "2019-06-01"
+        end
+        should "ask when the leave year started" do
+          assert_current_node :when_does_your_leave_year_start?
+        end
+        context "answer Jan 1st 2019" do
+          setup do
+            add_response "2019-01-01"
+          end
+          should "ask the number of hours worked per week" do
+            assert_current_node :how_many_hours_per_week?
+          end
+          context "answer 40 hours" do
+            setup do
+              add_response "40"
+            end
+            should "ask the number of days worked per week" do
+              assert_current_node :how_many_days_per_week_for_hours?
+            end
+            context "answer 5 days" do
+              setup do
+                add_response "5"
+              end
+              should "calculate the holiday entitlement" do
+                assert_current_node :compressed_hours_done
+                assert_state_variable "holiday_entitlement_hours", 93
+                assert_state_variable "holiday_entitlement_minutes", 17
                 assert_state_variable "hours_daily", 8
                 assert_state_variable "minutes_daily", 0
               end

--- a/test/integration/smart_answer_flows/calculate_your_holiday_entitlement_test.rb
+++ b/test/integration/smart_answer_flows/calculate_your_holiday_entitlement_test.rb
@@ -255,6 +255,50 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
         end
       end
     end
+    context "answer starting part way through the leave year" do
+      setup do
+        add_response "starting"
+      end
+      should "ask for the employment start date" do
+        assert_current_node :what_is_your_starting_date?
+      end
+      context "answer June 1st 2019" do
+        setup do
+          add_response "2019-06-01"
+        end
+        should "ask when the leave year started" do
+          assert_current_node :when_does_your_leave_year_start?
+        end
+        context "answer Jan 1st 2019" do
+          setup do
+            add_response "2019-01-01"
+          end
+          should "ask the number of hours worked per week" do
+            assert_current_node :how_many_hours_per_week?
+          end
+          context "answer 40 hours" do
+            setup do
+              add_response "40"
+            end
+            should "ask the number of days worked per week" do
+              assert_current_node :how_many_days_per_week_for_hours?
+            end
+            context "answer 5 days" do
+              setup do
+                add_response "5"
+              end
+              should "calculate the holiday entitlement" do
+                assert_current_node :compressed_hours_done
+                assert_state_variable "holiday_entitlement_hours", 132
+                assert_state_variable "holiday_entitlement_minutes", 0
+                assert_state_variable "hours_daily", 8
+                assert_state_variable "minutes_daily", 0
+              end
+            end
+          end
+        end
+      end
+    end
   end # compressed-hours
 
   context "shift worker" do

--- a/test/integration/smart_answer_flows/calculate_your_holiday_entitlement_test.rb
+++ b/test/integration/smart_answer_flows/calculate_your_holiday_entitlement_test.rb
@@ -65,23 +65,26 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
       should "ask for the employment start date" do
         assert_current_node :what_is_your_starting_date?
       end
-      context "answer June 15th this year" do
+      context "answer June 1st 2019" do
         setup do
-          add_response "#{Date.today.year}-06-15"
+          add_response "2019-06-01"
         end
         should "ask when the leave year started" do
           assert_current_node :when_does_your_leave_year_start?
         end
-        context "answer Jan 1st this year" do
+        context "answer Jan 1st 2019" do
           setup do
-            add_response "#{Date.today.year}-01-01"
+            add_response "2019-01-01"
           end
           should "ask the number of hours worked per week" do
             assert_current_node :how_many_hours_per_week?
           end
-          context "answer 37 hours" do
+          context "answer 40 hours" do
             setup do
-              add_response "37"
+              add_response "40"
+            end
+            should "ask the number of days worked per week" do
+              assert_current_node :how_many_days_per_week_for_hours?
             end
             context "answer 5 days" do
               setup do
@@ -91,18 +94,17 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
                 SmartAnswer::Calculators::HolidayEntitlement.
                   expects(:new).
                   with(
-                    hours_per_week: 37.0,
+                    hours_per_week: 40.0,
                     working_days_per_week: 5,
-                    start_date: Date.parse("#{Date.today.year}-06-15"),
+                    start_date: Date.parse("2019-06-01"),
                     leaving_date: nil,
-                    leave_year_start_date: Date.parse("#{Date.today.year}-01-01"),
+                    leave_year_start_date: Date.parse("2019-01-01"),
                   ).
                   returns(@stubbed_calculator)
-                @stubbed_calculator.expects(:full_time_part_time_hours).returns(79.5)
+                @stubbed_calculator.expects(:full_time_part_time_hours).returns(132.0)
 
                 assert_current_node :hours_per_week_done
-                assert_state_variable "holiday_entitlement_hours", 79
-                assert_state_variable "holiday_entitlement_minutes", 30
+                assert_state_variable "holiday_entitlement_hours", 132
               end
             end
           end


### PR DESCRIPTION
`hours-worked-per-week` and `compressed-hours` have identical flow, so made sense to work on them together. 

See individual commit messages for more context.

Trello card: https://trello.com/c/51GvBXcw/1466-8-update-the-hours-worked-per-week-and-compressed-hours-flows-for-the-holiday-entitlement-calculator

Screenshots of "Hours worked per week" outcomes:

`/y/hours-worked-per-week/full-year/40.0/5.0`
![:y:hours-worked-per-week:full-year:40 0:5 0](https://user-images.githubusercontent.com/19667619/68131232-98d47500-ff14-11e9-8495-bc6f81bb1e91.png)

`/y/hours-worked-per-week/starting/2019-06-01/2019-01-01/40.0/5.0`
![y:hours-worked-per-week:starting:2019-06-01:2019-01-01:40 0:5 0](https://user-images.githubusercontent.com/19667619/68131294-b73a7080-ff14-11e9-8d14-369dae6ae4ad.png)

Screenshots of "Compressed hours" outcomes:

`/y/compressed-hours/starting/2019-06-01/2019-01-01/40.0/5.0`
![Screenshot 2019-11-04 at 17 09 50](https://user-images.githubusercontent.com/19667619/68141715-f0c7a780-ff25-11e9-8da5-8b9b5d440f26.png)


`/y/compressed-hours/starting-and-leaving/2019-01-20/2019-07-18/40.0/5.0`
![y:compressed-hours:full-year:40 0:5 0](https://user-images.githubusercontent.com/19667619/68141638-cfff5200-ff25-11e9-9402-4bbffaeabfff.png)


