### PR TITLE
Add tests coronavirus business support

### DIFF
--- a/test/integration/smart_answer_flows/coronavirus_business_support_calculator_test.rb
+++ b/test/integration/smart_answer_flows/coronavirus_business_support_calculator_test.rb
@@ -1,0 +1,169 @@
+require_relative "../../test_helper"
+
+module SmartAnswer
+  class CoronavirusBusinessSupportCalculatorTest < ActiveSupport::TestCase
+    context "england based" do
+      setup do
+        @calculator = Calculators::CoronavirusBusinessSupportCalculator.new
+        @calculator.business_based = "england"
+      end
+
+      context "not self-employed" do
+        setup do
+          @calculator.self_employed = "no"
+        end
+
+        should "be eligible for corporate_financing" do
+          assert_equal true, @calculator.show_corporate_financing?
+        end
+
+        should "should be eligible for job retention scheme" do
+          assert_equal true, @calculator.show_job_retention_scheme?
+        end
+
+        context "annual_turnover greater than £45k" do
+          setup do
+            @calculator.annual_turnover = "over_85k"
+          end
+
+          should "be eligible for business_loan_scheme" do
+            assert_equal true, @calculator.show_business_loan_scheme?
+          end
+
+          should "be eligible for business_tax_support" do
+            assert_equal true, @calculator.show_business_tax_support?
+          end
+        end
+
+        context "small_medium_enterprise" do
+          setup do
+            @calculator.business_size = "small_medium_enterprise"
+          end
+
+          context "non-domestic property under £15k" do
+            setup do
+              @calculator.non_domestic_property = "under_15k"
+            end
+
+            should "be eligible for small_business_grant_funding" do
+              assert_equal true, @calculator.show_small_business_grant_funding?
+            end
+          end
+
+          context "filling a self assessment for July 2020" do
+            setup do
+              @calculator.self_assessment_july_2020 = "yes"
+            end
+
+            should "be eligible for statutory_sick_rebate" do
+              assert_equal true, @calculator.show_statutory_sick_rebate?
+            end
+          end
+        end
+      end
+
+      context "self-employed" do
+        setup do
+          @calculator.self_employed = "yes"
+        end
+
+        should "should not be eligible for job retention scheme" do
+          assert_equal false, @calculator.show_job_retention_scheme?
+        end
+
+        context "and small_medium_enterprise" do
+          setup do
+            @calculator.business_size = "small_medium_enterprise"
+          end
+
+          should "be eligible for self_employed_income_scheme" do
+            assert_equal true, @calculator.show_self_employed_income_scheme?
+          end
+        end
+      end
+
+      context "annual turnover under £85k" do
+        setup do
+          @calculator.annual_turnover = "under_85k"
+        end
+
+        should "be eiligible for VAT scheme" do
+          assert_equal true, @calculator.show_vat_scheme?
+        end
+      end
+
+      context "annual turnover over £85k" do
+        setup do
+          @calculator.annual_turnover = "over_85k"
+        end
+
+        should "not be eligible for VAT scheme" do
+          assert_equal false, @calculator.show_vat_scheme?
+        end
+      end
+
+      context "self assessments for July 2020" do
+        setup do
+          @calculator.self_assessment_july_2020 = "yes"
+        end
+
+        should "eligible for self assessment payment deferment" do
+          assert_equal true, @calculator.show_self_assessment_payments?
+        end
+      end
+
+      context "no self assessments for July 2020" do
+        setup do
+          @calculator.self_assessment_july_2020 = "no"
+        end
+
+        should "not eligible for self assessment payment deferment" do
+          assert_equal false, @calculator.show_self_assessment_payments?
+        end
+      end
+
+      context "in retail, hospitality or leisure sectors" do
+        setup do
+          @calculator.sectors = %w[retail hospitality leisure]
+        end
+
+        context "pays business rates and " do
+          setup do
+            @calculator.business_rates = "yes"
+          end
+
+          context "has non domestic property" do
+            setup do
+              @calculator.non_domestic_property = "over_51k"
+            end
+
+            should "be eligible for business rates scheme" do
+              assert_equal true, @calculator.show_business_rates?
+            end
+
+            context "domestic property value over £15k" do
+              setup do
+                @calculator.non_domestic_property = "over_15k"
+              end
+              should "be eligible for grant funding" do
+                assert_equal true, @calculator.show_grant_funding?
+              end
+            end
+          end
+        end
+      end
+
+      context "nursery sector, paying business rates, has a non-domestic property" do
+        setup do
+          @calculator.sectors = %w[nurseries]
+          @calculator.non_domestic_property = "over_51k"
+          @calculator.business_rates = "yes"
+        end
+
+        should "be eligible for nursery support" do
+          assert_equal true, @calculator.show_nursery_support?
+        end
+      end
+    end
+  end
+end

--- a/test/integration/smart_answer_flows/coronavirus_business_support_test.rb
+++ b/test/integration/smart_answer_flows/coronavirus_business_support_test.rb
@@ -1,0 +1,42 @@
+require_relative "../../test_helper"
+require_relative "flow_test_helper"
+
+require "smart_answer_flows/coronavirus-business-support.rb"
+
+class CoronaVirusBusinessSupportFlowTest < ActiveSupport::TestCase
+  include FlowTestHelper
+
+  setup do
+    setup_for_testing_flow SmartAnswer::CoronavirusBusinessSupportFlow
+  end
+
+  context "business based in England" do
+    setup do
+      assert_current_node :business_based?
+      add_response "england"
+      assert_current_node :business_size?
+      add_response "small_medium_enterprise"
+    end
+
+    context "not self-employed" do
+      setup do
+        assert_current_node :self_employed?
+        add_response "no"
+        assert_current_node :annual_turnover?
+        add_response "over_45m"
+        assert_current_node :business_rates?
+        add_response "yes"
+        assert_current_node :non_domestic_property?
+        add_response "over_15k"
+        assert_current_node :self_assessment_july_2020?
+        add_response "no"
+        assert_current_node :sectors?
+        add_response "retail"
+      end
+
+      should "reach results" do
+        assert_current_node :results
+      end
+    end
+  end
+end

--- a/test/unit/smart_answer_flows/coronavirus_business_support_flow_test.rb
+++ b/test/unit/smart_answer_flows/coronavirus_business_support_flow_test.rb
@@ -1,0 +1,159 @@
+require_relative "../../test_helper"
+require_relative "flow_unit_test_helper"
+
+require "smart_answer_flows/coronavirus-business-support.rb"
+
+
+module SmartAnswer
+  class CoronavirusBusinessSupportFlowTest < ActiveSupport::TestCase
+    include FlowUnitTestHelper
+
+    setup do
+      @calculator = Calculators::CoronavirusBusinessSupportCalculator.new
+      @flow = CoronavirusBusinessSupportFlow.build
+    end
+
+    should "start :business_based? question" do
+      assert_equal :business_based?, @flow.start_state.current_node
+    end
+
+    context "when answering :business_based? question" do
+      setup do
+        Calculators::CoronavirusBusinessSupportCalculator.stubs(:new).returns(@calculator)
+        setup_states_for_question(:business_based?, responding_with: "england")
+      end
+
+      should "instantiate and store calculator" do
+        assert_same @calculator, @new_state.calculator
+      end
+
+      should "set :business_based? to 'england'" do
+        assert_equal "england", @calculator.business_based
+      end
+
+      should "go to :business_size? question" do
+        assert_equal :business_size?, @new_state.current_node
+        assert_node_exists :business_size?
+      end
+    end
+
+    context "when answering :business_size? question" do
+      setup do
+        setup_states_for_question(:business_size?,
+                                  responding_with: "small_medium_enterprise",
+                                  initial_state: { calculator: @calculator })
+      end
+
+      should "store 'small_medium_enterprise' on calculator" do
+        assert_equal "small_medium_enterprise", @calculator.business_size
+      end
+
+      should "go to :self_employed? question" do
+        assert_equal :self_employed?, @new_state.current_node
+        assert_node_exists :self_employed?
+      end
+    end
+
+    context "when answering :self_employed? question" do
+      setup do
+        setup_states_for_question(:self_employed?,
+                                  responding_with: "no",
+                                  initial_state: { calculator: @calculator })
+      end
+
+      should "store 'no' for :self_employed? question" do
+        assert_equal "no", @calculator.self_employed
+      end
+
+      should "go to :annual_turnover? question" do
+        assert_equal :annual_turnover?, @new_state.current_node
+        assert_node_exists :annual_turnover?
+      end
+    end
+
+    context "when answering :annual_turnover? question" do
+      setup do
+        setup_states_for_question(:annual_turnover?,
+                                  responding_with: "over_85k",
+                                  initial_state: { calculator: @calculator })
+      end
+
+      should "store 'over_85k' for :annual_turnover? question" do
+        assert_equal "over_85k", @calculator.annual_turnover
+      end
+
+      should "go to :business_rates? question" do
+        assert_equal :business_rates?, @new_state.current_node
+        assert_node_exists :business_rates?
+      end
+    end
+
+    context "when answering :business_rates? question" do
+      setup do
+        setup_states_for_question(:business_rates?,
+                                  responding_with: "yes",
+                                  initial_state: { calculator: @calculator })
+      end
+
+      should "store 'yes' for :business_rates? question" do
+        assert_equal "yes", @calculator.business_rates
+      end
+
+      should "go to :non_domestic_property? question" do
+        assert_equal :non_domestic_property?, @new_state.current_node
+        assert_node_exists :non_domestic_property?
+      end
+    end
+
+    context "when answering :non_domestic_property? question" do
+      setup do
+        setup_states_for_question(:non_domestic_property?,
+                                  responding_with: "over_15k",
+                                  initial_state: { calculator: @calculator })
+      end
+
+      should "store 'over_15k' for :non_domestic_property? question" do
+        assert_equal "over_15k", @calculator.non_domestic_property
+      end
+
+      should "go to :self_assessment_july_2020? question" do
+        assert_equal :self_assessment_july_2020?, @new_state.current_node
+        assert_node_exists :self_assessment_july_2020?
+      end
+    end
+
+    context "when answering :self_assessment_july_2020? question" do
+      setup do
+        setup_states_for_question(:self_assessment_july_2020?,
+                                  responding_with: "no",
+                                  initial_state: { calculator: @calculator })
+      end
+
+      should "store 'no' for :self_assessment_july_2020? question" do
+        assert_equal "no", @calculator.self_assessment_july_2020
+      end
+
+      should "go to :sectors? question" do
+        assert_equal :sectors?, @new_state.current_node
+        assert_node_exists :sectors?
+      end
+    end
+
+    context "when answering :sectors? question" do
+      setup do
+        setup_states_for_question(:sectors?,
+                                  responding_with: %w[retail hospitality leisure],
+                                  initial_state: { calculator: @calculator })
+      end
+
+      should "store 'retail hospitality leisure' for :sectors? question" do
+        assert_same_elements %w[retail hospitality leisure], @calculator.sectors
+      end
+
+      should "go to :results outcome" do
+        assert_equal :results, @new_state.current_node
+        assert_node_exists :results
+      end
+    end
+  end
+end

--- a/test/unit/smart_answer_flows/coronavirus_business_support_view_test.rb
+++ b/test/unit/smart_answer_flows/coronavirus_business_support_view_test.rb
@@ -1,0 +1,216 @@
+require_relative "../../test_helper"
+
+require "smart_answer_flows/coronavirus-business-support.rb"
+
+module SmartAnswer
+  class CoronavirusBusinessSupportViewTest < ActiveSupport::TestCase
+    setup do
+      @flow = CoronavirusBusinessSupportFlow.build
+    end
+
+    context "when rendering :business_based? question" do
+      setup do
+        question = @flow.node(:business_based?)
+        @state = SmartAnswer::State.new(question)
+        @presenter = MultipleChoiceQuestionPresenter.new(question, @state)
+      end
+
+      should "have options with labels" do
+        assert_equal({ "england" => "England",
+                       "scotland" => "Scotland",
+                       "wales" => "Wales",
+                       "northern_ireland" => "Northern Ireland" },
+                     values_vs_labels(@presenter.options))
+      end
+
+      should "have a default error message" do
+        @state.error = "error-message"
+        assert_equal "Please answer this question", @presenter.error
+      end
+    end
+
+    context "when rendering :business_size? question" do
+      setup do
+        question = @flow.node(:business_size?)
+        @state = SmartAnswer::State.new(question)
+        @presenter = MultipleChoiceQuestionPresenter.new(question, @state)
+      end
+
+      should "have options with labels" do
+        assert_equal({ "small_medium_enterprise" => "Small or medium enterprise (SME): 0 to 249 employees.",
+                       "large_enterprise" => "Large enterprises: over 249 employees." },
+                     values_vs_labels(@presenter.options))
+      end
+
+      should "have a default error message" do
+        @state.error = "error-message"
+        assert_equal "Please answer this question", @presenter.error
+      end
+    end
+
+    context "when rendering :self_employed? question" do
+      setup do
+        question = @flow.node(:self_employed?)
+        @state = SmartAnswer::State.new(question)
+        @presenter = MultipleChoiceQuestionPresenter.new(question, @state)
+      end
+
+      should "have options with labels" do
+        assert_equal({ "yes" => "Yes", "no" => "No" }, values_vs_labels(@presenter.options))
+      end
+
+      should "have a default error message" do
+        @state.error = "error-message"
+        assert_equal "Please answer this question", @presenter.error
+      end
+    end
+
+    context "when rendering :annual_turnover? question" do
+      setup do
+        question = @flow.node(:annual_turnover?)
+        @state = SmartAnswer::State.new(question)
+        @presenter = MultipleChoiceQuestionPresenter.new(question, @state)
+      end
+
+      should "have options with labels" do
+        assert_equal({ "over_45m" => "Over £45m",
+                       "over_85k" => "Over £85,000 and under £45m",
+                       "under_85k" => "Under £85,000 (ie not VAT registered)" },
+                     values_vs_labels(@presenter.options))
+      end
+
+      should "have a default error message" do
+        @state.error = "error-message"
+        assert_equal "Please answer this question", @presenter.error
+      end
+    end
+
+    context "when rendering :business_rates? question" do
+      setup do
+        question = @flow.node(:business_rates?)
+        @state = SmartAnswer::State.new(question)
+        @presenter = MultipleChoiceQuestionPresenter.new(question, @state)
+      end
+
+      should "have options with labels" do
+        assert_equal({ "yes" => "Yes", "no" => "No" }, values_vs_labels(@presenter.options))
+      end
+
+      should "have a default error message" do
+        @state.error = "error-message"
+        assert_equal "Please answer this question", @presenter.error
+      end
+    end
+
+    context "when rendering :non_domestic_property? question" do
+      setup do
+        question = @flow.node(:non_domestic_property?)
+        @state = SmartAnswer::State.new(question)
+        @presenter = MultipleChoiceQuestionPresenter.new(question, @state)
+      end
+
+      should "have options with labels" do
+        assert_equal({ "over_51k" => "Over £51,000",
+                       "over_15k" => "Over £15,000 and under £51,000",
+                       "up_to_15k" => "Up to £15,000",
+                       "none" => "My business does not have a non-domestic property" },
+                     values_vs_labels(@presenter.options))
+      end
+
+      should "have a default error message" do
+        @state.error = "error-message"
+        assert_equal "Please answer this question", @presenter.error
+      end
+    end
+
+    context "when rendering :self_assessment_july_2020? question" do
+      setup do
+        question = @flow.node(:self_assessment_july_2020?)
+        @state = SmartAnswer::State.new(question)
+        @presenter = MultipleChoiceQuestionPresenter.new(question, @state)
+      end
+
+      should "have options with labels" do
+        assert_equal({ "yes" => "Yes", "no" => "No" }, values_vs_labels(@presenter.options))
+      end
+
+      should "have a default error message" do
+        @state.error = "error-message"
+        assert_equal "Please answer this question", @presenter.error
+      end
+    end
+
+    context "when rendering :sectors? question" do
+      setup do
+        question = @flow.node(:sectors?)
+        @state = SmartAnswer::State.new(question)
+        @presenter = MultipleChoiceQuestionPresenter.new(question, @state)
+      end
+
+      should "have options with labels" do
+        assert_equal({ "retail" => "Retail",
+                       "hospitality" => "Hospitality",
+                       "leisure" => "Leisure",
+                       "nurseries" => "Nurseries" },
+                     values_vs_labels(@presenter.options))
+      end
+
+      should "have a default error message" do
+        @state.error = "error-message"
+        assert_equal "Please answer this question", @presenter.error
+      end
+    end
+
+    context "when rendering the result outcome" do
+      setup do
+        @outcome = @flow.node(:results)
+        calculator_options = {
+          business_based: "england",
+          business_size: "small_medium_enterprise",
+          self_employed: "no",
+          annual_turnover: "over_85k",
+          business_rates: "yes",
+          non_domestic_property: "over_15k",
+          self_assessment_july_2020: "no",
+          sectors: %w[retail hospitality leisure],
+        }
+
+        @calculator = stub("calculator", calculator_options)
+        @calculator.responds_like_instance_of(Calculators::CoronavirusBusinessSupportCalculator)
+        @calculator.stubs(:show_job_retention_scheme?).returns(true)
+        @calculator.stubs(:show_vat_scheme?).returns(true)
+        @calculator.stubs(:show_self_assessment_payments?).returns(true)
+        @calculator.stubs(:show_statutory_sick_rebate?).returns(true)
+        @calculator.stubs(:show_self_employed_income_scheme?).returns(true)
+        @calculator.stubs(:show_business_rates?).returns(true)
+        @calculator.stubs(:show_grant_funding?).returns(true)
+        @calculator.stubs(:show_nursery_support?).returns(true)
+        @calculator.stubs(:show_small_business_grant_funding?).returns(true)
+        @calculator.stubs(:show_business_loan_scheme?).returns(true)
+        @calculator.stubs(:show_corporate_financing?).returns(true)
+        @calculator.stubs(:show_business_tax_support?).returns(true)
+        @state = SmartAnswer::State.new(@outcome)
+        @state.calculator = @calculator
+      end
+
+      context "common output" do
+        setup do
+          presenter = OutcomePresenter.new(@outcome, @state)
+          @body = presenter.body(html: false)
+        end
+
+        should "display title" do
+          assert_includes @body, "Coronavirus Job retention Scheme"
+        end
+      end
+    end
+
+    # TODO: add tests for various permutations of results outcome
+
+  private
+
+    def values_vs_labels(options)
+      options.inject({}) { |h, o| h[o.value] = o.label; h }
+    end
+  end
+end


### PR DESCRIPTION
Adds some unit tests for the `CoronavirusBusinessSupportFlow` for the flow and view outputs. 

Adds an integration test for the flow and also for the `CoronavirusBusinessSupportCalculator`.

Trello: https://trello.com/c/l2QKcqWf