### PR TITLE
Replace `govuk-lint`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,7 @@
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
+
 AllCops:
   Exclude:
     - 'tmp/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -36,9 +36,9 @@ end
 
 group :development, :test do
   gem "byebug"
-  gem "govuk-lint"
   gem "pry"
   gem "rspec-rails", "~> 3.9.0"
+  gem "rubocop-govuk"
   gem "timecop"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,11 +104,6 @@ GEM
       sanitize (~> 5)
     govuk-content-schema-test-helpers (1.6.1)
       json-schema (~> 2.8.0)
-    govuk-lint (4.3.0)
-      rubocop (~> 0.76)
-      rubocop-rails (~> 2)
-      rubocop-rspec (~> 1.28)
-      scss_lint
     govuk_app_config (2.0.1)
       logstasher (>= 1.2.2, < 1.4.0)
       sentry-raven (>= 2.7.1, < 2.12.0)
@@ -267,6 +262,10 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-govuk (1.0.0)
+      rubocop (~> 0.76)
+      rubocop-rails (~> 2)
+      rubocop-rspec (~> 1.28)
     rubocop-rails (2.3.2)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
@@ -298,8 +297,6 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    scss_lint (0.59.0)
-      sass (~> 3.5, >= 3.5.5)
     selenium-webdriver (3.142.6)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -376,7 +373,6 @@ DEPENDENCIES
   gds-api-adapters (~> 61.0.0)
   govspeak (~> 6.5.0)
   govuk-content-schema-test-helpers (~> 1.6.1)
-  govuk-lint
   govuk_app_config
   govuk_publishing_components (= 21.10.0)
   govuk_test
@@ -398,6 +394,7 @@ DEPENDENCIES
   rails_stdout_logging
   railties
   rspec-rails (~> 3.9.0)
+  rubocop-govuk
   sass-rails (~> 5.0.7)
   shoulda (~> 3.6.0)
   simplecov (~> 0.17.1)

--- a/doc/smart-answers-app-development/continuous-integration.md
+++ b/doc/smart-answers-app-development/continuous-integration.md
@@ -7,7 +7,7 @@ The [govuk_smart_answers master build](https://ci.integration.publishing.service
 * Attempts to merge the current branch (`master`) into `master` - this should always succeed and is effectively a no-op
 * Checks out the latest [govuk-content-schemas](https://github.com/alphagov/govuk-content-schemas) which are used in a few of the tests
 * Installs the bundled gems
-* Runs govuk-lint-ruby (see [Rubocop docs](rubocop.md))
+* Runs RuboCop with the linting rules provided by the `rubocop-govuk` gem
 * Runs the `test` rake task with `TEST_COVERAGE` enabled
 * Pre-compiles assets
 


### PR DESCRIPTION
- The GOV.UK Lint gem is deprecated in favour of using Rubocop directly
  with a set of shared configs.
- See https://github.com/alphagov/govuk-rfcs/pull/ 100 for more context.

https://trello.com/c/CdBFg6yw/1521-replace-govuk-lint-with-rubocop-govuk