### PR TITLE
Uprate redundancy pay rates for 2020

### DIFF
--- a/lib/data/rates/redundancy_pay.yml
+++ b/lib/data/rates/redundancy_pay.yml
@@ -31,3 +31,7 @@
   end_date: 2020-04-05
   max: "15,750"
   rate: 525
+- start_date: 2020-04-06
+  end_date: 2021-04-05
+  max: "16,140"
+  rate: 538

--- a/lib/data/rates/redundancy_pay_northern_ireland.yml
+++ b/lib/data/rates/redundancy_pay_northern_ireland.yml
@@ -31,3 +31,7 @@
   end_date: 2020-04-05
   max: "16,410"
   rate: 547
+- start_date: 2020-04-06
+  end_date: 2021-04-05
+  max: "16,800"
+  rate: 560

--- a/test/unit/calculators/redundancy_calculator_test.rb
+++ b/test/unit/calculators/redundancy_calculator_test.rb
@@ -30,6 +30,7 @@ module SmartAnswer::Calculators
         assert_equal 489, RedundancyCalculator.redundancy_rates(Date.new(2017, 4, 6)).rate
         assert_equal 508, RedundancyCalculator.redundancy_rates(Date.new(2018, 4, 6)).rate
         assert_equal 525, RedundancyCalculator.redundancy_rates(Date.new(2019, 4, 6)).rate
+        assert_equal 538, RedundancyCalculator.redundancy_rates(Date.new(2020, 4, 6)).rate
       end
 
       should "vary the max amount per year" do
@@ -43,13 +44,26 @@ module SmartAnswer::Calculators
         assert_equal "14,370", RedundancyCalculator.redundancy_rates(Date.new(2016, 4, 6)).max
         assert_equal "14,670", RedundancyCalculator.redundancy_rates(Date.new(2017, 4, 6)).max
         assert_equal "15,240", RedundancyCalculator.redundancy_rates(Date.new(2018, 4, 6)).max
-        assert_equal "15,750", RedundancyCalculator.redundancy_rates(Date.new(Time.zone.today.year, 12, 31)).max
+        assert_equal "15,750", RedundancyCalculator.redundancy_rates(Date.new(2019, 4, 6)).max
+        assert_equal "16,140", RedundancyCalculator.redundancy_rates(Date.new(Time.zone.today.year, 12, 31)).max
       end
 
       should "use the most recent rate for far future dates" do
         future_calculator = RedundancyCalculator.redundancy_rates(5.years.from_now.to_date)
         assert future_calculator.rate.is_a?(Numeric)
         assert future_calculator.max.present?
+      end
+    end
+
+    context "Northern Ireland amounts for the redundancy date" do
+      should "vary the rate per year" do
+        assert_equal 547, RedundancyCalculator.northern_ireland_redundancy_rates(Date.new(2019, 4, 6)).rate
+        assert_equal 560, RedundancyCalculator.northern_ireland_redundancy_rates(Date.new(2020, 4, 6)).rate
+      end
+
+      should "vary the max amount per year" do
+        assert_equal "16,410", RedundancyCalculator.northern_ireland_redundancy_rates(Date.new(2019, 4, 6)).max
+        assert_equal "16,800", RedundancyCalculator.northern_ireland_redundancy_rates(Date.new(Time.zone.today.year, 12, 31)).max
       end
     end
 


### PR DESCRIPTION
Redundancy pay rate uprating for 2020-2021

N Ireland figures: 
Weekly rate: 547 => 560 
Maximum amount: 16,410  => 16,800

Rest of UK figures:
Weekly rate: 525 => 538
Maximum amount: 15,750 =>  16,140



[trello](https://trello.com/c/ziSehECz/1835-2-6-april-uprating-calculate-your-redundancy-pay-employees-redundancy-pay)