### PR TITLE
Clarify how to publish a smart answer

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ This is a Ruby on Rails application that contains:
 * [Refactoring existing Smart Answers](doc/smart-answer-flow-development/refactoring.md)
 * Adding [content-ids](doc/smart-answer-flow-development/content-ids.md) to Smart Answers
 * [Creating a new Smart Answer](doc/smart-answer-flow-development/creating-a-new-smart-answer.md)
+* [Publishing a Smart Answer](doc/smart-answer-flow-development/publishing.md)
 * [Retiring a Smart Answer](doc/smart-answer-flow-development/retiring-a-smart-answer.md)
 * [Updating worldwide fixture data](doc/smart-answer-flow-development/updating-worldwide-fixture-data.md)
 
@@ -72,10 +73,6 @@ This is a Ruby on Rails application that contains:
 * [Common errors you might run into during development](doc/smart-answers-app-development/common-errors.md)
 * [Continuous integration](doc/smart-answers-app-development/continuous-integration.md)
 * [Testing](doc/smart-answers-app-development/testing.md)
-
-### Changes to the landing page
-
-Changes to landing pages need to be sent to be sent to the `content store` for them to be rendered on the page. The [rake task `publishing_api:sync_all`](https://github.com/alphagov/smart-answers/blob/master/lib/tasks/publishing_api.rake) needs to be run once you have deployed your changes in each environment and can be done in [Jenkins](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=smartanswers&MACHINE_CLASS=calculators_frontend&RAKE_TASK=publishing_api:sync_all).
 
 ### Debugging
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ This is a Ruby on Rails application that contains:
 * [Deploying changes for Factcheck](doc/smart-answer-flow-development/factcheck.md)
 * [Flattening outcomes](doc/smart-answer-flow-development/flattening-outcomes.md)
 * [Refactoring existing Smart Answers](doc/smart-answer-flow-development/refactoring.md)
-* Adding [content-ids](doc/smart-answer-flow-development/content-ids.md) to Smart Answers
 * [Creating a new Smart Answer](doc/smart-answer-flow-development/creating-a-new-smart-answer.md)
 * [Publishing a Smart Answer](doc/smart-answer-flow-development/publishing.md)
 * [Retiring a Smart Answer](doc/smart-answer-flow-development/retiring-a-smart-answer.md)

--- a/doc/smart-answer-flow-development/content-ids.md
+++ b/doc/smart-answer-flow-development/content-ids.md
@@ -1,7 +1,0 @@
-# Content IDs
-
-Smart answers need content-ids. You can generate one by running:
-
-```bash
-$ ruby -rsecurerandom -e "puts SecureRandom.uuid"
-```

--- a/doc/smart-answer-flow-development/creating-a-new-smart-answer.md
+++ b/doc/smart-answer-flow-development/creating-a-new-smart-answer.md
@@ -17,6 +17,9 @@ module SmartAnswer
   class ExampleSmartAnswerFlow < Flow
     def define
       name 'example-smart-answer'
+      start_page_content_id "<SecureRandom.uuid>"
+      flow_content_id "<SecureRandom.uuid>"
+      status :draft
 
       value_question :question_1? do
         next_node do

--- a/doc/smart-answer-flow-development/publishing.md
+++ b/doc/smart-answer-flow-development/publishing.md
@@ -1,0 +1,5 @@
+### Publishing
+
+Changes to smart answer pages need to be sent to be sent to the `content store` for them to appear on GOV.UK.
+
+The [rake task `publishing_api:sync_all`](https://github.com/alphagov/smart-answers/blob/master/lib/tasks/publishing_api.rake) needs to be run once you have deployed your changes in each environment and can be done in [Jenkins](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=smartanswers&MACHINE_CLASS=calculators_frontend&RAKE_TASK=publishing_api:sync_all).


### PR DESCRIPTION
Previously the README had a separate, short section about how to
'update' just the landing page of a smart answer, which I missed due to all
the other doc links above it. This rewrites and moves info about publishing
into a small, separate, doc in the main list.