### PR TITLE
Maternity, Paternity and Adoption Calculator For Employers uprating 2020

### DIFF
--- a/lib/data/rates/maternity_paternity_adoption.yml
+++ b/lib/data/rates/maternity_paternity_adoption.yml
@@ -24,5 +24,8 @@
   end_date: 2019-04-06
   lower_earning_limit_rate: 116
 - start_date: 2019-04-07
-  end_date: 2100-04-05
+  end_date: 2020-04-04
   lower_earning_limit_rate: 118
+- start_date: 2020-04-05
+  end_date: 2100-04-03
+  lower_earning_limit_rate: 120

--- a/lib/data/rates/maternity_paternity_birth.yml
+++ b/lib/data/rates/maternity_paternity_birth.yml
@@ -27,5 +27,8 @@
   end_date: 2019-04-05
   lower_earning_limit_rate: 116
 - start_date: 2019-04-06
-  end_date: 2100-04-05
+  end_date: 2020-04-04
   lower_earning_limit_rate: 118
+- start_date: 2020-04-05
+  end_date: 2100-04-03
+  lower_earning_limit_rate: 120

--- a/lib/smart_answer/calculators/maternity_pay_calculator.rb
+++ b/lib/smart_answer/calculators/maternity_pay_calculator.rb
@@ -289,7 +289,8 @@ module SmartAnswer::Calculators
         { min: uprating_date(2014), max: uprating_date(2017), amount: 139.58 },
         { min: uprating_date(2017), max: uprating_date(2018), amount: 140.98 },
         { min: uprating_date(2018), max: uprating_date(2019), amount: 145.18 },
-        { min: uprating_date(2019), max: uprating_date(2100), amount: 148.68 },
+        { min: uprating_date(2019), max: uprating_date(2020), amount: 148.68 },
+        { min: uprating_date(2020), max: uprating_date(2100), amount: 151.20 },
          ### Change year in future
       ]
       rate = rates.find { |r| r[:min] <= date && date < r[:max] } || rates.last

--- a/test/integration/smart_answer_flows/maternity_calculator_test.rb
+++ b/test/integration/smart_answer_flows/maternity_calculator_test.rb
@@ -516,6 +516,26 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
       end
     end
 
+    context "check for correct LEL Saturday, April 18th 2020 monthly" do
+      setup do
+        add_response Date.parse("2020-07-26")
+        add_response Date.parse("2020-06-29")
+        add_response :yes
+        add_response Date.parse("2020-04-06")
+        add_response Date.parse("2020-02-07")
+        add_response :monthly
+        add_response 956
+        add_response "2"
+        add_response "weekly_starting"
+      end
+
+      should "have LEL of 120" do
+        assert_state_variable :to_saturday_formatted, "Saturday, 18 April 2020"
+        assert_state_variable "lower_earning_limit", sprintf("%.2f", 120)
+        assert_current_node :maternity_leave_and_pay_result
+      end
+    end
+
 
     context "check for correct LEL Saturday, 12 April 2014 monthly" do
       setup do

--- a/test/unit/calculators/maternity_pay_calculator_test.rb
+++ b/test/unit/calculators/maternity_pay_calculator_test.rb
@@ -368,6 +368,7 @@ module SmartAnswer::Calculators
 
       context "statutory pay rate for given year" do
         {
+          2020 => 151.20,
           2019 => 148.68,
           2018 => 145.18,
           2017 => 140.98,


### PR DESCRIPTION
This PR uprates the lower earning limits for the Maternity, Paternity and Adoption Calculator for Employers.

Statutory pay increases to £151.20
Lower Earning Limit increases to £120 

[Trello](https://trello.com/c/tO8UDps0/1812-uprating-changes-to-maternity-adoption-and-paternity-calculator-for-employers)