### PR TITLE
Fix question body formatting

### DIFF
--- a/app/views/smart_answers/inputs/_checkbox_question.html.erb
+++ b/app/views/smart_answers/inputs/_checkbox_question.html.erb
@@ -1,7 +1,14 @@
+<% body = capture do %>
+  <%= render "govuk_publishing_components/components/govspeak", {
+  } do %>
+    <%= question.body %>
+  <% end %>
+<% end %>
+
 <%= render "govuk_publishing_components/components/checkboxes", {
   name: "response[]",
   heading: question.title,
-  description: question.body,
+  description: body,
   id: "response",
   error: question.error,
   hint_text: question.hint_text,

--- a/app/views/smart_answers/inputs/_date_question.html.erb
+++ b/app/views/smart_answers/inputs/_date_question.html.erb
@@ -1,6 +1,9 @@
 <% form_contents = capture do %>
   <% if question.body.present? %>
-    <%= question.body %>
+    <%= render "govuk_publishing_components/components/govspeak", {
+    } do %>
+      <%= question.body %>
+    <% end %>
   <% end %>
 
   <% if question.hint.present? %>

--- a/app/views/smart_answers/inputs/_multiple_choice_question.html.erb
+++ b/app/views/smart_answers/inputs/_multiple_choice_question.html.erb
@@ -1,9 +1,16 @@
+<% body = capture do %>
+  <%= render "govuk_publishing_components/components/govspeak", {
+  } do %>
+    <%= question.body %>
+  <% end %>
+<% end %>
+
 <%= render "govuk_publishing_components/components/radio", {
   name: "response",
   heading: question.title,
   hint: question.hint,
   id_prefix: "response",
-  description: question.body,
+  description: body,
   error_message: question.error,
   items: question.radio_buttons
 } %>

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/how_much_salary.govspeak.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/how_much_salary.govspeak.erb
@@ -4,6 +4,8 @@
 
 <% content_for :body do %>
   Body can contain further explanations.
+
+  - and govspeak
 <% end %>
 
 <% content_for :hint do %>

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_boolean_choice.govspeak.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_boolean_choice.govspeak.erb
@@ -4,6 +4,8 @@
 
 <% content_for :body do %>
   Body can contain further explanations.
+
+  - and govspeak
 <% end %>
 
 <% content_for :hint do %>

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_checkboxes.govspeak.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_checkboxes.govspeak.erb
@@ -4,6 +4,9 @@
 
 <% content_for :body do %>
   Body can contain further explanations.
+
+  - also formatting in a govspeak style
+  - like this
 <% end %>
 
 <% content_for :post_body do %>

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_choice.govspeak.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_choice.govspeak.erb
@@ -4,6 +4,8 @@
 
 <% content_for :body do %>
   Body can contain further explanations.
+
+  - and govspeak
 <% end %>
 
 <% content_for :hint do %>

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_country.govspeak.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_country.govspeak.erb
@@ -4,6 +4,8 @@
 
 <% content_for :body do %>
   Body can contain further explanations.
+
+  - and also govspeak
 <% end %>
 
 <% content_for :error_message do %>

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_date.govspeak.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_date.govspeak.erb
@@ -4,6 +4,8 @@
 
 <% content_for :body do %>
   Body can contain further explanations.
+
+  - and maybe govspeak
 <% end %>
 
 <% content_for :error_message do %>

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_date_of_birth.govspeak.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_date_of_birth.govspeak.erb
@@ -4,6 +4,8 @@
 
 <% content_for :body do %>
   Body can contain further explanations.
+
+  - and govspeak
 <% end %>
 
 <% content_for :error_message do %>

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_date_this_year.govspeak.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_date_this_year.govspeak.erb
@@ -4,6 +4,8 @@
 
 <% content_for :body do %>
   Body can contain further explanations.
+
+  - and govspeak
 <% end %>
 
 <% content_for :error_message do %>

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_date_within_range.govspeak.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_date_within_range.govspeak.erb
@@ -4,6 +4,8 @@
 
 <% content_for :body do %>
   Body can contain further explanations.
+
+  - and govspeak
 <% end %>
 
 <% content_for :error_message do %>


### PR DESCRIPTION
It's possible to pass govspeak formatting to to question body but this is currently not being rendered properly. This PR fixes that for the following question types:

- checkbox question
- date question
- multiple choice question

Before:

<img width="697" alt="Screenshot 2020-03-27 at 11 55 15" src="https://user-images.githubusercontent.com/861310/77753668-e10a4600-7021-11ea-81f8-6af9986fe610.png">

After:

<img width="741" alt="Screenshot 2020-03-27 at 11 55 23" src="https://user-images.githubusercontent.com/861310/77753684-e6679080-7021-11ea-800d-21d57259d9e4.png">
