### PR TITLE
Uprating for State Pension weekly rate and lower weekly rate for 2020

### DIFF
--- a/lib/data/rates/state_pension.yml
+++ b/lib/data/rates/state_pension.yml
@@ -35,6 +35,11 @@
   lower_weekly_rate: 75.50
 
 - start_date: 2019-04-08
-  end_date: 2020-04-08
+  end_date: 2020-04-05
   weekly_rate: 129.20
   lower_weekly_rate: 77.45
+
+- start_date: 2020-04-06
+  end_date: 2100-04-05
+  weekly_rate: 134.25
+  lower_weekly_rate: 80.45


### PR DESCRIPTION
This PR updates the State Pension Weekly and Lower Weekly limits for 2020

[Trello](https://trello.com/c/seIjzjUz/1836-2-6-april-uprating-update-the-your-partners-national-insurance-record-and-your-state-pension-calculator)