### PR TITLE
Correct linting errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,3 +10,4 @@ Metrics/BlockLength:
     - 'lib/tasks/**/*.rake'
     - 'lib/smart_answer_flows/**/*.rb'
     - 'test/**/*.rb'
+    - 'spec/**/*.rb'

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
@@ -293,7 +293,7 @@ module SmartAnswer
           Calculators::HolidayEntitlement.new(
             start_date: start_date,
             leave_year_start_date: leave_year_start_date,
-            leaving_date: leaving_date
+            leaving_date: leaving_date,
           )
         end
         precalculate :holiday_entitlement do

--- a/spec/integration/smart_answer_flows/calculate_your_holiday_entitlement_spec.rb
+++ b/spec/integration/smart_answer_flows/calculate_your_holiday_entitlement_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe(SmartAnswer::CalculateYourHolidayEntitlementFlow) do
                 working_days_per_week: working_days_per_week,
                 start_date: nil,
                 leaving_date: nil,
-                leave_year_start_date: nil
+                leave_year_start_date: nil,
               )
               .and_return(calculator_instance)
             expect(calculator_instance).to receive(:formatted_full_time_part_time_days)
@@ -82,7 +82,7 @@ RSpec.describe(SmartAnswer::CalculateYourHolidayEntitlementFlow) do
                 working_days_per_week: working_days_per_week,
                 start_date: Date.parse(start_date),
                 leaving_date: nil,
-                leave_year_start_date: Date.parse(leave_year_start_date)
+                leave_year_start_date: Date.parse(leave_year_start_date),
               )
               .and_return(calculator_instance)
             expect(calculator_instance).to receive(:formatted_full_time_part_time_days)
@@ -131,7 +131,7 @@ RSpec.describe(SmartAnswer::CalculateYourHolidayEntitlementFlow) do
                 working_days_per_week: working_days_per_week,
                 start_date: nil,
                 leaving_date: Date.parse(leaving_date),
-                leave_year_start_date: Date.parse(leave_year_start_date)
+                leave_year_start_date: Date.parse(leave_year_start_date),
               )
               .and_return(calculator_instance)
             expect(calculator_instance).to receive(:formatted_full_time_part_time_days)
@@ -180,7 +180,7 @@ RSpec.describe(SmartAnswer::CalculateYourHolidayEntitlementFlow) do
                 working_days_per_week: working_days_per_week,
                 start_date: Date.parse(start_date),
                 leaving_date: Date.parse(leaving_date),
-                leave_year_start_date: nil
+                leave_year_start_date: nil,
               )
               .and_return(calculator_instance)
             expect(calculator_instance).to receive(:formatted_full_time_part_time_days)

--- a/test/integration/smart_answer_flows/calculate_your_holiday_entitlement_test.rb
+++ b/test/integration/smart_answer_flows/calculate_your_holiday_entitlement_test.rb
@@ -410,7 +410,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
           .with(
             start_date: nil,
             leaving_date: nil,
-            leave_year_start_date: nil
+            leave_year_start_date: nil,
           ).returns(@stubbed_calculator)
         @stubbed_calculator.expects(:formatted_full_time_part_time_weeks).returns("5.6")
 
@@ -544,7 +544,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
           .with(
             start_date: nil,
             leaving_date: nil,
-            leave_year_start_date: nil
+            leave_year_start_date: nil,
           ).returns(@stubbed_calculator)
         @stubbed_calculator.expects(:formatted_full_time_part_time_weeks).returns("5.6")
 

--- a/test/integration/smart_answer_flows/flow_test_helper.rb
+++ b/test/integration/smart_answer_flows/flow_test_helper.rb
@@ -41,7 +41,7 @@ module FlowTestHelper
     assert_equal node_name, current_state.current_node
     assert @flow.node_exists?(node_name), "Node #{node_name} does not exist."
     if opts[:error]
-      assert_current_node_is_error(opts[:error].is_a?(Class) ? "#{opts[:error]}" : nil)
+      assert_current_node_is_error(opts[:error].is_a?(Class) ? opts[:error].to_s : nil)
     else
       assert_not_error
     end


### PR DESCRIPTION
Linting errors are preventing us from seeing the actual output from the new tests.