### PR TITLE
Replace 'civil partnership' with 'marry' in Equador same-sex outcomes

### DIFF
--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/_title.govspeak.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/_title.govspeak.erb
@@ -1,5 +1,5 @@
 <% if calculator.partner_is_same_sex? %>
-    Civil partnership in Ecuador
+    Marriage in Ecuador
 <% else %>
     Marriage in Ecuador
 <% end %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/ceremony_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/ceremony_country/partner_british/_same_sex.erb
@@ -1,10 +1,8 @@
-Same-sex partnerships in Ecuador are known as ‘union de hecho’.
-
 Contact the relevant local authorities in Ecuador to find out about local laws, including what documents you’ll need.
 
 ##What you need to do
 
-You’ll be asked for an affirmation or affidavit document to prove that you’re allowed to enter into this partnership.
+You’ll be asked for an affirmation or affidavit document to prove that you’re allowed to marry.
 
 To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-quito/oaths-affirmations-and-affidavits/slot_picker).
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/ceremony_country/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/ceremony_country/partner_local/_same_sex.erb
@@ -1,10 +1,8 @@
-Same-sex partnerships in Ecuador are known as ‘union de hecho’.
-
 Contact the relevant local authorities in Ecuador to find out about local laws, including what documents you’ll need.
 
 ##What you need to do
 
-You’ll be asked for an affirmation or affidavit document to prove that you’re allowed to enter into this partnership.
+You’ll be asked for an affirmation or affidavit document to prove that you’re allowed to marry.
 
 To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-quito/oaths-affirmations-and-affidavits/slot_picker).
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/ceremony_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/ceremony_country/partner_other/_same_sex.erb
@@ -1,10 +1,8 @@
-Same-sex partnerships in Ecuador are known as ‘union de hecho’.
-
 Contact the relevant local authorities in Ecuador to find out about local laws, including what documents you’ll need.
 
 ##What you need to do
 
-You’ll be asked for an affirmation or affidavit document to prove that you’re allowed to enter into this partnership.
+You’ll be asked for an affirmation or affidavit document to prove that you’re allowed to marry.
 
 To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-quito/oaths-affirmations-and-affidavits/slot_picker).
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/third_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/third_country/partner_british/_same_sex.erb
@@ -1,12 +1,10 @@
-Same-sex partnerships in Ecuador are known as ‘union de hecho’.
-
 Contact the relevant local authorities in Ecuador to find out about local laws, including what documents you’ll need.
 
 You should also check the [travel advice for Ecuador](/foreign-travel-advice/ecuador).
 
 ##What you need to do
 
-You’ll be asked for an affirmation or affidavit document to prove that you’re allowed to enter into this partnership.
+You’ll be asked for an affirmation or affidavit document to prove that you’re allowed to marry.
 
 To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-quito/oaths-affirmations-and-affidavits/slot_picker).
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/third_country/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/third_country/partner_local/_same_sex.erb
@@ -1,12 +1,10 @@
-Same-sex partnerships in Ecuador are known as ‘union de hecho’.
-
 Contact the relevant local authorities in Ecuador to find out about local laws, including what documents you’ll need.
 
 You should also check the [travel advice for Ecuador](/foreign-travel-advice/ecuador).
 
 ##What you need to do
 
-You’ll be asked for an affirmation or affidavit document to prove that you’re allowed to enter into this partnership.
+You’ll be asked for an affirmation or affidavit document to prove that you’re allowed to marry.
 
 To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-quito/oaths-affirmations-and-affidavits/slot_picker).
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/third_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/third_country/partner_other/_same_sex.erb
@@ -1,12 +1,10 @@
-Same-sex partnerships in Ecuador are known as ‘union de hecho’.
-
 Contact the relevant local authorities in Ecuador to find out about local laws, including what documents you’ll need.
 
 You should also check the [travel advice for Ecuador](/foreign-travel-advice/ecuador).
 
 ##What you need to do
 
-You’ll be asked for an affirmation or affidavit document to prove that you’re allowed to enter into this partnership.
+You’ll be asked for an affirmation or affidavit document to prove that you’re allowed to marry.
 
 To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-quito/oaths-affirmations-and-affidavits/slot_picker).
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/uk/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/uk/partner_british/_same_sex.erb
@@ -1,12 +1,10 @@
-Same-sex partnerships in Ecuador are known as ‘union de hecho’.
-
 Contact the [Embassy of Ecuador](/government/publications/foreign-embassies-in-the-uk) before making any plans to find out about local laws, including what documents you’ll need.
 
 You should also check the [travel advice for Ecuador](/foreign-travel-advice/ecuador).
 
 ##What you need to do
 
-You’ll be asked for an affirmation or affidavit document to prove that you’re allowed to enter into this partnership.
+You’ll be asked for an affirmation or affidavit document to prove that you’re allowed to marry.
 
 To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-quito/oaths-affirmations-and-affidavits/slot_picker).
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/uk/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/uk/partner_local/_same_sex.erb
@@ -1,12 +1,10 @@
-Same-sex partnerships in Ecuador are known as ‘union de hecho’.
-
 Contact the [Embassy of Ecuador](/government/publications/foreign-embassies-in-the-uk) before making any plans to find out about local laws, including what documents you’ll need.
 
 You should also check the [travel advice for Ecuador](/foreign-travel-advice/ecuador).
 
 ##What you need to do
 
-You’ll be asked for an affirmation or affidavit document to prove that you’re allowed to enter into this partnership.
+You’ll be asked for an affirmation or affidavit document to prove that you’re allowed to marry.
 
 To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-quito/oaths-affirmations-and-affidavits/slot_picker).
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/uk/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/uk/partner_other/_same_sex.erb
@@ -1,12 +1,10 @@
-Same-sex partnerships in Ecuador are known as ‘union de hecho’.
-
 Contact the [Embassy of Ecuador](/government/publications/foreign-embassies-in-the-uk) before making any plans to find out about local laws, including what documents you’ll need.
 
 You should also check the [travel advice for Ecuador](/foreign-travel-advice/ecuador).
 
 ##What you need to do
 
-You’ll be asked for an affirmation or affidavit document to prove that you’re allowed to enter into this partnership.
+You’ll be asked for an affirmation or affidavit document to prove that you’re allowed to marry.
 
 To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-quito/oaths-affirmations-and-affidavits/slot_picker).
 


### PR DESCRIPTION
Trello: https://trello.com/c/KzSeFv7l/2589-get-married-abroad-ecuador
Zen: https://govuk.zendesk.com/agent/tickets/3784342

Changes to all same sex outcomes for Ecuador to remove reference to 'civil partnership' and replace with 'marry' or 'marriage'.