### PR TITLE
Fix money formatting and feedback in Maternity/Paternity/Adoption calculator

### DIFF
--- a/app/presenters/money_question_presenter.rb
+++ b/app/presenters/money_question_presenter.rb
@@ -6,7 +6,7 @@ class MoneyQuestionPresenter < QuestionPresenter
   end
 
   def hint_text
-    text = [body, "in £", suffix_label].reject(&:blank?).compact.join(", ")
+    text = [body, suffix_label].reject(&:blank?).compact.join(", ")
     ActionView::Base.full_sanitizer.sanitize(text)
   end
 end

--- a/lib/smart_answer/money.rb
+++ b/lib/smart_answer/money.rb
@@ -27,7 +27,11 @@ module SmartAnswer
     end
 
     def self.parse(raw_input)
-      raw_input.is_a?(Numeric) ? raw_input : raw_input.to_s.delete(",").gsub(/\s/, "")
+      if raw_input.is_a?(Numeric)
+        raw_input
+      else
+        raw_input.to_s.delete(",").gsub(/\s/, "").gsub(/£/, "")
+      end
     end
 
     def self.validate!(input)

--- a/lib/smart_answer_flows/maternity-paternity-calculator/questions/_earnings_question_error_message.govspeak.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/questions/_earnings_question_error_message.govspeak.erb
@@ -1,0 +1,3 @@
+<% content_for :error_message do %>
+  Use numbers like 12.34
+<% end %>

--- a/lib/smart_answer_flows/maternity-paternity-calculator/questions/earnings_for_pay_period.govspeak.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/questions/earnings_for_pay_period.govspeak.erb
@@ -5,3 +5,7 @@
 <% content_for :hint do %>
   This is their earnings before deductions like PAYE, pension or National Insurance contributions.
 <% end %>
+
+<% content_for :error_message do %>
+  Use numbers like 12.34
+<% end %>

--- a/lib/smart_answer_flows/maternity-paternity-calculator/questions/earnings_for_pay_period.govspeak.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/questions/earnings_for_pay_period.govspeak.erb
@@ -6,6 +6,4 @@
   This is their earnings before deductions like PAYE, pension or National Insurance contributions.
 <% end %>
 
-<% content_for :error_message do %>
-  Use numbers like 12.34
-<% end %>
+<%= render partial: 'earnings_question_error_message.govspeak.erb' %>

--- a/lib/smart_answer_flows/maternity-paternity-calculator/questions/earnings_for_pay_period_adoption.govspeak.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/questions/earnings_for_pay_period_adoption.govspeak.erb
@@ -6,6 +6,4 @@
   This is their earnings before deductions like PAYE, pension or National Insurance contributions.
 <% end %>
 
-<% content_for :error_message do %>
-  Use numbers like 12.34
-<% end %>
+<%= render partial: 'earnings_question_error_message.govspeak.erb' %>

--- a/lib/smart_answer_flows/maternity-paternity-calculator/questions/earnings_for_pay_period_adoption.govspeak.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/questions/earnings_for_pay_period_adoption.govspeak.erb
@@ -7,5 +7,5 @@
 <% end %>
 
 <% content_for :error_message do %>
-  Please enter a number greater than 0
+  Use numbers like 12.34
 <% end %>

--- a/lib/smart_answer_flows/maternity-paternity-calculator/questions/earnings_for_pay_period_paternity.govspeak.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/questions/earnings_for_pay_period_paternity.govspeak.erb
@@ -6,6 +6,4 @@
   This is the earnings before deductions like PAYE, pension or National Insurance contributions.
 <% end %>
 
-<% content_for :error_message do %>
-  Use numbers like 12.34
-<% end %>
+<%= render partial: 'earnings_question_error_message.govspeak.erb' %>

--- a/lib/smart_answer_flows/maternity-paternity-calculator/questions/earnings_for_pay_period_paternity.govspeak.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/questions/earnings_for_pay_period_paternity.govspeak.erb
@@ -5,3 +5,7 @@
 <% content_for :hint do %>
   This is the earnings before deductions like PAYE, pension or National Insurance contributions.
 <% end %>
+
+<% content_for :error_message do %>
+  Use numbers like 12.34
+<% end %>

--- a/test/unit/money_test.rb
+++ b/test/unit/money_test.rb
@@ -24,6 +24,11 @@ module SmartAnswer
       assert two == 2000
     end
 
+    test "Values with £ sign are stripped out and parsed correctly" do
+      salary = SmartAnswer::Money.new("£15000")
+      assert salary == 15000
+    end
+
     test "should be possible to initialize with a BigDecimal" do
       v = BigDecimal("1234.5678")
       money = SmartAnswer::Money.new(v)


### PR DESCRIPTION
Content Support have identified issues with the feedback when interacting with the earnings question for this Smart Answer. Some of this feedback has come from users.

Content changes provided by Content Support.

Trello: https://trello.com/c/Nofkcp6B

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/424772/68585584-8f01c300-047a-11ea-8a08-bfbf675fe215.png)


### After
(Note the `x` is because `£15,000` is now valid)

![Screenshot at Nov 11 2-25-10 pm](https://user-images.githubusercontent.com/424772/68594281-1ce7a900-048f-11ea-86af-2d76c783f5a4.png)


## TODO
- [x] Strip out £ from input
- [x] Check whether hint text can be set to £ - is it accessible? Difference in opinion?
- [x] Screenshots