### PR TITLE
Switch to new colours

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,4 +1,5 @@
 $govuk-compatibility-govuktemplate: true;
+$govuk-use-legacy-palette: false;
 
 @import "govuk_publishing_components/all_components";
 @import "smart_answers";


### PR DESCRIPTION
## What

Turn on the newer, higher contrast and more accessible colours from the Design System.

## Visual changes

### Before
<img width="616" alt="Screenshot at Jan 09 1-41-12 pm" src="https://user-images.githubusercontent.com/424772/72074038-12a82680-32e9-11ea-840a-6a2486c36205.png">

### After
<img width="721" alt="Screenshot at Jan 09 1-14-51 pm" src="https://user-images.githubusercontent.com/424772/72073897-c826aa00-32e8-11ea-953e-e7b6269e610a.png">

---

### Before
<img width="454" alt="Screenshot at Jan 09 1-41-35 pm" src="https://user-images.githubusercontent.com/424772/72074093-2ce20480-32e9-11ea-913f-0f9a6d03f247.png">

### After
<img width="613" alt="Screenshot at Jan 09 1-15-43 pm" src="https://user-images.githubusercontent.com/424772/72074067-218ed900-32e9-11ea-9a4b-c9ac798266ac.png">


---

### Before
<img width="454" alt="Screenshot at Jan 09 1-40-58 pm" src="https://user-images.githubusercontent.com/424772/72074238-716da000-32e9-11ea-80aa-e822b9fc2d83.png">

### After
<img width="637" alt="Screenshot at Jan 09 1-40-37 pm" src="https://user-images.githubusercontent.com/424772/72074201-6155c080-32e9-11ea-8671-f0f4392a4a64.png">


---

### Before
<img width="605" alt="Screenshot at Jan 09 1-49-58 pm" src="https://user-images.githubusercontent.com/424772/72074284-8d714180-32e9-11ea-9eee-fe5c21f76bc2.png">

### After
<img width="679" alt="Screenshot at Jan 09 1-49-47 pm" src="https://user-images.githubusercontent.com/424772/72074292-9235f580-32e9-11ea-9c15-055e9c6337be.png">
