### PR TITLE
Use a capitalised none when showing answered questions

### DIFF
--- a/app/presenters/checkbox_question_presenter.rb
+++ b/app/presenters/checkbox_question_presenter.rb
@@ -4,7 +4,7 @@ class CheckboxQuestionPresenter < QuestionWithOptionsPresenter
   def response_labels(values)
     values.split(",").map do |value|
       if value == SmartAnswer::Question::Checkbox::NONE_OPTION
-        value.to_s
+        "None"
       else
         render_option(value)
       end

--- a/test/integration/engine/checkbox_questions_test.rb
+++ b/test/integration/engine/checkbox_questions_test.rb
@@ -61,7 +61,7 @@ class CheckboxQuestionsTest < EngineIntegrationTest
           within ".govuk-table__cell:nth-child(1)" do
             assert_page_has_content "What do you want on your pizza?"
           end
-          within(".govuk-table__cell:nth-child(2)") { assert_page_has_content "none" }
+          within(".govuk-table__cell:nth-child(2)") { assert_page_has_content "None" }
           within(".govuk-table__cell:nth-child(3)") { assert page.has_link?("Change", href: "/checkbox-sample/y?previous_response=none") }
         end
       end


### PR DESCRIPTION
As the more prevalent (but unfortunately not universal) convention is for
questions to have capitalised answers, it can be a bit jarring when you
select the none option on a checkbox question and have the previous
answer shown without capitalisation.

This amends this by hardcoding the response as a capitalised string.

I figured there wasn't much value in keeping this tied around the value
variable provided, since it can't vary, and was clearer as an explicit
string.

Before:

![Screenshot 2020-04-16 at 10 26 02](https://user-images.githubusercontent.com/282717/79439395-aebe8980-7fcc-11ea-96bf-978b23c70d1d.png)

After:

![Screenshot 2020-04-16 at 10 24 29](https://user-images.githubusercontent.com/282717/79439241-7b7bfa80-7fcc-11ea-9127-ec460504641b.png)