### PR TITLE
Hasty proof of concept of Coronavirus Business Support flow

### DIFF
--- a/lib/smart_answer/calculators/coronavirus_business_support_calculator.rb
+++ b/lib/smart_answer/calculators/coronavirus_business_support_calculator.rb
@@ -1,0 +1,18 @@
+module SmartAnswer::Calculators
+  class CoronavirusBusinessSupportCalculator
+    include ActiveModel::Model
+
+    attr_accessor :business_based
+    attr_accessor :business_size
+    attr_accessor :self_employed
+    attr_accessor :annual_turnover
+    attr_accessor :business_rates
+    attr_accessor :non_domestic_property
+    attr_accessor :self_assessment_july_2020
+    attr_accessor :sectors
+
+    def initialize(attributes = {})
+      super
+    end
+  end
+end

--- a/lib/smart_answer_flows/coronavirus-business-support.rb
+++ b/lib/smart_answer_flows/coronavirus-business-support.rb
@@ -1,0 +1,97 @@
+module SmartAnswer
+  class CoronavirusBusinessSupportFlow < Flow
+    def define
+      name "coronavirus-business-support"
+
+      # Q1
+      multiple_choice :business_based? do
+        option :england
+        option :scotland
+        option :wales
+        option :northern_ireland
+
+        next_node do
+          question :business_size?
+        end
+      end
+
+      # Q2
+      multiple_choice :business_size? do
+        option :small_medium_enterprise
+        option :large_enterprise
+
+        next_node do
+          question :self_employed?
+        end
+      end
+
+      # Q3
+      multiple_choice :self_employed? do
+        option :yes
+        option :no
+
+        next_node do
+          question :annual_turnover?
+        end
+      end
+
+      # Q4
+      multiple_choice :annual_turnover? do
+        option :over_45m
+        option :over_85k
+        option :under_85k
+
+        next_node do
+          question :business_rates?
+        end
+      end
+
+      # Q5
+      multiple_choice :business_rates? do
+        option :yes
+        option :no
+
+        next_node do
+          question :non_domestic_property?
+        end
+      end
+
+      # Q6
+      multiple_choice :non_domestic_property? do
+        option :over_51k
+        option :over_15k
+        option :up_to_15k
+        option :none
+
+        next_node do
+          question :self_assessment_july_2020?
+        end
+      end
+
+      # Q7
+      multiple_choice :self_assessment_july_2020? do
+        option :yes
+        option :no
+
+        next_node do
+          question :sectors?
+        end
+      end
+
+      # Q8
+      checkbox_question :sectors? do
+        option :retail
+        option :hospitality
+        option :leisure
+        option :nurseries
+        set_none_option(label: "None of the above")
+
+        next_node do
+          outcome :placeholder
+        end
+      end
+
+      outcome :placeholder
+    end
+  end
+end

--- a/lib/smart_answer_flows/coronavirus-business-support.rb
+++ b/lib/smart_answer_flows/coronavirus-business-support.rb
@@ -10,6 +10,11 @@ module SmartAnswer
         option :wales
         option :northern_ireland
 
+        on_response do |response|
+          self.calculator = Calculators::CoronavirusBusinessSupportCalculator.new
+          calculator.business_based = response
+        end
+
         next_node do
           question :business_size?
         end
@@ -20,6 +25,10 @@ module SmartAnswer
         option :small_medium_enterprise
         option :large_enterprise
 
+        on_response do |response|
+          calculator.business_size = response
+        end
+
         next_node do
           question :self_employed?
         end
@@ -29,6 +38,10 @@ module SmartAnswer
       multiple_choice :self_employed? do
         option :yes
         option :no
+
+        on_response do |response|
+          calculator.self_employed = response
+        end
 
         next_node do
           question :annual_turnover?
@@ -41,6 +54,10 @@ module SmartAnswer
         option :over_85k
         option :under_85k
 
+        on_response do |response|
+          calculator.annual_turnover = response
+        end
+
         next_node do
           question :business_rates?
         end
@@ -50,6 +67,10 @@ module SmartAnswer
       multiple_choice :business_rates? do
         option :yes
         option :no
+
+        on_response do |response|
+          calculator.business_rates = response
+        end
 
         next_node do
           question :non_domestic_property?
@@ -63,6 +84,10 @@ module SmartAnswer
         option :up_to_15k
         option :none
 
+        on_response do |response|
+          calculator.non_domestic_property = response
+        end
+
         next_node do
           question :self_assessment_july_2020?
         end
@@ -72,6 +97,10 @@ module SmartAnswer
       multiple_choice :self_assessment_july_2020? do
         option :yes
         option :no
+
+        on_response do |response|
+          calculator.self_assessment_july_2020 = response
+        end
 
         next_node do
           question :sectors?
@@ -85,6 +114,10 @@ module SmartAnswer
         option :leisure
         option :nurseries
         set_none_option(label: "None of the above")
+
+        on_response do |response|
+          calculator.sectors = response.split(",")
+        end
 
         next_node do
           outcome :placeholder

--- a/lib/smart_answer_flows/coronavirus-business-support/coronavirus_business_support.govspeak.erb
+++ b/lib/smart_answer_flows/coronavirus-business-support/coronavirus_business_support.govspeak.erb
@@ -1,0 +1,10 @@
+<% content_for :title do %>
+  Coronavirus Business Support
+<% end %>
+
+<% content_for :meta_description do %>
+<% end %>
+
+<% content_for :body do %>
+  Landing Page Body
+<% end %>

--- a/lib/smart_answer_flows/coronavirus-business-support/outcomes/placeholder.govspeak.erb
+++ b/lib/smart_answer_flows/coronavirus-business-support/outcomes/placeholder.govspeak.erb
@@ -1,0 +1,7 @@
+<% content_for :title do %>
+  Placeholder
+<% end %>
+
+<% content_for :body do %>
+  Placeholder
+<% end %>

--- a/lib/smart_answer_flows/coronavirus-business-support/questions/annual_turnover.govspeak.erb
+++ b/lib/smart_answer_flows/coronavirus-business-support/questions/annual_turnover.govspeak.erb
@@ -1,0 +1,9 @@
+<% content_for :title do %>
+  What is your turnover per year?
+<% end %>
+
+<% options(
+  "over_45m": "Over £45m",
+  "over_85k": "Over £85,000 and under £45m",
+  "under_85k": "Under £85,000 (ie not VAT registered)",
+) %>

--- a/lib/smart_answer_flows/coronavirus-business-support/questions/business_based.govspeak.erb
+++ b/lib/smart_answer_flows/coronavirus-business-support/questions/business_based.govspeak.erb
@@ -1,0 +1,10 @@
+<% content_for :title do %>
+  Where is your business based?
+<% end %>
+
+<% options(
+  "england": "England",
+  "scotland": "Scotland",
+  "wales": "Wales",
+  "northern_ireland": "Northern Ireland"
+) %>

--- a/lib/smart_answer_flows/coronavirus-business-support/questions/business_rates.govspeak.erb
+++ b/lib/smart_answer_flows/coronavirus-business-support/questions/business_rates.govspeak.erb
@@ -1,0 +1,8 @@
+<% content_for :title do %>
+  Does your business pay business rates?
+<% end %>
+
+<% options(
+  "yes": "Yes",
+  "no": "No",
+) %>

--- a/lib/smart_answer_flows/coronavirus-business-support/questions/business_size.govspeak.erb
+++ b/lib/smart_answer_flows/coronavirus-business-support/questions/business_size.govspeak.erb
@@ -1,0 +1,8 @@
+<% content_for :title do %>
+  What size was your business as of 28 February?
+<% end %>
+
+<% options(
+  "small_medium_enterprise": "Small or medium enterprise (SME): 0 to 249 employees.",
+  "large_enterprise": "Large enterprises: over 249 employees.",
+) %>

--- a/lib/smart_answer_flows/coronavirus-business-support/questions/non_domestic_property.govspeak.erb
+++ b/lib/smart_answer_flows/coronavirus-business-support/questions/non_domestic_property.govspeak.erb
@@ -1,0 +1,10 @@
+<% content_for :title do %>
+  Does your business have a non-domestic property with a rateable value of:
+<% end %>
+
+<% options(
+  "over_51k": "Over £51,000",
+  "over_15k": "Over £15,000 and under £51,000",
+  "up_to_15k": "Up to £15,000",
+  "none": "My business does not have a non-domestic property",
+) %>

--- a/lib/smart_answer_flows/coronavirus-business-support/questions/sectors.govspeak.erb
+++ b/lib/smart_answer_flows/coronavirus-business-support/questions/sectors.govspeak.erb
@@ -1,0 +1,10 @@
+<% content_for :title do %>
+  Is your business in any of the following sectors:
+<% end %>
+
+<% options(
+  "retail": "Retail",
+  "hospitality": "Hospitality",
+  "leisure": "Leisure",
+  "nurseries": "Nurseries",
+) %>

--- a/lib/smart_answer_flows/coronavirus-business-support/questions/self_assessment_july_2020.govspeak.erb
+++ b/lib/smart_answer_flows/coronavirus-business-support/questions/self_assessment_july_2020.govspeak.erb
@@ -1,0 +1,8 @@
+<% content_for :title do %>
+  Are you due to pay a self-assessment payment on account by 31 July 2020?
+<% end %>
+
+<% options(
+  "yes": "Yes",
+  "no": "No",
+) %>

--- a/lib/smart_answer_flows/coronavirus-business-support/questions/self_employed.govspeak.erb
+++ b/lib/smart_answer_flows/coronavirus-business-support/questions/self_employed.govspeak.erb
@@ -1,0 +1,8 @@
+<% content_for :title do %>
+  Are you self-employed?
+<% end %>
+
+<% options(
+  "yes": "Yes",
+  "no": "No",
+) %>


### PR DESCRIPTION
This serves as a quick example of the anticipated questions for checking
business requirements for coronavirus advice.