### PR TITLE
Review amends for the Business Coronavirus Support Finder

### DIFF
--- a/lib/smart_answer/calculators/business_coronavirus_support_finder_calculator.rb
+++ b/lib/smart_answer/calculators/business_coronavirus_support_finder_calculator.rb
@@ -52,7 +52,7 @@ module SmartAnswer::Calculators
         %w[under_85k 85k_to_45m].include?(calculator.annual_turnover)
       },
       large_business_loan_scheme: ->(calculator) {
-        calculator.annual_turnover == "45m_to_500m"
+        %w[45m_to_500m 500m_and_over].include?(calculator.annual_turnover)
       },
     }.freeze
 

--- a/lib/smart_answer_flows/business-coronavirus-support-finder/business_coronavirus_support_finder.govspeak.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/business_coronavirus_support_finder.govspeak.erb
@@ -3,15 +3,10 @@
 <% end %>
 
 <% content_for :body do %>
-  Coronavirus (COVID-19) support is available to businesses.
+  Coronavirus (COVID-19) support is available to employers and the
+  self-employed. You may be eligible for loans, tax relief and cash grants.
 
-  You can apply for loans, tax relief and cash grants.
-
-  Employers can apply for staff to get up to 80% pay if they can’t work.
-
-  Self-employed people can receive up to £2,500 per month in grants for at
-  least 3 months.
-
-  You can work out what financial support option is available to you.
+  Use this business support finder to see what support is available for you
+  and your business.
 <% end %>
 

--- a/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.govspeak.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.govspeak.erb
@@ -1,5 +1,5 @@
 <% content_for :title do %>
-  Support you're entitled to
+  Support you may be entitled to
 <% end %>
 
 <% content_for :body do %>

--- a/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.govspeak.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.govspeak.erb
@@ -191,7 +191,20 @@
     $CTA
     **Coronavirus Large Business Interruption Loan Scheme**
 
-    If your annual turnover is between £45 million and £500 million, you can access loans of up to £25 million offered at commercial rates. The government will provide lenders with an 80% guarantee on individual loans for businesses that would be otherwise unable to access the finance they need.
+    The Coronavirus Large Business Interruption Loan Scheme (CLBILS) will provide a government guarantee of 80% on each loan, to give banks further confidence in financing businesses impacted by coronavirus.
+
+    It allows banks to make loans of:
+
+    - up to £25 million to businesses with an annual turnover of £45 million to £250 million
+    - up to £50 million to businesses with an annual turnover of over £250 million
+
+    You can apply for this loan if your business:
+
+    - is UK based
+    - has an annual turnover of at least £45 million
+    - meets the other British Business Bank eligibility requirements
+
+    The scheme will be delivered through commercial lenders, supported by the Government-backed British Business Bank. Facilities backed by a guarantee under CLBILS will be offered at commercial rates of interest.
 
     [Apply for the Coronavirus Large Business Interruption Loan Scheme](https://www.gov.uk/guidance/apply-for-the-coronavirus-large-business-interruption-loan-scheme)
     $CTA

--- a/test/unit/calculators/business_coronavirus_support_calculator_test.rb
+++ b/test/unit/calculators/business_coronavirus_support_calculator_test.rb
@@ -216,8 +216,13 @@ module SmartAnswer::Calculators
           assert @calculator.show?(:large_business_loan_scheme)
         end
 
-        should "return false when annual turnover is not £45m to £500m" do
+        should "return true when annual turnover is £500m and over" do
           @calculator.annual_turnover = "500m_and_over"
+          assert @calculator.show?(:large_business_loan_scheme)
+        end
+
+        should "return false when annual turnover is not £45m and over" do
+          @calculator.annual_turnover = "85k_to_45m"
           assert_not @calculator.show?(:large_business_loan_scheme)
         end
       end


### PR DESCRIPTION
Trello: https://trello.com/c/MSXJ4jb8/106-feedback-to-address-for-beis-spad-sign-off

This is a number of amends made following the review of this smart answer. The eligibility for the large business loan scheme has been clarified and the criteria changed to include businesses with turnovers of £500 million and more.

The start page and result page text have also been changed.