### PR TITLE
Add CLBILS scheme to the Coronavirus Business Support results

### DIFF
--- a/lib/smart_answer/calculators/coronavirus_business_support_calculator.rb
+++ b/lib/smart_answer/calculators/coronavirus_business_support_calculator.rb
@@ -14,7 +14,7 @@ module SmartAnswer::Calculators
         calculator.self_employed == "no"
       },
       vat_scheme: ->(calculator) {
-        calculator.annual_turnover == "under_85k"
+        calculator.annual_turnover != "under_85k"
       },
       self_assessment_payments: ->(calculator) {
         calculator.self_assessment_july_2020 == "yes"
@@ -53,14 +53,13 @@ module SmartAnswer::Calculators
       },
       business_loan_scheme: ->(calculator) {
         calculator.self_employed == "no" &&
-          calculator.annual_turnover != "over_45m"
+          %w[under_85k over_85k].include?(calculator.annual_turnover)
       },
       corporate_financing: ->(calculator) {
         calculator.self_employed == "no"
       },
       business_tax_support: ->(calculator) {
-        calculator.self_employed == "no" &&
-          calculator.annual_turnover != "over_45m"
+        calculator.self_employed == "no"
       },
     }.freeze
 

--- a/lib/smart_answer/calculators/coronavirus_business_support_calculator.rb
+++ b/lib/smart_answer/calculators/coronavirus_business_support_calculator.rb
@@ -61,6 +61,10 @@ module SmartAnswer::Calculators
       business_tax_support: ->(calculator) {
         calculator.self_employed == "no"
       },
+      large_business_loan_scheme: ->(calculator) {
+        calculator.self_employed == "no" &&
+          calculator.annual_turnover == "over_45m"
+      },
     }.freeze
 
     def show?(result_id)

--- a/lib/smart_answer_flows/coronavirus-business-support.rb
+++ b/lib/smart_answer_flows/coronavirus-business-support.rb
@@ -53,6 +53,7 @@ module SmartAnswer
 
       # Q4
       multiple_choice :annual_turnover? do
+        option :over_500m
         option :over_45m
         option :over_85k
         option :under_85k

--- a/lib/smart_answer_flows/coronavirus-business-support/outcomes/results.govspeak.erb
+++ b/lib/smart_answer_flows/coronavirus-business-support/outcomes/results.govspeak.erb
@@ -123,5 +123,15 @@
     $CTA
   <% end %>
 
+  <% if calculator.show?(:large_business_loan_scheme) %>
+    $CTA
+    **Coronavirus Large Business Interruption Loan Scheme**
+
+    If your annual turnover is between £45 million and £500 million, you can access loans of up to £25 million offered at commercial rates. The government will provide lenders with an 80% guarantee on individual loans for businesses that would be otherwise unable to access the finance they need.
+
+    [Apply for the Coronavirus Large Business Interruption Loan Scheme](https://www.gov.uk/guidance/apply-for-the-coronavirus-large-business-interruption-loan-scheme)
+    $CTA
+  <% end %>
+
   <%= render "devolved_nations", calculator: calculator %>
 <% end %>

--- a/lib/smart_answer_flows/coronavirus-business-support/questions/annual_turnover.govspeak.erb
+++ b/lib/smart_answer_flows/coronavirus-business-support/questions/annual_turnover.govspeak.erb
@@ -3,7 +3,8 @@
 <% end %>
 
 <% options(
-  "over_45m": "Over £45m",
+  "over_500m": "Over £500m",
+  "over_45m": "Over £45m and under £500m",
   "over_85k": "Over £85,000 and under £45m",
   "under_85k": "Under £85,000 (ie not VAT registered)",
 ) %>


### PR DESCRIPTION
This is an another scheme to be shown to business with more than 45m and less than 500m turnover.