### PR TITLE
Show eligible student finance dependants allowances

### DIFF
--- a/lib/smart_answer/calculators/student_finance_calculator.rb
+++ b/lib/smart_answer/calculators/student_finance_calculator.rb
@@ -59,6 +59,8 @@ module SmartAnswer
         "2019-2020" => 3_007,
       }.freeze
 
+      ADULT_DEPENDANT_HOUSEHOLD_INCOME = 14_933.98
+
       TUITION_FEE_MAXIMUM = {
         "full-time" => 9_250,
         "part-time" => 6_935,
@@ -115,6 +117,10 @@ module SmartAnswer
 
       def parent_learning_allowance
         PARENTS_LEARNING_ALLOWANCE.fetch(@course_start)
+      end
+
+      def eligible_for_adult_dependant_allowance?
+        uk_ft_circumstances.include?("dependant-adult") && household_income <= ADULT_DEPENDANT_HOUSEHOLD_INCOME
       end
 
       def adult_dependant_allowance

--- a/lib/smart_answer/calculators/student_finance_calculator.rb
+++ b/lib/smart_answer/calculators/student_finance_calculator.rb
@@ -54,6 +54,8 @@ module SmartAnswer
         "2019-2020" => 1_716,
       }.freeze
 
+      PARENTS_LEARNING_HOUSEHOLD_INCOME = 18_441.98
+
       ADULT_DEPENDANT_ALLOWANCE = {
         "2018-2019" => 2_925,
         "2019-2020" => 3_007,
@@ -113,6 +115,10 @@ module SmartAnswer
 
       def childcare_grant_more_than_one_child
         CHILD_CARE_GRANTS.fetch(@course_start).fetch("more-than-one-child")
+      end
+
+      def eligible_for_parent_learning_allowance?
+        uk_ft_circumstances.include?("children-under-17") && household_income <= PARENTS_LEARNING_HOUSEHOLD_INCOME
       end
 
       def parent_learning_allowance

--- a/lib/smart_answer/calculators/student_finance_calculator.rb
+++ b/lib/smart_answer/calculators/student_finance_calculator.rb
@@ -49,6 +49,9 @@ module SmartAnswer
         },
       }.freeze
 
+      CHILD_CARE_GRANTS_ONE_CHILD_HOUSEHOLD_INCOME = 18_786.43
+      CHILD_CARE_GRANTS_MORE_THAN_ONE_CHILD_HOUSEHOLD_INCOME = 26_649.87
+
       PARENTS_LEARNING_ALLOWANCE = {
         "2018-2019" => 1_669,
         "2019-2020" => 1_716,
@@ -107,6 +110,14 @@ module SmartAnswer
 
       def reduced_maintenance_loan_for_healthcare
         REDUCED_MAINTENTANCE_LOAN_AMOUNTS.fetch(@course_start).fetch(@residence)
+      end
+
+      def eligible_for_childcare_grant_one_child?
+        uk_ft_circumstances.include?("children-under-17") && household_income <= CHILD_CARE_GRANTS_ONE_CHILD_HOUSEHOLD_INCOME
+      end
+
+      def eligible_for_childcare_grant_more_than_one_child?
+        uk_ft_circumstances.include?("children-under-17") && household_income <= CHILD_CARE_GRANTS_MORE_THAN_ONE_CHILD_HOUSEHOLD_INCOME
       end
 
       def childcare_grant_one_child

--- a/lib/smart_answer/calculators/student_finance_calculator.rb
+++ b/lib/smart_answer/calculators/student_finance_calculator.rb
@@ -24,6 +24,7 @@ module SmartAnswer
           "away-in-london" => 11_672,
         },
       }.freeze
+
       REDUCED_MAINTENTANCE_LOAN_AMOUNTS = {
         "2018-2019" => {
           "at-home" => 1744,
@@ -36,6 +37,7 @@ module SmartAnswer
           "away-outside-london" => 2389,
         },
       }.freeze
+
       CHILD_CARE_GRANTS = {
         "2018-2019" => {
           "one-child" => 164.70,
@@ -46,18 +48,22 @@ module SmartAnswer
           "more-than-one-child" => 290.27,
         },
       }.freeze
+
       PARENTS_LEARNING_ALLOWANCE = {
         "2018-2019" => 1_669,
         "2019-2020" => 1_716,
       }.freeze
+
       ADULT_DEPENDANT_ALLOWANCE = {
         "2018-2019" => 2_925,
         "2019-2020" => 3_007,
       }.freeze
+
       TUITION_FEE_MAXIMUM = {
         "full-time" => 9_250,
         "part-time" => 6_935,
       }.freeze
+
       LOAN_MINIMUMS = {
         "2018-2019" => {
           "at-home" => 3_224,
@@ -70,6 +76,7 @@ module SmartAnswer
           "away-in-london" => 5_812,
         },
       }.freeze
+
       INCOME_PENALTY_RATIO = {
         "2018-2019" => {
           "at-home" => 8.10,

--- a/lib/smart_answer/calculators/student_finance_calculator.rb
+++ b/lib/smart_answer/calculators/student_finance_calculator.rb
@@ -9,6 +9,7 @@ module SmartAnswer
         :part_time_credits,
         :full_time_credits,
         :doctor_or_dentist,
+        :uk_ft_circumstances,
       )
 
       LOAN_MAXIMUMS = {
@@ -90,6 +91,7 @@ module SmartAnswer
         @part_time_credits = params[:part_time_credits]
         @full_time_credits = params[:full_time_credits]
         @doctor_or_dentist = params[:doctor_or_dentist]
+        @uk_ft_circumstances = params.fetch(:uk_ft_circumstances, [])
       end
 
       def reduced_maintenance_loan_for_healthcare

--- a/lib/smart_answer_flows/student-finance-calculator.rb
+++ b/lib/smart_answer_flows/student-finance-calculator.rb
@@ -139,6 +139,10 @@ module SmartAnswer
           response.split(",")
         end
 
+        on_response do |response|
+          calculator.uk_ft_circumstances = response.split(",")
+        end
+
         next_node do
           question :what_course_are_you_studying?
         end

--- a/lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_uk_full_time_dental_medical_students.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_uk_full_time_dental_medical_students.govspeak.erb
@@ -10,6 +10,9 @@
 
     <% if uk_ft_circumstances.include?('children-under-17') %>
       - up to <%= format_money(calculator.childcare_grant_one_child) %> a week (1 child) or up to <%= format_money(calculator.childcare_grant_more_than_one_child) %> a week (2 or more children) [Childcare Grant](/childcare-grant)
+    <% end %>
+
+    <% if calculator.eligible_for_parent_learning_allowance? %>
       - up to <%= format_money(calculator.parent_learning_allowance) %> per year [Parents’ Learning Allowance](/parents-learning-allowance)
     <% end %>
 

--- a/lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_uk_full_time_dental_medical_students.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_uk_full_time_dental_medical_students.govspeak.erb
@@ -8,8 +8,10 @@
 
     <%= render partial: 'full_time_tuition.govspeak.erb', locals: { tuition_fee_amount: tuition_fee_amount, maintenance_loan_amount: calculator.maintenance_loan_amount, maintenance_grant_amount: calculator.maintenance_grant_amount, start_date: start_date } %>
 
-    <% if uk_ft_circumstances.include?('children-under-17') %>
-      - up to <%= format_money(calculator.childcare_grant_one_child) %> a week (1 child) or up to <%= format_money(calculator.childcare_grant_more_than_one_child) %> a week (2 or more children) [Childcare Grant](/childcare-grant)
+    <% if calculator.eligible_for_childcare_grant_one_child? %>
+      - up to 85% of your childcare costs (maximum <%= format_money(calculator.childcare_grant_one_child) %> a week for a single child or <%= format_money(calculator.childcare_grant_more_than_one_child) %> a week if you have more than one) in Childcare Grant
+    <% elsif calculator.eligible_for_childcare_grant_more_than_one_child? %>
+      - up to 85% of your childcare costs to a maximum <%= format_money(calculator.childcare_grant_more_than_one_child) %> a week in Childcare Grant if you have 2 or more children
     <% end %>
 
     <% if calculator.eligible_for_parent_learning_allowance? %>

--- a/lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_uk_full_time_dental_medical_students.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_uk_full_time_dental_medical_students.govspeak.erb
@@ -13,7 +13,7 @@
       - up to <%= format_money(calculator.parent_learning_allowance) %> per year [Parents’ Learning Allowance](/parents-learning-allowance)
     <% end %>
 
-    <% if uk_ft_circumstances.include?('dependant-adult') %>
+    <% if calculator.eligible_for_adult_dependant_allowance? %>
       - up to <%= format_money(calculator.adult_dependant_allowance) %> per year [Adult Dependant’s Grant](/adult-dependants-grant)
     <% end %>
 

--- a/lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_uk_full_time_students.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_uk_full_time_students.govspeak.erb
@@ -14,8 +14,10 @@
   <% else %>
     Depending on your income and circumstances, you could get:
 
-    <% if uk_ft_circumstances.include?('children-under-17') %>
-      - up to <%= format_money(calculator.childcare_grant_one_child) %> a week (1 child) or up to <%= format_money(calculator.childcare_grant_more_than_one_child) %> a week (2 or more children) [Childcare Grant](/childcare-grant)
+    <% if calculator.eligible_for_childcare_grant_one_child? %>
+      - up to 85% of your childcare costs (maximum <%= format_money(calculator.childcare_grant_one_child) %> a week for a single child or <%= format_money(calculator.childcare_grant_more_than_one_child) %> a week if you have more than one) in Childcare Grant
+    <% elsif calculator.eligible_for_childcare_grant_more_than_one_child? %>
+      - up to 85% of your childcare costs to a maximum <%= format_money(calculator.childcare_grant_more_than_one_child) %> a week in Childcare Grant if you have 2 or more children
     <% end %>
 
     <% if calculator.eligible_for_parent_learning_allowance? %>

--- a/lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_uk_full_time_students.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_uk_full_time_students.govspeak.erb
@@ -16,7 +16,13 @@
 
     <% if uk_ft_circumstances.include?('children-under-17') %>
       - up to <%= format_money(calculator.childcare_grant_one_child) %> a week (1 child) or up to <%= format_money(calculator.childcare_grant_more_than_one_child) %> a week (2 or more children) [Childcare Grant](/childcare-grant)
+    <% end %>
+
+    <% if calculator.eligible_for_parent_learning_allowance? %>
       - up to <%= format_money(calculator.parent_learning_allowance) %> per year [Parents’ Learning Allowance](/parents-learning-allowance)
+    <% end %>
+
+    <% if uk_ft_circumstances.include?('children-under-17') %>
       - [Child Tax Credit](/child-tax-credit)
     <% end %>
 

--- a/lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_uk_full_time_students.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_uk_full_time_students.govspeak.erb
@@ -20,7 +20,7 @@
       - [Child Tax Credit](/child-tax-credit)
     <% end %>
 
-    <% if uk_ft_circumstances.include?('dependant-adult') %>
+    <% if calculator.eligible_for_adult_dependant_allowance? %>
       - up to <%= format_money(calculator.adult_dependant_allowance) %> per year [Adult Dependant’s Grant](/adult-dependants-grant)
     <% end %>
 

--- a/lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_uk_full_time_students.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_uk_full_time_students.govspeak.erb
@@ -12,7 +12,7 @@
   <% if uk_ft_circumstances.include?('no') && course_studied == 'none-of-the-above' %>
     You don’t qualify for extra grants and allowances.
   <% else %>
-    You could get:
+    Depending on your income and circumstances, you could get:
 
     <% if uk_ft_circumstances.include?('children-under-17') %>
       - up to <%= format_money(calculator.childcare_grant_one_child) %> a week (1 child) or up to <%= format_money(calculator.childcare_grant_more_than_one_child) %> a week (2 or more children) [Childcare Grant](/childcare-grant)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,8 +15,8 @@ FLOW_REGISTRY_OPTIONS[:preload_flows] = true
 
 require "rails/test_help"
 
-require "mocha/setup"
-Mocha::Configuration.prevent(:stubbing_non_existent_method)
+require "mocha/minitest"
+Mocha.configure { |c| c.stubbing_non_existent_method = :prevent }
 
 require "webmock/minitest"
 WebMock.disable_net_connect!(allow_localhost: true)

--- a/test/unit/calculators/student_finance_calculator_test.rb
+++ b/test/unit/calculators/student_finance_calculator_test.rb
@@ -66,6 +66,38 @@ module SmartAnswer
         end
       end
 
+      context "#eligible_for_parent_learning_allowance?" do
+        should "have low household income and no dependencies" do
+          calculator = StudentFinanceCalculator.new(
+            household_income: 18_441,
+          )
+          assert_not calculator.eligible_for_parent_learning_allowance?
+        end
+
+        should "have high household income and no dependencies" do
+          calculator = StudentFinanceCalculator.new(
+            household_income: 18_442,
+          )
+          assert_not calculator.eligible_for_parent_learning_allowance?
+        end
+
+        should "have low household income and adult dependant" do
+          calculator = StudentFinanceCalculator.new(
+            household_income: 18_441,
+            uk_ft_circumstances: %w(children-under-17),
+          )
+          assert calculator.eligible_for_parent_learning_allowance?
+        end
+
+        should "have high household income and adult dependant" do
+          calculator = StudentFinanceCalculator.new(
+            household_income: 18_442,
+            uk_ft_circumstances: %w(children-under-17),
+          )
+          assert_not calculator.eligible_for_parent_learning_allowance?
+        end
+      end
+
       context "#parent_learning_allowance" do
         should "be 1669 in 2018-2019" do
           calculator = StudentFinanceCalculator.new(

--- a/test/unit/calculators/student_finance_calculator_test.rb
+++ b/test/unit/calculators/student_finance_calculator_test.rb
@@ -77,6 +77,38 @@ module SmartAnswer
         end
       end
 
+      context "#eligible_for_adult_dependant_allowance?" do
+        should "have low household income and no dependencies" do
+          calculator = StudentFinanceCalculator.new(
+            household_income: 14_933,
+          )
+          assert_not calculator.eligible_for_adult_dependant_allowance?
+        end
+
+        should "have high household income and no dependencies" do
+          calculator = StudentFinanceCalculator.new(
+            household_income: 14_934,
+          )
+          assert_not calculator.eligible_for_adult_dependant_allowance?
+        end
+
+        should "have low household income and adult dependant" do
+          calculator = StudentFinanceCalculator.new(
+            household_income: 14_933,
+            uk_ft_circumstances: %w(dependant-adult),
+          )
+          assert calculator.eligible_for_adult_dependant_allowance?
+        end
+
+        should "have high household income and adult dependant" do
+          calculator = StudentFinanceCalculator.new(
+            household_income: 14_934,
+            uk_ft_circumstances: %w(dependant-adult),
+          )
+          assert_not calculator.eligible_for_adult_dependant_allowance?
+        end
+      end
+
       context "#adult_dependant_allowance" do
         should "be 2925 in 2018-2019" do
           calculator = StudentFinanceCalculator.new(

--- a/test/unit/calculators/student_finance_calculator_test.rb
+++ b/test/unit/calculators/student_finance_calculator_test.rb
@@ -39,6 +39,70 @@ module SmartAnswer
         assert_equal "uk-full-time", calculator.course_type
       end
 
+      context "#eligible_for_childcare_grant_one_child?" do
+        should "have low household income and no dependencies" do
+          calculator = StudentFinanceCalculator.new(
+            household_income: 18_786,
+          )
+          assert_not calculator.eligible_for_childcare_grant_one_child?
+        end
+
+        should "have high household income and no dependencies" do
+          calculator = StudentFinanceCalculator.new(
+            household_income: 18_787,
+          )
+          assert_not calculator.eligible_for_childcare_grant_one_child?
+        end
+
+        should "have low household income and children" do
+          calculator = StudentFinanceCalculator.new(
+            household_income: 18_786,
+            uk_ft_circumstances: %w(children-under-17),
+          )
+          assert calculator.eligible_for_childcare_grant_one_child?
+        end
+
+        should "have high household income and children" do
+          calculator = StudentFinanceCalculator.new(
+            household_income: 18_787,
+            uk_ft_circumstances: %w(children-under-17),
+          )
+          assert_not calculator.eligible_for_childcare_grant_one_child?
+        end
+      end
+
+      context "#eligible_for_childcare_grant_more_than_one_child?" do
+        should "have low household income and no dependencies" do
+          calculator = StudentFinanceCalculator.new(
+            household_income: 26_649,
+          )
+          assert_not calculator.eligible_for_childcare_grant_more_than_one_child?
+        end
+
+        should "have high household income and no dependencies" do
+          calculator = StudentFinanceCalculator.new(
+            household_income: 26_650,
+          )
+          assert_not calculator.eligible_for_childcare_grant_more_than_one_child?
+        end
+
+        should "have low household income and children" do
+          calculator = StudentFinanceCalculator.new(
+            household_income: 26_649,
+            uk_ft_circumstances: %w(children-under-17),
+          )
+          assert calculator.eligible_for_childcare_grant_more_than_one_child?
+        end
+
+        should "have high household income and children" do
+          calculator = StudentFinanceCalculator.new(
+            household_income: 26_650,
+            uk_ft_circumstances: %w(children-under-17),
+          )
+          assert_not calculator.eligible_for_childcare_grant_more_than_one_child?
+        end
+      end
+
       context "childcare_grant" do
         context "for one child" do
           context "in 2018-2019" do


### PR DESCRIPTION
This updates the outcomes for the student finance calculator to only show dependants allowances when the person would be eligible for it, rather than all the time (as it does currently).

[Trello Card](https://trello.com/c/s7DtNBkI/1618-5-add-functionality-for-dependants-allowances-on-student-finance-calculator)