### PR TITLE
Irregular annualised hours flow

### DIFF
--- a/lib/smart_answer/calculators/holiday_entitlement.rb
+++ b/lib/smart_answer/calculators/holiday_entitlement.rb
@@ -140,6 +140,8 @@ module SmartAnswer::Calculators
       started_after_year_began? ? (pro_rated_shifts * 2).ceil / 2.0 : pro_rated_shifts
     end
 
+  private
+
     def worked_full_year?
       start_date.nil? && leaving_date.nil?
     end
@@ -147,8 +149,6 @@ module SmartAnswer::Calculators
     def left_before_year_end?
       start_date.nil? && leaving_date.present?
     end
-
-  private
 
     def shifts_per_week
       (shifts_per_shift_pattern / days_per_shift_pattern * DAYS_PER_WEEK).round(10)

--- a/lib/smart_answer/calculators/holiday_entitlement.rb
+++ b/lib/smart_answer/calculators/holiday_entitlement.rb
@@ -144,6 +144,10 @@ module SmartAnswer::Calculators
       start_date.nil? && leaving_date.nil?
     end
 
+    def left_before_year_end?
+      start_date.nil? && leaving_date.present?
+    end
+
   private
 
     def shifts_per_week
@@ -156,10 +160,6 @@ module SmartAnswer::Calculators
 
     def started_after_year_began?
       start_date.present? && leaving_date.nil?
-    end
-
-    def left_before_year_end?
-      start_date.nil? && leaving_date.present?
     end
 
     def worked_partial_year?

--- a/lib/smart_answer/calculators/holiday_entitlement.rb
+++ b/lib/smart_answer/calculators/holiday_entitlement.rb
@@ -140,6 +140,10 @@ module SmartAnswer::Calculators
       started_after_year_began? ? (pro_rated_shifts * 2).ceil / 2.0 : pro_rated_shifts
     end
 
+    def worked_full_year?
+      start_date.nil? && leaving_date.nil?
+    end
+
   private
 
     def shifts_per_week
@@ -148,10 +152,6 @@ module SmartAnswer::Calculators
 
     def calculate_leave_year_start_date
       leaving_date ? leaving_date.beginning_of_year : Date.today.beginning_of_year
-    end
-
-    def worked_full_year?
-      start_date.nil? && leaving_date.nil?
     end
 
     def started_after_year_began?

--- a/lib/smart_answer/calculators/holiday_entitlement.rb
+++ b/lib/smart_answer/calculators/holiday_entitlement.rb
@@ -142,14 +142,6 @@ module SmartAnswer::Calculators
 
   private
 
-    def worked_full_year?
-      start_date.nil? && leaving_date.nil?
-    end
-
-    def left_before_year_end?
-      start_date.nil? && leaving_date.present?
-    end
-
     def shifts_per_week
       (shifts_per_shift_pattern / days_per_shift_pattern * DAYS_PER_WEEK).round(10)
     end
@@ -158,8 +150,16 @@ module SmartAnswer::Calculators
       leaving_date ? leaving_date.beginning_of_year : Date.today.beginning_of_year
     end
 
+    def worked_full_year?
+      start_date.nil? && leaving_date.nil?
+    end
+
     def started_after_year_began?
       start_date.present? && leaving_date.nil?
+    end
+
+    def left_before_year_end?
+      start_date.nil? && leaving_date.present?
     end
 
     def worked_partial_year?

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
@@ -288,7 +288,8 @@ module SmartAnswer
       outcome :irregular_and_annualised_done do
         precalculate :calculator do
           Calculators::HolidayEntitlement.new(start_date: start_date,
-                                              leave_year_start_date: leave_year_start_date)
+                                              leave_year_start_date: leave_year_start_date,
+                                              leaving_date: leaving_date)
         end
         precalculate :holiday_entitlement do
           calculator.formatted_full_time_part_time_weeks
@@ -296,8 +297,8 @@ module SmartAnswer
         precalculate :irregular_and_annualised_hours do
           true
         end
-        precalculate :worked_full_year do
-          calculator.worked_full_year?
+        precalculate :worked_full_year_and_left_before_year_end do
+          calculator.worked_full_year? || calculator.left_before_year_end?
         end
       end
     end

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
@@ -101,6 +101,8 @@ module SmartAnswer
               question :how_many_hours_per_week?
             when "shift-worker"
               question :shift_worker_hours_per_shift?
+            when "irregular-hours"
+              outcome :irregular_and_annualised_done
             end
           else
             question :when_does_your_leave_year_start?
@@ -293,12 +295,6 @@ module SmartAnswer
         end
         precalculate :holiday_entitlement do
           calculator.formatted_full_time_part_time_weeks
-        end
-        precalculate :irregular_and_annualised_hours do
-          true
-        end
-        precalculate :worked_full_year_and_left_before_year_end do
-          calculator.worked_full_year? || calculator.left_before_year_end?
         end
       end
     end

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
@@ -12,6 +12,7 @@ module SmartAnswer
         option "days-worked-per-week"
         option "hours-worked-per-week"
         option "irregular-hours"
+        option "annualised-hours"
         option "compressed-hours"
         option "shift-worker"
         save_input_as :calculation_basis
@@ -22,7 +23,7 @@ module SmartAnswer
 
         next_node do |response|
           case response
-          when "days-worked-per-week", "hours-worked-per-week", "compressed-hours", "irregular-hours"
+          when "days-worked-per-week", "hours-worked-per-week", "compressed-hours", "irregular-hours", "annualised-hours"
             question :calculation_period?
           when "shift-worker"
             question :shift_worker_basis?
@@ -45,7 +46,7 @@ module SmartAnswer
           when "leaving"
             question :what_is_your_leaving_date?
           when "full-year"
-            if calculation_basis == "irregular-hours"
+            if calculation_basis == "irregular-hours" || calculation_basis == "annualised-hours"
               outcome :irregular_and_annualised_done
             end
           else
@@ -101,7 +102,7 @@ module SmartAnswer
               question :how_many_hours_per_week?
             when "shift-worker"
               question :shift_worker_hours_per_shift?
-            when "irregular-hours"
+            when "irregular-hours", "annualised-hours"
               outcome :irregular_and_annualised_done
             end
           else
@@ -122,7 +123,7 @@ module SmartAnswer
             question :how_many_days_per_week?
           when "hours-worked-per-week", "compressed-hours"
             question :how_many_hours_per_week?
-          when "irregular-hours"
+          when "irregular-hours", "annualised-hours"
             outcome :irregular_and_annualised_done
           when "shift-worker"
             question :shift_worker_hours_per_shift?

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
@@ -11,6 +11,7 @@ module SmartAnswer
       multiple_choice :basis_of_calculation? do
         option "days-worked-per-week"
         option "hours-worked-per-week"
+        option "irregular-hours"
         option "compressed-hours"
         option "shift-worker"
         save_input_as :calculation_basis
@@ -21,7 +22,7 @@ module SmartAnswer
 
         next_node do |response|
           case response
-          when "days-worked-per-week", "hours-worked-per-week", "compressed-hours"
+          when "days-worked-per-week", "hours-worked-per-week", "compressed-hours", "irregular-hours"
             question :calculation_period?
           when "shift-worker"
             question :shift_worker_basis?
@@ -29,7 +30,7 @@ module SmartAnswer
         end
       end
 
-      # Q2
+      # Q2, Q35
       multiple_choice :calculation_period? do
         option "full-year"
         option "starting"
@@ -43,6 +44,10 @@ module SmartAnswer
             question :what_is_your_starting_date?
           when "leaving"
             question :what_is_your_leaving_date?
+          when "full-year"
+            if calculation_basis == "irregular-hours"
+              outcome :irregular_and_annualised_done
+            end
           else
             if calculation_basis == "days-worked-per-week"
               question :how_many_days_per_week?
@@ -115,6 +120,8 @@ module SmartAnswer
             question :how_many_days_per_week?
           when "hours-worked-per-week", "compressed-hours"
             question :how_many_hours_per_week?
+          when "irregular-hours"
+            outcome :irregular_and_annualised_done
           when "shift-worker"
             question :shift_worker_hours_per_shift?
           end
@@ -275,6 +282,22 @@ module SmartAnswer
         end
         precalculate :minutes_daily do
           calculator.compressed_hours_daily_average.last
+        end
+      end
+
+      outcome :irregular_and_annualised_done do
+        precalculate :calculator do
+          Calculators::HolidayEntitlement.new(start_date: start_date,
+                                              leave_year_start_date: leave_year_start_date)
+        end
+        precalculate :holiday_entitlement do
+          calculator.formatted_full_time_part_time_weeks
+        end
+        precalculate :irregular_and_annualised_hours do
+          true
+        end
+        precalculate :worked_full_year do
+          calculator.worked_full_year?
         end
       end
     end

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
@@ -71,7 +71,7 @@ module SmartAnswer
         end
       end
 
-      # Q4 - Q12 - Q20
+      # Q4 - Q12 - Q20 - Q36
       date_question :what_is_your_starting_date? do
         from { Date.civil(1.year.ago.year, 1, 1) }
         to { Date.civil(1.year.since(Date.today).year, 12, 31) }
@@ -86,7 +86,7 @@ module SmartAnswer
         end
       end
 
-      # Q5 - Q13 - Q21
+      # Q5 - Q13 - Q21 - Q37
       date_question :what_is_your_leaving_date? do
         from { Date.civil(1.year.ago.year, 1, 1) }
         to { Date.civil(1.year.since(Date.today).year, 12, 31) }
@@ -110,7 +110,7 @@ module SmartAnswer
         end
       end
 
-      # Q6 - Q14 - Q22
+      # Q6 - Q14 - Q22 - Q38
       date_question :when_does_your_leave_year_start? do
         from { Date.civil(1.year.ago.year, 1, 1) }
         to { Date.civil(1.year.since(Date.today).year, 12, 31) }

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
@@ -290,9 +290,11 @@ module SmartAnswer
 
       outcome :irregular_and_annualised_done do
         precalculate :calculator do
-          Calculators::HolidayEntitlement.new(start_date: start_date,
-                                              leave_year_start_date: leave_year_start_date,
-                                              leaving_date: leaving_date)
+          Calculators::HolidayEntitlement.new(
+            start_date: start_date,
+            leave_year_start_date: leave_year_start_date,
+            leaving_date: leaving_date
+          )
         end
         precalculate :holiday_entitlement do
           calculator.formatted_full_time_part_time_weeks

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/_entitlement_restriction.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/_entitlement_restriction.govspeak.erb
@@ -1,0 +1,3 @@
+Users should be aware:
+
+* The entitlement may be subject to a restriction of 28 days a year

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/_irregular_and_annualised_user_awareness.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/_irregular_and_annualised_user_awareness.govspeak.erb
@@ -1,0 +1,8 @@
+The User should be aware:
+
+* Leave entitlement accrues differently in a workers first year - further information is
+[available online](/holiday-entitlement-rights/calculate-leave-entitlement)
+* When a worker leaves employment within the first twelve months, their leave is calculated using the 'For somebody
+starting and leaving part way through a leave year' option in the calculator
+* This entitlement may be subject to a statutory cap of 28 days per year
+* This entitlement may need to be rounded up to the next half day of the workers working pattern

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/irregular_and_annualised_done.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/irregular_and_annualised_done.govspeak.erb
@@ -3,9 +3,9 @@
 
   <%= render partial: 'your_employer_with_rounding.govspeak.erb' %>
 
-  <% if worked_full_year_and_left_before_year_end %>
-    <%= render partial: 'entitlement_restriction.govspeak.erb' %>
-  <% else %>
+  <% if holiday_period == 'starting' %>
     <%= render partial: 'irregular_and_annualised_user_awareness.govspeak.erb' %>
+  <% else %>
+    <%= render partial: 'entitlement_restriction.govspeak.erb' %>
   <% end %>
 <% end %>

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/irregular_and_annualised_done.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/irregular_and_annualised_done.govspeak.erb
@@ -1,0 +1,11 @@
+<% content_for :body do %>
+  The statutory holiday entitlement is <%= holiday_entitlement %> weeks holiday.
+
+  <%= render partial: 'your_employer_with_rounding.govspeak.erb' %>
+
+  <% if worked_full_year %>
+    <%= render partial: 'entitlement_restriction.govspeak.erb' %>
+  <% else %>
+    <%= render partial: 'irregular_and_annualised_user_awareness.govspeak.erb' %>
+  <% end %>
+<% end %>

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/irregular_and_annualised_done.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/irregular_and_annualised_done.govspeak.erb
@@ -3,7 +3,7 @@
 
   <%= render partial: 'your_employer_with_rounding.govspeak.erb' %>
 
-  <% if worked_full_year %>
+  <% if worked_full_year_and_left_before_year_end %>
     <%= render partial: 'entitlement_restriction.govspeak.erb' %>
   <% else %>
     <%= render partial: 'irregular_and_annualised_user_awareness.govspeak.erb' %>

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/questions/basis_of_calculation.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/questions/basis_of_calculation.govspeak.erb
@@ -6,6 +6,7 @@
   "days-worked-per-week": "days worked per week",
   "hours-worked-per-week": "hours worked per week",
   "irregular-hours": "casual or irregular hours, including zero hours contracts",
+  "annualised-hours": "annualised hours",
   "compressed-hours": "compressed hours",
   "shift-worker": "shifts"
 ) %>

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/questions/basis_of_calculation.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/questions/basis_of_calculation.govspeak.erb
@@ -5,6 +5,7 @@
 <% options(
   "days-worked-per-week": "days worked per week",
   "hours-worked-per-week": "hours worked per week",
+  "irregular-hours": "casual or irregular hours, including zero hours contracts",
   "compressed-hours": "compressed hours",
   "shift-worker": "shifts"
 ) %>

--- a/test/integration/smart_answer_flows/calculate_your_holiday_entitlement_test.rb
+++ b/test/integration/smart_answer_flows/calculate_your_holiday_entitlement_test.rb
@@ -392,6 +392,274 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
     end
   end # compressed-hours
 
+  context "irregular hours" do
+    setup do
+      add_response "irregular-hours"
+    end
+    should "ask the time period for the calculation" do
+      assert_current_node :calculation_period?
+    end
+
+    context "answer full leave year" do
+      setup do
+        add_response "full-year"
+      end
+      should "calculate the holiday entitlement" do
+        SmartAnswer::Calculators::HolidayEntitlement
+          .expects(:new)
+          .with(
+            start_date: nil,
+            leaving_date: nil,
+            leave_year_start_date: nil
+          ).returns(@stubbed_calculator)
+        @stubbed_calculator.expects(:formatted_full_time_part_time_weeks).returns("5.6")
+
+        assert_state_variable "holiday_entitlement", "5.6"
+        assert_current_node :irregular_and_annualised_done
+      end
+    end
+
+    context "answer starting part way through the leave year" do
+      setup do
+        add_response "starting"
+      end
+      should "ask for the employment start date" do
+        assert_current_node :what_is_your_starting_date?
+      end
+      context "answer June 1st this year" do
+        setup do
+          add_response "#{Date.today.year}-06-01"
+        end
+        should "ask when the leave year started" do
+          assert_current_node :when_does_your_leave_year_start?
+        end
+        context "answer Jan 1st this year" do
+          setup do
+            add_response "#{Date.today.year}-01-01"
+          end
+          should "calculate the holiday entitlement" do
+            SmartAnswer::Calculators::HolidayEntitlement.
+              expects(:new).
+              with(
+                start_date: Date.parse("#{Date.today.year}-06-01"),
+                leaving_date: nil,
+                leave_year_start_date: Date.parse("#{Date.today.year}-01-01"),
+              ).returns(@stubbed_calculator)
+            @stubbed_calculator.expects(:formatted_full_time_part_time_weeks).returns("3.27")
+
+            assert_current_node :irregular_and_annualised_done
+            assert_state_variable "holiday_entitlement", "3.27"
+          end
+        end
+      end
+    end
+
+    context "answer leaving part way through the leave year" do
+      setup do
+        add_response "leaving"
+      end
+      should "ask for the employment end date" do
+        assert_current_node :what_is_your_leaving_date?
+      end
+      context "answer June 1st this year" do
+        setup do
+          add_response "#{Date.today.year}-06-01"
+        end
+        should "ask when the leave year started" do
+          assert_current_node :when_does_your_leave_year_start?
+        end
+        context "answer Jan 01 this year" do
+          setup do
+            add_response "#{Date.today.year}-01-01"
+          end
+
+          should "calculate the holiday entitlement" do
+            SmartAnswer::Calculators::HolidayEntitlement.
+              expects(:new).
+              with(
+                start_date: nil,
+                leaving_date: Date.parse("#{Date.today.year}-06-01"),
+                leave_year_start_date: Date.parse("#{Date.today.year}-01-01"),
+              ).returns(@stubbed_calculator)
+            @stubbed_calculator.expects(:formatted_full_time_part_time_weeks).returns("2.34")
+
+            assert_state_variable "holiday_entitlement", "2.34"
+            assert_current_node :irregular_and_annualised_done
+          end
+        end
+      end
+    end
+
+    context "starting and leaving within a leave year" do
+      setup do
+        add_response "starting-and-leaving"
+      end
+      should "ask what was the employment start date" do
+        assert_current_node :what_is_your_starting_date?
+      end
+      context "answer Jan 20th this year" do
+        setup do
+          add_response "#{Date.today.year}-01-20"
+        end
+        should "ask what date employment finished" do
+          assert_current_node :what_is_your_leaving_date?
+        end
+        context "answer June 18th this year" do
+          setup do
+            add_response "#{Date.today.year}-07-18"
+          end
+          should "calculate the holiday entitlement" do
+            SmartAnswer::Calculators::HolidayEntitlement
+              .expects(:new)
+              .with(
+                start_date: Date.parse("#{Date.today.year}-01-20"),
+                leaving_date: Date.parse("#{Date.today.year}-07-18"),
+                leave_year_start_date: nil,
+              ).returns(@stubbed_calculator)
+            @stubbed_calculator.expects(:formatted_full_time_part_time_weeks).returns("2.77")
+
+            assert_state_variable "holiday_entitlement", "2.77"
+            assert_current_node :irregular_and_annualised_done
+          end
+        end
+      end
+    end
+  end # irregular hours
+
+  context "annualised hours" do
+    setup do
+      add_response "annualised-hours"
+    end
+    should "ask the time period for the calculation" do
+      assert_current_node :calculation_period?
+    end
+
+    context "answer full leave year" do
+      setup do
+        add_response "full-year"
+      end
+      should "calculate the holiday entitlement" do
+        SmartAnswer::Calculators::HolidayEntitlement
+          .expects(:new)
+          .with(
+            start_date: nil,
+            leaving_date: nil,
+            leave_year_start_date: nil
+          ).returns(@stubbed_calculator)
+        @stubbed_calculator.expects(:formatted_full_time_part_time_weeks).returns("5.6")
+
+        assert_state_variable "holiday_entitlement", "5.6"
+        assert_current_node :irregular_and_annualised_done
+      end
+    end
+
+    context "answer starting part way through the leave year" do
+      setup do
+        add_response "starting"
+      end
+      should "ask for the employment start date" do
+        assert_current_node :what_is_your_starting_date?
+      end
+      context "answer June 1st this year" do
+        setup do
+          add_response "#{Date.today.year}-06-01"
+        end
+        should "ask when the leave year started" do
+          assert_current_node :when_does_your_leave_year_start?
+        end
+        context "answer Jan 1st this year" do
+          setup do
+            add_response "#{Date.today.year}-01-01"
+          end
+          should "calculate the holiday entitlement" do
+            SmartAnswer::Calculators::HolidayEntitlement.
+              expects(:new).
+              with(
+                start_date: Date.parse("#{Date.today.year}-06-01"),
+                leaving_date: nil,
+                leave_year_start_date: Date.parse("#{Date.today.year}-01-01"),
+              ).returns(@stubbed_calculator)
+            @stubbed_calculator.expects(:formatted_full_time_part_time_weeks).returns("3.27")
+
+            assert_current_node :irregular_and_annualised_done
+            assert_state_variable "holiday_entitlement", "3.27"
+          end
+        end
+      end
+    end
+
+    context "answer leaving part way through the leave year" do
+      setup do
+        add_response "leaving"
+      end
+      should "ask for the employment end date" do
+        assert_current_node :what_is_your_leaving_date?
+      end
+      context "answer June 1st this year" do
+        setup do
+          add_response "#{Date.today.year}-06-01"
+        end
+        should "ask when the leave year started" do
+          assert_current_node :when_does_your_leave_year_start?
+        end
+        context "answer Jan 01 this year" do
+          setup do
+            add_response "#{Date.today.year}-01-01"
+          end
+
+          should "calculate the holiday entitlement" do
+            SmartAnswer::Calculators::HolidayEntitlement.
+              expects(:new).
+              with(
+                start_date: nil,
+                leaving_date: Date.parse("#{Date.today.year}-06-01"),
+                leave_year_start_date: Date.parse("#{Date.today.year}-01-01"),
+              ).returns(@stubbed_calculator)
+            @stubbed_calculator.expects(:formatted_full_time_part_time_weeks).returns("2.34")
+
+            assert_state_variable "holiday_entitlement", "2.34"
+            assert_current_node :irregular_and_annualised_done
+          end
+        end
+      end
+    end
+
+    context "starting and leaving within a leave year" do
+      setup do
+        add_response "starting-and-leaving"
+      end
+      should "ask what was the employment start date" do
+        assert_current_node :what_is_your_starting_date?
+      end
+      context "answer Jan 20th this year" do
+        setup do
+          add_response "#{Date.today.year}-01-20"
+        end
+        should "ask what date employment finished" do
+          assert_current_node :what_is_your_leaving_date?
+        end
+        context "answer June 18th this year" do
+          setup do
+            add_response "#{Date.today.year}-07-18"
+          end
+          should "calculate the holiday entitlement" do
+            SmartAnswer::Calculators::HolidayEntitlement
+              .expects(:new)
+              .with(
+                start_date: Date.parse("#{Date.today.year}-01-20"),
+                leaving_date: Date.parse("#{Date.today.year}-07-18"),
+                leave_year_start_date: nil,
+              ).returns(@stubbed_calculator)
+            @stubbed_calculator.expects(:formatted_full_time_part_time_weeks).returns("2.77")
+
+            assert_state_variable "holiday_entitlement", "2.77"
+            assert_current_node :irregular_and_annualised_done
+          end
+        end
+      end
+    end
+  end #annualised hours
+
   context "shift worker" do
     setup do
       add_response "shift-worker"


### PR DESCRIPTION
`annualised` and `irregular` hours are actually the same calculations, so have a shared flow.

(Trello)[https://trello.com/c/lVBGXi8r/1469-8-create-the-irregular-hours-and-annualised-hours-flow-for-the-holiday-entitlement-calculator]

Screenshots of "irregular hours" outcomes:

Full year: `calculate-your-holiday-entitlement/y/irregular-hours/full-year`
<img width="559" alt="Screenshot 2019-11-05 at 13 38 04" src="https://user-images.githubusercontent.com/13475227/68212518-94ba5d00-ffd1-11e9-82ba-e474cae155ee.png">

Starting partway through a year: `calculate-your-holiday-entitlement/y/irregular-hours/starting/2019-06-01/2019-01-01`
<img width="523" alt="Screenshot 2019-11-05 at 13 27 14" src="https://user-images.githubusercontent.com/13475227/68211723-05607a00-ffd0-11e9-8088-bf0f7675cb1a.png">

Leaving partway thorough a year: `/calculate-your-holiday-entitlement/y/irregular-hours/leaving/2019-06-01/2019-01-01`
<img width="567" alt="Screenshot 2019-11-05 at 13 28 39" src="https://user-images.githubusercontent.com/13475227/68211825-393b9f80-ffd0-11e9-8fd8-7b6c86025447.png">

Starting and leaving through a year: `calculate-your-holiday-entitlement/y/irregular-hours/starting-and-leaving/2019-01-20/2019-07-18`
<img width="565" alt="Screenshot 2019-11-05 at 13 31 15" src="https://user-images.githubusercontent.com/13475227/68211993-920b3800-ffd0-11e9-8645-777890da63b8.png">


