### PR TITLE
heroku: Set `PLEK_SERVICE_WHITEHALL_FRONTEND_URI`

### DIFF
--- a/app.json
+++ b/app.json
@@ -8,6 +8,7 @@
     "GOVUK_WEBSITE_ROOT": "https://www.gov.uk",
     "PLEK_SERVICE_CONTENT_STORE_URI": "https://www.gov.uk/api" ,
     "PLEK_SERVICE_STATIC_URI": "https://assets.integration.publishing.service.gov.uk/",
+    "PLEK_SERVICE_WHITEHALL_FRONTEND_URI": "https://www.gov.uk",
     "RUNNING_ON_HEROKU": "true",
     "EXPOSE_GOVSPEAK": "true",
     "ERRBIT_ENV": "integration"

--- a/startup.sh
+++ b/startup.sh
@@ -6,6 +6,7 @@ if [[ $1 == "--live" ]] ; then
   GOVUK_APP_DOMAIN=www.gov.uk \
   GOVUK_WEBSITE_ROOT=https://www.gov.uk \
   PLEK_SERVICE_WHITEHALL_ADMIN_URI=${PLEK_SERVICE_WHITEHALL_ADMIN_URI-https://www.gov.uk} \
+  PLEK_SERVICE_WHITEHALL_FRONTEND_URI=${PLEK_SERVICE_WHITEHALL_ADMIN_URI-http://www.gov.uk} \
   PLEK_SERVICE_CONTENT_STORE_URI=${PLEK_SERVICE_CONTENT_STORE_URI-https://www.gov.uk/api} \
   PLEK_SERVICE_STATIC_URI=${PLEK_SERVICE_STATIC_URI-assets.publishing.service.gov.uk} \
   bundle exec rails s -p 3010

--- a/startup_heroku.sh
+++ b/startup_heroku.sh
@@ -22,6 +22,7 @@ heroku config:set \
 GOVUK_APP_DOMAIN=integration.publishing.service.gov.uk \
 PLEK_SERVICE_CONTENT_STORE_URI=https://www.gov.uk/api \
 PLEK_SERVICE_STATIC_URI=https://assets-origin.integration.publishing.service.gov.uk/ \
+PLEK_SERVICE_WHITEHALL_FRONTEND_URI=https://www.gov.uk \
 RUNNING_ON_HEROKU=true \
 EXPOSE_GOVSPEAK=true \
 


### PR DESCRIPTION
- The PR review apps weren't working for Marriage Abroad smart-answers
  due to:

```
2020-02-04T15:16:53.897379+00:00 app[web.1]: {"method":"GET","path":"/marriage-abroad/y","format":"html","controller":"smart_answers","action":"show","status":500,"duration":63.38,"error":"ActionView::Template::Error\nGdsApi::SocketErrorException\n/app/vendor/bundle/ruby/2.6.0/gems/gds-api-adapters-63.3.0/lib/gds_api/json_client.rb:198:in `rescue in do_request'
```

- Cribbed from https://github.com/alphagov/finder-frontend/pull/1905.