### PR TITLE
Fix spacing for previous questions

### DIFF
--- a/app/assets/stylesheets/smart_answers.scss
+++ b/app/assets/stylesheets/smart_answers.scss
@@ -80,7 +80,3 @@ $is-ie: false !default;
   @include govuk-font($size: 16);
   color: $govuk-secondary-text-colour;
 }
-
-.app-o-spacing {
-  margin-bottom: govuk-spacing(6);
-}

--- a/app/views/smart_answers/landing.html.erb
+++ b/app/views/smart_answers/landing.html.erb
@@ -13,7 +13,7 @@
     } %>
 
     <article role="article" data-debug-template-path="<%= start_node.relative_erb_template_path %>">
-      <section class="app-o-spacing">
+      <section class="govuk-!-margin-bottom-6">
         <%= render "govuk_publishing_components/components/govspeak", {
         } do %>
           <%= start_node.body %>

--- a/app/views/smart_answers/landing.html.erb
+++ b/app/views/smart_answers/landing.html.erb
@@ -23,7 +23,8 @@
           text: start_node.start_button_text,
           href: smart_answer_path(@name.to_s, started: "y"),
           rel: "nofollow",
-          start: true
+          start: true,
+          margin_bottom: true,
         } %>
       </section>
 

--- a/app/views/smart_answers/question.html.erb
+++ b/app/views/smart_answers/question.html.erb
@@ -13,7 +13,7 @@
       margin_bottom: 9
     } %>
     <%= form_tag calculate_current_question_path(@presenter), :method => :get do %>
-      <div class="govuk-!-margin-top-9 app-o-spacing" id="current-question">
+      <div class="govuk-!-margin-bottom-6" id="current-question">
         <div data-debug-template-path="<%= question.relative_erb_template_path %>">
           <% show_body = ['salary_question', 'country_select_question'].include? question.partial_template_name %>
 

--- a/app/views/smart_answers/question.html.erb
+++ b/app/views/smart_answers/question.html.erb
@@ -13,7 +13,7 @@
       margin_bottom: 9
     } %>
     <%= form_tag calculate_current_question_path(@presenter), :method => :get do %>
-      <div class="govuk-!-margin-top-9" id="current-question">
+      <div class="govuk-!-margin-top-9 app-o-spacing" id="current-question">
         <div data-debug-template-path="<%= question.relative_erb_template_path %>">
           <% show_body = ['salary_question', 'country_select_question'].include? question.partial_template_name %>
 

--- a/app/views/smart_answers/result.html.erb
+++ b/app/views/smart_answers/result.html.erb
@@ -11,7 +11,7 @@
 
     <% outcome = @presenter.current_node %>
 
-    <div class="app-o-spacing" data-debug-template-path="<%= outcome.relative_erb_template_path %>">
+    <div class="govuk-!-margin-bottom-6" data-debug-template-path="<%= outcome.relative_erb_template_path %>">
       <% if outcome.title.present? %>
         <%= render "govuk_publishing_components/components/heading", {
           text: outcome.title,
@@ -26,7 +26,7 @@
     </div>
 
     <% if outcome.next_steps.present? %>
-      <div class="app-o-spacing">
+      <div class="govuk-!-margin-bottom-6">
         <%= render "govuk_publishing_components/components/heading", {
           text: "Next steps",
           margin_bottom: 6


### PR DESCRIPTION
This is consistent with the margin/class used on the results page,
and is particularly helpful on mobile.

### Before

<img width="292" alt="Screenshot 2020-04-14 at 11 03 21" src="https://user-images.githubusercontent.com/9029009/79212532-b3096c00-7e3f-11ea-9716-9c2c9c179a55.png">

### After

<img width="292" alt="Screenshot 2020-04-14 at 11 03 59" src="https://user-images.githubusercontent.com/9029009/79212547-b866b680-7e3f-11ea-9fe7-88b8e2e30a88.png">
