### PR TITLE
Fix the visualise system

### DIFF
--- a/app/assets/javascripts/visualise.js
+++ b/app/assets/javascripts/visualise.js
@@ -123,9 +123,9 @@
           rankSep: 100
         });
         if (rankDir == 'LR') {
-          toggleButton.text('Show in landscape');
-        } else {
           toggleButton.text('Show in portrait');
+        } else {
+          toggleButton.text('Show in landscape');
         }
         var padding = 400;
         paper.fitToContent(10, 10, padding);

--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -52,7 +52,8 @@ class SmartAnswersController < ApplicationController
       end
 
       format.gv do
-        render text: GraphvizPresenter.new(@smart_answer).to_gv
+        render plain: GraphvizPresenter.new(@smart_answer).to_gv,
+               content_type: "text/vnd.graphviz"
       end
     end
   end

--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -11,6 +11,12 @@ class SmartAnswersController < ApplicationController
   rescue_from SmartAnswer::FlowRegistry::NotFound, with: :error_404
   rescue_from SmartAnswer::InvalidNode, with: :error_404
 
+  content_security_policy only: :visualise do |p|
+    # The script used to render the visualise tool requires eval execution
+    # unfortunately
+    p.script_src(*p.script_src, :unsafe_eval)
+  end
+
   def index
     @flows = flow_registry.flows.sort_by(&:name)
     @title = "Smart Answers Index"

--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -45,14 +45,15 @@ class SmartAnswersController < ApplicationController
 
   def visualise
     respond_to do |format|
-      format.html {
+      format.html do
         @graph_presenter = GraphPresenter.new(@smart_answer)
         @graph_data = @graph_presenter.to_hash
         render layout: "application"
-      }
-      format.gv {
+      end
+
+      format.gv do
         render text: GraphvizPresenter.new(@smart_answer).to_gv
-      }
+      end
     end
   end
 

--- a/app/views/smart_answers/visualise.html.erb
+++ b/app/views/smart_answers/visualise.html.erb
@@ -29,7 +29,7 @@
 
     <p>Having problems reading the visualisation? Changing the orientation may help.</p>
     <%= render "govuk_publishing_components/components/button", {
-      text: "Show in portrait",
+      text: "Show in landscape",
       data_attributes: {
         click_action: "visualise"
       }

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -222,4 +222,15 @@ class SmartAnswersControllerTest < ActionController::TestCase
       assert_select "h1", /Smart answers controller sample/
     end
   end
+
+  context "GET /<slug>/visualise.gz" do
+    should "display the visualisation in graphviz format" do
+      stub_smart_answer_in_content_store("smart-answers-controller-sample")
+
+      get :visualise, format: :gv, params: { id: "smart-answers-controller-sample" }
+
+      assert_equal "text/vnd.graphviz", response.media_type
+      assert_match "digraph", response.body
+    end
+  end
 end


### PR DESCRIPTION
This fixes both the JS and Graphviz abilities to see visualisation of Smart Answers. The JS version wasn't working on non-prod environments because of the content security policy and the Graphviz version was raising a template error.

I also corrected the show landscape / portrait button as this was set the wrong way round. 

Fixes https://github.com/alphagov/smart-answers/issues/3707