### PR TITLE
Add 'Statutory Parental Bereavement Pay' option

### DIFF
--- a/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
+++ b/lib/smart_answer/calculators/statutory_sick_pay_calculator.rb
@@ -82,11 +82,11 @@ module SmartAnswer
       end
 
       def paternity_maternity_warning?
-        (other_pay_types_received & %w{statutory_paternity_pay shared_parental_leave_and_pay statutory_adoption_pay}).any?
+        (other_pay_types_received & %w{statutory_paternity_pay shared_parental_leave_and_pay statutory_parental_bereavement_pay statutory_adoption_pay}).any?
       end
 
       def already_getting_maternity_pay?
-        (other_pay_types_received & %w{statutory_paternity_pay shared_parental_leave_and_pay statutory_adoption_pay none}).none?
+        (other_pay_types_received & %w{statutory_paternity_pay shared_parental_leave_and_pay statutory_parental_bereavement_pay statutory_adoption_pay none}).none?
       end
 
       def valid_last_sick_day?

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -14,6 +14,7 @@ module SmartAnswer
         option :maternity_allowance
         option :statutory_paternity_pay
         option :statutory_adoption_pay
+        option :statutory_parental_bereavement_pay
         option :shared_parental_leave_and_pay
 
         on_response do |response|

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/entitled_to_sick_pay.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/entitled_to_sick_pay.govspeak.erb
@@ -18,7 +18,7 @@
   ##What you need to know
 
   <% if calculator.paternity_maternity_warning? %>
-    ^ Your employee will not be able to collect Statutory Shared Parental Pay, Statutory Paternity Pay or Statutory Adoption Pay while collecting Statutory Sick Pay. ^
+    ^ Your employee will not be able to collect Statutory Shared Parental Pay, Statutory Paternity Pay, Statutory Parental Bereavement Pay or Statutory Adoption Pay while collecting Statutory Sick Pay. ^
   <% end %>
 
   SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of <%= pattern_days_total %> days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. <% if calculator.enough_notice_of_absence %>They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).<% end %>

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/questions/is_your_employee_getting.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/questions/is_your_employee_getting.govspeak.erb
@@ -7,6 +7,7 @@
   "maternity_allowance": "Maternity Allowance",
   "statutory_paternity_pay": "Statutory Paternity Pay",
   "statutory_adoption_pay": "Statutory Adoption Pay",
+  "statutory_parental_bereavement_pay": "Statutory Parental Bereavement Pay",
   "shared_parental_leave_and_pay": "Shared Parental Leave and Pay"
 ) %>
 

--- a/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
@@ -26,7 +26,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
 
   context "Not getting maternity allowance" do
     setup do
-      add_response "statutory_paternity_pay,statutory_adoption_pay"
+      add_response "statutory_paternity_pay,statutory_adoption_pay,statutory_parental_bereavement_pay"
     end
 
     should "set adoption warning state variable" do
@@ -366,7 +366,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
 
   context "tabular output for final SSP calculation" do
     should "have the adjusted rates in place for the week crossing through 6th April" do
-      add_response :statutory_paternity_pay
+      add_response "statutory_paternity_pay,statutory_parental_bereavement_pay"
       add_response :yes
       add_response :no
       add_response :no
@@ -404,7 +404,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
     end
 
     should "have consistent rates for all weekly rates that are produced" do
-      add_response :statutory_paternity_pay
+      add_response "statutory_paternity_pay,statutory_parental_bereavement_pay"
       add_response :yes
       add_response :no
       add_response :no
@@ -442,7 +442,7 @@ class CalculateStatutorySickPayTest < ActiveSupport::TestCase
     end
 
     should "show formatted weekly payment amounts with adjusted 3 days start amount for ordinary SPP" do
-      add_response :statutory_paternity_pay
+      add_response "statutory_paternity_pay,statutory_parental_bereavement_pay"
       add_response :yes
       add_response :no
       add_response :no


### PR DESCRIPTION
This adds a new 'Statutory Parental Bereavement Pay' option to statutory sick pay calculator when asking if a person is already receiving some kind of other payment.

It follows the same logic as the 'Statutory Paternity Pay' option.

[Trello Card](https://trello.com/c/fRtGx0g8/1886-2-update-to-statutory-sick-pay-calculator-parental-bereavement-pay)