### PR TITLE
Holiday entitlement calculator beis edits

### DIFF
--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
@@ -211,7 +211,8 @@ module SmartAnswer
       value_question :shift_worker_hours_per_shift?, parse: Float do
         calculate :hours_per_shift do |response|
           hours_per_shift = response
-          raise InvalidResponse if hours_per_shift <= 0
+          raise InvalidResponse, :no_hours_worked if hours_per_shift <= 0
+          raise InvalidResponse, :over_24_hours_worked if hours_per_shift > 24
 
           hours_per_shift
         end

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
@@ -132,6 +132,7 @@ module SmartAnswer
             raise InvalidResponse, :end_date_outside_leave_year_range if !YearRange.new(begins_on: leave_year_start_date).include?(leaving_date)
           end
           if start_date
+            raise InvalidResponse, :start_date_before_start_leave_year_date if start_date <= leave_year_start_date
             raise InvalidResponse, :start_date_outside_leave_year_range if !YearRange.new(begins_on: leave_year_start_date).include?(start_date)
           end
           leave_year_start_date

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/_guidance_on_calculations.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/_guidance_on_calculations.govspeak.erb
@@ -1,0 +1,1 @@
+[Read detailed guidance on how holiday entitlement is calculated.](/government/publications/holiday-entitlement-calculator-temporary-replacement)

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/compressed_hours_done.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/compressed_hours_done.govspeak.erb
@@ -5,4 +5,6 @@
   <% if holiday_period == "starting" %>
     <%= render partial: "the_user_should_be_aware.govspeak.erb" %>
   <% end %>
+
+  <%= render partial: "guidance_on_calculations.govspeak.erb" %>
 <% end %>

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/days_per_week_done.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/days_per_week_done.govspeak.erb
@@ -11,4 +11,5 @@
     <%= render partial: "the_user_should_be_aware.govspeak.erb" %>
   <% end %>
 
+   <%= render partial: "guidance_on_calculations.govspeak.erb" %>
 <% end %>

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/hours_per_week_done.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/hours_per_week_done.govspeak.erb
@@ -10,4 +10,6 @@
   <% if holiday_period == "starting" %>
     <%= render partial: "the_user_should_be_aware.govspeak.erb" %>
   <% end %>
+
+  <%= render partial: "guidance_on_calculations.govspeak.erb" %>
 <% end %>

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/irregular_and_annualised_done.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/irregular_and_annualised_done.govspeak.erb
@@ -8,4 +8,6 @@
   <% else %>
     <%= render partial: 'entitlement_restriction.govspeak.erb' %>
   <% end %>
+
+  <%= render partial: "guidance_on_calculations.govspeak.erb" %>
 <% end %>

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/shift_worker_done.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/shift_worker_done.govspeak.erb
@@ -9,4 +9,6 @@
   <% if holiday_period == "starting" %>
     <%= render partial: "the_user_should_be_aware.govspeak.erb" %>
   <% end %>
+
+  <%= render partial: "guidance_on_calculations.govspeak.erb" %>
 <% end %>

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/questions/shift_worker_hours_per_shift.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/questions/shift_worker_hours_per_shift.govspeak.erb
@@ -6,6 +6,10 @@
   Hours per shift
 <% end %>
 
-<% content_for :error_message do %>
+<% content_for :no_hours_worked do %>
   You need to enter a number greater than 0. Don't enter fractions. If you work half-hours, enter .5 for half. eg 4.5
+<% end %>
+
+<% content_for :over_24_hours_worked do %>
+  24 is the maximum number of hours per shift. Don't enter fractions. If you work half-hours, enter .5 for half. eg 4.5
 <% end %>

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/questions/when_does_your_leave_year_start.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/questions/when_does_your_leave_year_start.govspeak.erb
@@ -17,6 +17,10 @@
 <% end %>
 
 <% if start_date%>
+  <% content_for :start_date_before_start_leave_year_date do %>
+    Your leave year start date must be earlier than your employment start date of <%="#{start_date.strftime('%d %B %Y')}"%>.
+  <% end%>
+
   <% content_for :start_date_outside_leave_year_range do %>
     Your employment start date of <%="#{start_date.strftime('%d %B %Y')}"%> must be within 1 year of the leave year start date.
   <% end %>

--- a/test/integration/smart_answer_flows/calculate_your_holiday_entitlement_test.rb
+++ b/test/integration/smart_answer_flows/calculate_your_holiday_entitlement_test.rb
@@ -1122,6 +1122,26 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
       should "ask how many hours in each shift" do
         assert_current_node :shift_worker_hours_per_shift?
       end
+      context "with invalid hours" do
+        context "with 0 hours" do
+          setup do
+            add_response "0"
+          end
+
+          should "present an error" do
+            assert_current_node :shift_worker_hours_per_shift?, error: true
+          end
+        end
+        context "with over 24 hours" do
+          setup do
+            add_response "25"
+          end
+
+          should "present an error" do
+            assert_current_node :shift_worker_hours_per_shift?, error: true
+          end
+        end
+      end
       context "answer 6 hours" do
         setup do
           add_response "6"


### PR DESCRIPTION
Following a departmental review, the following changes were required:

* Restricting hours per shift to 24
* Prevent an employment start date earlier than a leave year start date
* Adding a link to detailed guidance on outcome pages

[trello](https://trello.com/c/qC2HVOeC/1595-final-edits-on-holiday-calculator)