### PR TITLE
Update the link for the Coronavirus callout

### DIFF
--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/calculate_statutory_sick_pay.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/calculate_statutory_sick_pay.govspeak.erb
@@ -11,7 +11,7 @@
 
   ##What you need to know
 
-  ^Emergency legislation is being brought forward for employees who are [self-isolating because of coronavirus (COVID-19)](https://www.nhs.uk/conditions/coronavirus-covid-19/). They will be able to get SSP from the first day they are off work. This will begin from 13 March. This calculator will be updated if the law changes.^
+  ^Emergency legislation is being brought forward for employees who are [self-isolating because of coronavirus (COVID-19)](/government/publications/covid-19-stay-at-home-guidance). They will be able to get SSP from the first day they are off work. This will begin from 13 March. This calculator will be updated if the law changes.^
 
   You’re only responsible for paying SSP if:
 


### PR DESCRIPTION
On the Calculate statutory sick pay start page.

Related to Zendesk ticket: 3972370