### PR TITLE
Remove file_watcher config from development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -48,5 +48,5 @@ Rails.application.configure do
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 end


### PR DESCRIPTION
When running the application locally we receive the error:
`Could not load the 'listen' gem. Add 'gem 'listen' to the development group of your Gemfile (LoadError)`

This has been added by the recent rails 6 upgrade which adds config to
the development.rb:
`config.file_watcher = ActiveSupport::EventedFileUpdateChecker`

This watches files to asynchronously update code when in development.
It is reliant on the gem `listen` which we do not currently have in this
repo, and seems unnecessary to add, so we have commented the additional
config out to run the repo locally again.