### PR TITLE
[DO NOT MERGE BEFORE alphagov/govuk-puppet#10054] Access Worldwide API via whitehall-frontend

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "sprockets-rails"
 gem "govuk_app_config"
 
 gem "ast"
-gem "gds-api-adapters", "~> 63.2.0"
+gem "gds-api-adapters", "~> 63.3"
 gem "govspeak", "~> 6.5.2"
 gem "govuk-content-schema-test-helpers", "~> 1.6.1"
 gem "govuk_publishing_components", "21.20.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,8 +80,8 @@ GEM
     execjs (2.7.0)
     faraday (0.17.3)
       multipart-post (>= 1.2, < 3)
-    ffi (1.12.1)
-    gds-api-adapters (63.2.0)
+    ffi (1.11.3)
+    gds-api-adapters (63.3.0)
       addressable
       link_header
       null_logger
@@ -365,7 +365,7 @@ DEPENDENCIES
   binding_of_caller
   byebug
   ci_reporter
-  gds-api-adapters (~> 63.2.0)
+  gds-api-adapters (~> 63.3)
   govspeak (~> 6.5.2)
   govuk-content-schema-test-helpers (~> 1.6.1)
   govuk_app_config

--- a/doc/smart-answers-app-development/common-errors.md
+++ b/doc/smart-answers-app-development/common-errors.md
@@ -2,7 +2,6 @@
 
 A list of some of the errors you might run into when developing on Smart Answers locally.
 
-
 ## "NoMethodError" when visiting the root URL
 
 You'll see this error if you visit the root URL of the Smart Answers app (e.g. http://localhost:3000 or http://smartanswers.dev.gov.uk/). This is because we don't have anything configured to respond at this path.
@@ -18,10 +17,9 @@ undefined method `to_html' for nil:NilClass
 
 Visit a specific Smart Answer, e.g. /marriage-abroad.
 
-
 ## "SocketError" when viewing a Smart Answer (relating to Content Store)
 
-__NOTE.__ This is specifically when the exception is raised in `SmartAnswerPresenter#artefact`.
+**NOTE.** This is specifically when the exception is raised in `SmartAnswerPresenter#artefact`.
 
 You'll see this error if the Smart Answers app can't connect to the Content Store.
 
@@ -40,10 +38,9 @@ There are a couple of solutions to this problem:
 
 2. Configure a web server (e.g. Apache) on your machine to respond to http://content_store.dev.gov.uk. This is the default location of the Content Store in development so configuring this means that you won't have to set the `PLEK_SERVICE_CONTENT_STORE_URI` environment variable.
 
-
 ## "SocketError" when viewing a Smart Answer (relating to Worldwide API)
 
-__NOTE.__ This is specifically when the exception is raised in methods like `WorldLocation#find`, `WorldLocation.all` or `WorldwideOrganisation.for_location` which try to access the Worldwide API.
+**NOTE.** This is specifically when the exception is raised in methods like `WorldLocation#find`, `WorldLocation.all` or `WorldwideOrganisation.for_location` which try to access the Worldwide API.
 
 You'll see this error if the Smart Answers app can't connect to the Worldwide API.
 
@@ -51,7 +48,7 @@ You'll see this error if the Smart Answers app can't connect to the Worldwide AP
 
 ```
 SocketError at /marriage-abroad/y
-Failed to open TCP connection to whitehall-admin.dev.gov.uk:80 (getaddrinfo: nodename nor servname provided, or not known)
+Failed to open TCP connection to whitehall-frontend.dev.gov.uk:80 (getaddrinfo: nodename nor servname provided, or not known)
 ```
 
 ### Resolution
@@ -60,8 +57,7 @@ There are a couple of solutions to this problem:
 
 1. Set the `PLEK_SERVICE_WHITEHALL_ADMIN_URI` environment variable to "https://www.gov.uk".
 
-2. Configure a web server (e.g. Apache) on your machine to respond to http://whitehall-admin.dev.gov.uk. This is the default location of the Worldwide API in development so configuring this means that you won't have to set the `PLEK_SERVICE_WHITEHALL_ADMIN_URI` environment variable.
-
+2. Configure a web server (e.g. Apache) on your machine to respond to http://whitehall-frontend.dev.gov.uk. This is the default location of the Worldwide API in development so configuring this means that you won't have to set the `PLEK_SERVICE_WHITEHALL_FRONTEND_URI` environment variable.
 
 ## "Slimmer::CouldNotRetrieveTemplate" when viewing a Smart Answer
 
@@ -80,6 +76,6 @@ There are a couple of solutions to this problem:
 
 1. Set the `PLEK_SERVICE_STATIC_URI` environment variable to "https://assets-origin.integration.publishing.service.gov.uk", which is the static/assets server running in integration.
 
-2. Run the static/assets server locally at http://static.dev.gov.uk. This is the default location of the static/asset server in development so configuring this  means that you won't have to set the `PLEK_SERVICE_STATIC_URI` environment variable.
+2. Run the static/assets server locally at http://static.dev.gov.uk. This is the default location of the static/asset server in development so configuring this means that you won't have to set the `PLEK_SERVICE_STATIC_URI` environment variable.
 
 [static]: https://github.com/alphagov/static

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,8 +1,8 @@
 require "statsd"
+require "gds_api"
 require "gds_api/publishing_api_v2"
 require "gds_api/content_store"
 require "gds_api/imminence"
-require "gds_api/worldwide"
 
 module Services
   def self.publishing_api
@@ -17,7 +17,7 @@ module Services
   end
 
   def self.worldwide_api
-    @worldwide_api ||= GdsApi::Worldwide.new(Plek.new.find("whitehall-admin"))
+    @worldwide_api ||= GdsApi.worldwide
   end
 
   def self.content_store


### PR DESCRIPTION
To simplify the migration of Whitehall to AWS, calls to the Worldwide API should be directed to whitehall-frontend, not whitehall-admin.