### PR TITLE
Remove call out

### DIFF
--- a/lib/smart_answer_flows/register-a-death/register_a_death.govspeak.erb
+++ b/lib/smart_answer_flows/register-a-death/register_a_death.govspeak.erb
@@ -13,5 +13,4 @@
 
   You can only register a death abroad if it happened on or after 1 January 1983.
 
-  %The service to register an overseas death with the UK authorities is currently suspended. This page will be updated when it has resumed.%
 <% end %>


### PR DESCRIPTION
Remove %The service to register an overseas death with the UK authorities is currently suspended. This page will be updated when it has resumed.% 
Because it draws the user's eye down to that warning. Users may not realise they can use the tool to find out how to register a death in the UK. The majority of users will be registering a death in the UK.
The General Register Office asked for it to be removed. FCO - who had asked for it to be added - agreed that it could be removed