### PR TITLE
Use Rails parallel tests for build improvements

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,6 +35,7 @@ require_relative "support/world_location_stubbing_methods"
 class ActiveSupport::TestCase
   include FixtureMethods
   include WorldLocationStubbingMethods
+  parallelize workers: 6
 end
 
 require "slimmer/test"

--- a/test/unit/smart_answer_files_test.rb
+++ b/test/unit/smart_answer_files_test.rb
@@ -32,7 +32,7 @@ class SmartAnswerFilesTest < ActiveSupport::TestCase
 
   context "with erb template files" do
     should "include the path of erb templates" do
-      flow_name = "flow-name"
+      flow_name = SecureRandom.alphanumeric(10)
       smart_answer_with_erb_templates(flow_name) do |erb_template_files|
         smart_answer_files = SmartAnswerFiles.new(flow_name)
         erb_template_files.each do |file|
@@ -90,7 +90,7 @@ private
       FileUtils.mkdir_p(erb_template_directory)
 
       files = (1..2).collect do |count|
-        Tempfile.new(["flow_name-#{count}", ".erb"], erb_template_directory)
+        Tempfile.new(["#{flow_name}-#{count}", ".erb"], erb_template_directory)
       end
 
       partial_dir = FileUtils.mkdir_p(erb_template_directory.join("partials"))


### PR DESCRIPTION
Since this project uses minitest we can make use of the parallelisation feature provided by Rails. More details of the feature is available here: https://edgeguides.rubyonrails.org/testing.html#parallel-testing

I thought I may as well make the most of this being a minitest project before we do the RSpec rewrite - which hopefully will find lots of different ways to improve test performance (I've no idea what this suite does that takes so long since this project doesn't have a DB)

## Benchmarks

### On my local machine running govuk-docker

Before:

Finished in 800.161678s, 9.2006 runs/s, 25.1274 assertions/s.
7362 runs, 20106 assertions, 0 failures, 0 errors, 0 skips

After:

Finished in 216.857922s, 33.9485 runs/s, 92.7151 assertions/s.
7362 runs, 20106 assertions, 0 failures, 0 errors, 0 skips

### On CI

Before:

Finished in 659.463267s, 11.1636 runs/s, 30.4884 assertions/s.
7362 runs, 20106 assertions, 0 failures, 0 errors, 0 skips

After:

Finished in 94.375381s, 78.0076 runs/s, 213.0428 assertions/s.
7362 runs, 20106 assertions, 1 failures, 0 errors, 0 skips