### PR TITLE
[DO NOT MERGE] Married couples allowance 2020/21 uprating

### DIFF
--- a/lib/data/rates/married_couples_allowance.yml
+++ b/lib/data/rates/married_couples_allowance.yml
@@ -33,3 +33,8 @@
   end_date: 2020-04-05
   maximum_married_couple_allowance: 8915
   minimum_married_couple_allowance: 3450
+
+- start_date: 2020-04-06
+  end_date: 2021-04-05
+  maximum_married_couple_allowance: 9075
+  minimum_married_couple_allowance: 3510

--- a/lib/data/rates/personal_allowance.yml
+++ b/lib/data/rates/personal_allowance.yml
@@ -47,3 +47,10 @@
   higher_allowance_1: 12500
   higher_allowance_2: 12500
   income_limit_for_personal_allowances: 29600.0
+
+- start_date: 2020-04-06
+  end_date: 2021-04-05
+  personal_allowance: 12500
+  higher_allowance_1: 12500
+  higher_allowance_2: 12500
+  income_limit_for_personal_allowances: 30200.0

--- a/test/unit/calculators/married_couple_allowance_calculator_test.rb
+++ b/test/unit/calculators/married_couple_allowance_calculator_test.rb
@@ -189,5 +189,16 @@ module SmartAnswer::Calculators
         assert_equal 3450, calculator.minimum_mca
       end
     end
+
+    test "rate values for 2020/21" do
+      Timecop.freeze(Date.parse("2020-06-01")) do
+        calculator = MarriedCouplesAllowanceCalculator.new
+
+        assert_equal 12500, calculator.personal_allowance
+        assert_equal 30200, calculator.income_limit_for_personal_allowances
+        assert_equal 9075, calculator.maximum_mca
+        assert_equal 3510, calculator.minimum_mca
+      end
+    end
   end
 end


### PR DESCRIPTION
This updates the rates for the married couples allowance for 2020/21.

[Trello Card](https://trello.com/c/YfywXpAJ/1815-2-uprating-changes-to-calculate-your-married-couples-allowance)