### PR TITLE
Update personal allowance in tests

### DIFF
--- a/test/integration/smart_answer_flows/calculate_married_couples_allowance_test.rb
+++ b/test/integration/smart_answer_flows/calculate_married_couples_allowance_test.rb
@@ -59,7 +59,7 @@ class CalculateMarriedCouplesAllowanceTest < ActiveSupport::TestCase
       context "income > 25400" do
         setup do
           add_response "1930-05-25"
-          add_response "30000"
+          add_response "35000"
         end
 
         should "ask if paying into a pension" do
@@ -229,7 +229,7 @@ class CalculateMarriedCouplesAllowanceTest < ActiveSupport::TestCase
       context "income > 25400" do
         setup do
           add_response "1930-05-14"
-          add_response "30000"
+          add_response "35000"
         end
 
         should "ask if paying into a pension" do


### PR DESCRIPTION
The threshold has changed from 29600.0 to 30200.0 in https://github.com/alphagov/smart-answers/pull/4359 so we need to update the tests to reflect this.