### PR TITLE
Adding VAT payment deadline callout

### DIFF
--- a/lib/smart_answer_flows/vat-payment-deadlines/vat_payment_deadlines.govspeak.erb
+++ b/lib/smart_answer_flows/vat-payment-deadlines/vat_payment_deadlines.govspeak.erb
@@ -12,5 +12,7 @@
   You can't use this calculator if you make payments on account or use the annual
   accounting scheme.
 
-^ From 1 April 2019, most businesses will need to [keep digital VAT records and use software to submit VAT Returns](/guidance/check-when-a-business-must-follow-the-rules-for-making-tax-digital-for-vat).
+^ Because of coronavirus (COVID-19), you can delay (defer) any VAT payments due between 20 March 2020 and 30 June 2020. If you choose to defer a VAT payment, you will have until 31 March 2021 to pay it.
+
+  Most businesses must [keep digital VAT records and use software to submit VAT Returns](/guidance/check-when-a-business-must-follow-the-rules-for-making-tax-digital-for-vat).
 <% end %>


### PR DESCRIPTION
Trello: https://trello.com/c/FUMfC7nR/1609-add-vat-deadline-callout-content-requests

+ added callout about deferring VAT payments until next year - due to coronavirus.
+ amended notice on keeping digital records from April 2019 as now in the past.