### PR TITLE
Revert content type to remove UTF information

### DIFF
--- a/app/presenters/start_page_content_item.rb
+++ b/app/presenters/start_page_content_item.rb
@@ -16,12 +16,12 @@ class StartPageContentItem
         introductory_paragraph: [
           {
             content: flow_presenter.start_page_body,
-            content_type: "text/govspeak; charset=utf-8",
+            content_type: "text/govspeak",
           },
         ],
         more_information: [
           content: flow_presenter.start_page_post_body,
-          content_type: "text/govspeak; charset=utf-8",
+          content_type: "text/govspeak",
         ],
         transaction_start_link: base_path + "/y",
         start_button_text: flow_presenter.start_page_button_text,

--- a/app/services/content_item_publisher.rb
+++ b/app/services/content_item_publisher.rb
@@ -106,7 +106,7 @@ private
         body: [
           {
             content: content,
-            content_type: "text/govspeak; charset=utf-8",
+            content_type: "text/govspeak",
           },
         ],
       },
@@ -134,7 +134,7 @@ private
         introductory_paragraph: [
           {
             content: content,
-            content_type: "text/govspeak; charset=utf-8",
+            content_type: "text/govspeak",
           },
         ],
         transaction_start_link: link,

--- a/test/unit/start_page_content_item_test.rb
+++ b/test/unit/start_page_content_item_test.rb
@@ -82,7 +82,7 @@ module SmartAnswer
       content_item = StartPageContentItem.new(presenter)
 
       assert_equal "start-page-body", content_item.payload[:details][:introductory_paragraph][0][:content]
-      assert_equal "text/govspeak; charset=utf-8", content_item.payload[:details][:introductory_paragraph][0][:content_type]
+      assert_equal "text/govspeak", content_item.payload[:details][:introductory_paragraph][0][:content_type]
     end
 
     test "#payload details hash includes more information as govspeak" do
@@ -91,7 +91,7 @@ module SmartAnswer
       content_item = StartPageContentItem.new(presenter)
 
       assert_equal "start-page-post-body", content_item.payload[:details][:more_information][0][:content]
-      assert_equal "text/govspeak; charset=utf-8", content_item.payload[:details][:more_information][0][:content_type]
+      assert_equal "text/govspeak", content_item.payload[:details][:more_information][0][:content_type]
     end
 
     test "#payload details hash includes the link to the flow" do


### PR DESCRIPTION
This was added in ba67c415410e8cec4f412e80f3fefd06d87c09d5
automatically as part of Rails 6 upgrade. However, it caused
our publishing API rake tasks to break:

> GdsApi::HTTPUnprocessableEntity: URL: https://publishing-api.integration.govuk-internal.digital/v2/content/05d5412d-455b-485e-a570-020c9176a46e
> Response body:
> {"error":{"code":422,"message":"Details there must be at least one content type of (text/html, text/govspeak)","fields":{"details":["there must be at least one content type of (text/html, text/govspeak)"]}}}

Ideally we should add a test in future which validates against
the schema.

This is needed ASAP so we can publish https://github.com/alphagov/smart-answers/pull/4372 today.