### PR TITLE
Fix govspeak

### DIFF
--- a/app/assets/stylesheets/smart_answers.scss
+++ b/app/assets/stylesheets/smart_answers.scss
@@ -81,7 +81,6 @@ $is-ie: false !default;
   color: $govuk-secondary-text-colour;
 }
 
-.app-o-next-steps,
-.app-o-answer {
+.app-o-spacing {
   margin-bottom: govuk-spacing(6);
 }

--- a/app/views/smart_answers/landing.html.erb
+++ b/app/views/smart_answers/landing.html.erb
@@ -13,28 +13,34 @@
     } %>
 
     <div class="article-container group">
-      <article role="article" class="group govspeak-wrapper" data-debug-template-path="<%= start_node.relative_erb_template_path %>">
+      <article role="article" class="group" data-debug-template-path="<%= start_node.relative_erb_template_path %>">
         <div class="inner">
-          <section class="intro">
-            <div class="descriptive__text">
+          <section class="app-o-spacing">
+            <%= render "govuk_publishing_components/components/govspeak", {
+            } do %>
               <%= start_node.body %>
-            </div>
+            <% end %>
 
-            <p class="get-started">
-              <%= render "govuk_publishing_components/components/button", {
-                text: start_node.start_button_text,
-                href: smart_answer_path(@name.to_s, started: "y"),
-                rel: "nofollow",
-                start: true
-              } %>
-            </p>
+            <%= render "govuk_publishing_components/components/button", {
+              text: start_node.start_button_text,
+              href: smart_answer_path(@name.to_s, started: "y"),
+              rel: "nofollow",
+              start: true
+            } %>
           </section>
+
           <section class="more">
             <% unless start_node.post_body.blank? %>
-              <div id="before-you-start" class="descriptive__text">
-                <h2>Before you start</h2>
+              <%= render "govuk_publishing_components/components/govspeak", {
+              } do %>
+              <div id="before-you-start">
+                <%= render "govuk_publishing_components/components/heading", {
+                  text: "Before you start",
+                  padding: true
+                } %>
                 <%= start_node.post_body %>
               </div>
+              <% end %>
             <% end %>
           </section>
         </div>

--- a/app/views/smart_answers/landing.html.erb
+++ b/app/views/smart_answers/landing.html.erb
@@ -12,39 +12,35 @@
       title: start_node.title
     } %>
 
-    <div class="article-container group">
-      <article role="article" class="group" data-debug-template-path="<%= start_node.relative_erb_template_path %>">
-        <div class="inner">
-          <section class="app-o-spacing">
-            <%= render "govuk_publishing_components/components/govspeak", {
-            } do %>
-              <%= start_node.body %>
-            <% end %>
+    <article role="article" data-debug-template-path="<%= start_node.relative_erb_template_path %>">
+      <section class="app-o-spacing">
+        <%= render "govuk_publishing_components/components/govspeak", {
+        } do %>
+          <%= start_node.body %>
+        <% end %>
 
-            <%= render "govuk_publishing_components/components/button", {
-              text: start_node.start_button_text,
-              href: smart_answer_path(@name.to_s, started: "y"),
-              rel: "nofollow",
-              start: true
+        <%= render "govuk_publishing_components/components/button", {
+          text: start_node.start_button_text,
+          href: smart_answer_path(@name.to_s, started: "y"),
+          rel: "nofollow",
+          start: true
+        } %>
+      </section>
+
+      <% unless start_node.post_body.blank? %>
+        <section>
+          <%= render "govuk_publishing_components/components/govspeak", {
+          } do %>
+          <div id="before-you-start">
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Before you start",
+              padding: true
             } %>
-          </section>
-
-          <section class="more">
-            <% unless start_node.post_body.blank? %>
-              <%= render "govuk_publishing_components/components/govspeak", {
-              } do %>
-              <div id="before-you-start">
-                <%= render "govuk_publishing_components/components/heading", {
-                  text: "Before you start",
-                  padding: true
-                } %>
-                <%= start_node.post_body %>
-              </div>
-              <% end %>
-            <% end %>
-          </section>
-        </div>
-      </article>
-    </div>
+            <%= start_node.post_body %>
+          </div>
+          <% end %>
+        </section>
+      <% end %>
+    </article>
   </div>
 </div>

--- a/app/views/smart_answers/question.html.erb
+++ b/app/views/smart_answers/question.html.erb
@@ -14,18 +14,24 @@
     } %>
     <%= form_tag calculate_current_question_path(@presenter), :method => :get do %>
       <div class="govuk-!-margin-top-9" id="current-question">
-        <div class="question govspeak-wrapper" data-debug-template-path="<%= question.relative_erb_template_path %>">
+        <div class="question" data-debug-template-path="<%= question.relative_erb_template_path %>">
           <% show_body = ['salary_question', 'country_select_question'].include? question.partial_template_name %>
 
           <% if question.body.present? && show_body %>
             <article role="article">
-              <%= question.body %>
+              <%= render "govuk_publishing_components/components/govspeak", {
+              } do %>
+                <%= question.body %>
+              <% end %>
             </article>
           <% end %>
 
           <%= render partial: "smart_answers/inputs/#{question.partial_template_name}", locals: { question: question } %>
 
-          <%= question.post_body %>
+          <%= render "govuk_publishing_components/components/govspeak", {
+          } do %>
+            <%= question.post_body %>
+          <% end %>
         </div>
 
         <input type="hidden" name="next" value="1" />
@@ -39,5 +45,3 @@
     <%= render 'previous_answers' %>
   </div>
 </div>
-
-

--- a/app/views/smart_answers/question.html.erb
+++ b/app/views/smart_answers/question.html.erb
@@ -14,7 +14,7 @@
     } %>
     <%= form_tag calculate_current_question_path(@presenter), :method => :get do %>
       <div class="govuk-!-margin-top-9" id="current-question">
-        <div class="question" data-debug-template-path="<%= question.relative_erb_template_path %>">
+        <div data-debug-template-path="<%= question.relative_erb_template_path %>">
           <% show_body = ['salary_question', 'country_select_question'].include? question.partial_template_name %>
 
           <% if question.body.present? && show_body %>

--- a/app/views/smart_answers/result.html.erb
+++ b/app/views/smart_answers/result.html.erb
@@ -11,23 +11,31 @@
 
     <% outcome = @presenter.current_node %>
 
-    <div class="app-o-answer govspeak-wrapper" data-debug-template-path="<%= outcome.relative_erb_template_path %>">
+    <div class="app-o-spacing" data-debug-template-path="<%= outcome.relative_erb_template_path %>">
       <% if outcome.title.present? %>
         <%= render "govuk_publishing_components/components/heading", {
-          text: outcome.title
+          text: outcome.title,
+          margin_bottom: 6
         } %>
       <% end %>
 
-      <%= outcome.body %>
+      <%= render "govuk_publishing_components/components/govspeak", {
+      } do %>
+        <%= outcome.body %>
+      <% end %>
     </div>
 
     <% if outcome.next_steps.present? %>
-      <div class="app-o-next-steps govspeak-wrapper">
+      <div class="app-o-spacing">
         <%= render "govuk_publishing_components/components/heading", {
-          text: "Next steps"
+          text: "Next steps",
+          margin_bottom: 6
         } %>
 
-        <%= outcome.next_steps %>
+        <%= render "govuk_publishing_components/components/govspeak", {
+        } do %>
+          <%= outcome.next_steps %>
+        <% end %>
       </div>
     <% end %>
 
@@ -53,5 +61,3 @@
     </div>
   <% end %>
 </div>
-
-

--- a/test/integration/engine/checkbox_questions_test.rb
+++ b/test/integration/engine/checkbox_questions_test.rb
@@ -66,9 +66,7 @@ class CheckboxQuestionsTest < EngineIntegrationTest
         end
       end
 
-      within(".question") do
-        assert_page_has_content "Are you sure you don't want any toppings?"
-      end
+      assert_page_has_content "Are you sure you don't want any toppings?"
 
       check("Definitely no toppings", visible: false)
 
@@ -84,9 +82,7 @@ class CheckboxQuestionsTest < EngineIntegrationTest
     should "expect explicit selection of 'none' option when present" do
       visit "/checkbox-sample/y/none"
 
-      within(".question") do
-        assert_page_has_content "Are you sure you don't want any toppings?"
-      end
+      assert_page_has_content "Are you sure you don't want any toppings?"
 
       click_on "Next step"
 

--- a/test/integration/engine/multiple_choice_and_value_questions_test.rb
+++ b/test/integration/engine/multiple_choice_and_value_questions_test.rb
@@ -17,12 +17,11 @@ class MultipleChoiceAndValueQuestionsTest < EngineIntegrationTest
       within "h1" do
         assert_page_has_content("The Bridge of Death")
       end
-      within ".intro" do
+
+      within "article" do
         within("h2") { assert_page_has_content("STOP!") }
         assert_page_has_content("He who would cross the Bridge of Death Must answer me These questions three Ere the other side he see.")
-
         assert page.has_no_content?("-----") # markdown should be rendered, not output
-
         assert page.has_link?("Start now", href: "/bridge-of-death/y")
       end
 

--- a/test/integration/engine/precalculations_test.rb
+++ b/test/integration/engine/precalculations_test.rb
@@ -11,9 +11,7 @@ class PrecalculationsTest < EngineIntegrationTest
 
       assert_current_url "/precalculation-sample"
 
-      within ".intro" do
-        assert page.has_link?("Start now", href: "/precalculation-sample/y")
-      end
+      assert page.has_link?("Start now", href: "/precalculation-sample/y")
 
       click_on "Start now"
 


### PR DESCRIPTION
## What / why

Govspeak content on smart-answers wasn't being rendered properly because it wasn't using the gem component but instead wrapping the content in an outdated govspeak class. This PR removes that class and replaces it with the correct component.

Example problems:

- https://www.gov.uk/marriage-abroad/y/russia/uk/partner_british/opposite_sex
- https://www.gov.uk/marriage-abroad/y/france/opposite_sex
- see trello card for specifics

Trello card: https://trello.com/c/RcXI7NMQ/1520-fix-markdown-issues-in-smart-answers

## Visual changes

There are a number of pages with problems, here is one example.

Before:

![Screenshot 2020-02-24 at 13 37 05](https://user-images.githubusercontent.com/861310/75156795-ce42df80-570a-11ea-8cfc-41d35e8b35ee.png)

After:

![Screenshot 2020-02-24 at 13 37 21](https://user-images.githubusercontent.com/861310/75156811-d3079380-570a-11ea-8858-18bdf71d9c63.png)
