### PR TITLE
Coronavirus business support questions update

### DIFF
--- a/lib/smart_answer/calculators/business_coronavirus_support_finder_calculator.rb
+++ b/lib/smart_answer/calculators/business_coronavirus_support_finder_calculator.rb
@@ -2,7 +2,7 @@ module SmartAnswer::Calculators
   class BusinessCoronavirusSupportFinderCalculator
     attr_accessor :business_based,
                   :business_size,
-                  :self_employed,
+                  :paye_scheme,
                   :annual_turnover,
                   :business_rates,
                   :non_domestic_property,
@@ -11,7 +11,7 @@ module SmartAnswer::Calculators
 
     RULES = {
       job_retention_scheme: ->(calculator) {
-        calculator.self_employed == "no"
+        calculator.paye_scheme == "yes"
       },
       vat_scheme: ->(calculator) {
         calculator.annual_turnover != "under_85k"
@@ -21,12 +21,10 @@ module SmartAnswer::Calculators
       },
       statutory_sick_rebate: ->(calculator) {
         calculator.business_size == "0_to_249" &&
-          calculator.self_employed == "no" &&
           calculator.self_assessment_july_2020 == "yes"
       },
       self_employed_income_scheme: ->(calculator) {
-        calculator.business_size == "0_to_249" &&
-          calculator.self_employed == "yes"
+        calculator.business_size == "0_to_249"
       },
       business_rates: ->(calculator) {
         calculator.business_based == "england" &&
@@ -52,27 +50,15 @@ module SmartAnswer::Calculators
           calculator.non_domestic_property == "up_to_15k"
       },
       business_loan_scheme: ->(calculator) {
-        calculator.self_employed == "no" &&
-          %w[under_85k 85k_to_45m].include?(calculator.annual_turnover)
-      },
-      corporate_financing: ->(calculator) {
-        calculator.self_employed == "no"
-      },
-      business_tax_support: ->(calculator) {
-        calculator.self_employed == "no"
+        %w[under_85k 85k_to_45m].include?(calculator.annual_turnover)
       },
       large_business_loan_scheme: ->(calculator) {
-        calculator.self_employed == "no" &&
-          calculator.annual_turnover == "45m_to_500m"
+        calculator.annual_turnover == "45m_to_500m"
       },
     }.freeze
 
     def show?(result_id)
       RULES[result_id].call(self)
-    end
-
-    def no_results?
-      RULES.values.none? { |rule| rule.call(self) }
     end
   end
 end

--- a/lib/smart_answer/calculators/business_coronavirus_support_finder_calculator.rb
+++ b/lib/smart_answer/calculators/business_coronavirus_support_finder_calculator.rb
@@ -4,7 +4,6 @@ module SmartAnswer::Calculators
                   :business_size,
                   :paye_scheme,
                   :annual_turnover,
-                  :business_rates,
                   :non_domestic_property,
                   :self_assessment_july_2020,
                   :sectors
@@ -28,19 +27,16 @@ module SmartAnswer::Calculators
       },
       business_rates: ->(calculator) {
         calculator.business_based == "england" &&
-          calculator.business_rates == "yes" &&
           calculator.non_domestic_property != "none" &&
           (%w[retail hospitality leisure] & calculator.sectors).any?
       },
       grant_funding: ->(calculator) {
         calculator.business_based == "england" &&
-          calculator.business_rates == "yes" &&
           calculator.non_domestic_property == "over_15k" &&
           (%w[retail hospitality leisure] & calculator.sectors).any?
       },
       nursery_support: ->(calculator) {
         calculator.business_based == "england" &&
-          calculator.business_rates == "yes" &&
           calculator.non_domestic_property != "none" &&
           calculator.sectors.include?("nurseries")
       },

--- a/lib/smart_answer/calculators/business_coronavirus_support_finder_calculator.rb
+++ b/lib/smart_answer/calculators/business_coronavirus_support_finder_calculator.rb
@@ -20,12 +20,12 @@ module SmartAnswer::Calculators
         calculator.self_assessment_july_2020 == "yes"
       },
       statutory_sick_rebate: ->(calculator) {
-        calculator.business_size == "small_medium_enterprise" &&
+        calculator.business_size == "0_to_249" &&
           calculator.self_employed == "no" &&
           calculator.self_assessment_july_2020 == "yes"
       },
       self_employed_income_scheme: ->(calculator) {
-        calculator.business_size == "small_medium_enterprise" &&
+        calculator.business_size == "0_to_249" &&
           calculator.self_employed == "yes"
       },
       business_rates: ->(calculator) {
@@ -48,7 +48,7 @@ module SmartAnswer::Calculators
       },
       small_business_grant_funding: ->(calculator) {
         calculator.business_based == "england" &&
-          calculator.business_size == "small_medium_enterprise" &&
+          calculator.business_size == "0_to_249" &&
           calculator.non_domestic_property == "up_to_15k"
       },
       business_loan_scheme: ->(calculator) {

--- a/lib/smart_answer/calculators/business_coronavirus_support_finder_calculator.rb
+++ b/lib/smart_answer/calculators/business_coronavirus_support_finder_calculator.rb
@@ -53,7 +53,7 @@ module SmartAnswer::Calculators
       },
       business_loan_scheme: ->(calculator) {
         calculator.self_employed == "no" &&
-          %w[under_85k over_85k].include?(calculator.annual_turnover)
+          %w[under_85k 85k_to_45m].include?(calculator.annual_turnover)
       },
       corporate_financing: ->(calculator) {
         calculator.self_employed == "no"
@@ -63,7 +63,7 @@ module SmartAnswer::Calculators
       },
       large_business_loan_scheme: ->(calculator) {
         calculator.self_employed == "no" &&
-          calculator.annual_turnover == "over_45m"
+          calculator.annual_turnover == "45m_to_500m"
       },
     }.freeze
 

--- a/lib/smart_answer_flows/business-coronavirus-support-finder.rb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder.rb
@@ -49,17 +49,17 @@ module SmartAnswer
         end
 
         next_node do
-          question :self_employed?
+          question :paye_scheme?
         end
       end
 
       # Q4
-      multiple_choice :self_employed? do
+      multiple_choice :paye_scheme? do
         option :yes
         option :no
 
         on_response do |response|
-          calculator.self_employed = response
+          calculator.paye_scheme = response
         end
 
         next_node do
@@ -124,16 +124,11 @@ module SmartAnswer
         end
 
         next_node do
-          if calculator.no_results?
-            outcome :no_results
-          else
-            outcome :results
-          end
+          outcome :results
         end
       end
 
       outcome :results
-      outcome :no_results
     end
   end
 end

--- a/lib/smart_answer_flows/business-coronavirus-support-finder.rb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder.rb
@@ -39,9 +39,9 @@ module SmartAnswer
 
       # Q3
       multiple_choice :annual_turnover? do
-        option :over_500m
-        option :over_45m
-        option :over_85k
+        option :"500m_and_over"
+        option :"45m_to_500m"
+        option :"85k_to_45m"
         option :under_85k
 
         on_response do |response|

--- a/lib/smart_answer_flows/business-coronavirus-support-finder.rb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder.rb
@@ -33,25 +33,11 @@ module SmartAnswer
         end
 
         next_node do
-          question :self_employed?
-        end
-      end
-
-      # Q3
-      multiple_choice :self_employed? do
-        option :yes
-        option :no
-
-        on_response do |response|
-          calculator.self_employed = response
-        end
-
-        next_node do
           question :annual_turnover?
         end
       end
 
-      # Q4
+      # Q3
       multiple_choice :annual_turnover? do
         option :over_500m
         option :over_45m
@@ -60,6 +46,20 @@ module SmartAnswer
 
         on_response do |response|
           calculator.annual_turnover = response
+        end
+
+        next_node do
+          question :self_employed?
+        end
+      end
+
+      # Q4
+      multiple_choice :self_employed? do
+        option :yes
+        option :no
+
+        on_response do |response|
+          calculator.self_employed = response
         end
 
         next_node do

--- a/lib/smart_answer_flows/business-coronavirus-support-finder.rb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder.rb
@@ -25,8 +25,8 @@ module SmartAnswer
 
       # Q2
       multiple_choice :business_size? do
-        option :small_medium_enterprise
-        option :large_enterprise
+        option :"0_to_249"
+        option :over_249
 
         on_response do |response|
           calculator.business_size = response

--- a/lib/smart_answer_flows/business-coronavirus-support-finder.rb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder.rb
@@ -63,25 +63,11 @@ module SmartAnswer
         end
 
         next_node do
-          question :business_rates?
-        end
-      end
-
-      # Q5
-      multiple_choice :business_rates? do
-        option :yes
-        option :no
-
-        on_response do |response|
-          calculator.business_rates = response
-        end
-
-        next_node do
           question :non_domestic_property?
         end
       end
 
-      # Q6
+      # Q5
       multiple_choice :non_domestic_property? do
         option :over_51k
         option :over_15k
@@ -97,7 +83,7 @@ module SmartAnswer
         end
       end
 
-      # Q7
+      # Q6
       multiple_choice :self_assessment_july_2020? do
         option :yes
         option :no
@@ -111,7 +97,7 @@ module SmartAnswer
         end
       end
 
-      # Q8
+      # Q7
       checkbox_question :sectors? do
         option :retail
         option :hospitality

--- a/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/no_results.govspeak.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/no_results.govspeak.erb
@@ -1,9 +1,0 @@
-<% content_for :title do %>
-  No results found
-<% end %>
-
-<% content_for :body do %>
-  There are no schemes at the moment that apply to your situation. To change your answers, follow the links below.
-
-  <%= render "devolved_nations", calculator: calculator %>
-<% end %>

--- a/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.govspeak.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.govspeak.erb
@@ -7,9 +7,9 @@
     $CTA
     **Coronavirus Job retention scheme**
 
-    If you are an employer with a PAYE scheme, you should be able to access support to continue paying part of your employees’ salary instead of laying them off. 
+    If you are an employer with a PAYE scheme, you should be able to access support to continue paying part of your employees’ salary instead of laying them off.
 
-    This applies to employees who have been asked to stop working because of coronavirus, but are being kept on the payroll. They are known as ‘furloughed workers’. HMRC will pay 80% of their wages, up to £2,500 per month. 
+    This applies to employees who have been asked to stop working because of coronavirus, but are being kept on the payroll. They are known as ‘furloughed workers’. HMRC will pay 80% of their wages, up to £2,500 per month.
 
     [Check if you are eligible for the Coronavirus Job Retention Scheme ](https://www.gov.uk/guidance/claim-for-wage-costs-through-the-coronavirus-job-retention-scheme)
     $CTA
@@ -95,17 +95,17 @@
     $CTA
     **Retail, Hospitality and Leisure Grant Fund**
 
-    Your business may be eligible for a grant of up to £25,000 per property. 
- 
+    Your business may be eligible for a grant of up to £25,000 per property.
+
     If your business has a property with a rateable value of £15,000 or under, you may be eligible for a grant of £10,000.
-     
+
     If your business has a property that has a rateable value of over £15,000 but less than £51,000, you may be eligible for a grant of £25,000.
-     
+
     You are eligible if your business:
 
     - is based in England
-    - is in the retail, hospitality or leisure sector 
-    - has a property that is wholly or mainly used as hospitality, retail, or leisure venue 
+    - is in the retail, hospitality or leisure sector
+    - has a property that is wholly or mainly used as hospitality, retail, or leisure venue
 
 
     [Coronavirus guidance on business support grant funding](https://www.gov.uk/government/publications/coronavirus-covid-19-guidance-on-business-support-grant-funding)
@@ -152,16 +152,16 @@
     **Coronavirus Business Interruption Loan scheme**
 
     If you are a small to medium-sized business (SME) you may be able to apply for a temporary loan, overdraft, invoice finance and asset finance of up to £5 million, for up to 6 years.
-     
+
     You may also be eligible for Business Interruption Payment to cover the first 12 months of interest payments and any lender fees. The government will give lenders 80% guarantee on each loan (subject to pre-lender cap on claims).
-     
+
     You may be eligible for the scheme if your business:
 
     - is UK based
     - has a turnover of no more than £45 million per year
-     
-     
-    You also need to provide a borrowing proposal which the banks would find viable, if not for coronavirus. 
+
+
+    You also need to provide a borrowing proposal which the banks would find viable, if not for coronavirus.
 
 
     [Apply for the coronavirus business interruption loan scheme](https://www.gov.uk/guidance/apply-for-the-coronavirus-business-interruption-loan-scheme)
@@ -182,12 +182,12 @@
     $CTA
     **Support for businesses paying tax: Time To Pay Service**
 
-    If you cannot pay your tax bill on time because of coronavirus, you may be able to delay it without penalty using HMRC’s Time to Pay service. 
+    If you cannot pay your tax bill on time because of coronavirus, you may be able to delay it without penalty using HMRC’s Time to Pay service.
 
     You may be eligible if you are a UK business that:
 
     - pays tax to the UK government
-    - has outstanding tax liabilities 
+    - has outstanding tax liabilities
 
 
     [If you cannot pay your tax bill on time](https://www.gov.uk/difficulties-paying-hmrc)

--- a/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.govspeak.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.govspeak.erb
@@ -169,14 +169,6 @@
   <% end %>
 
   $CTA
-  **COVID-19 Corporate Financing Facility**
-
-  If you are a non-financial company, you may be eligible for COVID-19 Corporate Financing Facility. This scheme allows the Bank of England to buy short-term debt from companies which are fundamentally strong but are affected by coronavirus.
-
-  [Eligibility criteria for the COVID-19 Corporate Financing Facility](https://www.bankofengland.co.uk/news/2020/march/the-covid-corporate-financing-facility)
-  $CTA
-
-  $CTA
   **Support for businesses paying tax: Time To Pay Service**
 
   If you cannot pay your tax bill on time because of coronavirus, you may be able to delay it without penalty using HMRC’s Time to Pay service.

--- a/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.govspeak.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.govspeak.erb
@@ -168,31 +168,27 @@
     $CTA
   <% end %>
 
-  <% if calculator.show?(:corporate_financing) %>
-    $CTA
-    **COVID-19 Corporate Financing Facility**
+  $CTA
+  **COVID-19 Corporate Financing Facility**
 
-    If you are a non-financial company, you may be eligible for COVID-19 Corporate Financing Facility. This scheme allows the Bank of England to buy short-term debt from companies which are fundamentally strong but are affected by coronavirus.
+  If you are a non-financial company, you may be eligible for COVID-19 Corporate Financing Facility. This scheme allows the Bank of England to buy short-term debt from companies which are fundamentally strong but are affected by coronavirus.
 
-    [Eligibility criteria for the COVID-19 Corporate Financing Facility](https://www.bankofengland.co.uk/news/2020/march/the-covid-corporate-financing-facility)
-    $CTA
-  <% end %>
+  [Eligibility criteria for the COVID-19 Corporate Financing Facility](https://www.bankofengland.co.uk/news/2020/march/the-covid-corporate-financing-facility)
+  $CTA
 
-  <% if calculator.show?(:business_tax_support) %>
-    $CTA
-    **Support for businesses paying tax: Time To Pay Service**
+  $CTA
+  **Support for businesses paying tax: Time To Pay Service**
 
-    If you cannot pay your tax bill on time because of coronavirus, you may be able to delay it without penalty using HMRC’s Time to Pay service.
+  If you cannot pay your tax bill on time because of coronavirus, you may be able to delay it without penalty using HMRC’s Time to Pay service.
 
-    You may be eligible if you are a UK business that:
+  You may be eligible if you are a UK business that:
 
-    - pays tax to the UK government
-    - has outstanding tax liabilities
+  - pays tax to the UK government
+  - has outstanding tax liabilities
 
 
-    [If you cannot pay your tax bill on time](https://www.gov.uk/difficulties-paying-hmrc)
-    $CTA
-  <% end %>
+  [If you cannot pay your tax bill on time](https://www.gov.uk/difficulties-paying-hmrc)
+  $CTA
 
   <% if calculator.show?(:large_business_loan_scheme) %>
     $CTA

--- a/lib/smart_answer_flows/business-coronavirus-support-finder/questions/annual_turnover.govspeak.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/questions/annual_turnover.govspeak.erb
@@ -1,10 +1,10 @@
 <% content_for :title do %>
-  What is your turnover per year?
+  What is your annual turnover?
 <% end %>
 
 <% options(
-  "over_500m": "Over £500m",
-  "over_45m": "Over £45m and under £500m",
-  "over_85k": "Over £85,000 and under £45m",
-  "under_85k": "Under £85,000 (ie not VAT registered)",
+  "500m_and_over": "£500m and over",
+  "45m_to_500m": "£45m, and over, and under £500m",
+  "85k_to_45m": "£85,000, and over, and under £45m",
+  "under_85k": "Under £85,000",
 ) %>

--- a/lib/smart_answer_flows/business-coronavirus-support-finder/questions/business_rates.govspeak.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/questions/business_rates.govspeak.erb
@@ -1,8 +1,0 @@
-<% content_for :title do %>
-  Does your business pay business rates?
-<% end %>
-
-<% options(
-  "yes": "Yes",
-  "no": "No",
-) %>

--- a/lib/smart_answer_flows/business-coronavirus-support-finder/questions/business_size.govspeak.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/questions/business_size.govspeak.erb
@@ -1,8 +1,8 @@
 <% content_for :title do %>
-  What size was your business as of 28 February?
+  How many employees does your business have?
 <% end %>
 
 <% options(
-  "small_medium_enterprise": "Small or medium enterprise (SME): 0 to 249 employees.",
-  "large_enterprise": "Large enterprises: over 249 employees.",
+  "0_to_249": "0 to 249 employees",
+  "over_249": "Over 249 employee",
 ) %>

--- a/lib/smart_answer_flows/business-coronavirus-support-finder/questions/paye_scheme.govspeak.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/questions/paye_scheme.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :title do %>
-  Are you self-employed?
+  Are you an employer with a PAYE scheme?
 <% end %>
 
 <% options(

--- a/test/integration/smart_answer_flows/business_coronavirus_support_finder_test.rb
+++ b/test/integration/smart_answer_flows/business_coronavirus_support_finder_test.rb
@@ -20,8 +20,6 @@ class BusinessCoronavirusSupportFinderFlowTest < ActiveSupport::TestCase
       add_response "45m_to_500m"
       assert_current_node :paye_scheme?
       add_response "no"
-      assert_current_node :business_rates?
-      add_response "yes"
       assert_current_node :non_domestic_property?
       add_response "over_15k"
       assert_current_node :self_assessment_july_2020?

--- a/test/integration/smart_answer_flows/business_coronavirus_support_finder_test.rb
+++ b/test/integration/smart_answer_flows/business_coronavirus_support_finder_test.rb
@@ -15,7 +15,7 @@ class BusinessCoronavirusSupportFinderFlowTest < ActiveSupport::TestCase
       assert_current_node :business_based?
       add_response "england"
       assert_current_node :business_size?
-      add_response "small_medium_enterprise"
+      add_response "0_to_249"
       assert_current_node :self_employed?
       add_response "no"
       assert_current_node :annual_turnover?
@@ -37,7 +37,7 @@ class BusinessCoronavirusSupportFinderFlowTest < ActiveSupport::TestCase
       assert_current_node :business_based?
       add_response "scotland"
       assert_current_node :business_size?
-      add_response "large_enterprise"
+      add_response "over_249"
       assert_current_node :self_employed?
       add_response "yes"
       assert_current_node :annual_turnover?

--- a/test/integration/smart_answer_flows/business_coronavirus_support_finder_test.rb
+++ b/test/integration/smart_answer_flows/business_coronavirus_support_finder_test.rb
@@ -10,38 +10,30 @@ class BusinessCoronavirusSupportFinderFlowTest < ActiveSupport::TestCase
     setup_for_testing_flow SmartAnswer::BusinessCoronavirusSupportFinderFlow
   end
 
-  context "business based in England" do
-    setup do
+  context "flow to a results outcome" do
+    should "reach results node" do
       assert_current_node :business_based?
       add_response "england"
       assert_current_node :business_size?
       add_response "small_medium_enterprise"
-    end
-
-    context "not self-employed" do
-      setup do
-        assert_current_node :self_employed?
-        add_response "no"
-        assert_current_node :annual_turnover?
-        add_response "over_45m"
-        assert_current_node :business_rates?
-        add_response "yes"
-        assert_current_node :non_domestic_property?
-        add_response "over_15k"
-        assert_current_node :self_assessment_july_2020?
-        add_response "no"
-        assert_current_node :sectors?
-        add_response "retail"
-      end
-
-      should "reach results" do
-        assert_current_node :results
-      end
+      assert_current_node :self_employed?
+      add_response "no"
+      assert_current_node :annual_turnover?
+      add_response "over_45m"
+      assert_current_node :business_rates?
+      add_response "yes"
+      assert_current_node :non_domestic_property?
+      add_response "over_15k"
+      assert_current_node :self_assessment_july_2020?
+      add_response "no"
+      assert_current_node :sectors?
+      add_response "retail"
+      assert_current_node :results
     end
   end
 
-  context "business based in devolved nation" do
-    setup do
+  context "flow to a no results outcome" do
+    should "reach no_results node" do
       assert_current_node :business_based?
       add_response "scotland"
       assert_current_node :business_size?
@@ -58,9 +50,6 @@ class BusinessCoronavirusSupportFinderFlowTest < ActiveSupport::TestCase
       add_response "no"
       assert_current_node :sectors?
       add_response "none"
-    end
-
-    should "reach no results" do
       assert_current_node :no_results
     end
   end

--- a/test/integration/smart_answer_flows/business_coronavirus_support_finder_test.rb
+++ b/test/integration/smart_answer_flows/business_coronavirus_support_finder_test.rb
@@ -16,10 +16,10 @@ class BusinessCoronavirusSupportFinderFlowTest < ActiveSupport::TestCase
       add_response "england"
       assert_current_node :business_size?
       add_response "0_to_249"
-      assert_current_node :self_employed?
-      add_response "no"
       assert_current_node :annual_turnover?
       add_response "over_45m"
+      assert_current_node :self_employed?
+      add_response "no"
       assert_current_node :business_rates?
       add_response "yes"
       assert_current_node :non_domestic_property?
@@ -38,10 +38,10 @@ class BusinessCoronavirusSupportFinderFlowTest < ActiveSupport::TestCase
       add_response "scotland"
       assert_current_node :business_size?
       add_response "over_249"
-      assert_current_node :self_employed?
-      add_response "yes"
       assert_current_node :annual_turnover?
       add_response "under_85k"
+      assert_current_node :self_employed?
+      add_response "yes"
       assert_current_node :business_rates?
       add_response "no"
       assert_current_node :non_domestic_property?

--- a/test/integration/smart_answer_flows/business_coronavirus_support_finder_test.rb
+++ b/test/integration/smart_answer_flows/business_coronavirus_support_finder_test.rb
@@ -17,7 +17,7 @@ class BusinessCoronavirusSupportFinderFlowTest < ActiveSupport::TestCase
       assert_current_node :business_size?
       add_response "0_to_249"
       assert_current_node :annual_turnover?
-      add_response "over_45m"
+      add_response "45m_to_500m"
       assert_current_node :self_employed?
       add_response "no"
       assert_current_node :business_rates?

--- a/test/integration/smart_answer_flows/business_coronavirus_support_finder_test.rb
+++ b/test/integration/smart_answer_flows/business_coronavirus_support_finder_test.rb
@@ -18,7 +18,7 @@ class BusinessCoronavirusSupportFinderFlowTest < ActiveSupport::TestCase
       add_response "0_to_249"
       assert_current_node :annual_turnover?
       add_response "45m_to_500m"
-      assert_current_node :self_employed?
+      assert_current_node :paye_scheme?
       add_response "no"
       assert_current_node :business_rates?
       add_response "yes"
@@ -29,28 +29,6 @@ class BusinessCoronavirusSupportFinderFlowTest < ActiveSupport::TestCase
       assert_current_node :sectors?
       add_response "retail"
       assert_current_node :results
-    end
-  end
-
-  context "flow to a no results outcome" do
-    should "reach no_results node" do
-      assert_current_node :business_based?
-      add_response "scotland"
-      assert_current_node :business_size?
-      add_response "over_249"
-      assert_current_node :annual_turnover?
-      add_response "under_85k"
-      assert_current_node :self_employed?
-      add_response "yes"
-      assert_current_node :business_rates?
-      add_response "no"
-      assert_current_node :non_domestic_property?
-      add_response "none"
-      assert_current_node :self_assessment_july_2020?
-      add_response "no"
-      assert_current_node :sectors?
-      add_response "none"
-      assert_current_node :no_results
     end
   end
 end

--- a/test/unit/calculators/business_coronavirus_support_calculator_test.rb
+++ b/test/unit/calculators/business_coronavirus_support_calculator_test.rb
@@ -9,12 +9,12 @@ module SmartAnswer::Calculators
     context "#show?" do
       context "job_retention_scheme" do
         should "return true when criteria met" do
-          @calculator.self_employed = "no"
+          @calculator.paye_scheme = "yes"
           assert @calculator.show?(:job_retention_scheme)
         end
 
         should "return false when criteria not met" do
-          @calculator.self_employed = "yes"
+          @calculator.paye_scheme = "no"
           assert_not @calculator.show?(:job_retention_scheme)
         end
       end
@@ -46,7 +46,6 @@ module SmartAnswer::Calculators
       context "statutory_sick_rebate" do
         setup do
           @calculator.business_size = "0_to_249"
-          @calculator.self_employed = "no"
           @calculator.self_assessment_july_2020 = "yes"
         end
 
@@ -59,11 +58,6 @@ module SmartAnswer::Calculators
           assert_not @calculator.show?(:statutory_sick_rebate)
         end
 
-        should "return false when self-employed" do
-          @calculator.self_employed = "yes"
-          assert_not @calculator.show?(:statutory_sick_rebate)
-        end
-
         should "return false when not submitting self assessment for July 2020" do
           @calculator.self_assessment_july_2020 = "no"
           assert_not @calculator.show?(:statutory_sick_rebate)
@@ -71,22 +65,13 @@ module SmartAnswer::Calculators
       end
 
       context "self_employed_income_scheme" do
-        setup do
+        should "return true when business size is 0 to 249 employees" do
           @calculator.business_size = "0_to_249"
-          @calculator.self_employed = "yes"
-        end
-
-        should "return true when criteria met" do
           assert @calculator.show?(:self_employed_income_scheme)
         end
 
-        should "return false when business has over 249 employees" do
+        should "return false when business size is over 249 employees" do
           @calculator.business_size = "over_249"
-          assert_not @calculator.show?(:self_employed_income_scheme)
-        end
-
-        should "return false when employed" do
-          @calculator.self_employed = "no"
           assert_not @calculator.show?(:self_employed_income_scheme)
         end
       end
@@ -213,71 +198,29 @@ module SmartAnswer::Calculators
       end
 
       context "business_loan_scheme" do
-        setup do
-          @calculator.self_employed = "no"
+        should "return true when annual turnover is £85,000 to 45m" do
           @calculator.annual_turnover = "85k_to_45m"
-        end
-
-        should "return true when annual turnover is 85k_to_45m" do
           assert @calculator.show?(:business_loan_scheme)
         end
 
-        should "return true when annual turnover under_85k" do
+        should "return true when annual turnover under £85,000" do
           @calculator.annual_turnover = "under_85k"
           assert @calculator.show?(:business_loan_scheme)
         end
 
-        should "return false when self employed" do
-          @calculator.self_employed = "yes"
-          assert_not @calculator.show?(:business_loan_scheme)
-        end
-
-        should "return false when annual turnover not under_85k or 85k_to_45m" do
+        should "return false when annual turnover not under £85,000 or £85,000 to £45m" do
           @calculator.annual_turnover = "45m_to_500m"
           assert_not @calculator.show?(:business_loan_scheme)
-        end
-      end
-
-      context "corporate_financing" do
-        should "return true when criteria met" do
-          @calculator.self_employed = "no"
-          assert @calculator.show?(:corporate_financing)
-        end
-
-        should "return false when criteria not met" do
-          @calculator.self_employed = "yes"
-          assert_not @calculator.show?(:corporate_financing)
-        end
-      end
-
-      context "business_tax_support" do
-        should "return true when criteria met" do
-          @calculator.self_employed = "no"
-          assert @calculator.show?(:business_tax_support)
-        end
-
-        should "return false when criteria not met" do
-          @calculator.self_employed = "yes"
-          assert_not @calculator.show?(:business_tax_support)
         end
       end
 
       context "large_business_loan_scheme" do
-        setup do
-          @calculator.self_employed = "no"
+        should "return true when annual turnover is £45m to 500m" do
           @calculator.annual_turnover = "45m_to_500m"
-        end
-
-        should "return true when criteria met" do
           assert @calculator.show?(:large_business_loan_scheme)
         end
 
-        should "return false when self employed" do
-          @calculator.self_employed = "yes"
-          assert_not @calculator.show?(:large_business_loan_scheme)
-        end
-
-        should "return false when annual turnover does not equal 45m_to_500m" do
+        should "return false when annual turnover is not £45m to £500m" do
           @calculator.annual_turnover = "500m_and_over"
           assert_not @calculator.show?(:large_business_loan_scheme)
         end

--- a/test/unit/calculators/business_coronavirus_support_calculator_test.rb
+++ b/test/unit/calculators/business_coronavirus_support_calculator_test.rb
@@ -45,7 +45,7 @@ module SmartAnswer::Calculators
 
       context "statutory_sick_rebate" do
         setup do
-          @calculator.business_size = "small_medium_enterprise"
+          @calculator.business_size = "0_to_249"
           @calculator.self_employed = "no"
           @calculator.self_assessment_july_2020 = "yes"
         end
@@ -54,8 +54,8 @@ module SmartAnswer::Calculators
           assert @calculator.show?(:statutory_sick_rebate)
         end
 
-        should "return false when not small mediume enterprise" do
-          @calculator.business_size = "large_enterprise"
+        should "return false when business has over 249 employees" do
+          @calculator.business_size = "over_249"
           assert_not @calculator.show?(:statutory_sick_rebate)
         end
 
@@ -72,7 +72,7 @@ module SmartAnswer::Calculators
 
       context "self_employed_income_scheme" do
         setup do
-          @calculator.business_size = "small_medium_enterprise"
+          @calculator.business_size = "0_to_249"
           @calculator.self_employed = "yes"
         end
 
@@ -80,8 +80,8 @@ module SmartAnswer::Calculators
           assert @calculator.show?(:self_employed_income_scheme)
         end
 
-        should "return false when large enterprise" do
-          @calculator.business_size = "large_enterprise"
+        should "return false when business has over 249 employees" do
+          @calculator.business_size = "over_249"
           assert_not @calculator.show?(:self_employed_income_scheme)
         end
 
@@ -188,7 +188,7 @@ module SmartAnswer::Calculators
       context "small_business_grant_funding" do
         setup do
           @calculator.business_based = "england"
-          @calculator.business_size = "small_medium_enterprise"
+          @calculator.business_size = "0_to_249"
           @calculator.non_domestic_property = "up_to_15k"
         end
 
@@ -201,8 +201,8 @@ module SmartAnswer::Calculators
           assert_not @calculator.show?(:small_business_grant_funding)
         end
 
-        should "return false when not small mediume enterprise" do
-          @calculator.business_size = "large_enterprise"
+        should "return false when business has over 249 employees" do
+          @calculator.business_size = "over_249"
           assert_not @calculator.show?(:small_business_grant_funding)
         end
 

--- a/test/unit/calculators/business_coronavirus_support_calculator_test.rb
+++ b/test/unit/calculators/business_coronavirus_support_calculator_test.rb
@@ -54,21 +54,19 @@ module SmartAnswer::Calculators
           assert_equal true, @calculator.show?(:statutory_sick_rebate)
         end
 
-        context "criteria not met" do
-          should "return false when not small mediume enterprise" do
-            @calculator.business_size = "large_enterprise"
-            assert_equal false, @calculator.show?(:statutory_sick_rebate)
-          end
+        should "return false when not small mediume enterprise" do
+          @calculator.business_size = "large_enterprise"
+          assert_equal false, @calculator.show?(:statutory_sick_rebate)
+        end
 
-          should "return false when self-employed" do
-            @calculator.self_employed = "yes"
-            assert_equal false, @calculator.show?(:statutory_sick_rebate)
-          end
+        should "return false when self-employed" do
+          @calculator.self_employed = "yes"
+          assert_equal false, @calculator.show?(:statutory_sick_rebate)
+        end
 
-          should "return false when not submitting self assessment for July 2020" do
-            @calculator.self_assessment_july_2020 = "no"
-            assert_equal false, @calculator.show?(:statutory_sick_rebate)
-          end
+        should "return false when not submitting self assessment for July 2020" do
+          @calculator.self_assessment_july_2020 = "no"
+          assert_equal false, @calculator.show?(:statutory_sick_rebate)
         end
       end
 
@@ -77,20 +75,19 @@ module SmartAnswer::Calculators
           @calculator.business_size = "small_medium_enterprise"
           @calculator.self_employed = "yes"
         end
+
         should "return true when criteria met" do
           assert_equal true, @calculator.show?(:self_employed_income_scheme)
         end
 
-        context "criteria not met" do
-          should "return false when large enterprise" do
-            @calculator.business_size = "large_enterprise"
-            assert_equal false, @calculator.show?(:self_employed_income_scheme)
-          end
+        should "return false when large enterprise" do
+          @calculator.business_size = "large_enterprise"
+          assert_equal false, @calculator.show?(:self_employed_income_scheme)
+        end
 
-          should "return false when employed" do
-            @calculator.self_employed = "no"
-            assert_equal false, @calculator.show?(:self_employed_income_scheme)
-          end
+        should "return false when employed" do
+          @calculator.self_employed = "no"
+          assert_equal false, @calculator.show?(:self_employed_income_scheme)
         end
       end
 
@@ -106,21 +103,19 @@ module SmartAnswer::Calculators
           assert_equal true, @calculator.show?(:business_rates)
         end
 
-        context "criteria not met" do
-          should "return false when in a devolved admininstration" do
-            @calculator.business_based = "scotland"
-            assert_equal false, @calculator.show?(:business_rates)
-          end
+        should "return false when in a devolved admininstration" do
+          @calculator.business_based = "scotland"
+          assert_equal false, @calculator.show?(:business_rates)
+        end
 
-          should "return false when no non domestic property" do
-            @calculator.non_domestic_property = "none"
-            assert_equal false, @calculator.show?(:business_rates)
-          end
+        should "return false when no non domestic property" do
+          @calculator.non_domestic_property = "none"
+          assert_equal false, @calculator.show?(:business_rates)
+        end
 
-          should "return false when not supported business sectors" do
-            @calculator.sectors = ["None of the above"]
-            assert_equal false, @calculator.show?(:business_rates)
-          end
+        should "return false when not supported business sectors" do
+          @calculator.sectors = ["None of the above"]
+          assert_equal false, @calculator.show?(:business_rates)
         end
       end
 
@@ -136,26 +131,24 @@ module SmartAnswer::Calculators
           assert_equal true, @calculator.show?(:grant_funding)
         end
 
-        context "criteria not met" do
-          should "return false when in a devolved administration" do
-            @calculator.business_based = "scotland"
-            assert_equal false, @calculator.show?(:grant_funding)
-          end
+        should "return false when in a devolved administration" do
+          @calculator.business_based = "scotland"
+          assert_equal false, @calculator.show?(:grant_funding)
+        end
 
-          should "return false when not paying business rates" do
-            @calculator.business_rates = "no"
-            assert_equal false, @calculator.show?(:grant_funding)
-          end
+        should "return false when not paying business rates" do
+          @calculator.business_rates = "no"
+          assert_equal false, @calculator.show?(:grant_funding)
+        end
 
-          should "return false when non domestic property not over £15k" do
-            @calculator.non_domestic_property = "over_51k"
-            assert_equal false, @calculator.show?(:grant_funding)
-          end
+        should "return false when non domestic property not over £15k" do
+          @calculator.non_domestic_property = "over_51k"
+          assert_equal false, @calculator.show?(:grant_funding)
+        end
 
-          should "return false when not in supported business sector" do
-            @calculator.sectors = %w[nurseries]
-            assert_equal false, @calculator.show?(:grant_funding)
-          end
+        should "return false when not in supported business sector" do
+          @calculator.sectors = %w[nurseries]
+          assert_equal false, @calculator.show?(:grant_funding)
         end
       end
 
@@ -171,26 +164,24 @@ module SmartAnswer::Calculators
           assert_equal true, @calculator.show?(:nursery_support)
         end
 
-        context "criteria not met" do
-          should "return false when based in devolved administration" do
-            @calculator.business_based = "scotland"
-            assert_equal false, @calculator.show?(:nursery_support)
-          end
+        should "return false when based in devolved administration" do
+          @calculator.business_based = "scotland"
+          assert_equal false, @calculator.show?(:nursery_support)
+        end
 
-          should "return false when not paying business rates" do
-            @calculator.business_rates = "no"
-            assert_equal false, @calculator.show?(:nursery_support)
-          end
+        should "return false when not paying business rates" do
+          @calculator.business_rates = "no"
+          assert_equal false, @calculator.show?(:nursery_support)
+        end
 
-          should "return false when no non domestic property" do
-            @calculator.non_domestic_property = "none"
-            assert_equal false, @calculator.show?(:nursery_support)
-          end
+        should "return false when no non domestic property" do
+          @calculator.non_domestic_property = "none"
+          assert_equal false, @calculator.show?(:nursery_support)
+        end
 
-          should "return false when not supported business sector" do
-            @calculator.sectors = %w[retail hospitality leisure]
-            assert_equal false, @calculator.show?(:nursery_support)
-          end
+        should "return false when not supported business sector" do
+          @calculator.sectors = %w[retail hospitality leisure]
+          assert_equal false, @calculator.show?(:nursery_support)
         end
       end
 
@@ -205,21 +196,19 @@ module SmartAnswer::Calculators
           assert_equal true, @calculator.show?(:small_business_grant_funding)
         end
 
-        context "criteria not met" do
-          should "return false when based in devolved administration" do
-            @calculator.business_based = "scotland"
-            assert_equal false, @calculator.show?(:small_business_grant_funding)
-          end
+        should "return false when based in devolved administration" do
+          @calculator.business_based = "scotland"
+          assert_equal false, @calculator.show?(:small_business_grant_funding)
+        end
 
-          should "return false when not small mediume enterprise" do
-            @calculator.business_size = "large_enterprise"
-            assert_equal false, @calculator.show?(:small_business_grant_funding)
-          end
+        should "return false when not small mediume enterprise" do
+          @calculator.business_size = "large_enterprise"
+          assert_equal false, @calculator.show?(:small_business_grant_funding)
+        end
 
-          should "return false when non domestic property not over £15k" do
-            @calculator.non_domestic_property = "over_51k"
-            assert_equal false, @calculator.show?(:small_business_grant_funding)
-          end
+        should "return false when non domestic property not over £15k" do
+          @calculator.non_domestic_property = "over_51k"
+          assert_equal false, @calculator.show?(:small_business_grant_funding)
         end
       end
 
@@ -229,27 +218,23 @@ module SmartAnswer::Calculators
           @calculator.annual_turnover = "over_85k"
         end
 
-        context "criteria met" do
-          should "return true when annual turnover over_85k" do
-            assert_equal true, @calculator.show?(:business_loan_scheme)
-          end
-
-          should "return true when annual turnover under_85k" do
-            @calculator.annual_turnover = "under_85k"
-            assert_equal true, @calculator.show?(:business_loan_scheme)
-          end
+        should "return true when annual turnover over_85k" do
+          assert_equal true, @calculator.show?(:business_loan_scheme)
         end
 
-        context "criteria not met" do
-          should "return false when self employed" do
-            @calculator.self_employed = "yes"
-            assert_equal false, @calculator.show?(:business_loan_scheme)
-          end
+        should "return true when annual turnover under_85k" do
+          @calculator.annual_turnover = "under_85k"
+          assert_equal true, @calculator.show?(:business_loan_scheme)
+        end
 
-          should "return false when annual turnover not under 85k or over 85k" do
-            @calculator.annual_turnover = "over_500m"
-            assert_equal false, @calculator.show?(:business_loan_scheme)
-          end
+        should "return false when self employed" do
+          @calculator.self_employed = "yes"
+          assert_equal false, @calculator.show?(:business_loan_scheme)
+        end
+
+        should "return false when annual turnover not under 85k or over 85k" do
+          @calculator.annual_turnover = "over_500m"
+          assert_equal false, @calculator.show?(:business_loan_scheme)
         end
       end
 
@@ -287,16 +272,14 @@ module SmartAnswer::Calculators
           assert_equal true, @calculator.show?(:large_business_loan_scheme)
         end
 
-        context "criteria not met" do
-          should "return false when self employed" do
-            @calculator.self_employed = "yes"
-            assert_equal false, @calculator.show?(:large_business_loan_scheme)
-          end
+        should "return false when self employed" do
+          @calculator.self_employed = "yes"
+          assert_equal false, @calculator.show?(:large_business_loan_scheme)
+        end
 
-          should "return false when annual turnover does not equal over_45m" do
-            @calculator.annual_turnover = "under_85k"
-            assert_equal false, @calculator.show?(:large_business_loan_scheme)
-          end
+        should "return false when annual turnover does not equal over_45m" do
+          @calculator.annual_turnover = "under_85k"
+          assert_equal false, @calculator.show?(:large_business_loan_scheme)
         end
       end
     end

--- a/test/unit/calculators/business_coronavirus_support_calculator_test.rb
+++ b/test/unit/calculators/business_coronavirus_support_calculator_test.rb
@@ -10,36 +10,36 @@ module SmartAnswer::Calculators
       context "job_retention_scheme" do
         should "return true when criteria met" do
           @calculator.self_employed = "no"
-          assert_equal true, @calculator.show?(:job_retention_scheme)
+          assert @calculator.show?(:job_retention_scheme)
         end
 
         should "return false when criteria not met" do
           @calculator.self_employed = "yes"
-          assert_equal false, @calculator.show?(:job_retention_scheme)
+          assert_not @calculator.show?(:job_retention_scheme)
         end
       end
 
       context "vat_scheme" do
         should "return true when criteria met" do
           @calculator.annual_turnover = "over_500m"
-          assert_equal true, @calculator.show?(:vat_scheme)
+          assert @calculator.show?(:vat_scheme)
         end
 
         should "return false when criteria not met" do
           @calculator.annual_turnover = "under_85k"
-          assert_equal false, @calculator.show?(:vat_scheme)
+          assert_not @calculator.show?(:vat_scheme)
         end
       end
 
       context "self_assessment_payments" do
         should "return true when criteria met" do
           @calculator.self_assessment_july_2020 = "yes"
-          assert_equal true, @calculator.show?(:self_assessment_payments)
+          assert @calculator.show?(:self_assessment_payments)
         end
 
         should "return false when criteria not met" do
           @calculator.self_assessment_july_2020 = "no"
-          assert_equal false, @calculator.show?(:self_assessment_payments)
+          assert_not @calculator.show?(:self_assessment_payments)
         end
       end
 
@@ -51,22 +51,22 @@ module SmartAnswer::Calculators
         end
 
         should "return true when criteria met" do
-          assert_equal true, @calculator.show?(:statutory_sick_rebate)
+          assert @calculator.show?(:statutory_sick_rebate)
         end
 
         should "return false when not small mediume enterprise" do
           @calculator.business_size = "large_enterprise"
-          assert_equal false, @calculator.show?(:statutory_sick_rebate)
+          assert_not @calculator.show?(:statutory_sick_rebate)
         end
 
         should "return false when self-employed" do
           @calculator.self_employed = "yes"
-          assert_equal false, @calculator.show?(:statutory_sick_rebate)
+          assert_not @calculator.show?(:statutory_sick_rebate)
         end
 
         should "return false when not submitting self assessment for July 2020" do
           @calculator.self_assessment_july_2020 = "no"
-          assert_equal false, @calculator.show?(:statutory_sick_rebate)
+          assert_not @calculator.show?(:statutory_sick_rebate)
         end
       end
 
@@ -77,17 +77,17 @@ module SmartAnswer::Calculators
         end
 
         should "return true when criteria met" do
-          assert_equal true, @calculator.show?(:self_employed_income_scheme)
+          assert @calculator.show?(:self_employed_income_scheme)
         end
 
         should "return false when large enterprise" do
           @calculator.business_size = "large_enterprise"
-          assert_equal false, @calculator.show?(:self_employed_income_scheme)
+          assert_not @calculator.show?(:self_employed_income_scheme)
         end
 
         should "return false when employed" do
           @calculator.self_employed = "no"
-          assert_equal false, @calculator.show?(:self_employed_income_scheme)
+          assert_not @calculator.show?(:self_employed_income_scheme)
         end
       end
 
@@ -100,22 +100,22 @@ module SmartAnswer::Calculators
         end
 
         should "return true when criteria met" do
-          assert_equal true, @calculator.show?(:business_rates)
+          assert @calculator.show?(:business_rates)
         end
 
         should "return false when in a devolved admininstration" do
           @calculator.business_based = "scotland"
-          assert_equal false, @calculator.show?(:business_rates)
+          assert_not @calculator.show?(:business_rates)
         end
 
         should "return false when no non domestic property" do
           @calculator.non_domestic_property = "none"
-          assert_equal false, @calculator.show?(:business_rates)
+          assert_not @calculator.show?(:business_rates)
         end
 
         should "return false when not supported business sectors" do
           @calculator.sectors = ["None of the above"]
-          assert_equal false, @calculator.show?(:business_rates)
+          assert_not @calculator.show?(:business_rates)
         end
       end
 
@@ -128,27 +128,27 @@ module SmartAnswer::Calculators
         end
 
         should "return true when criteria met" do
-          assert_equal true, @calculator.show?(:grant_funding)
+          assert @calculator.show?(:grant_funding)
         end
 
         should "return false when in a devolved administration" do
           @calculator.business_based = "scotland"
-          assert_equal false, @calculator.show?(:grant_funding)
+          assert_not @calculator.show?(:grant_funding)
         end
 
         should "return false when not paying business rates" do
           @calculator.business_rates = "no"
-          assert_equal false, @calculator.show?(:grant_funding)
+          assert_not @calculator.show?(:grant_funding)
         end
 
         should "return false when non domestic property not over £15k" do
           @calculator.non_domestic_property = "over_51k"
-          assert_equal false, @calculator.show?(:grant_funding)
+          assert_not @calculator.show?(:grant_funding)
         end
 
         should "return false when not in supported business sector" do
           @calculator.sectors = %w[nurseries]
-          assert_equal false, @calculator.show?(:grant_funding)
+          assert_not @calculator.show?(:grant_funding)
         end
       end
 
@@ -161,27 +161,27 @@ module SmartAnswer::Calculators
         end
 
         should "return true when criteria met" do
-          assert_equal true, @calculator.show?(:nursery_support)
+          assert @calculator.show?(:nursery_support)
         end
 
         should "return false when based in devolved administration" do
           @calculator.business_based = "scotland"
-          assert_equal false, @calculator.show?(:nursery_support)
+          assert_not @calculator.show?(:nursery_support)
         end
 
         should "return false when not paying business rates" do
           @calculator.business_rates = "no"
-          assert_equal false, @calculator.show?(:nursery_support)
+          assert_not @calculator.show?(:nursery_support)
         end
 
         should "return false when no non domestic property" do
           @calculator.non_domestic_property = "none"
-          assert_equal false, @calculator.show?(:nursery_support)
+          assert_not @calculator.show?(:nursery_support)
         end
 
         should "return false when not supported business sector" do
           @calculator.sectors = %w[retail hospitality leisure]
-          assert_equal false, @calculator.show?(:nursery_support)
+          assert_not @calculator.show?(:nursery_support)
         end
       end
 
@@ -193,22 +193,22 @@ module SmartAnswer::Calculators
         end
 
         should "return true when criteria met" do
-          assert_equal true, @calculator.show?(:small_business_grant_funding)
+          assert @calculator.show?(:small_business_grant_funding)
         end
 
         should "return false when based in devolved administration" do
           @calculator.business_based = "scotland"
-          assert_equal false, @calculator.show?(:small_business_grant_funding)
+          assert_not @calculator.show?(:small_business_grant_funding)
         end
 
         should "return false when not small mediume enterprise" do
           @calculator.business_size = "large_enterprise"
-          assert_equal false, @calculator.show?(:small_business_grant_funding)
+          assert_not @calculator.show?(:small_business_grant_funding)
         end
 
         should "return false when non domestic property not over £15k" do
           @calculator.non_domestic_property = "over_51k"
-          assert_equal false, @calculator.show?(:small_business_grant_funding)
+          assert_not @calculator.show?(:small_business_grant_funding)
         end
       end
 
@@ -219,46 +219,46 @@ module SmartAnswer::Calculators
         end
 
         should "return true when annual turnover over_85k" do
-          assert_equal true, @calculator.show?(:business_loan_scheme)
+          assert @calculator.show?(:business_loan_scheme)
         end
 
         should "return true when annual turnover under_85k" do
           @calculator.annual_turnover = "under_85k"
-          assert_equal true, @calculator.show?(:business_loan_scheme)
+          assert @calculator.show?(:business_loan_scheme)
         end
 
         should "return false when self employed" do
           @calculator.self_employed = "yes"
-          assert_equal false, @calculator.show?(:business_loan_scheme)
+          assert_not @calculator.show?(:business_loan_scheme)
         end
 
         should "return false when annual turnover not under 85k or over 85k" do
           @calculator.annual_turnover = "over_500m"
-          assert_equal false, @calculator.show?(:business_loan_scheme)
+          assert_not @calculator.show?(:business_loan_scheme)
         end
       end
 
       context "corporate_financing" do
         should "return true when criteria met" do
           @calculator.self_employed = "no"
-          assert_equal true, @calculator.show?(:corporate_financing)
+          assert @calculator.show?(:corporate_financing)
         end
 
         should "return false when criteria not met" do
           @calculator.self_employed = "yes"
-          assert_equal false, @calculator.show?(:corporate_financing)
+          assert_not @calculator.show?(:corporate_financing)
         end
       end
 
       context "business_tax_support" do
         should "return true when criteria met" do
           @calculator.self_employed = "no"
-          assert_equal true, @calculator.show?(:business_tax_support)
+          assert @calculator.show?(:business_tax_support)
         end
 
         should "return false when criteria not met" do
           @calculator.self_employed = "yes"
-          assert_equal false, @calculator.show?(:business_tax_support)
+          assert_not @calculator.show?(:business_tax_support)
         end
       end
 
@@ -269,17 +269,17 @@ module SmartAnswer::Calculators
         end
 
         should "return true when criteria met" do
-          assert_equal true, @calculator.show?(:large_business_loan_scheme)
+          assert @calculator.show?(:large_business_loan_scheme)
         end
 
         should "return false when self employed" do
           @calculator.self_employed = "yes"
-          assert_equal false, @calculator.show?(:large_business_loan_scheme)
+          assert_not @calculator.show?(:large_business_loan_scheme)
         end
 
         should "return false when annual turnover does not equal over_45m" do
           @calculator.annual_turnover = "under_85k"
-          assert_equal false, @calculator.show?(:large_business_loan_scheme)
+          assert_not @calculator.show?(:large_business_loan_scheme)
         end
       end
     end

--- a/test/unit/calculators/business_coronavirus_support_calculator_test.rb
+++ b/test/unit/calculators/business_coronavirus_support_calculator_test.rb
@@ -21,7 +21,7 @@ module SmartAnswer::Calculators
 
       context "vat_scheme" do
         should "return true when criteria met" do
-          @calculator.annual_turnover = "over_500m"
+          @calculator.annual_turnover = "500m_and_over"
           assert @calculator.show?(:vat_scheme)
         end
 
@@ -215,10 +215,10 @@ module SmartAnswer::Calculators
       context "business_loan_scheme" do
         setup do
           @calculator.self_employed = "no"
-          @calculator.annual_turnover = "over_85k"
+          @calculator.annual_turnover = "85k_to_45m"
         end
 
-        should "return true when annual turnover over_85k" do
+        should "return true when annual turnover is 85k_to_45m" do
           assert @calculator.show?(:business_loan_scheme)
         end
 
@@ -232,8 +232,8 @@ module SmartAnswer::Calculators
           assert_not @calculator.show?(:business_loan_scheme)
         end
 
-        should "return false when annual turnover not under 85k or over 85k" do
-          @calculator.annual_turnover = "over_500m"
+        should "return false when annual turnover not under_85k or 85k_to_45m" do
+          @calculator.annual_turnover = "45m_to_500m"
           assert_not @calculator.show?(:business_loan_scheme)
         end
       end
@@ -265,7 +265,7 @@ module SmartAnswer::Calculators
       context "large_business_loan_scheme" do
         setup do
           @calculator.self_employed = "no"
-          @calculator.annual_turnover = "over_45m"
+          @calculator.annual_turnover = "45m_to_500m"
         end
 
         should "return true when criteria met" do
@@ -277,8 +277,8 @@ module SmartAnswer::Calculators
           assert_not @calculator.show?(:large_business_loan_scheme)
         end
 
-        should "return false when annual turnover does not equal over_45m" do
-          @calculator.annual_turnover = "under_85k"
+        should "return false when annual turnover does not equal 45m_to_500m" do
+          @calculator.annual_turnover = "500m_and_over"
           assert_not @calculator.show?(:large_business_loan_scheme)
         end
       end

--- a/test/unit/calculators/business_coronavirus_support_calculator_test.rb
+++ b/test/unit/calculators/business_coronavirus_support_calculator_test.rb
@@ -79,7 +79,6 @@ module SmartAnswer::Calculators
       context "business_rates" do
         setup do
           @calculator.business_based = "england"
-          @calculator.business_rates = "yes"
           @calculator.non_domestic_property = "over_15k"
           @calculator.sectors = %w[retail hospitality leisure]
         end
@@ -107,7 +106,6 @@ module SmartAnswer::Calculators
       context "grant_funding" do
         setup do
           @calculator.business_based = "england"
-          @calculator.business_rates = "yes"
           @calculator.non_domestic_property = "over_15k"
           @calculator.sectors = %w[retail hospitality leisure]
         end
@@ -118,11 +116,6 @@ module SmartAnswer::Calculators
 
         should "return false when in a devolved administration" do
           @calculator.business_based = "scotland"
-          assert_not @calculator.show?(:grant_funding)
-        end
-
-        should "return false when not paying business rates" do
-          @calculator.business_rates = "no"
           assert_not @calculator.show?(:grant_funding)
         end
 
@@ -140,7 +133,6 @@ module SmartAnswer::Calculators
       context "nursery_support" do
         setup do
           @calculator.business_based = "england"
-          @calculator.business_rates = "yes"
           @calculator.non_domestic_property = "over_51k"
           @calculator.sectors = %w[nurseries]
         end
@@ -151,11 +143,6 @@ module SmartAnswer::Calculators
 
         should "return false when based in devolved administration" do
           @calculator.business_based = "scotland"
-          assert_not @calculator.show?(:nursery_support)
-        end
-
-        should "return false when not paying business rates" do
-          @calculator.business_rates = "no"
           assert_not @calculator.show?(:nursery_support)
         end
 


### PR DESCRIPTION
Trello:
https://trello.com/c/bm2hkvT2/71-question-2-what-size-was-your-business-as-of-28-february
https://trello.com/c/7QkI45eK/72-question-3-what-is-your-annual-turnover-per-year
https://trello.com/c/6Y2zVIJp/73-question-4-new-question-are-you-an-employer-with-a-paye-scheme
https://trello.com/c/e1rNPQHT/75-delete-question-does-your-business-pay-business-rates
https://trello.com/c/KE3UOTap/84-exclude-scheme-covid-19-corporate-financing-facility

This makes a number of amends that are confirmed for Coronavirus business support finder as well as resolving some of the remaining comments on: https://github.com/alphagov/smart-answers/pull/4449

A few notes on this:

- the questions are still somewhat in a state of flux with ones still under development, there needs to be a wider review of how they all fit together as this gets closer to a published state
- the change in questions here did lead to it being impossible to see the no results screen so I've removed it for now
- this is easiest reviewed commit by commit.
