### PR TITLE
Update slimmer template

### DIFF
--- a/app/assets/stylesheets/smart_answers.scss
+++ b/app/assets/stylesheets/smart_answers.scss
@@ -67,3 +67,8 @@ $is-ie: false !default;
   @include govuk-font($size: 16);
   color: $govuk-secondary-text-colour;
 }
+
+.app-o-next-steps,
+.app-o-answer {
+  margin-bottom: govuk-spacing(6);
+}

--- a/app/assets/stylesheets/smart_answers.scss
+++ b/app/assets/stylesheets/smart_answers.scss
@@ -62,3 +62,8 @@ $is-ie: false !default;
     margin-bottom: govuk-spacing(3);
   }
 }
+
+.app-c-meta-data {
+  @include govuk-font($size: 16);
+  color: $govuk-secondary-text-colour;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
   rescue_from GdsApi::HTTPForbidden, with: :error_403
   rescue_from ActionController::UnknownFormat, with: :error_404
 
-  slimmer_template "wrapper"
+  slimmer_template "core_layout"
 
 protected
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <title><%= yield :title %> - GOV.UK</title>
     <%= stylesheet_link_tag "application", :media => "all" %>
     <%= stylesheet_link_tag "print.css", media: "print" %>
-    <title><%= yield :title %> - GOV.UK</title>
     <%= yield :head %>
-
     <% if @content_item %>
       <%= render "govuk_publishing_components/components/meta_tags",
         content_item: @content_item,
@@ -13,12 +12,10 @@
         strip_postcode_pii: true %>
     <% end %>
   </head>
-<body class="mainstream">
-  <%= yield :before_wrapper %>
-
-  <div id="wrapper" class="govuk-width-container answer smart_answer">
-    <%= yield %>
-    <%= render "govuk_publishing_components/components/feedback" %>
-  </div>
-</body>
+  <body class="govuk-template__body">
+    <div class="govuk-width-container smart_answer" id="wrapper">
+      <%= yield %>
+      <%= render "govuk_publishing_components/components/feedback" %>
+    </div>
+  </body>
 </html>

--- a/app/views/smart_answers/_previous_answers.html.erb
+++ b/app/views/smart_answers/_previous_answers.html.erb
@@ -1,8 +1,8 @@
 <% if @presenter.current_question_number > 1 %>
-  <table class="govuk-table govuk-!-margin-top-9">
+  <table class="govuk-table">
     <caption class="govuk-table__caption">
-      Previous answers
-      <p><%= link_to "Start again", smart_answer_path(params[:id]), :class => "govuk-link" %></p>
+      <h2 class="govuk-heading-m">Previous answers</h2>
+      <p class="govuk-body"><%= link_to "Start again", smart_answer_path(params[:id]), :class => "govuk-link" %></p>
     </caption>
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">

--- a/app/views/smart_answers/_smartanswer_metadata.html.erb
+++ b/app/views/smart_answers/_smartanswer_metadata.html.erb
@@ -1,9 +1,3 @@
-<div class="meta-wrapper">
-  <div class="meta-data group">
-    <div class="inner">
-      <div class="print-and-modified-date group">
-        <p class="modified-date">Last updated: <%= last_updated_date.strftime('%e %B %Y') %></p>
-      </div>
-    </div>
-  </div>
-</div>
+<p class="app-c-meta-data">
+  Last updated: <%= last_updated_date.strftime('%e %B %Y') %>
+</p>

--- a/app/views/smart_answers/question.html.erb
+++ b/app/views/smart_answers/question.html.erb
@@ -14,10 +14,9 @@
     } %>
     <%= form_tag calculate_current_question_path(@presenter), :method => :get do %>
       <div class="govuk-!-margin-top-9" id="current-question">
-        <div class="question" data-debug-template-path="<%= question.relative_erb_template_path %>">
-          <%
-            show_body = ['salary_question', 'country_select_question'].include? question.partial_template_name
-          %>
+        <div class="question govspeak-wrapper" data-debug-template-path="<%= question.relative_erb_template_path %>">
+          <% show_body = ['salary_question', 'country_select_question'].include? question.partial_template_name %>
+
           <% if question.body.present? && show_body %>
             <article role="article">
               <%= question.body %>
@@ -31,7 +30,8 @@
 
         <input type="hidden" name="next" value="1" />
         <%= render "govuk_publishing_components/components/button", {
-          text: "Next step"
+          text: "Next step",
+          margin_bottom: true
         } %>
       </div>
     <% end %>

--- a/app/views/smart_answers/question.html.erb
+++ b/app/views/smart_answers/question.html.erb
@@ -12,7 +12,7 @@
       title: @presenter.title,
       margin_bottom: 9
     } %>
-    <%= form_tag calculate_current_question_path(@presenter), :method => :get %>
+    <%= form_tag calculate_current_question_path(@presenter), :method => :get do %>
       <div class="govuk-!-margin-top-9" id="current-question">
         <div class="question" data-debug-template-path="<%= question.relative_erb_template_path %>">
           <%
@@ -34,7 +34,7 @@
           text: "Next step"
         } %>
       </div>
-    </form>
+    <% end %>
 
     <%= render 'previous_answers' %>
   </div>

--- a/app/views/smart_answers/result.html.erb
+++ b/app/views/smart_answers/result.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <div class="govuk-grid-row">
-  <div id="result-info" class="govuk-grid-column-two-thirds outcome govspeak-wrapper">
+  <div id="result-info" class="govuk-grid-column-two-thirds outcome">
     <%= render 'debug' %>
     <%= render "govuk_publishing_components/components/title", {
       title: @presenter.title
@@ -11,7 +11,7 @@
 
     <% outcome = @presenter.current_node %>
 
-    <div data-debug-template-path="<%= outcome.relative_erb_template_path %>">
+    <div class="app-o-answer govspeak-wrapper" data-debug-template-path="<%= outcome.relative_erb_template_path %>">
       <% if outcome.title.present? %>
         <%= render "govuk_publishing_components/components/heading", {
           text: outcome.title
@@ -22,11 +22,13 @@
     </div>
 
     <% if outcome.next_steps.present? %>
-      <%= render "govuk_publishing_components/components/heading", {
-        text: "Next steps"
-      } %>
+      <div class="app-o-next-steps govspeak-wrapper">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: "Next steps"
+        } %>
 
-      <%= outcome.next_steps %>
+        <%= outcome.next_steps %>
+      </div>
     <% end %>
 
     <script type="text/javascript">


### PR DESCRIPTION
Update smart-answers to not need the `wrapper` layout and use the default `core_layout`.
We're using the `govspeak-wrapper` class for sections where content comes as markup from the database.

[Trello card](https://trello.com/c/Dpe7MWQp)

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

![smart-answers-before](https://user-images.githubusercontent.com/788096/69882964-fbc5eb80-12c9-11ea-8f10-593409b121b4.png)

</td><td valign="top">

![smart-answers after](https://user-images.githubusercontent.com/788096/69883001-24e67c00-12ca-11ea-9838-7e475ddb3882.png)


</td></tr>
</table>