### PR TITLE
Add hint text to money questions

### DIFF
--- a/app/presenters/money_question_presenter.rb
+++ b/app/presenters/money_question_presenter.rb
@@ -6,7 +6,7 @@ class MoneyQuestionPresenter < QuestionPresenter
   end
 
   def hint_text
-    text = [body, suffix_label].reject(&:blank?).compact.join(", ")
+    text = [body, hint, suffix_label].reject(&:blank?).compact.join(", ")
     ActionView::Base.full_sanitizer.sanitize(text)
   end
 end

--- a/test/unit/money_question_presenter_test.rb
+++ b/test/unit/money_question_presenter_test.rb
@@ -1,0 +1,27 @@
+require_relative "../test_helper"
+
+module SmartAnswer
+  class MoneyQuestionPresenterTest < ActiveSupport::TestCase
+    setup do
+      @question = Question::Base.new(nil, :question_name?)
+      @renderer = stub("renderer")
+      @presenter = MoneyQuestionPresenter.new(@question, nil, renderer: @renderer)
+    end
+
+    test "#hint_text returns single line of content rendered for hint block" do
+      @renderer.stubs(:content_for).with(:body, { html: true }).returns("")
+      @renderer.stubs(:single_line_of_content_for).with(:hint).returns("hint-text")
+      @renderer.stubs(:single_line_of_content_for).with(:suffix_label).returns("")
+
+      assert_equal "hint-text", @presenter.hint_text
+    end
+
+    test "#hint_text also returns body and suffix_label if present" do
+      @renderer.stubs(:content_for).with(:body, { html: true }).returns("body")
+      @renderer.stubs(:single_line_of_content_for).with(:hint).returns("hint-text")
+      @renderer.stubs(:single_line_of_content_for).with(:suffix_label).returns("suffix")
+
+      assert_equal "body, hint-text, suffix", @presenter.hint_text
+    end
+  end
+end

--- a/test/unit/value_question_presenter_test.rb
+++ b/test/unit/value_question_presenter_test.rb
@@ -1,0 +1,27 @@
+require_relative "../test_helper"
+
+module SmartAnswer
+  class ValueQuestionPresenterTest < ActiveSupport::TestCase
+    setup do
+      @question = Question::Base.new(nil, :question_name?)
+      @renderer = stub("renderer")
+      @presenter = ValueQuestionPresenter.new(@question, nil, renderer: @renderer)
+    end
+
+    test "#hint_text returns single line of content rendered for hint block" do
+      @renderer.stubs(:content_for).with(:body, { html: true }).returns("")
+      @renderer.stubs(:single_line_of_content_for).with(:hint).returns("hint-text")
+      @renderer.stubs(:single_line_of_content_for).with(:suffix_label).returns("")
+
+      assert_equal "hint-text", @presenter.hint_text
+    end
+
+    test "#hint_text also returns body and suffix_label if present" do
+      @renderer.stubs(:content_for).with(:body, { html: true }).returns("body")
+      @renderer.stubs(:single_line_of_content_for).with(:hint).returns("hint-text")
+      @renderer.stubs(:single_line_of_content_for).with(:suffix_label).returns("suffix")
+
+      assert_equal "body, hint-text, suffix", @presenter.hint_text
+    end
+  end
+end


### PR DESCRIPTION
Previously all money questions had a [default hint-text of `in £`](https://github.com/alphagov/smart-answers/pull/4150/commits/dfa0742c44874c4abbcf363451be86f7c9a8e607)

This was recently [removed for content clarity](https://github.com/alphagov/smart-answers/commit/cc7fb3a11b028fa0c6a125d24c9891cda32d6e94#diff-b627e4f8bfa513f82bdc12cb0d7e22d7)

Money questions currently render no hint text.

This change ensures that, should a money question have custom hint text,
it will be correctly rendered.

For example, for [this money question](https://github.com/alphagov/smart-answers/blob/master/lib/smart_answer_flows/maternity-paternity-calculator/questions/earnings_for_pay_period_adoption.govspeak.erb)

### Before
<img width="666" alt="Screenshot 2020-04-29 at 12 59 52" src="https://user-images.githubusercontent.com/13475227/80593744-9f522e00-8a19-11ea-8c6b-9e590e953f23.png">

### After
<img width="661" alt="Screenshot 2020-04-29 at 13 02 20" src="https://user-images.githubusercontent.com/13475227/80593842-c90b5500-8a19-11ea-9ac9-9f746bf56c9b.png">

[trello](https://trello.com/c/r4iK31ZL/1933-3-hint-text-not-displayed-on-some-smart-answer-questions)

