### PR TITLE
Merge pull request #4297 from alphagov/update-dates-for-maternity-calculator

### DIFF
--- a/lib/data/rates/maternity_paternity_adoption.yml
+++ b/lib/data/rates/maternity_paternity_adoption.yml
@@ -1,28 +1,28 @@
 ---
-- start_date: 2010-04-03
+- start_date: 2010-04-04
   end_date: 2011-04-02
   lower_earning_limit_rate: 97
 - start_date: 2011-04-03
   end_date: 2012-03-31
   lower_earning_limit_rate: 102
 - start_date: 2012-04-01
-  end_date: 2013-03-31
+  end_date: 2013-04-06
   lower_earning_limit_rate: 107
-- start_date: 2013-04-01
+- start_date: 2013-04-07
   end_date: 2014-04-05
   lower_earning_limit_rate: 109
 - start_date: 2014-04-06
-  end_date: 2015-04-05
+  end_date: 2015-04-04
   lower_earning_limit_rate: 111
-- start_date: 2015-04-06
-  end_date: 2017-04-05
+- start_date: 2015-04-05
+  end_date: 2017-04-01
   lower_earning_limit_rate: 112
-- start_date: 2017-04-06
-  end_date: 2018-04-05
+- start_date: 2017-04-02
+  end_date: 2018-03-31
   lower_earning_limit_rate: 113
-- start_date: 2018-04-06
-  end_date: 2019-04-05
+- start_date: 2018-04-01
+  end_date: 2019-04-06
   lower_earning_limit_rate: 116
-- start_date: 2019-04-06
+- start_date: 2019-04-07
   end_date: 2100-04-05
   lower_earning_limit_rate: 118


### PR DESCRIPTION
Rate changes happen on the first Sunday of April each year. This doesn't
necessarily coincide with the start of the fiscal or financial year.

For the moment, this only updates
`lib/data/rates/maternity_paternity_adoption.yml`
and not
`lib/data/rates/maternity_paternity_birth.yml`
because we're waiting for an update from HMRC on whether the dates there
should be different and why some of them are in July instead of April.

Trello card: https://trello.com/c/9v5Az2SA/1697-3-employers-maternity-calculator-built-on-tax-years