### PR TITLE
Exclude Congo from the marriage abroad country select

### DIFF
--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -16,7 +16,7 @@ module SmartAnswer
       status :published
       satisfies_need "101000"
 
-      exclude_countries = %w(holy-see british-antarctic-territory the-occupied-palestinian-territories)
+      exclude_countries = %w(congo holy-see british-antarctic-territory the-occupied-palestinian-territories)
 
       # Q1
       country_select :country_of_ceremony?, exclude_countries: exclude_countries do


### PR DESCRIPTION
We don't currently have content for this outcome.  Content Support are
working with the FCO to get this written but, for now, disable it to
prevent an error page.