### PR TITLE
Apply the special COVID-19 related rules for SSP

### DIFF
--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -4,6 +4,7 @@ module SmartAnswer
       class PeriodOfIncapacityForWork < DateRange
         MAXIMUM_NUMBER_OF_WAITING_DAYS = 3
         MINIMUM_NUMBER_OF_DAYS = 4
+        CORONAVIRUS_SSP_START_DATE = Time.zone.local(2020, 3, 13)
 
         def qualifying_days(pattern)
           dates = begins_on..ends_on
@@ -23,7 +24,7 @@ module SmartAnswer
       include ActiveModel::Model
 
       attr_accessor :sick_start_date, :sick_end_date, :days_of_the_week_worked
-      attr_accessor :other_pay_types_received, :enough_notice_of_absence
+      attr_accessor :other_pay_types_received, :enough_notice_of_absence, :has_coronavirus
       attr_accessor :has_linked_sickness
       attr_accessor :linked_sickness_start_date, :linked_sickness_end_date
       attr_accessor :relevant_period_to, :relevant_period_from
@@ -55,12 +56,12 @@ module SmartAnswer
         linked_piw.qualifying_days(days_of_the_week_worked).length
       end
 
-      def number_of_waiting_days_in_linked_piw
-        [prev_sick_days, PeriodOfIncapacityForWork::MAXIMUM_NUMBER_OF_WAITING_DAYS].min
-      end
-
       def number_of_waiting_days_not_in_linked_piw
-        PeriodOfIncapacityForWork::MAXIMUM_NUMBER_OF_WAITING_DAYS - number_of_waiting_days_in_linked_piw
+        if has_coronavirus && current_piw.begins_on >= PeriodOfIncapacityForWork::CORONAVIRUS_SSP_START_DATE
+          0
+        else
+          [0, PeriodOfIncapacityForWork::MAXIMUM_NUMBER_OF_WAITING_DAYS - prev_sick_days].max
+        end
       end
 
       def pattern_days

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -40,11 +40,25 @@ module SmartAnswer
         end
 
         next_node do
-          question :employee_work_different_days?
+          question :has_coronavirus?
         end
       end
 
       # Question 3
+      multiple_choice :has_coronavirus? do
+        option :yes
+        option :no
+
+        on_response do |response|
+          calculator.has_coronavirus = response == "yes"
+        end
+
+        next_node do
+          question :employee_work_different_days?
+        end
+      end
+
+      # Question 4
       multiple_choice :employee_work_different_days? do
         option :yes
         option :no
@@ -59,7 +73,7 @@ module SmartAnswer
         end
       end
 
-      # Question 4
+      # Question 5
       date_question :first_sick_day? do
         from { Date.new(2011, 1, 1) }
         to { Calculators::StatutorySickPayCalculator.year_of_sickness }
@@ -75,7 +89,7 @@ module SmartAnswer
         end
       end
 
-      # Question 5
+      # Question 6
       date_question :last_sick_day? do
         from { Date.new(2011, 1, 1) }
         to { Calculators::StatutorySickPayCalculator.year_of_sickness }
@@ -99,7 +113,7 @@ module SmartAnswer
         end
       end
 
-      # Question 6
+      # Question 7
       multiple_choice :has_linked_sickness? do
         option :yes
         option :no
@@ -122,7 +136,7 @@ module SmartAnswer
         end
       end
 
-      # Question 6.1
+      # Question 7.1
       date_question :linked_sickness_start_date? do
         from { Date.new(2010, 1, 1) }
         to { Calculators::StatutorySickPayCalculator.year_of_sickness }
@@ -142,7 +156,7 @@ module SmartAnswer
         end
       end
 
-      # Question 6.2
+      # Question 7.2
       date_question :linked_sickness_end_date? do
         from { Date.new(2010, 1, 1) }
         to { Calculators::StatutorySickPayCalculator.year_of_sickness }
@@ -170,7 +184,7 @@ module SmartAnswer
         end
       end
 
-      # Question 7.1
+      # Question 8.1
       multiple_choice :paid_at_least_8_weeks? do
         option :eight_weeks_more
         option :eight_weeks_less
@@ -195,7 +209,7 @@ module SmartAnswer
         end
       end
 
-      # Question 7.2
+      # Question 8.2
       multiple_choice :how_often_pay_employee_pay_patterns? do
         option :weekly
         option :fortnightly
@@ -216,7 +230,7 @@ module SmartAnswer
         end
       end
 
-      # Question 8
+      # Question 9
       date_question :last_payday_before_sickness? do
         from { Date.new(2010, 1, 1) }
         to { Calculators::StatutorySickPayCalculator.year_of_sickness }
@@ -239,7 +253,7 @@ module SmartAnswer
         end
       end
 
-      # Question 8.1
+      # Question 9.1
       date_question :last_payday_before_offset? do
         from { Date.new(2010, 1, 1) }
         to { Calculators::StatutorySickPayCalculator.year_of_sickness }
@@ -262,7 +276,7 @@ module SmartAnswer
         end
       end
 
-      # Question 8.2
+      # Question 9.2
       money_question :total_employee_earnings? do
         precalculate :relevant_period_from do
           calculator.relevant_period_from
@@ -281,7 +295,7 @@ module SmartAnswer
         end
       end
 
-      # Question 9
+      # Question 10
       money_question :pay_amount_if_not_sick? do
         precalculate :sick_start_date_for_awe do
           calculator.sick_start_date_for_awe
@@ -296,7 +310,7 @@ module SmartAnswer
         end
       end
 
-      # Question 9.1
+      # Question 10.1
       value_question :contractual_days_covered_by_earnings? do
         on_response do |response|
           calculator.contractual_days_covered_by_earnings = response
@@ -311,7 +325,7 @@ module SmartAnswer
         end
       end
 
-      # Question 10
+      # Question 11
       money_question :total_earnings_before_sick_period? do
         on_response do |response|
           calculator.total_earnings_before_sick_period = response
@@ -322,7 +336,7 @@ module SmartAnswer
         end
       end
 
-      # Question 10.1
+      # Question 11.1
       value_question :days_covered_by_earnings? do
         on_response do |response|
           calculator.days_covered_by_earnings = response.to_i
@@ -333,7 +347,7 @@ module SmartAnswer
         end
       end
 
-      # Question 11
+      # Question 12
       checkbox_question :usual_work_days? do
         %w{1 2 3 4 5 6 0}.each { |n| option n.to_s }
 

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/calculate_statutory_sick_pay.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/calculate_statutory_sick_pay.govspeak.erb
@@ -11,8 +11,6 @@
 
   ##What you need to know
 
-  ^Emergency legislation is being brought forward for employees who are [self-isolating because of coronavirus (COVID-19)](/government/publications/covid-19-stay-at-home-guidance). They will be able to get SSP from the first day they are off work. This will begin from 13 March. This calculator will be updated if the law changes.^
-
   You’re only responsible for paying SSP if:
 
   - you pay Class 1 National Insurance contributions for your employee (or would do if not for their age or their level of earnings)

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/questions/has_coronavirus.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/questions/has_coronavirus.govspeak.erb
@@ -1,0 +1,8 @@
+<% content_for :title do %>
+  Is your employee off sick with coronavirus (COVID-19) or self-isolating because of it?
+<% end %>
+
+<% options(
+  "yes": "Yes",
+  "no": "No"
+) %>

--- a/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
@@ -53,6 +53,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
     context "employee didn't tell employer within time limit" do
       setup do
         add_response :no
+        add_response :no
       end
 
       should "go to entitled_to_sick_pay outcome" do
@@ -81,6 +82,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
     context "employee told employer within time limit" do
       setup do
         add_response :yes
+        add_response :no
       end
 
       should "take you to Q3" do
@@ -267,14 +269,15 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response "none" # Q1
       add_response "yes" # Q2
       add_response "no" # Q3
-      add_response "2018-06-10" # Q4
-      add_response "2018-06-20" # Q5
-      add_response "no" # Q11
-      add_response "before_payday" # Q5.1
-      add_response "weekly" # Q5.2
-      add_response "115" # Q7
-      add_response "7" # Q7.1
-      add_response "1,2,3,4,5" # Q13
+      add_response "no" # Q4
+      add_response "2018-06-10" # Q5
+      add_response "2018-06-20" # Q6
+      add_response "no" # Q12
+      add_response "before_payday" # Q6.1
+      add_response "weekly" # Q6.2
+      add_response "115" # Q8
+      add_response "7" # Q8.1
+      add_response "1,2,3,4,5" # Q14
     end
     should "take you to result A5 as awe < LEL (as of 2018-06-10)" do
       assert_equal current_state.calculator.employee_average_weekly_earnings, 115
@@ -286,6 +289,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
     setup do
       add_response "none"
       add_response "yes"
+      add_response "no"
       add_response "no"
       add_response "2013-06-10"
       add_response "2013-06-12"
@@ -299,6 +303,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
     setup do
       add_response "none"
       add_response "yes"
+      add_response "no"
       add_response "no"
       add_response "2015-03-12"
       add_response "2015-03-19"
@@ -328,6 +333,8 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response "none"
       assert_current_node :employee_tell_within_limit?
       add_response "yes"
+      assert_current_node :has_coronavirus?
+      add_response "no"
       assert_current_node :employee_work_different_days?
       add_response "no"
       assert_current_node :first_sick_day?
@@ -361,6 +368,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
     should "have the adjusted rates in place for the week crossing through 6th April" do
       add_response :statutory_paternity_pay
       add_response :yes
+      add_response :no
       add_response :no
       add_response "2013-01-08"
       add_response "2013-05-03"
@@ -399,6 +407,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response :statutory_paternity_pay
       add_response :yes
       add_response :no
+      add_response :no
       add_response "2013-01-08"
       add_response "2013-05-03"
       add_response :yes
@@ -436,6 +445,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response :statutory_paternity_pay
       add_response :yes
       add_response :no
+      add_response :no
       add_response "2013-01-07"
       add_response "2013-05-03"
       add_response :no
@@ -470,6 +480,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
     should "show formatted weekly payment amounts with adjusted 3 days start amount for additional SPP" do
       add_response :shared_parental_leave_and_pay
       add_response :yes
+      add_response :no
       add_response :no
       add_response "2013-01-07"
       add_response "2013-05-03"
@@ -508,6 +519,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response :shared_parental_leave_and_pay
       add_response :no
       add_response :no
+      add_response :no
       assert_current_node :first_sick_day?
     end
 
@@ -528,6 +540,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
     setup do
       add_response :shared_parental_leave_and_pay
       add_response :yes
+      add_response :no
       add_response :no
       add_response "02/04/2013"
       assert_current_node :last_sick_day?
@@ -556,6 +569,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response :shared_parental_leave_and_pay
       add_response :yes
       add_response :no
+      add_response :no
       add_response "2015-03-19"
       add_response "2015-03-27"
       add_response :yes
@@ -582,6 +596,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
     setup do
       add_response :shared_parental_leave_and_pay
       add_response :yes
+      add_response :no
       add_response :no
       add_response "2015-05-21"
       add_response "2015-05-29"
@@ -622,6 +637,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response :shared_parental_leave_and_pay
       add_response :yes
       add_response :no
+      add_response :no
       add_response "02/04/2013"
       add_response "10/04/2013"
       add_response :no
@@ -645,6 +661,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
     setup do
       add_response :shared_parental_leave_and_pay
       add_response :yes
+      add_response :no
       add_response :no
       add_response "02/04/2013"
       add_response "10/04/2013"


### PR DESCRIPTION
This introduces a new question to see if the worker is self-isolating for Coronavirus on or after 13 March 2020. If so, new rules for qualifying for SSP apply. In all other cases, the calculation remains the same.

https://trello.com/c/td0XUZol/1834-5-urgent-amend-statutory-sick-pay-calculator-for-coronavirus

Co-authored-by: Alan Gabbianelli <alan.gabbianelli@digital.cabinet-office.gov.uk>