### PR TITLE
Uprating 2020 paid leave for parents

### DIFF
--- a/lib/smart_answer/calculators/pay_leave_for_parents_calculator.rb
+++ b/lib/smart_answer/calculators/pay_leave_for_parents_calculator.rb
@@ -49,8 +49,10 @@ module SmartAnswer::Calculators
         SmartAnswer::Money.new(116)
       when 2019
         SmartAnswer::Money.new(118)
+      when 2020
+        SmartAnswer::Money.new(120)
       else
-        SmartAnswer::Money.new(118)
+        SmartAnswer::Money.new(120)
       end
     end
 

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_additional_pat_pay.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_additional_pat_pay.govspeak.erb
@@ -45,3 +45,9 @@ Weekly rate (between 6 April 2018 and 5 April 2019) | £145.18, or 90% of their 
 Weekly rate (between 6 April 2019 and 5 April 2020) | £148.68, or 90% of their average weekly earnings (whichever is lower).
 
 <% end %>
+
+<% if calculator.paid_leave_is_in_tax_year?(2020) %>
+
+Weekly rate (between 6 April 2020 and 5 April 2021) | £151.20, or 90% of their average weekly earnings (whichever is lower).
+
+<% end %>

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_both_shared_pay.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_both_shared_pay.govspeak.erb
@@ -40,6 +40,12 @@ Mother’s shared parental pay (between 6 April 2019 and 5 April 2020) | £148.6
 
 <% end %>
 
+<% if calculator.paid_leave_is_in_tax_year?(2020) %>
+
+Mother’s shared parental pay (between 6 April 2020 and 5 April 2021) | £151.20 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+<% end %>
+
 <% if calculator.paid_leave_is_in_tax_year?(2014) %>
 
 Partner's shared parental pay (between 6 April 2014 and 5 April 2015) | £138.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
@@ -73,5 +79,11 @@ Partner's shared parental pay (between 6 April 2018 and 5 April 2019) | £145.18
 <% if calculator.paid_leave_is_in_tax_year?(2019) %>
 
 Partner's shared parental pay (between 6 April 2019 and 5 April 2020) | £148.68 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+<% end %>
+
+<% if calculator.paid_leave_is_in_tax_year?(2020) %>
+
+Partner's shared parental pay (between 6 April 2020 and 5 April 2021) | £151.20 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_allowance.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_allowance.govspeak.erb
@@ -50,4 +50,10 @@ Weekly rate (between 6 April 2019 and 5 April 2020) | £148.68, or 90% of her av
 
 <% end %>
 
+<% if calculator.paid_leave_is_in_tax_year?(2020) %>
+
+Weekly rate (between 6 April 2020 and 5 April 2021) | £151.20, or 90% of her average weekly earnings (whichever is lower)
+
+<% end %>
+
 The mother can claim maternity allowance as soon as she’s been pregnant for 26 weeks. She won’t have to pay tax on it.

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_pay.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_pay.govspeak.erb
@@ -48,6 +48,12 @@ Remaining weeks (between 6 April 2019 and 5 April 2020) | £148.68 per week or 9
 
 <% end %>
 
+<% if calculator.paid_leave_is_in_tax_year?(2020) %>
+
+Remaining weeks (between 6 April 2020 and 5 April 2021) | £151.20 per week or 90% of her average weekly earnings (before tax), whichever is lower
+
+<% end %>
+
 Tell the mother’s employer | 28 days before she wants want to start maternity pay
 
 Tax and National Insurance will be deducted.

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_shared_pay.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_shared_pay.govspeak.erb
@@ -39,3 +39,9 @@ Shared Parental Pay (between 6 April 2018 and 5 April 2019) | £145.18 per week 
 Shared Parental Pay (between 6 April 2019 and 5 April 2020) | £148.68 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
+
+<% if calculator.paid_leave_is_in_tax_year?(2020) %>
+
+Shared Parental Pay (between 6 April 2020 and 5 April 2021) | £151.20 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+<% end %>

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_pay.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_pay.govspeak.erb
@@ -46,6 +46,12 @@ Weekly rate (between 6 April 2019 and 5 April 2020) | £148.68 per week or 90% o
 
 <% end %>
 
+<% if calculator.paid_leave_is_in_tax_year?(2020) %>
+
+Weekly rate (between 6 April 2020 and 5 April 2021) | £151.20 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+<% end %>
+
 <% if calculator.paid_leave_is_in_tax_year?(2013) %>
 
 Tell the partner’s employer | 28 days before they want to start paternity pay

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_shared_pay.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_shared_pay.govspeak.erb
@@ -39,3 +39,9 @@ Shared Parental Pay (between 6 April 2018 and 5 April 2019) | £145.18 per week 
 Shared Parental Pay (between 6 April 2019 and 5 April 2020) | £148.68 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
+
+<% if calculator.paid_leave_is_in_tax_year?(2020) %>
+
+Shared Parental Pay (between 6 April 2020 and 5 April 2021) | £151.20 per week or 90% of their average weekly earnings (before tax), whichever is lower
+
+<% end %>

--- a/test/unit/calculators/pay_leave_for_parents_calculator_test.rb
+++ b/test/unit/calculators/pay_leave_for_parents_calculator_test.rb
@@ -147,6 +147,18 @@ module SmartAnswer
         end
       end
 
+      context "due date in 2020-2021 range" do
+        setup do
+          @date = Date.parse("2021-01-01")
+          @calculator = PayLeaveForParentsCalculator.new
+          @calculator.due_date = @date
+        end
+
+        should "return £120 for lower_earnings_amount" do
+          assert_equal 120, @calculator.lower_earnings_amount
+        end
+      end
+
       context "due date outside all ranges" do
         setup do
           @date = Date.parse("2022-01-01")
@@ -155,7 +167,7 @@ module SmartAnswer
         end
 
         should "return the latest known lower_earnings_amount" do
-          assert_equal 118, @calculator.lower_earnings_amount
+          assert_equal 120, @calculator.lower_earnings_amount
         end
       end
 


### PR DESCRIPTION
Uprating increase rates on parents pay leave calculator from tax year beginning 2020

Parental leave increased from £148.68 to £151.20 (from 5 April 2020)
LEL increased from £118 to £120

Zendesk: https://govuk.zendesk.com/agent/tickets/3909456
Trello: https://trello.com/c/rISiAv7X/1801-2-uprating-pay-leave-for-parents