### PR TITLE
Fix table styles by including relevant classes from design system

### DIFF
--- a/app/assets/stylesheets/smart_answers.scss
+++ b/app/assets/stylesheets/smart_answers.scss
@@ -29,6 +29,19 @@ $is-ie: false !default;
       @extend %govuk-list;
       @extend %govuk-list--bullet;
     }
+
+    table {
+      @extend .govuk-table;
+    }
+
+    th {
+      @extend .govuk-table__header;
+    }
+
+    td {
+      @extend .govuk-table__cell;
+    }
+
   }
 
   .application-notice {


### PR DESCRIPTION
https://trello.com/c/Y4gmoUSP/186-investigate-issues-with-the-parental-leave-checker

Tables throughout smart answers lost styling somehow. This was probably a result of govuk_publishing_components removing frontend toolkit, thought it's hard to be sure. This PR includes the classes from the design system in the basic table tags to fix the look. Usually we would add the appropriate classes to the table, but the table is rendered by govspeak. The changes are scoped to target only table/tr/td rules within govspeak for this reason. 

Example paths: 
/pay-leave-for-parents/y/yes/2020-01-02/unemployed/self-employed/yes/no
/maternity-paternity-calculator/y/maternity/2020-05-03/2020-02-19/yes/2020-01-02/2019-11-05/monthly/50000.0/2/usual_paydates/last_working_day_of_the_month/1,2,3,4,5

### Before 
![Screenshot 2020-01-08 at 14 23 42](https://user-images.githubusercontent.com/31649453/71985506-9c40f100-3222-11ea-99d3-9423d5c2c418.png)

### After 
![Screenshot 2020-01-08 at 14 24 19](https://user-images.githubusercontent.com/31649453/71985507-9c40f100-3222-11ea-870c-4bbfab62bdb0.png)

=========
### Before 
![Screenshot 2020-01-08 at 14 24 41](https://user-images.githubusercontent.com/31649453/71985510-9c40f100-3222-11ea-8c37-91acc3791d10.png)

### After
![Screenshot 2020-01-08 at 14 24 53](https://user-images.githubusercontent.com/31649453/71985512-9cd98780-3222-11ea-89ee-5d41495e9759.png)
