### PR TITLE
Apply the special COVID-19 related rules for SSP

### DIFF
--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -4,6 +4,7 @@ module SmartAnswer
       class PeriodOfIncapacityForWork < DateRange
         MAXIMUM_NUMBER_OF_WAITING_DAYS = 3
         MINIMUM_NUMBER_OF_DAYS = 4
+        CORONAVIRUS_SSP_START_DATE = Time.zone.local(2020, 3, 13)
 
         def qualifying_days(pattern)
           dates = begins_on..ends_on
@@ -24,6 +25,7 @@ module SmartAnswer
 
       attr_accessor :sick_start_date, :sick_end_date, :days_of_the_week_worked
       attr_accessor :other_pay_types_received, :enough_notice_of_absence
+      attr_accessor :coronavirus_related, :has_coronavirus, :cohabitant_has_coronavirus
       attr_accessor :has_linked_sickness
       attr_accessor :linked_sickness_start_date, :linked_sickness_end_date
       attr_accessor :relevant_period_to, :relevant_period_from
@@ -55,12 +57,12 @@ module SmartAnswer
         linked_piw.qualifying_days(days_of_the_week_worked).length
       end
 
-      def number_of_waiting_days_in_linked_piw
-        [prev_sick_days, PeriodOfIncapacityForWork::MAXIMUM_NUMBER_OF_WAITING_DAYS].min
-      end
-
       def number_of_waiting_days_not_in_linked_piw
-        PeriodOfIncapacityForWork::MAXIMUM_NUMBER_OF_WAITING_DAYS - number_of_waiting_days_in_linked_piw
+        if coronavirus_related && !before_coronavirus_entitlement_date?
+          0
+        else
+          [0, PeriodOfIncapacityForWork::MAXIMUM_NUMBER_OF_WAITING_DAYS - prev_sick_days].max
+        end
       end
 
       def pattern_days
@@ -279,6 +281,10 @@ module SmartAnswer
         else
           current_day.end_of_year
         end
+      end
+
+      def before_coronavirus_entitlement_date?
+        current_piw.begins_on < PeriodOfIncapacityForWork::CORONAVIRUS_SSP_START_DATE
       end
 
     private

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/calculate_statutory_sick_pay.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/calculate_statutory_sick_pay.govspeak.erb
@@ -11,8 +11,6 @@
 
   ##What you need to know
 
-  ^Emergency legislation is being brought forward for employees who are [self-isolating because of coronavirus (COVID-19)](/government/publications/covid-19-stay-at-home-guidance). They will be able to get SSP from the first day they are off work. This will begin from 13 March. This calculator will be updated if the law changes.^
-
   You’re only responsible for paying SSP if:
 
   - you pay Class 1 National Insurance contributions for your employee (or would do if not for their age or their level of earnings)

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/not_entitled_coronavirus_selfisolation.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/not_entitled_coronavirus_selfisolation.govspeak.erb
@@ -1,0 +1,5 @@
+<% content_for :body do %>
+  Your employee is not eligible for Statutory Sick Pay.
+
+  They started self-isolating because someone they live with had symptoms of coronavirus (COVID-19) before 13 March 2020. The regulations for Statutory Sick Pay and self-isolation changed from 13 March 2020.
+<% end %>

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/questions/coronavirus_related.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/questions/coronavirus_related.govspeak.erb
@@ -1,0 +1,8 @@
+<% content_for :title do %>
+  Is your employee off sick with coronavirus (COVID-19) or self-isolating because of it?
+<% end %>
+
+<% options(
+  "yes": "Yes",
+  "no": "No"
+) %>

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/questions/coronavirus_self_or_cohabitant.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/questions/coronavirus_self_or_cohabitant.govspeak.erb
@@ -1,0 +1,8 @@
+<% content_for :title do %>
+  Has your employee or someone they live with got symptoms of coronavirus (COVID-19)?
+<% end %>
+
+<% options(
+  self: "They have symptoms",
+  cohabitant: "They live with someone who has symptoms"
+) %>

--- a/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
@@ -53,6 +53,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
     context "employee didn't tell employer within time limit" do
       setup do
         add_response :no
+        add_response :no
       end
 
       should "go to entitled_to_sick_pay outcome" do
@@ -81,6 +82,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
     context "employee told employer within time limit" do
       setup do
         add_response :yes
+        add_response :no
       end
 
       should "take you to Q3" do
@@ -267,14 +269,15 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response "none" # Q1
       add_response "yes" # Q2
       add_response "no" # Q3
-      add_response "2018-06-10" # Q4
-      add_response "2018-06-20" # Q5
-      add_response "no" # Q11
-      add_response "before_payday" # Q5.1
-      add_response "weekly" # Q5.2
-      add_response "115" # Q7
-      add_response "7" # Q7.1
-      add_response "1,2,3,4,5" # Q13
+      add_response "no" # Q4
+      add_response "2018-06-10" # Q5
+      add_response "2018-06-20" # Q6
+      add_response "no" # Q12
+      add_response "before_payday" # Q6.1
+      add_response "weekly" # Q6.2
+      add_response "115" # Q8
+      add_response "7" # Q8.1
+      add_response "1,2,3,4,5" # Q14
     end
     should "take you to result A5 as awe < LEL (as of 2018-06-10)" do
       assert_equal current_state.calculator.employee_average_weekly_earnings, 115
@@ -286,6 +289,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
     setup do
       add_response "none"
       add_response "yes"
+      add_response "no"
       add_response "no"
       add_response "2013-06-10"
       add_response "2013-06-12"
@@ -299,6 +303,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
     setup do
       add_response "none"
       add_response "yes"
+      add_response "no"
       add_response "no"
       add_response "2015-03-12"
       add_response "2015-03-19"
@@ -328,6 +333,8 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response "none"
       assert_current_node :employee_tell_within_limit?
       add_response "yes"
+      assert_current_node :coronavirus_related?
+      add_response "no"
       assert_current_node :employee_work_different_days?
       add_response "no"
       assert_current_node :first_sick_day?
@@ -361,6 +368,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
     should "have the adjusted rates in place for the week crossing through 6th April" do
       add_response :statutory_paternity_pay
       add_response :yes
+      add_response :no
       add_response :no
       add_response "2013-01-08"
       add_response "2013-05-03"
@@ -399,6 +407,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response :statutory_paternity_pay
       add_response :yes
       add_response :no
+      add_response :no
       add_response "2013-01-08"
       add_response "2013-05-03"
       add_response :yes
@@ -436,6 +445,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response :statutory_paternity_pay
       add_response :yes
       add_response :no
+      add_response :no
       add_response "2013-01-07"
       add_response "2013-05-03"
       add_response :no
@@ -470,6 +480,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
     should "show formatted weekly payment amounts with adjusted 3 days start amount for additional SPP" do
       add_response :shared_parental_leave_and_pay
       add_response :yes
+      add_response :no
       add_response :no
       add_response "2013-01-07"
       add_response "2013-05-03"
@@ -508,6 +519,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response :shared_parental_leave_and_pay
       add_response :no
       add_response :no
+      add_response :no
       assert_current_node :first_sick_day?
     end
 
@@ -528,6 +540,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
     setup do
       add_response :shared_parental_leave_and_pay
       add_response :yes
+      add_response :no
       add_response :no
       add_response "02/04/2013"
       assert_current_node :last_sick_day?
@@ -556,6 +569,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response :shared_parental_leave_and_pay
       add_response :yes
       add_response :no
+      add_response :no
       add_response "2015-03-19"
       add_response "2015-03-27"
       add_response :yes
@@ -582,6 +596,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
     setup do
       add_response :shared_parental_leave_and_pay
       add_response :yes
+      add_response :no
       add_response :no
       add_response "2015-05-21"
       add_response "2015-05-29"
@@ -622,6 +637,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
       add_response :shared_parental_leave_and_pay
       add_response :yes
       add_response :no
+      add_response :no
       add_response "02/04/2013"
       add_response "10/04/2013"
       add_response :no
@@ -645,6 +661,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
     setup do
       add_response :shared_parental_leave_and_pay
       add_response :yes
+      add_response :no
       add_response :no
       add_response "02/04/2013"
       add_response "10/04/2013"

--- a/test/unit/calculators/statutory_sick_pay_calculator_test.rb
+++ b/test/unit/calculators/statutory_sick_pay_calculator_test.rb
@@ -1010,6 +1010,82 @@ module SmartAnswer
           assert_equal StatutorySickPayCalculator.year_of_sickness, Date.parse("31 Dec 2018")
         end
       end
+
+
+      context "when the employee is self-isolating due to coronavirus" do
+        context "starting before 13 March 2020" do
+          start_date = Date.parse("12 March 2020") # thursday
+          end_date = Date.parse("17 March 2020") # tuesday
+
+          should "use normal rules for SSP if they're ill themselves" do
+            calc = StatutorySickPayCalculator.new(
+              sick_start_date: start_date,
+              sick_end_date: end_date,
+              days_of_the_week_worked: %w(1 2 3 4 5),
+              has_linked_sickness: false,
+              coronavirus_related: true,
+              has_coronavirus: true,
+            )
+
+            assert_equal 1, calc.days_paid
+            assert_equal true, calc.valid_period_of_incapacity_for_work?
+          end
+
+          should "not pay SSP if they're self-isolating due to someone they live with" do
+            calc = StatutorySickPayCalculator.new(
+              sick_start_date: start_date,
+              sick_end_date: end_date,
+              days_of_the_week_worked: %w(1 2 3 4 5),
+              has_linked_sickness: false,
+              coronavirus_related: true,
+              has_coronavirus: false,
+              cohabitant_has_coronavirus: false,
+            )
+
+            assert_equal 1, calc.days_paid
+            assert_equal true, calc.valid_period_of_incapacity_for_work?
+            assert_equal true, calc.before_coronavirus_entitlement_date?
+          end
+        end
+
+        context "starting on or after 13 March 2020" do
+          start_date = Date.parse("13 March 2020") # friday
+
+          context "lasting four days or more" do
+            end_date = Date.parse("16 March 2020") # monday
+
+            should "pay SSP for all days of absence" do
+              calc = StatutorySickPayCalculator.new(
+                sick_start_date: start_date,
+                sick_end_date: end_date,
+                days_of_the_week_worked: %w(1 2 3 4 5),
+                has_linked_sickness: false,
+                coronavirus_related: true,
+              )
+
+              assert_equal 2, calc.days_paid
+              assert_equal true, calc.valid_period_of_incapacity_for_work?
+            end
+          end
+
+          context "lasting less than four days" do
+            end_date = Date.parse("15 March 2020") # sunday
+
+            should "not pay SSP" do
+              calc = StatutorySickPayCalculator.new(
+                sick_start_date: start_date,
+                sick_end_date: end_date,
+                days_of_the_week_worked: %w(1 2 3 4 5),
+                has_linked_sickness: false,
+                coronavirus_related: true,
+              )
+
+              assert_equal 1, calc.days_paid # will never be called by the calculator
+              assert_equal false, calc.valid_period_of_incapacity_for_work? # because this determines the outcome that no days are to be paid
+            end
+          end
+        end
+      end
     end # SSP calculator
   end
 end


### PR DESCRIPTION
This introduces a new question to see if the worker is self-isolating for Coronavirus on or after 13 March 2020. If so, new rules for qualifying for SSP apply. In all other cases, the calculation remains the same.

https://trello.com/c/td0XUZol/1834-5-urgent-amend-statutory-sick-pay-calculator-for-coronavirus

Co-authored-by: Alan Gabbianelli alan.gabbianelli@digital.cabinet-office.gov.uk

Reverts alphagov/smart-answers#4387, which was a reversion of the original PR alphagov/smart-answers#4382