### PR TITLE
[DO NOT MERGE] Uprating changes to Minimum wage calculator

### DIFF
--- a/lib/data/rates/minimum_wage.yml
+++ b/lib/data/rates/minimum_wage.yml
@@ -227,17 +227,17 @@
 - :start_date: 2020-04-01
   :end_date: 3000-01-01
   :minimum_rates:
-  - :min-age: 0
-    :max-age: 18
+  - :min_age: 0
+    :max_age: 18
     :rate: 4.55
-  - :min-age: 18
-    :max-age: 21
+  - :min_age: 18
+    :max_age: 21
     :rate: 6.45
-  - :min-age: 21
-    :max-age: 25
+  - :min_age: 21
+    :max_age: 25
     :rate: 8.20
-  - :min-age: 25
-    :max-age: 1000
+  - :min_age: 25
+    :max_age: 1000
     :rate: 8.72
   :apprentice_rate: 4.15
   :accommodation_rate: 8.20

--- a/lib/data/rates/minimum_wage.yml
+++ b/lib/data/rates/minimum_wage.yml
@@ -208,7 +208,7 @@
   :apprentice_rate: 3.70
   :accommodation_rate: 7.00
 - :start_date: 2019-04-01
-  :end_date: 3000-01-01
+  :end_date: 2020-03-31
   :minimum_rates:
   - :min_age: 0
     :max_age: 18
@@ -224,3 +224,20 @@
     :rate: 8.21
   :apprentice_rate: 3.90
   :accommodation_rate: 7.55
+- :start_date: 2020-04-01
+  :end_date: 3000-01-01
+  :minimum_rates:
+  - :min-age: 0
+    :max-age: 18
+    :rate: 4.55
+  - :min-age: 18
+    :max-age: 21
+    :rate: 6.45
+  - :min-age: 21
+    :max-age: 25
+    :rate: 8.20
+  - :min-age: 25
+    :max-age: 1000
+    :rate: 8.72
+  :apprentice_rate: 4.15
+  :accommodation_rate: 8.20

--- a/lib/smart_answer_flows/am-i-getting-minimum-wage.rb
+++ b/lib/smart_answer_flows/am-i-getting-minimum-wage.rb
@@ -16,7 +16,7 @@ module SmartAnswer
 
         calculate :calculator do |response|
           if response == "past_payment"
-            Calculators::MinimumWageCalculator.new(date: Date.parse("2018-04-01"))
+            Calculators::MinimumWageCalculator.new(date: Date.parse("2019-04-01"))
           else
             Calculators::MinimumWageCalculator.new
           end

--- a/lib/smart_answer_flows/am-i-getting-minimum-wage/am_i_getting_minimum_wage.govspeak.erb
+++ b/lib/smart_answer_flows/am-i-getting-minimum-wage/am_i_getting_minimum_wage.govspeak.erb
@@ -15,5 +15,5 @@
 
   ^You must be at least 25 years old to get the National Living Wage.^
 
-  Check [National Minimum Wage and National Living Wage rates](/national-minimum-wage-rates) before March 2018.
+  Check [National Minimum Wage and National Living Wage rates](/national-minimum-wage-rates) before March 2019.
 <% end %>

--- a/lib/smart_answer_flows/am-i-getting-minimum-wage/questions/what_would_you_like_to_check.govspeak.erb
+++ b/lib/smart_answer_flows/am-i-getting-minimum-wage/questions/what_would_you_like_to_check.govspeak.erb
@@ -4,5 +4,5 @@
 
 <% options(
   "current_payment": "If you're getting the National Minimum Wage or the National Living Wage",
-  "past_payment": "If an employer owes you payments from last year (April 2018 to March 2019)"
+  "past_payment": "If an employer owes you payments from last year (April 2019 to March 2020)"
 ) %>

--- a/lib/smart_answer_flows/minimum-wage-calculator-employers.rb
+++ b/lib/smart_answer_flows/minimum-wage-calculator-employers.rb
@@ -16,7 +16,7 @@ module SmartAnswer
 
         calculate :calculator do |response|
           if response == "past_payment"
-            Calculators::MinimumWageCalculator.new(date: Date.parse("2018-04-01"))
+            Calculators::MinimumWageCalculator.new(date: Date.parse("2019-04-01"))
           else
             Calculators::MinimumWageCalculator.new
           end

--- a/lib/smart_answer_flows/minimum-wage-calculator-employers/minimum_wage_calculator_employers.govspeak.erb
+++ b/lib/smart_answer_flows/minimum-wage-calculator-employers/minimum_wage_calculator_employers.govspeak.erb
@@ -15,5 +15,5 @@
 
   ^Your employee must be at least 25 years old to get the national living wage.^
 
-Check [National Minimum Wage and National Living Wage rates](/national-minimum-wage-rates) before March 2018
+Check [National Minimum Wage and National Living Wage rates](/national-minimum-wage-rates) before March 2019
 <% end %>

--- a/lib/smart_answer_flows/minimum-wage-calculator-employers/questions/what_would_you_like_to_check.govspeak.erb
+++ b/lib/smart_answer_flows/minimum-wage-calculator-employers/questions/what_would_you_like_to_check.govspeak.erb
@@ -4,5 +4,5 @@
 
 <% options(
   "current_payment": "If you’re paying a worker the National Minimum Wage or the National Living Wage",
-  "past_payment": "If you owe a worker payments from last year (April 2018 to March 2019)"
+  "past_payment": "If you owe a worker payments from last year (April 2019 to March 2020)"
 ) %>

--- a/test/integration/smart_answer_flows/am_i_getting_minimum_wage_test.rb
+++ b/test/integration/smart_answer_flows/am_i_getting_minimum_wage_test.rb
@@ -891,35 +891,35 @@ class AmIGettingMinimumWageTest < ActiveSupport::TestCase
     context "27 year old, not apprentice, no additional charges" do
       should "earn above minimum wage" do
         assert_current_node :what_would_you_like_to_check?
-        add_response "past_payment"
+        add_response "current_payment"
 
-        assert_current_node :were_you_an_apprentice?
-        add_response "no"
+        assert_current_node :are_you_an_apprentice?
+        add_response "not_an_apprentice"
 
-        assert_current_node :how_old_were_you?
+        assert_current_node :how_old_are_you?
         add_response "27"
 
-        assert_current_node :how_often_did_you_get_paid?
+        assert_current_node :how_often_do_you_get_paid?
         add_response "7"
 
-        assert_current_node :how_many_hours_did_you_work?
+        assert_current_node :how_many_hours_do_you_work?
         add_response "37"
 
-        assert_current_node :how_much_were_you_paid_during_pay_period?
+        assert_current_node :how_much_are_you_paid_during_pay_period?
         add_response "305"
 
-        assert_current_node :was_provided_with_accommodation?
+        assert_current_node :is_provided_with_accommodation?
         add_response "no"
 
-        assert_current_node :did_employer_charge_for_job_requirements?
+        assert_current_node :does_employer_charge_for_job_requirements?
         add_response "no"
 
-        assert_current_node :past_additional_work_outside_shift?
+        assert_current_node :current_additional_work_outside_shift?
         add_response "no"
 
         assert_equal 8.24, current_state.calculator.total_hourly_rate
         assert_equal 8.21, current_state.calculator.minimum_hourly_rate
-        assert_current_node :past_payment_above
+        assert_current_node :current_payment_above
       end
     end
 
@@ -1321,6 +1321,444 @@ class AmIGettingMinimumWageTest < ActiveSupport::TestCase
         assert_current_node :current_payment_below
         assert_equal 8.20, current_state.calculator.total_hourly_rate
         assert_equal 8.21, current_state.calculator.minimum_hourly_rate
+      end
+    end
+  end
+  context "2020 scenarios" do
+    setup do
+      Timecop.freeze(Date.parse("2020-04-01"))
+      setup_for_testing_flow SmartAnswer::AmIGettingMinimumWageFlow
+    end
+    context "27 year old, not apprentice, no additional charges" do
+      should "earn above minimum wage" do
+        assert_current_node :what_would_you_like_to_check?
+        add_response "past_payment"
+
+        assert_current_node :were_you_an_apprentice?
+        add_response "no"
+
+        assert_current_node :how_old_were_you?
+        add_response "27"
+
+        assert_current_node :how_often_did_you_get_paid?
+        add_response "7"
+
+        assert_current_node :how_many_hours_did_you_work?
+        add_response "37"
+
+        assert_current_node :how_much_were_you_paid_during_pay_period?
+        add_response "325"
+
+        assert_current_node :was_provided_with_accommodation?
+        add_response "no"
+
+        assert_current_node :did_employer_charge_for_job_requirements?
+        add_response "no"
+
+        assert_current_node :past_additional_work_outside_shift?
+        add_response "no"
+
+        assert_equal 8.78, current_state.calculator.total_hourly_rate
+        assert_equal 8.21, current_state.calculator.minimum_hourly_rate
+        assert_current_node :past_payment_above
+      end
+    end
+
+    context "23 year old, 2nd year apprentice, paid additional work" do
+      should "earn below minimum wage" do
+        assert_current_node :what_would_you_like_to_check?
+        add_response "current_payment"
+
+        assert_current_node :are_you_an_apprentice?
+        add_response "apprentice_over_19_second_year_onwards"
+
+        assert_current_node :how_old_are_you?
+        add_response "23"
+
+        assert_current_node :how_often_do_you_get_paid?
+        add_response "7"
+
+        assert_current_node :how_many_hours_do_you_work?
+        add_response "40"
+
+        assert_current_node :how_much_are_you_paid_during_pay_period?
+        add_response "156"
+
+        assert_current_node :is_provided_with_accommodation?
+        add_response "no"
+
+        assert_current_node :does_employer_charge_for_job_requirements?
+        add_response "no"
+
+        assert_current_node :current_additional_work_outside_shift?
+        add_response "yes"
+
+        assert_current_node :current_paid_for_work_outside_shift?
+        add_response "yes"
+
+        assert_current_node :current_payment_below
+        assert_equal 3.90, current_state.calculator.total_hourly_rate
+        assert_equal 8.20, current_state.calculator.minimum_hourly_rate
+      end
+    end
+
+    context "20 year old, second year apprentice, charged for job requirements" do
+      should "earn below minmum wage" do
+        assert_current_node :what_would_you_like_to_check?
+        add_response "current_payment"
+
+        assert_current_node :are_you_an_apprentice?
+        add_response "apprentice_over_19_second_year_onwards"
+
+        assert_current_node :how_old_are_you?
+        add_response "20"
+
+        assert_current_node :how_often_do_you_get_paid?
+        add_response "7"
+
+        assert_current_node :how_many_hours_do_you_work?
+        add_response "38"
+
+        assert_current_node :how_much_are_you_paid_during_pay_period?
+        add_response "200"
+
+        assert_current_node :is_provided_with_accommodation?
+        add_response "no"
+
+        assert_current_node :does_employer_charge_for_job_requirements?
+        add_response "yes"
+
+        assert_current_node :current_additional_work_outside_shift?
+        add_response "no"
+
+        assert_current_node :current_payment_below
+        assert_equal 5.26, current_state.calculator.total_hourly_rate
+        assert_equal 6.45, current_state.calculator.minimum_hourly_rate
+      end
+    end
+
+    context "when user is earning below minimum wage, with accomodation" do
+      should "adjust underpayment based on the current rate" do
+        assert_current_node :what_would_you_like_to_check?
+        add_response "current_payment"
+
+        assert_current_node :are_you_an_apprentice?
+        add_response "not_an_apprentice"
+
+        assert_current_node :how_old_are_you?
+        add_response "30"
+
+        assert_current_node :how_often_do_you_get_paid?
+        add_response "21"
+
+        assert_current_node :how_many_hours_do_you_work?
+        add_response "120"
+
+        assert_current_node :how_much_are_you_paid_during_pay_period?
+        add_response "988.80"
+
+        assert_current_node :is_provided_with_accommodation?
+        add_response "yes_charged"
+
+        assert_current_node :current_accommodation_charge?
+        add_response 7.80
+
+        assert_current_node :current_accommodation_usage?
+        add_response 7
+
+        assert_current_node :does_employer_charge_for_job_requirements?
+        add_response "no"
+
+        assert_current_node :current_additional_work_outside_shift?
+        add_response "no"
+
+        assert_current_node :current_payment_below
+        assert_equal 8.24, current_state.calculator.total_hourly_rate
+        assert_equal 8.72, current_state.calculator.minimum_hourly_rate
+      # 7.80 accomodation * 21 days = £163.80
+      # £7.55 (offset rate used when accommodation is free) × 21 = £158.55
+      # #988.80 pay - £163.80 accomodation + £158.55 offset = £938.55
+      # £983.55 ÷ 120 (total hours in pay period) = £8.20 an hour
+      end
+    end
+
+    context "Over 25 years old, not an apprentice, free accomodation" do
+      should "earn above minmum wage" do
+        assert_current_node :what_would_you_like_to_check?
+        add_response "current_payment"
+
+        assert_current_node :are_you_an_apprentice?
+        add_response "not_an_apprentice"
+
+        assert_current_node :how_old_are_you?
+        add_response "30"
+
+        assert_current_node :how_often_do_you_get_paid?
+        add_response "7"
+
+        assert_current_node :how_many_hours_do_you_work?
+        add_response "30"
+
+        assert_current_node :how_much_are_you_paid_during_pay_period?
+        add_response "210"
+
+        assert_current_node :is_provided_with_accommodation?
+        add_response "yes_free"
+
+        assert_current_node :current_accommodation_usage?
+        add_response 7
+
+        assert_current_node :does_employer_charge_for_job_requirements?
+        add_response "no"
+
+        assert_current_node :current_additional_work_outside_shift?
+        add_response "yes"
+
+        assert_current_node :current_paid_for_work_outside_shift?
+        add_response "yes"
+
+        assert_current_node :current_payment_above
+        assert_equal 8.91, current_state.calculator.total_hourly_rate
+        assert_equal 8.72, current_state.calculator.minimum_hourly_rate
+        # £210/30 = £7 an hour
+        # £7.55 (offset rate used when accommodation is free) × 7 = £52.85
+        # £52.85 + 210 = £262.85
+        # £262.85 ÷ 30 (total hours in pay period) = £8.76
+      end
+    end
+
+    context "22 years old, not an apprentice, charged accomodation but below offset" do
+      should "earn above minmum wage" do
+        assert_current_node :what_would_you_like_to_check?
+        add_response "current_payment"
+
+        assert_current_node :are_you_an_apprentice?
+        add_response "not_an_apprentice"
+
+        assert_current_node :how_old_are_you?
+        add_response "22"
+
+        assert_current_node :how_often_do_you_get_paid?
+        add_response "7"
+
+        assert_current_node :how_many_hours_do_you_work?
+        add_response "41"
+
+        assert_current_node :how_much_are_you_paid_during_pay_period?
+        add_response "320"
+
+        assert_current_node :is_provided_with_accommodation?
+        add_response "yes_charged"
+
+        assert_current_node :current_accommodation_charge?
+        add_response 3.50
+
+        assert_current_node :current_accommodation_usage?
+        add_response 7
+
+        assert_current_node :does_employer_charge_for_job_requirements?
+        add_response "no"
+
+        assert_current_node :current_additional_work_outside_shift?
+        add_response "no"
+
+        assert_current_node :current_payment_below
+        assert_equal 7.80, current_state.calculator.total_hourly_rate
+        assert_equal 8.20, current_state.calculator.minimum_hourly_rate
+        # £320/41 = £7.80 an hour
+        # £3.50 accomodation chage below £7.55 offset
+      end
+    end
+
+    context "18 years old, first year apprentice, paid extra working time" do
+      should "earn above minmum wage" do
+        assert_current_node :what_would_you_like_to_check?
+        add_response "current_payment"
+
+        assert_current_node :are_you_an_apprentice?
+        add_response "apprentice_under_19"
+
+        assert_current_node :how_often_do_you_get_paid?
+        add_response "14"
+
+        assert_current_node :how_many_hours_do_you_work?
+        add_response "70"
+
+        assert_current_node :how_much_are_you_paid_during_pay_period?
+        add_response "273"
+
+        assert_current_node :is_provided_with_accommodation?
+        add_response "no"
+
+        assert_current_node :does_employer_charge_for_job_requirements?
+        add_response "no"
+
+        assert_current_node :current_additional_work_outside_shift?
+        add_response "yes"
+
+        assert_current_node :current_paid_for_work_outside_shift?
+        add_response "yes"
+
+        assert_current_node :current_payment_below
+        assert_equal 3.90, current_state.calculator.total_hourly_rate
+        assert_equal 4.15, current_state.calculator.minimum_hourly_rate
+      end
+    end
+    context "18 years old, first year apprentice" do
+      should "earn above minmum wage" do
+        assert_current_node :what_would_you_like_to_check?
+        add_response "current_payment"
+
+        assert_current_node :are_you_an_apprentice?
+        add_response "apprentice_under_19"
+
+        assert_current_node :how_often_do_you_get_paid?
+        add_response "7"
+
+        assert_current_node :how_many_hours_do_you_work?
+        add_response "20"
+
+        assert_current_node :how_much_are_you_paid_during_pay_period?
+        add_response "205"
+
+        assert_current_node :is_provided_with_accommodation?
+        add_response "no"
+
+        assert_current_node :does_employer_charge_for_job_requirements?
+        add_response "no"
+
+        assert_current_node :current_additional_work_outside_shift?
+        add_response "no"
+
+        assert_current_node :current_payment_above
+        assert_equal 10.25, current_state.calculator.total_hourly_rate
+        assert_equal 4.15, current_state.calculator.minimum_hourly_rate
+      end
+    end
+    context "25 years old, not an apprentice, charged accomodation, paid working time" do
+      should "earn above minmum wage" do
+        assert_current_node :what_would_you_like_to_check?
+        add_response "current_payment"
+
+        assert_current_node :are_you_an_apprentice?
+        add_response "not_an_apprentice"
+
+        assert_current_node :how_old_are_you?
+        add_response "25"
+
+        assert_current_node :how_often_do_you_get_paid?
+        add_response "5"
+
+        assert_current_node :how_many_hours_do_you_work?
+        add_response "25"
+
+        assert_current_node :how_much_are_you_paid_during_pay_period?
+        add_response "70"
+
+        assert_current_node :is_provided_with_accommodation?
+        add_response "yes_charged"
+
+        assert_current_node :current_accommodation_charge?
+        add_response 3.50
+
+        assert_current_node :current_accommodation_usage?
+        add_response 7
+
+        assert_current_node :does_employer_charge_for_job_requirements?
+        add_response "no"
+
+        assert_current_node :current_additional_work_outside_shift?
+        add_response "yes"
+
+        assert_current_node :current_paid_for_work_outside_shift?
+        add_response "yes"
+
+        assert_current_node :current_payment_below
+        assert_equal 2.80, current_state.calculator.total_hourly_rate
+        assert_equal 8.72, current_state.calculator.minimum_hourly_rate
+      end
+    end
+    context "26 years old, not an apprentice, paid extra working time" do
+      should "earn above minmum wage" do
+        assert_current_node :what_would_you_like_to_check?
+        add_response "current_payment"
+
+        assert_current_node :are_you_an_apprentice?
+        add_response "not_an_apprentice"
+
+        assert_current_node :how_old_are_you?
+        add_response "26"
+
+        assert_current_node :how_often_do_you_get_paid?
+        add_response "7"
+
+        assert_current_node :how_many_hours_do_you_work?
+        add_response "10"
+
+        assert_current_node :how_much_are_you_paid_during_pay_period?
+        add_response "205"
+
+        assert_current_node :is_provided_with_accommodation?
+        add_response "yes_charged"
+
+        assert_current_node :current_accommodation_charge?
+        add_response 1
+
+        assert_current_node :current_accommodation_usage?
+        add_response 7
+
+        assert_current_node :does_employer_charge_for_job_requirements?
+        add_response "no"
+
+        assert_current_node :current_additional_work_outside_shift?
+        add_response "yes"
+
+        assert_current_node :current_paid_for_work_outside_shift?
+        add_response "yes"
+
+        assert_current_node :current_payment_above
+        assert_equal 20.5, current_state.calculator.total_hourly_rate
+        assert_equal 8.72, current_state.calculator.minimum_hourly_rate
+      end
+    end
+    context "35 years old, not an apprentice, charged accomodation" do
+      should "earn above minmum wage" do
+        assert_current_node :what_would_you_like_to_check?
+        add_response "current_payment"
+
+        assert_current_node :are_you_an_apprentice?
+        add_response "not_an_apprentice"
+
+        assert_current_node :how_old_are_you?
+        add_response "35"
+
+        assert_current_node :how_often_do_you_get_paid?
+        add_response "21"
+
+        assert_current_node :how_many_hours_do_you_work?
+        add_response "120"
+
+        assert_current_node :how_much_are_you_paid_during_pay_period?
+        add_response "988.80"
+
+        assert_current_node :is_provided_with_accommodation?
+        add_response "yes_charged"
+
+        assert_current_node :current_accommodation_charge?
+        add_response "7.80"
+
+        assert_current_node :current_accommodation_usage?
+        add_response 7
+
+        assert_current_node :does_employer_charge_for_job_requirements?
+        add_response "no"
+
+        assert_current_node :current_additional_work_outside_shift?
+        add_response "no"
+
+        assert_current_node :current_payment_below
+        assert_equal 8.24, current_state.calculator.total_hourly_rate
+        assert_equal 8.72, current_state.calculator.minimum_hourly_rate
       end
     end
   end

--- a/test/integration/smart_answer_flows/am_i_getting_minimum_wage_test.rb
+++ b/test/integration/smart_answer_flows/am_i_getting_minimum_wage_test.rb
@@ -493,13 +493,13 @@ class AmIGettingMinimumWageTest < ActiveSupport::TestCase
                       end
 
                       should "show results'" do
-                        assert_current_node :past_payment_above
+                        assert_current_node :past_payment_below
                       end
                       should "make outcome calculations" do
                         assert_equal 42, current_state.calculator.total_hours
-                        assert_equal 3.7, current_state.calculator.minimum_hourly_rate
+                        assert_equal 3.9, current_state.calculator.minimum_hourly_rate
                         assert_equal 3.77, current_state.calculator.total_hourly_rate
-                        assert_equal true, current_state.calculator.minimum_wage_or_above?
+                        assert_equal false, current_state.calculator.minimum_wage_or_above?
                       end
                     end
                   end
@@ -775,7 +775,7 @@ class AmIGettingMinimumWageTest < ActiveSupport::TestCase
 
                         should "make outcome calculations" do
                           assert_equal 42, current_state.calculator.total_hours
-                          assert_equal 5.9, current_state.calculator.minimum_hourly_rate
+                          assert_equal 6.15, current_state.calculator.minimum_hourly_rate
                           assert_equal 3.77, current_state.calculator.total_hourly_rate
                           assert_equal false, current_state.calculator.minimum_wage_or_above?
                         end
@@ -874,9 +874,9 @@ class AmIGettingMinimumWageTest < ActiveSupport::TestCase
       add_response "no"
 
       assert_current_node :past_payment_below
-      assert_equal 7.38, current_state.calculator.minimum_hourly_rate # rate on '2018-07-01'
+      assert_equal 7.7, current_state.calculator.minimum_hourly_rate # rate on '2018-07-01'
 
-      expected_underpayment = 95.2
+      expected_underpayment = 103.51
       # (hours worked * hourly rate back then - paid by employer) / minimum hourly rate back then * minimum hourly rate today
       # (40h * £7.38 - £200.0) / 7.38 * 7.38 = 49.98
       assert_equal expected_underpayment, current_state.calculator.historical_adjustment
@@ -918,7 +918,7 @@ class AmIGettingMinimumWageTest < ActiveSupport::TestCase
         add_response "no"
 
         assert_equal 8.24, current_state.calculator.total_hourly_rate
-        assert_equal 7.83, current_state.calculator.minimum_hourly_rate
+        assert_equal 8.21, current_state.calculator.minimum_hourly_rate
         assert_current_node :past_payment_above
       end
     end


### PR DESCRIPTION
Yearly changes to minimum wage rates in line with the budget.

https://trello.com/c/SbkE4h98/1802-3-uprating-minimum-wage-data-and-content

Also updated so test cases that were added since the last uprating change.

Exact changes to rates:

National Living Wage and National Minimum Wage will increase:

* for those 25 and over – from £8.21 per hour to £8.72
* for 21 to 24 year olds – from £7.70 per hour to £8.20
* for 18 to 20 year olds – from £6.15 per hour to £6.45
* for 16 to 17 year olds – from £4.35 per hour to £4.55
* for apprentices – from £3.90 per hour to £4.15

Accommodation offset rates will also change:

* daily – from £7.55 to £8.20
* weekly – from £52.85 to £57.40