### PR TITLE
Add initial flow for coronavirus business support

### DIFF
--- a/lib/smart_answer/calculators/coronavirus_business_support_calculator.rb
+++ b/lib/smart_answer/calculators/coronavirus_business_support_calculator.rb
@@ -1,0 +1,76 @@
+module SmartAnswer::Calculators
+  class CoronavirusBusinessSupportCalculator
+    attr_accessor :business_based,
+                  :business_size,
+                  :self_employed,
+                  :annual_turnover,
+                  :business_rates,
+                  :non_domestic_property,
+                  :self_assessment_july_2020,
+                  :sectors
+
+    def show_job_retention_scheme?
+      self_employed == "no"
+    end
+
+    def show_vat_scheme?
+      annual_turnover == "under_85k"
+    end
+
+    def show_self_assessment_payments?
+      self_assessment_july_2020 == "yes"
+    end
+
+    def show_statutory_sick_rebate?
+      business_size == "small_medium_enterprise" &&
+        self_employed == "no" &&
+        self_assessment_july_2020 == "yes"
+    end
+
+    def show_self_employed_income_scheme?
+      business_size == "small_medium_enterprise" &&
+        self_employed == "yes"
+    end
+
+    def show_business_rates?
+      business_based == "england" &&
+        business_rates == "yes" &&
+        non_domestic_property != "none" &&
+        (%w[retail hospitality leisure] & sectors).any?
+    end
+
+    def show_grant_funding?
+      business_based == "england" &&
+        business_rates == "yes" &&
+        non_domestic_property == "over_15k" &&
+        (%w[retail hospitality leisure] & sectors).any?
+    end
+
+    def show_nursery_support?
+      business_based == "england" &&
+        business_rates == "yes" &&
+        non_domestic_property != "none" &&
+        sectors.include?("nurseries")
+    end
+
+    def show_small_business_grant_funding?
+      business_based == "england" &&
+        business_size == "small_medium_enterprise" &&
+        non_domestic_property == "under_15k"
+    end
+
+    def show_business_loan_scheme?
+      self_employed == "no" &&
+        annual_turnover != "over_45m"
+    end
+
+    def show_corporate_financing?
+      self_employed == "no"
+    end
+
+    def show_business_tax_support?
+      self_employed == "no" &&
+        annual_turnover != "over_45m"
+    end
+  end
+end

--- a/lib/smart_answer_flows/coronavirus-business-support.rb
+++ b/lib/smart_answer_flows/coronavirus-business-support.rb
@@ -1,0 +1,133 @@
+module SmartAnswer
+  class CoronavirusBusinessSupportFlow < Flow
+    def define
+      start_page_content_id "89edffd2-3046-40bd-810c-cc1a13c05b6a"
+      flow_content_id "1f589327-a6b3-4b5c-aea0-7a2752e2eddf"
+      name "coronavirus-business-support"
+      status :draft
+
+      # Q1
+      multiple_choice :business_based? do
+        option :england
+        option :scotland
+        option :wales
+        option :northern_ireland
+
+        on_response do |response|
+          self.calculator = Calculators::CoronavirusBusinessSupportCalculator.new
+          calculator.business_based = response
+        end
+
+        next_node do
+          question :business_size?
+        end
+      end
+
+      # Q2
+      multiple_choice :business_size? do
+        option :small_medium_enterprise
+        option :large_enterprise
+
+        on_response do |response|
+          calculator.business_size = response
+        end
+
+        next_node do
+          question :self_employed?
+        end
+      end
+
+      # Q3
+      multiple_choice :self_employed? do
+        option :yes
+        option :no
+
+        on_response do |response|
+          calculator.self_employed = response
+        end
+
+        next_node do
+          question :annual_turnover?
+        end
+      end
+
+      # Q4
+      multiple_choice :annual_turnover? do
+        option :over_45m
+        option :over_85k
+        option :under_85k
+
+        on_response do |response|
+          calculator.annual_turnover = response
+        end
+
+        next_node do
+          question :business_rates?
+        end
+      end
+
+      # Q5
+      multiple_choice :business_rates? do
+        option :yes
+        option :no
+
+        on_response do |response|
+          calculator.business_rates = response
+        end
+
+        next_node do
+          question :non_domestic_property?
+        end
+      end
+
+      # Q6
+      multiple_choice :non_domestic_property? do
+        option :over_51k
+        option :over_15k
+        option :up_to_15k
+        option :none
+
+        on_response do |response|
+          calculator.non_domestic_property = response
+        end
+
+        next_node do
+          question :self_assessment_july_2020?
+        end
+      end
+
+      # Q7
+      multiple_choice :self_assessment_july_2020? do
+        option :yes
+        option :no
+
+        on_response do |response|
+          calculator.self_assessment_july_2020 = response
+        end
+
+        next_node do
+          question :sectors?
+        end
+      end
+
+      # Q8
+      checkbox_question :sectors? do
+        option :retail
+        option :hospitality
+        option :leisure
+        option :nurseries
+        set_none_option(label: "None of the above")
+
+        on_response do |response|
+          calculator.sectors = response.split(",")
+        end
+
+        next_node do
+          outcome :results
+        end
+      end
+
+      outcome :results
+    end
+  end
+end

--- a/lib/smart_answer_flows/coronavirus-business-support/coronavirus_business_support.govspeak.erb
+++ b/lib/smart_answer_flows/coronavirus-business-support/coronavirus_business_support.govspeak.erb
@@ -1,0 +1,8 @@
+<% content_for :title do %>
+  Coronavirus Business Support
+<% end %>
+
+<% content_for :body do %>
+  Something here.
+<% end %>
+

--- a/lib/smart_answer_flows/coronavirus-business-support/outcomes/results.govspeak.erb
+++ b/lib/smart_answer_flows/coronavirus-business-support/outcomes/results.govspeak.erb
@@ -1,0 +1,125 @@
+<% content_for :title do %>
+  Support you're entitled to
+<% end %>
+
+<% content_for :body do %>
+  <% if calculator.show_job_retention_scheme? %>
+    $CTA
+    **[Coronavirus Job retention Scheme](https://www.google.com)**
+
+    UK-wide. Under the coronavirus Job Retention Scheme, all UK employers with a PAYE scheme will be able to access support to continue paying part of their employees’ salary for those that would otherwise have been laid off during this crisis.
+
+    [Find out more](https://www.google.com)
+    $CTA
+  <% end %>
+
+  <% if calculator.show_vat_scheme? %>
+    $CTA
+    **[Deferring VAT](https://www.google.com)**
+
+    UK-Wide. We will support businesses by deferring Valued Added Tax (VAT) payments for 3 months.
+
+    [Find out more](https://www.google.com)
+    $CTA
+  <% end %>
+
+  <% if calculator.show_self_assessment_payments? %>
+    $CTA
+    **[Deferring Self-Assessment payments on account](https://www.google.com)**
+
+    UK-wide. The Self- Assessment payment on account, that is ordinarily due to be paid to HMRC by 31 July 2020 may now be deferred until January 2021.
+
+    [Find out more](https://www.google.com)
+    $CTA
+  <% end %>
+
+  <% if calculator.show_statutory_sick_rebate? %>
+    $CTA
+    **[Statutory Sick Pay Rebate](https://www.google.com)**
+
+    UK-wide. The Government will bring forward legislation to allow small and medium-sized businesses to reclaim Statutory Sick Pay (SSP) paid for staff sickness absence due to coronavirus.
+
+    [Find out more](https://www.google.com)
+    $CTA
+  <% end %>
+
+  <% if calculator.show_self_employed_income_scheme? %>
+    $CTA
+    **[Support for self-employed through the Self-employment Income Support Scheme](https://www.google.com)**
+
+    The Self-employment Income Support Scheme (SEISS) will support self-employed individuals (including members of partnerships) whose income has been negatively impacted by COVID-19.
+
+    [Find out more](https://www.google.com)
+    $CTA
+  <% end %>
+
+  <% if calculator.show_business_rates? %>
+    $CTA
+    **[Business Rates holiday for retail, hospitality and leisure](https://www.google.com)**
+
+    Some description.
+
+    [Find out more](https://www.google.com)
+    $CTA
+  <% end %>
+
+  <% if calculator.show_grant_funding? %>
+    $CTA
+    **[Retail, Hospitality and Leisure Grant Funding](https://www.google.com)**
+
+    Some description.
+
+    [Find out more](https://www.google.com)
+    $CTA
+  <% end %>
+
+  <% if calculator.show_nursery_support? %>
+    $CTA
+    **[Support for nursery businesses that pay business rates](https://www.google.com)**
+
+    Some description.
+
+    [Find out more](https://www.google.com)
+    $CTA
+  <% end %>
+
+  <% if calculator.show_small_business_grant_funding? %>
+    $CTA
+    **[Small Business Grant Funding](https://www.google.com)**
+
+    Some description.
+
+    [Find out more](https://www.google.com)
+    $CTA
+  <% end %>
+
+  <% if calculator.show_business_loan_scheme? %>
+    $CTA
+    **[Coronavirus Business Interruption Loan Scheme](https://www.google.com)**
+
+    Some description.
+
+    [Find out more](https://www.google.com)
+    $CTA
+  <% end %>
+
+  <% if calculator.show_corporate_financing? %>
+    $CTA
+    **[Covid-19 Corporate Financing Facility](https://www.google.com)**
+
+    Some description.
+
+    [Find out more](https://www.google.com)
+    $CTA
+  <% end %>
+
+  <% if calculator.show_business_tax_support? %>
+    $CTA
+    **[Support for businesses paying tax: Time To Pay Service](https://www.google.com)**
+
+    Some description.
+
+    [Find out more](https://www.google.com)
+    $CTA
+  <% end %>
+<% end %>

--- a/lib/smart_answer_flows/coronavirus-business-support/questions/annual_turnover.govspeak.erb
+++ b/lib/smart_answer_flows/coronavirus-business-support/questions/annual_turnover.govspeak.erb
@@ -1,0 +1,9 @@
+<% content_for :title do %>
+  What is your turnover per year?
+<% end %>
+
+<% options(
+  "over_45m": "Over £45m",
+  "over_85k": "Over £85,000 and under £45m",
+  "under_85k": "Under £85,000 (ie not VAT registered)",
+) %>

--- a/lib/smart_answer_flows/coronavirus-business-support/questions/business_based.govspeak.erb
+++ b/lib/smart_answer_flows/coronavirus-business-support/questions/business_based.govspeak.erb
@@ -1,0 +1,10 @@
+<% content_for :title do %>
+  Where is your business based?
+<% end %>
+
+<% options(
+  "england": "England",
+  "scotland": "Scotland",
+  "wales": "Wales",
+  "northern_ireland": "Northern Ireland"
+) %>

--- a/lib/smart_answer_flows/coronavirus-business-support/questions/business_rates.govspeak.erb
+++ b/lib/smart_answer_flows/coronavirus-business-support/questions/business_rates.govspeak.erb
@@ -1,0 +1,8 @@
+<% content_for :title do %>
+  Does your business pay business rates?
+<% end %>
+
+<% options(
+  "yes": "Yes",
+  "no": "No",
+) %>

--- a/lib/smart_answer_flows/coronavirus-business-support/questions/business_size.govspeak.erb
+++ b/lib/smart_answer_flows/coronavirus-business-support/questions/business_size.govspeak.erb
@@ -1,0 +1,8 @@
+<% content_for :title do %>
+  What size was your business as of 28 February?
+<% end %>
+
+<% options(
+  "small_medium_enterprise": "Small or medium enterprise (SME): 0 to 249 employees.",
+  "large_enterprise": "Large enterprises: over 249 employees.",
+) %>

--- a/lib/smart_answer_flows/coronavirus-business-support/questions/non_domestic_property.govspeak.erb
+++ b/lib/smart_answer_flows/coronavirus-business-support/questions/non_domestic_property.govspeak.erb
@@ -1,0 +1,10 @@
+<% content_for :title do %>
+  Does your business have a non-domestic property with a rateable value of:
+<% end %>
+
+<% options(
+  "over_51k": "Over £51,000",
+  "over_15k": "Over £15,000 and under £51,000",
+  "up_to_15k": "Up to £15,000",
+  "none": "My business does not have a non-domestic property",
+) %>

--- a/lib/smart_answer_flows/coronavirus-business-support/questions/sectors.govspeak.erb
+++ b/lib/smart_answer_flows/coronavirus-business-support/questions/sectors.govspeak.erb
@@ -1,0 +1,10 @@
+<% content_for :title do %>
+  Is your business in any of the following sectors:
+<% end %>
+
+<% options(
+  "retail": "Retail",
+  "hospitality": "Hospitality",
+  "leisure": "Leisure",
+  "nurseries": "Nurseries",
+) %>

--- a/lib/smart_answer_flows/coronavirus-business-support/questions/self_assessment_july_2020.govspeak.erb
+++ b/lib/smart_answer_flows/coronavirus-business-support/questions/self_assessment_july_2020.govspeak.erb
@@ -1,0 +1,8 @@
+<% content_for :title do %>
+  Are you due to pay a self-assessment payment on account by 31 July 2020?
+<% end %>
+
+<% options(
+  "yes": "Yes",
+  "no": "No",
+) %>

--- a/lib/smart_answer_flows/coronavirus-business-support/questions/self_employed.govspeak.erb
+++ b/lib/smart_answer_flows/coronavirus-business-support/questions/self_employed.govspeak.erb
@@ -1,0 +1,8 @@
+<% content_for :title do %>
+  Are you self-employed?
+<% end %>
+
+<% options(
+  "yes": "Yes",
+  "no": "No",
+) %>

--- a/lib/smart_answer_flows/coronavirus-business-support/questions/what_size_was_your_business.govspeak.erb
+++ b/lib/smart_answer_flows/coronavirus-business-support/questions/what_size_was_your_business.govspeak.erb
@@ -1,0 +1,8 @@
+<% content_for :title do %>
+  What size was your business as of 28 February?
+<% end %>
+
+<% options(
+  "sme": "Small or medium enterprise (SME): 0 to 249 employees",
+  "large": "Large enterprises: over 249 employees",
+) %>

--- a/lib/smart_answer_flows/coronavirus-business-support/questions/where_is_your_business_based.govspeak.erb
+++ b/lib/smart_answer_flows/coronavirus-business-support/questions/where_is_your_business_based.govspeak.erb
@@ -1,0 +1,10 @@
+<% content_for :title do %>
+  Where is your business based?
+<% end %>
+
+<% options(
+  "england": "England",
+  "scotland": "Scotland",
+  "wales": "Wales",
+  "northern_ireland": "Northern Ireland"
+) %>


### PR DESCRIPTION
https://trello.com/c/LoPI3DJc/31-investigate-viability-of-using-smart-answers

This adds a draft smart answer flow for supporting businesses during
the Coronavirus pandemic. Content is placeholder only, and we intend
to iterate this and add tests once the initial code is merged. Using
a 'draft' status means this will only be visible in development [1].
    
Since the purpose of this smart answer is to filter from a number of
potential results, we've chosen to use a single 'results' outcome page,
and a Calculator class [2] to determine which of the results to display
to the user; each result has its own bespoke criteria to display.
    
[1]: https://github.com/alphagov/smart-answers/blob/master/doc/smart-answers/flow-definition.md#metadata
[2]: https://github.com/alphagov/smart-answers/blob/master/doc/smart-answer-flow-development/refactoring.md