### PR TITLE
Remove redundant style

### DIFF
--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -1,8 +1,1 @@
-// Hide uneeded elements for print
-.smart_answer {
-  .outcome .inner {
-    padding-top: 1em;
-  }
-}
-
 @import "govuk_publishing_components/all_components_print";


### PR DESCRIPTION
This app no longer uses the 'inner' class anywhere (the style
was added in 2014, and appears to be out-of-date).