### PR TITLE
Coronavirus updates

### DIFF
--- a/lib/smart_answer_flows/register-a-death/outcomes/uk_result.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-death/outcomes/uk_result.govspeak.erb
@@ -1,18 +1,14 @@
 <% content_for :body do %>
   You should register the death within 5 days.
 
-  You can go to any [register office](/register-offices) but if you use the one in the area where the person died you’ll be given the documents you’ll need on the day.
-
-  If you use a different register office the documents will be sent to the office in the area where the person died before they’re issued to you. This means you’ll usually wait a few days.
-
-  ^Registering the death will take about 30 minutes - you might need to make an appointment.^
+  Contact a [register office](/register-offices) to register the death. You can contact any register office but it will be quicker if you use the one in the area where the person died.
 
   Who should register the death
   --------
 
   A relative should register the death. 
   
-  If a relative can’t register the death, you can do it if you:
+  If a relative cannot register the death, you can do it if you:
 
 
   <% if calculator.died_at_home_or_in_hospital? %>
@@ -31,9 +27,9 @@
     What you need to do
     --------
 
-    Take the medical certificate showing the cause of death (signed by a doctor) with you.
+    The register office will tell you what you need to do when you contact them. 
 
-    If available (but don't worry if not), also take the person’s:
+    The register office may also want to see the person’s:
 
     - birth certificate
     - Council Tax bill
@@ -42,11 +38,14 @@
     - NHS medical card
     - passport
     - proof of address (eg utility bill)
+ 
+  Ask the register office what to do if you do not have them. 
+
   <% else %>
     What you need to do
     --------
 
-    Take the medical certificate showing the cause of death (signed by a doctor) with you.
+    The register office will tell you what you need to do when you contact them. 
 
     If the cause of death is unknown, sudden or unexplained it may be reported to the coroner.
 
@@ -59,11 +58,14 @@
 
     ###If form 100A or 100B is issued (ie there is no inquest)
 
-    If available (but don't worry if not), also take the person’s:
+    The register office may also want to see the person’s:
 
     - birth certificate
     - marriage or civil partnership certificate
     - NHS medical card
+    
+   Ask the register office what to do if you do not have them. 
+
   <% end %>
 
   You’ll need to tell the registrar:
@@ -76,7 +78,7 @@
   - the full name, date of birth and occupation of a surviving or late spouse or civil partner
   - whether they were getting a State Pension or any other benefits
 
-  You should also take supporting documents that show your name and address (eg a utility bill) but you can still register a death without them.
+
 
   <% if calculator.death_expected? %>
     Documents you’ll get
@@ -85,14 +87,14 @@
     When you register a death you’ll get:
 
     - a Certificate for Burial or Cremation (the ‘green form’) - gives permission for burial or an application for cremation
-    - a Certificate of Registration of Death (form BD8) - you may need to fill this out and return it if the person was getting a State Pension or benefits (the form will come with a pre-paid envelope so you know where to send it)
+    - a Certificate of Registration of Death (form BD8) - you may need to fill this in and return it if the person was getting a State Pension or benefits (the form will come with a pre-paid envelope so you know where to send it)
 
     You can buy extra death certificates - these will be needed for [sorting out the person’s affairs](/when-someone-dies).
   <% else %>
     Documents you’ll get
     --------
 
-    When you register a death you’ll get a Certificate of Registration of Death (form BD8). You may need to fill this out and return it if the person was getting a State Pension or benefits (the form will come with a pre-paid envelope so you know where to send it).
+    When you register a death you’ll get a Certificate of Registration of Death (form BD8). You may need to fill this in and return it if the person was getting a State Pension or benefits (the form will come with a pre-paid envelope so you know where to send it).
 
     You can buy extra death certificates - these will be needed for [sorting out the person’s affairs](/when-someone-dies).
   <% end %>


### PR DESCRIPTION
CHANGED

You should register the death within 5 days.

You can contact any [register office](/register-offices) but if you use the one in the area where the person died you’ll be given the documents you’ll need on the day.

If you use a different register office the documents will be sent to the office in the area where the person died before they’re issued to you. This means you’ll usually wait a few days.

TO

You should register the death within 5 days.  

Contact a [register office](/register-offices) to register the death. You can contact any register office but it will be quicker if you use the one in the area where the person died.

BECAUSE


Conversation with Austin Hayes, the SME at General Register Office (GRO). They have advised register offices what to do but different register offices are doing different things - depending on where they are and how badly their area has been affected by coronavirus. 

The advice is still that you should register the death within 5 days. It’s not that you ‘must’ register the death. So didn’t change that sentence.

The law was changed in the Coronavirus Act to allow death registrations to be done by phone but they don’t have to be done by phone. But people are unlikely to get the documents they need on the day because of the sheer number of deaths that are expected. 
-----------------

REMOVED
Registering the death will take about 30 minutes - you might need to make an appointment.

BECAUSE
We don’t know how long the phone call will take if someone is registering the death over the phone. People won’t be able to make an appointment in lots of areas. 

-----------------

---------
##Who should register the death
---------

Corrected contraction 
FROM
Can’t

TO
Cannot

----------------------

----------
##What you need to do
----------

CHANGED 
Take the medical certificate showing the cause of death (signed by a doctor) with you.

TO
The register office will tell you what you need to do when you contact them. 

BECAUSE
Medical certificates will probably be emailed by the hospital directly to the register office but that will depend on individual register offices and hospitals. Agreed with the GRO that the best thing for people to do is ask the register office what they are doing.

----------------------

###If form 100A or 100B is issued (ie there is no inquest)

CHANGED
If available (but don’t worry if not), also take the person’s:
- birth certificate
- marriage or civil partnership certificate
- NHS medical card


TO
The register office may also want to see the persons:
- birth certificate
- marriage or civil partnership certificate
- NHS medical card

Ask the register office if they need them when you contact them. 

BECAUSE
Many death registrations are going to be done over the phone, so the user won’t ‘take’ any documents to the register office. They might have to send, scan and email - but it will be up to each register office. 
-------------------------------

REMOVED
You should also take supporting documents that show your name and address (eg a utility bill) but you can still register a death without them.

BECAUSE
Many register offices will be registering deaths over the phone and will tell people what to take with them. Further up the page, we are telling people to contact the register office and that the register office will tell them what they need to do.