### PR TITLE
Amy laurence austria

### DIFF
--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/ceremony_country/partner_british/_opposite_sex.erb
@@ -1,6 +1,6 @@
 You can get married or enter into a civil partnership in Austria.
 
-Civil partnerships are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’ in Austria. Opposite-sex civil partnerships aren’t recognised in the UK.
+Civil partnerships are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’ in Austria. Opposite-sex civil partnerships are recognised under British law in England and Wales. 
 
 Contact the relevant local authorities in Austria to find out about local civil partnership and marriage laws, including what documents you’ll need.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/ceremony_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/ceremony_country/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 It’s possible to have either a civil partnership or a same-sex marriage in Austria.
 
-Same-sex relationships in Austria that are recognised as civil partnerships under British law are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’.
+Civil partnerships are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’ in Austria.
 
 Contact the relevant local authorities in Austria to find out about local civil partnership and same-sex marriage laws, including what documents you’ll need.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/ceremony_country/partner_local/_opposite_sex.erb
@@ -1,6 +1,6 @@
 You can get married or enter into a civil partnership in Austria.
 
-Civil partnerships are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’ in Austria. Opposite-sex civil partnerships aren’t recognised in the UK.
+Civil partnerships are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’ in Austria. Opposite-sex civil partnerships are recognised under British law in England and Wales. 
 
 Contact the relevant local authorities in Austria to find out about local civil partnership and marriage laws, including what documents you’ll need.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/ceremony_country/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/ceremony_country/partner_local/_same_sex.erb
@@ -1,6 +1,6 @@
 It’s possible to have either a civil partnership or a same-sex marriage in Austria.
 
-Same-sex relationships in Austria that are recognised as civil partnerships under British law are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’.
+Civil partnerships are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’ in Austria.
 
 Contact the relevant local authorities in Austria to find out about local civil partnership and same-sex marriage laws, including what documents you’ll need.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/ceremony_country/partner_other/_opposite_sex.erb
@@ -1,6 +1,6 @@
 You can get married or enter into a civil partnership in Austria.
 
-Civil partnerships are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’ in Austria. Opposite-sex civil partnerships aren’t recognised in the UK.
+Civil partnerships are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’ in Austria. Opposite-sex civil partnerships are recognised under British law in England and Wales.
 
 Contact the relevant local authorities in Austria to find out about local civil partnership and marriage laws, including what documents you’ll need.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/ceremony_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/ceremony_country/partner_other/_same_sex.erb
@@ -1,6 +1,6 @@
 It’s possible to have either a civil partnership or a same-sex marriage in Austria.
 
-Same-sex relationships in Austria that are recognised as civil partnerships under British law are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’.
+Civil partnerships are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’ in Austria.
 
 Contact the relevant local authorities in Austria to find out about local civil partnership and same-sex marriage laws, including what documents you’ll need.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/third_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/third_country/partner_british/_opposite_sex.erb
@@ -1,6 +1,6 @@
 You can get married or enter into a civil partnership in Austria. 
 
-Civil partnerships are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’ in Austria. Opposite-sex civil partnerships aren’t recognised in the UK.
+Civil partnerships are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’ in Austria. Opposite-sex civil partnerships are recognised under British law in England and Wales.
 
 Contact the relevant local authorities in Austria to find out about local civil partnership and marriage laws, including what documents you’ll need.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/third_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/third_country/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 It’s possible to have either a civil partnership or a same-sex marriage in Austria.
 
-Same-sex relationships in Austria that are recognised as civil partnerships under British law are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’.
+Civil partnerships are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’ in Austria.
 
 Contact the [Embassy of Austria](/government/publications/foreign-embassies-in-the-uk) before making any plans to find out about local civil partnership and same-sex marriage laws, including what documents you’ll need.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/third_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/third_country/partner_local/_opposite_sex.erb
@@ -1,6 +1,7 @@
 You can get married or enter into a civil partnership in Austria. 
 
-Civil partnerships are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’ in Austria. Opposite-sex civil partnerships aren’t recognised in the UK.
+Civil partnerships are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’ in Austria. Opposite-sex civil partnerships are recognised under British law in England and Wales. 
+
 
 Contact the relevant local authorities in Austria to find out about local civil partnership and marriage laws, including what documents you’ll need.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/third_country/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/third_country/partner_local/_same_sex.erb
@@ -1,6 +1,6 @@
 It’s possible to have either a civil partnership or a same-sex marriage in Austria.
 
-Same-sex relationships in Austria that are recognised as civil partnerships under British law are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’.
+Civil partnerships are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’ in Austria.
 
 Contact the [Embassy of Austria](/government/publications/foreign-embassies-in-the-uk) before making any plans to find out about local civil partnership and same-sex marriage laws, including what documents you’ll need.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/third_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/third_country/partner_other/_opposite_sex.erb
@@ -1,6 +1,6 @@
 You can get married or enter into a civil partnership in Austria. 
 
-Civil partnerships are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’ in Austria. Opposite-sex civil partnerships aren’t recognised in the UK.
+Civil partnerships are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’ in Austria. Opposite-sex civil partnerships are recognised under British law in England and Wales. 
 
 Contact the relevant local authorities in Austria to find out about local civil partnership and marriage laws, including what documents you’ll need.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/third_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/third_country/partner_other/_same_sex.erb
@@ -1,6 +1,6 @@
 It’s possible to have either a civil partnership or a same-sex marriage in Austria.
 
-Same-sex relationships in Austria that are recognised as civil partnerships under British law are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’.
+Civil partnerships are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’ in Austria.
 
 Contact the [Embassy of Austria](/government/publications/foreign-embassies-in-the-uk) before making any plans to find out about local civil partnership and same-sex marriage laws, including what documents you’ll need.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/uk/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/uk/partner_british/_opposite_sex.erb
@@ -2,6 +2,7 @@ You can get married or enter into a civil partnership in Austria.
 
 Civil partnerships are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’ in Austria. Opposite-sex civil partnerships are recognised under British law in England and Wales. 
 
+
 Contact the [Embassy of Austria](https://www.gov.uk/government/publications/foreign-embassies-in-the-uk) before making plans to find out about local marriage and civil partnership laws, including what documents you’ll need. 
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Austria](/foreign-travel-advice/austria) before making any plans.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/uk/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/uk/partner_british/_opposite_sex.erb
@@ -1,6 +1,7 @@
 You can get married or enter into a civil partnership in Austria. 
 
 Civil partnerships are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’ in Austria. Opposite-sex civil partnerships are recognised under British law in England and Wales. 
+
 Contact the [Embassy of Austria](https://www.gov.uk/government/publications/foreign-embassies-in-the-uk) before making plans to find out about local marriage and civil partnership laws, including what documents you’ll need. 
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Austria](/foreign-travel-advice/austria) before making any plans.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/uk/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/uk/partner_british/_opposite_sex.erb
@@ -1,7 +1,6 @@
 You can get married or enter into a civil partnership in Austria. 
 
-Civil partnerships are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’ in Austria. Opposite-sex civil partnerships aren’t recognised in the UK.
-
+Civil partnerships are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’ in Austria. Opposite-sex civil partnerships are recognised under British law in England and Wales. 
 Contact the [Embassy of Austria](https://www.gov.uk/government/publications/foreign-embassies-in-the-uk) before making plans to find out about local marriage and civil partnership laws, including what documents you’ll need. 
 
 ^You should [get legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Austria](/foreign-travel-advice/austria) before making any plans.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/uk/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/uk/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 It’s possible to have either a civil partnership or a same-sex marriage in Austria.
 
-Same-sex relationships in Austria that are recognised as civil partnerships under British law are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’.
+Civil partnerships are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’ in Austria.
 
 Contact the [Embassy of Austria](/government/publications/foreign-embassies-in-the-uk) before making any plans to find out about local laws, including what documents you’ll need.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/uk/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/uk/partner_local/_opposite_sex.erb
@@ -1,6 +1,6 @@
 You can get married or enter into a civil partnership in Austria. 
 
-Civil partnerships are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’ in Austria. Opposite-sex civil partnerships aren’t recognised in the UK.
+Civil partnerships are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’ in Austria. Opposite-sex civil partnerships are recognised under British law in England and Wales.
 
 Contact the [Embassy of Austria](https://www.gov.uk/government/publications/foreign-embassies-in-the-uk) before making plans to find out about local marriage and civil partnership laws, including what documents you’ll need. 
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/uk/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/uk/partner_local/_same_sex.erb
@@ -1,6 +1,6 @@
 It’s possible to have either a civil partnership or a same-sex marriage in Austria.
 
-Same-sex relationships in Austria that are recognised as civil partnerships under British law are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’.
+Civil partnerships are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’ in Austria.
 
 Contact the [Embassy of Austria](/government/publications/foreign-embassies-in-the-uk) before making any plans to find out about local laws, including what documents you’ll need.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/uk/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/uk/partner_other/_opposite_sex.erb
@@ -1,6 +1,6 @@
 You can get married or enter into a civil partnership in Austria. 
 
-Civil partnerships are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’ in Austria. Opposite-sex civil partnerships aren’t recognised in the UK.
+Civil partnerships are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’ in Austria. Opposite-sex civil partnerships are recognised under British law in England and Wales. 
 
 Contact the [Embassy of Austria](https://www.gov.uk/government/publications/foreign-embassies-in-the-uk) before making plans to find out about local marriage and civil partnership laws, including what documents you’ll need. 
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/uk/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/uk/partner_other/_same_sex.erb
@@ -1,6 +1,6 @@
 It’s possible to have either a civil partnership or a same-sex marriage in Austria.
 
-Same-sex relationships in Austria that are recognised as civil partnerships under British law are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’.
+Civil partnerships are known as ‘eingetragene Partnerschaft’, or ‘registered partnership’ in Austria.
 
 Contact the [Embassy of Austria](/government/publications/foreign-embassies-in-the-uk) before making any plans to find out about local laws, including what documents you’ll need.
 


### PR DESCRIPTION
Trello
https://trello.com/c/ONq8tUdf/2561-marriage-abroad-austria-oscp

##Marriage and civil partnership in Austria 
Summary:
Updated information for the married abroad outcomes in Austria to say that opposite-sex civil partnerships are now legally recognised in England and Wales. 

Shortened sentence about same-sex partnerships and made it consistent with phrasing on the opposite-sex pages. 
