### PR TITLE
Always show VAT deferral scheme

### DIFF
--- a/lib/smart_answer/calculators/business_coronavirus_support_finder_calculator.rb
+++ b/lib/smart_answer/calculators/business_coronavirus_support_finder_calculator.rb
@@ -14,9 +14,6 @@ module SmartAnswer::Calculators
       job_retention_scheme: ->(calculator) {
         calculator.paye_scheme == "yes"
       },
-      vat_scheme: ->(calculator) {
-        calculator.annual_turnover != "under_85k"
-      },
       self_assessment_payments: ->(calculator) {
         calculator.self_assessment_july_2020 == "yes"
       },

--- a/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.govspeak.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.govspeak.erb
@@ -15,15 +15,13 @@
     $CTA
   <% end %>
 
-  <% if calculator.show?(:vat_scheme) %>
-    $CTA
-    ### Deferring VAT
+  $CTA
+  ### Deferring VAT
 
-    If you’re a UK VAT registered business and have a VAT payment due between 20 March 2020 and 30 June 2020, you have the option to defer payment until 31 March 2021.
+  If you’re a UK VAT registered business and have a VAT payment due between 20 March 2020 and 30 June 2020, you have the option to defer payment until 31 March 2021.
 
-    [Check if you are eligible to defer your VAT payment](https://www.gov.uk/guidance/deferral-of-vat-payments-due-to-coronavirus-covid-19)
-    $CTA
-  <% end %>
+  [Check if you are eligible to defer your VAT payment](https://www.gov.uk/guidance/deferral-of-vat-payments-due-to-coronavirus-covid-19)
+  $CTA
 
   <% if calculator.show?(:self_assessment_payments) %>
     $CTA

--- a/test/unit/calculators/business_coronavirus_support_calculator_test.rb
+++ b/test/unit/calculators/business_coronavirus_support_calculator_test.rb
@@ -19,18 +19,6 @@ module SmartAnswer::Calculators
         end
       end
 
-      context "vat_scheme" do
-        should "return true when criteria met" do
-          @calculator.annual_turnover = "500m_and_over"
-          assert @calculator.show?(:vat_scheme)
-        end
-
-        should "return false when criteria not met" do
-          @calculator.annual_turnover = "under_85k"
-          assert_not @calculator.show?(:vat_scheme)
-        end
-      end
-
       context "self_assessment_payments" do
         should "return true when criteria met" do
           @calculator.self_assessment_july_2020 = "yes"


### PR DESCRIPTION
All users will see the VAT deferral scheme in the results page for the business coronavirus support finder.