### PR TITLE
Mark retail, hospitality and leisure schemes explicitly

### DIFF
--- a/lib/smart_answer/calculators/business_coronavirus_support_finder_calculator.rb
+++ b/lib/smart_answer/calculators/business_coronavirus_support_finder_calculator.rb
@@ -28,12 +28,12 @@ module SmartAnswer::Calculators
       self_employed_income_scheme: ->(calculator) {
         calculator.business_size == "0_to_249"
       },
-      business_rates: ->(calculator) {
+      retail_hospitality_leisure_business_rates: ->(calculator) {
         calculator.business_based == "england" &&
           calculator.non_domestic_property != "none" &&
           calculator.sectors.include?("retail_hospitality_or_leisure")
       },
-      grant_funding: ->(calculator) {
+      retail_hospitality_leisure_grant_funding: ->(calculator) {
         calculator.business_based == "england" &&
           calculator.non_domestic_property == "51k_and_over" &&
           calculator.sectors.include?("retail_hospitality_or_leisure")

--- a/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.govspeak.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.govspeak.erb
@@ -80,7 +80,7 @@
     $CTA
   <% end %>
 
-  <% if calculator.show?(:business_rates) %>
+  <% if calculator.show?(:retail_hospitality_leisure_business_rates) %>
     $CTA
     **Business rates holiday for retail, hospitality and leisure**
 
@@ -100,7 +100,7 @@
     $CTA
   <% end %>
 
-  <% if calculator.show?(:grant_funding) %>
+  <% if calculator.show?(:retail_hospitality_leisure_grant_funding) %>
     $CTA
     **Retail, Hospitality and Leisure Grant Fund**
 

--- a/test/unit/calculators/business_coronavirus_support_calculator_test.rb
+++ b/test/unit/calculators/business_coronavirus_support_calculator_test.rb
@@ -85,7 +85,7 @@ module SmartAnswer::Calculators
         end
       end
 
-      context "business_rates" do
+      context "retail_hospitality_leisure_business_rates" do
         setup do
           @calculator.business_based = "england"
           @calculator.non_domestic_property = "51k_and_over"
@@ -93,26 +93,26 @@ module SmartAnswer::Calculators
         end
 
         should "return true when criteria met" do
-          assert @calculator.show?(:business_rates)
+          assert @calculator.show?(:retail_hospitality_leisure_business_rates)
         end
 
         should "return false when in a devolved admininstration" do
           @calculator.business_based = "scotland"
-          assert_not @calculator.show?(:business_rates)
+          assert_not @calculator.show?(:retail_hospitality_leisure_business_rates)
         end
 
         should "return false when no non-domestic property" do
           @calculator.non_domestic_property = "none"
-          assert_not @calculator.show?(:business_rates)
+          assert_not @calculator.show?(:retail_hospitality_leisure_business_rates)
         end
 
         should "return false when not supported business sectors" do
           @calculator.sectors = %w[none]
-          assert_not @calculator.show?(:business_rates)
+          assert_not @calculator.show?(:retail_hospitality_leisure_business_rates)
         end
       end
 
-      context "grant_funding" do
+      context "retail_hospitality_leisure_grant_funding" do
         setup do
           @calculator.business_based = "england"
           @calculator.non_domestic_property = "51k_and_over"
@@ -120,22 +120,22 @@ module SmartAnswer::Calculators
         end
 
         should "return true when criteria met" do
-          assert @calculator.show?(:grant_funding)
+          assert @calculator.show?(:retail_hospitality_leisure_grant_funding)
         end
 
         should "return false when in a devolved administration" do
           @calculator.business_based = "scotland"
-          assert_not @calculator.show?(:grant_funding)
+          assert_not @calculator.show?(:retail_hospitality_leisure_grant_funding)
         end
 
         should "return false when non-domestic property is valued under £51k" do
           @calculator.non_domestic_property = "under_51k"
-          assert_not @calculator.show?(:grant_funding)
+          assert_not @calculator.show?(:retail_hospitality_leisure_grant_funding)
         end
 
         should "return false when not in supported business sector" do
           @calculator.sectors = %w[nurseries]
-          assert_not @calculator.show?(:grant_funding)
+          assert_not @calculator.show?(:retail_hospitality_leisure_grant_funding)
         end
       end
 


### PR DESCRIPTION
I kept being caught out by the generic nature of the naming of these
schemes compared to similar broader ones (such as grant_funding vs
small_business_grant_funding) so I felt these more verbose names would
make the code easier to understand.