### PR TITLE
Fix shift additional message

### DIFF
--- a/lib/smart_answer/calculators/holiday_entitlement.rb
+++ b/lib/smart_answer/calculators/holiday_entitlement.rb
@@ -140,11 +140,11 @@ module SmartAnswer::Calculators
       started_after_year_began? ? (pro_rated_shifts * 2).ceil / 2.0 : pro_rated_shifts
     end
 
-  private
-
     def shifts_per_week
       (shifts_per_shift_pattern / days_per_shift_pattern * DAYS_PER_WEEK).round(10)
     end
+
+  private
 
     def calculate_leave_year_start_date
       leaving_date ? leaving_date.beginning_of_year : Date.today.beginning_of_year

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
@@ -227,6 +227,9 @@ module SmartAnswer
         precalculate :holiday_entitlement_shifts do
           calculator.shift_entitlement
         end
+        precalculate :shifts_per_week do
+          calculator.shifts_per_week
+        end
       end
 
       outcome :days_per_week_done do


### PR DESCRIPTION
In order for this message to be displayed (https://github.com/alphagov/smart-answers/pull/4175/commits/ea56bd78af03a5a159a6d0c516b39fcf247170e6) it requires one of the
methods which is currently private.

`/y/shift-worker/full-year/36.0/12/14.0`
<img width="661" alt="Screenshot 2019-11-08 at 10 52 45" src="https://user-images.githubusercontent.com/19667619/68471891-1949ed00-0217-11ea-99aa-8c5bd2cabb07.png">
