### PR TITLE
Update shifts flow

### DIFF
--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
@@ -85,7 +85,7 @@ module SmartAnswer
         end
       end
 
-      # Q5 - Q13 - Q21 - Q29 - Q37
+      # Q5 - Q13 - Q21 - Q29 - Q30 - Q37
       date_question :what_is_your_leaving_date? do
         from { Date.civil(1.year.ago.year, 1, 1) }
         to { Date.civil(1.year.since(Date.today).year, 12, 31) }
@@ -109,7 +109,7 @@ module SmartAnswer
         end
       end
 
-      # Q6 - Q14 - Q22 - Q38
+      # Q6 - Q14 - Q22 - Q31 - Q38
       date_question :when_does_your_leave_year_start? do
         from { Date.civil(1.year.ago.year, 1, 1) }
         to { Date.civil(1.year.since(Date.today).year, 12, 31) }
@@ -225,7 +225,7 @@ module SmartAnswer
           )
         end
         precalculate :holiday_entitlement_shifts do
-          calculator.rounded_shift_entitlement
+          calculator.shift_entitlement
         end
       end
 

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
@@ -70,7 +70,7 @@ module SmartAnswer
         end
       end
 
-      # Q4 - Q12 - Q20 - Q36
+      # Q4 - Q12 - Q20 - Q29 - Q36
       date_question :what_is_your_starting_date? do
         from { Date.civil(1.year.ago.year, 1, 1) }
         to { Date.civil(1.year.since(Date.today).year, 12, 31) }
@@ -85,7 +85,7 @@ module SmartAnswer
         end
       end
 
-      # Q5 - Q13 - Q21 - Q37
+      # Q5 - Q13 - Q21 - Q29 - Q37
       date_question :what_is_your_leaving_date? do
         from { Date.civil(1.year.ago.year, 1, 1) }
         to { Date.civil(1.year.since(Date.today).year, 12, 31) }
@@ -174,7 +174,7 @@ module SmartAnswer
         end
       end
 
-      # Q26
+      # Q26 - Q32
       value_question :shift_worker_hours_per_shift?, parse: Float do
         calculate :hours_per_shift do |response|
           hours_per_shift = response
@@ -187,7 +187,7 @@ module SmartAnswer
         end
       end
 
-      # Q27
+      # Q27 - Q33
       value_question :shift_worker_shifts_per_shift_pattern?, parse: Integer do
         calculate :shifts_per_shift_pattern do |response|
           shifts = response
@@ -200,7 +200,7 @@ module SmartAnswer
         end
       end
 
-      # Q28
+      # Q28 - Q34
       value_question :shift_worker_days_per_shift_pattern?, parse: Float do
         calculate :days_per_shift_pattern do |response|
           days = response

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
@@ -174,6 +174,7 @@ module SmartAnswer
         end
       end
 
+      # Q26
       value_question :shift_worker_hours_per_shift?, parse: Float do
         calculate :hours_per_shift do |response|
           hours_per_shift = response
@@ -186,6 +187,7 @@ module SmartAnswer
         end
       end
 
+      # Q27
       value_question :shift_worker_shifts_per_shift_pattern?, parse: Integer do
         calculate :shifts_per_shift_pattern do |response|
           shifts = response
@@ -198,6 +200,7 @@ module SmartAnswer
         end
       end
 
+      # Q28
       value_question :shift_worker_days_per_shift_pattern?, parse: Float do
         calculate :days_per_shift_pattern do |response|
           days = response
@@ -217,16 +220,12 @@ module SmartAnswer
             start_date: start_date,
             leaving_date: leaving_date,
             leave_year_start_date: leave_year_start_date,
-            hours_per_shift: hours_per_shift,
             shifts_per_shift_pattern: shifts_per_shift_pattern,
             days_per_shift_pattern: days_per_shift_pattern,
           )
         end
         precalculate :holiday_entitlement_shifts do
-          calculator.formatted_shift_entitlement
-        end
-        precalculate :hours_per_shift do
-          calculator.strip_zeros hours_per_shift
+          calculator.rounded_shift_entitlement
         end
       end
 

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/_shift_worker_your_employer_with_rounding.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/_shift_worker_your_employer_with_rounding.govspeak.erb
@@ -1,0 +1,5 @@
+The employer:
+
+* can include public and bank holidays as part of the statutory entitlement
+* can give more paid holiday - this will be in the employment contract and is called 'contractual leave entitlement'
+* must provide [holiday pay](/holiday-entitlement-rights/holiday-pay-the-basics "Holiday pay") during the statutory leave

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/shift_worker_done.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/shift_worker_done.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :body do %>
   $!The statutory holiday entitlement is <%= "#{holiday_entitlement_shifts} #{'shift'.pluralize(holiday_entitlement_shifts)}" %> for the year. Each shift being <%= "#{hours_per_shift} #{'hour'.pluralize(hours_per_shift)}" %>.$!
 
-  <%= render partial: 'your_employer_with_rounding.govspeak.erb' %>
+  <%= render partial: 'shift_worker_your_employer_with_rounding.govspeak.erb' %>
 <% end %>

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/shift_worker_done.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/shift_worker_done.govspeak.erb
@@ -2,4 +2,7 @@
   $!The statutory holiday entitlement is <%= "#{holiday_entitlement_shifts} #{'shift'.pluralize(holiday_entitlement_shifts)}" %> for the year. Each shift being <%= "#{hours_per_shift} #{'hour'.pluralize(hours_per_shift)}" %>.$!
 
   <%= render partial: 'shift_worker_your_employer_with_rounding.govspeak.erb' %>
+  <% if holiday_period == "starting" %>
+    <%= render partial: "the_user_should_be_aware.govspeak.erb" %>
+  <% end %>
 <% end %>

--- a/test/integration/smart_answer_flows/calculate_your_holiday_entitlement_test.rb
+++ b/test/integration/smart_answer_flows/calculate_your_holiday_entitlement_test.rb
@@ -942,7 +942,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
                   shifts_per_shift_pattern: 8,
                   days_per_shift_pattern: 14,
                 ).returns(@stubbed_calculator)
-              @stubbed_calculator.expects(:rounded_shift_entitlement).returns(22.40)
+              @stubbed_calculator.expects(:shift_entitlement).returns(22.40)
 
               assert_current_node :shift_worker_done
 
@@ -1015,7 +1015,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
                     shifts_per_shift_pattern: 8,
                     days_per_shift_pattern: 14,
                   ).returns(@stubbed_calculator)
-                  @stubbed_calculator.expects(:rounded_shift_entitlement).returns(13.5)
+                  @stubbed_calculator.expects(:shift_entitlement).returns(13.5)
 
                   assert_current_node :shift_worker_done
 
@@ -1036,13 +1036,13 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
         add_response "leaving"
       end
 
-      should "ask your leaving date" do
+      should "ask for the employment leaving date" do
         assert_current_node :what_is_your_leaving_date?
       end
 
       context "with a date" do
         setup do
-          add_response "#{Date.today.year}-02-16"
+          add_response "#{Date.today.year}-06-01"
         end
 
         should "ask when your leave year starts" do
@@ -1051,48 +1051,56 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
 
         context "with a leave year start date" do
           setup do
-            add_response "#{Date.today.year}-08-01"
+            add_response "#{Date.today.year}-01-01"
           end
 
           should "ask how many hours in each shift" do
             assert_current_node :shift_worker_hours_per_shift?
           end
 
-          should "ask how many shifts per shift pattern" do
-            add_response "8"
-            assert_current_node :shift_worker_shifts_per_shift_pattern?
-          end
+          context "answer 6 hours" do
+            setup do
+              add_response "6"
+            end
 
-          should "ask how many days per shift pattern" do
-            add_response "8"
-            add_response "4"
-            assert_current_node :shift_worker_days_per_shift_pattern?
-          end
+            should "ask how many shifts per shift pattern" do
+              assert_current_node :shift_worker_shifts_per_shift_pattern?
+            end
 
-          should "be done when all entered" do
-            add_response "7"
-            add_response "4"
-            add_response "8"
+            context "answer 8 shifts" do
+              setup do
+                add_response "8"
+              end
 
-            SmartAnswer::Calculators::HolidayEntitlement
-              .expects(:new)
-              .with(
-                start_date: nil,
-                leaving_date: Date.parse("#{Date.today.year}-02-16"),
-                leave_year_start_date: Date.parse("#{Date.today.year}-08-01"),
-                hours_per_shift: 7,
-                shifts_per_shift_pattern: 4,
-                days_per_shift_pattern: 8,
-              ).returns(@stubbed_calculator)
-            @stubbed_calculator.expects(:formatted_shift_entitlement).returns("some shifts")
+              should "ask how many days per shift pattern" do
+                assert_current_node :shift_worker_days_per_shift_pattern?
+              end
 
-            assert_current_node :shift_worker_done
+              context "answer 14 days" do
+                setup do
+                  add_response "14"
+                end
+                should "calculate the holiday entitlement" do
+                  SmartAnswer::Calculators::HolidayEntitlement
+                  .expects(:new)
+                  .with(
+                    start_date: nil,
+                    leaving_date: Date.parse("#{Date.today.year}-06-01"),
+                    leave_year_start_date: Date.parse("#{Date.today.year}-01-01"),
+                    shifts_per_shift_pattern: 8,
+                    days_per_shift_pattern: 14,
+                  ).returns(@stubbed_calculator)
+                  @stubbed_calculator.expects(:shift_entitlement).returns(9.33)
 
-            assert_state_variable :hours_per_shift, "7"
-            assert_state_variable :shifts_per_shift_pattern, 4
-            assert_state_variable :days_per_shift_pattern, 8
+                  assert_current_node :shift_worker_done
 
-            assert_state_variable :holiday_entitlement_shifts, "some shifts"
+                  assert_state_variable :hours_per_shift, 6
+                  assert_state_variable :shifts_per_shift_pattern, 8
+                  assert_state_variable :days_per_shift_pattern, 14
+                  assert_state_variable :holiday_entitlement_shifts, 9.33
+                end
+              end
+            end
           end
         end # with a leave year start date
       end # with a date

--- a/test/integration/smart_answer_flows/calculate_your_holiday_entitlement_test.rb
+++ b/test/integration/smart_answer_flows/calculate_your_holiday_entitlement_test.rb
@@ -906,7 +906,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
       assert_current_node :shift_worker_basis?
     end
 
-    context "answer full year year" do
+    context "answer full leave year" do
       setup do
         add_response "full-year"
       end
@@ -1005,7 +1005,6 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
                   add_response "14"
                 end
                 should "calculate the holiday entitlement" do
-
                   SmartAnswer::Calculators::HolidayEntitlement
                   .expects(:new)
                   .with(


### PR DESCRIPTION
The final flow in this series.

See individual commit messages for more context.

Trello card: https://trello.com/c/hTMfP27m/1468-8-update-the-shifts-flow-for-the-holiday-entitlement-calculator

Paired with @edwardkerry 

Screenshots of "Shifts" outcomes:

Full leave year - `/y/shift-worker/full-year/6.0/8/14.0`
![:y:shift-worker:full-year:6 0:8:14 0](https://user-images.githubusercontent.com/19667619/68312831-89d3fb00-00ab-11ea-9a82-9be17fe53041.png)

Starting part way through a leave year - `/y/shift-worker/starting/2019-06-01/2019-01-01/6.0/8/14.0`
![:y:shift-worker:starting:2019-06-01:2019-01-01:6 0:8:14 0](https://user-images.githubusercontent.com/19667619/68312895-a1ab7f00-00ab-11ea-8c20-a1172c1b8c0b.png)

Leaving part way through a leave year - `/y/shift-worker/leaving/2019-06-01/2019-01-01/6.0/8/14.0`
![:y:shift-worker:leaving:2019-06-01:2019-01-01:6 0:8:14 0](https://user-images.githubusercontent.com/19667619/68312933-b12ac800-00ab-11ea-867f-cbe373132c92.png)

Starting and leaving part way through a leave year - `/y/shift-worker/starting-and-leaving/2019-01-20/2019-07-18/6.0/8/14.0`
![:y:shift-worker:starting-and-leaving:2019-01-20:2019-07-18:6 0:8:14 0](https://user-images.githubusercontent.com/19667619/68312967-bee04d80-00ab-11ea-9eb5-7818bda1b0e8.png)

