### PR TITLE
Remove Whitehall environment variables

### DIFF
--- a/app.json
+++ b/app.json
@@ -8,7 +8,6 @@
     "GOVUK_WEBSITE_ROOT": "https://www.gov.uk",
     "PLEK_SERVICE_CONTENT_STORE_URI": "https://www.gov.uk/api" ,
     "PLEK_SERVICE_STATIC_URI": "https://assets.integration.publishing.service.gov.uk/",
-    "PLEK_SERVICE_WHITEHALL_FRONTEND_URI": "https://www.gov.uk",
     "RUNNING_ON_HEROKU": "true",
     "EXPOSE_GOVSPEAK": "true",
     "ERRBIT_ENV": "integration"

--- a/lib/marriage_abroad_outcome_flattener.rb
+++ b/lib/marriage_abroad_outcome_flattener.rb
@@ -25,7 +25,7 @@ private
   def stubs_etc
     Timecop.freeze(current_time)
     Services.content_store = FakeContentStore.new
-    ENV["PLEK_SERVICE_WHITEHALL_ADMIN_URI"] = "https://www.gov.uk"
+    ENV["GOVUK_WEBSITE_ROOT"] = "https://www.gov.uk"
   end
 
   def generate_and_add_partials_to_country_files

--- a/startup.sh
+++ b/startup.sh
@@ -5,8 +5,6 @@ bundle install
 if [[ $1 == "--live" ]] ; then
   GOVUK_APP_DOMAIN=www.gov.uk \
   GOVUK_WEBSITE_ROOT=https://www.gov.uk \
-  PLEK_SERVICE_WHITEHALL_ADMIN_URI=${PLEK_SERVICE_WHITEHALL_ADMIN_URI-https://www.gov.uk} \
-  PLEK_SERVICE_WHITEHALL_FRONTEND_URI=${PLEK_SERVICE_WHITEHALL_ADMIN_URI-http://www.gov.uk} \
   PLEK_SERVICE_CONTENT_STORE_URI=${PLEK_SERVICE_CONTENT_STORE_URI-https://www.gov.uk/api} \
   PLEK_SERVICE_STATIC_URI=${PLEK_SERVICE_STATIC_URI-assets.publishing.service.gov.uk} \
   bundle exec rails s -p 3010

--- a/startup_heroku.sh
+++ b/startup_heroku.sh
@@ -22,7 +22,6 @@ heroku config:set \
 GOVUK_APP_DOMAIN=integration.publishing.service.gov.uk \
 PLEK_SERVICE_CONTENT_STORE_URI=https://www.gov.uk/api \
 PLEK_SERVICE_STATIC_URI=https://assets-origin.integration.publishing.service.gov.uk/ \
-PLEK_SERVICE_WHITEHALL_FRONTEND_URI=https://www.gov.uk \
 RUNNING_ON_HEROKU=true \
 EXPOSE_GOVSPEAK=true \
 


### PR DESCRIPTION
These no longer have any affect as the worldwide API is loaded from
www.gov.uk hostname rather than speaking to Whitehall directly.