### PR TITLE
Edit childcare tax credit payment questions

### DIFF
--- a/lib/smart_answer_flows/childcare-costs-for-tax-credits.rb
+++ b/lib/smart_answer_flows/childcare-costs-for-tax-credits.rb
@@ -135,13 +135,13 @@ module SmartAnswer
 
       #Q9
       money_question :how_much_12_months_2? do
-        calculate :weekly_cost do |response|
+        calculate :new_weekly_costs do |response|
           Calculators::ChildcareCostCalculator.weekly_cost(response)
         end
 
         next_node do |response|
           amount = SmartAnswer::Money.new(response)
-          amount == 0 ? outcome(:no_longer_paying) : question(:old_weekly_amount_1?) # rubocop:disable Style/NumericPredicate
+          amount == 0 ? outcome(:no_longer_paying) : question(:old_monthly_amount?) # rubocop:disable Style/NumericPredicate
         end
       end
 
@@ -280,7 +280,7 @@ module SmartAnswer
 
         next_node do |response|
           amount = SmartAnswer::Money.new(response)
-          amount == 0 ? outcome(:no_longer_paying) : question(:old_weekly_amount_3?) # rubocop:disable Style/NumericPredicate
+          amount == 0 ? outcome(:no_longer_paying) : question(:old_monthly_amount?) # rubocop:disable Style/NumericPredicate
         end
       end
 
@@ -306,9 +306,9 @@ module SmartAnswer
       end
 
       #Q21
-      money_question :old_weekly_amount_3? do
+      money_question :old_monthly_amount? do
         calculate :old_weekly_costs do |response|
-          Float(response).ceil
+          Calculators::ChildcareCostCalculator.weekly_cost_from_monthly(response)
         end
 
         calculate :weekly_difference do

--- a/lib/smart_answer_flows/childcare-costs-for-tax-credits/questions/old_monthly_amount.govspeak.erb
+++ b/lib/smart_answer_flows/childcare-costs-for-tax-credits/questions/old_monthly_amount.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :title do %>
-  What was the old average weekly amount you gave the Tax Credit Office?
+  What was the old monthly amount you gave the Tax Credit Office?
 <% end %>
 
 <% content_for :hint do %>

--- a/test/integration/smart_answer_flows/childcare_costs_for_tax_credits_test.rb
+++ b/test/integration/smart_answer_flows/childcare_costs_for_tax_credits_test.rb
@@ -310,13 +310,13 @@ class ChildcareCostsForTaxCreditsTest < ActiveSupport::TestCase
     should "take the user to Q21 if they give an answer" do
       add_response 4
       assert_state_variable :new_weekly_costs, 1
-      assert_current_node :old_weekly_amount_3?
+      assert_current_node :old_monthly_amount?
     end
 
     context "answering Q21" do
       setup do
         add_response 4 # Q19
-        add_response 10
+        add_response 40
       end
 
       should "calculate old costs and difference" do


### PR DESCRIPTION
Two scenarios were confusing for users as we were asking for monthly
costs in a question and weekly costs in the next question.

With these changes, we now ask for monthly costs in both questions.

Trello card: https://trello.com/c/hK9ByAB0/1535-2-tax-credits-calculator-working-out-your-childcare-costs-content-requests

Co-authored-by: Ed Kerry <edward.kerry@digital.cabinet-office.gov.uk>
Co-authored-by: Alan Gabbianelli <alan.gabbianelli@digital.cabinet-office.gov.uk>

Previously closed in https://github.com/alphagov/smart-answers/pull/4069