### PR TITLE
Fix missing content coronavirus business support start page.

### DIFF
--- a/lib/smart_answer_flows/business-coronavirus-support-finder/business_coronavirus_support_finder.govspeak.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/business_coronavirus_support_finder.govspeak.erb
@@ -10,7 +10,8 @@
 
 <% content_for :body do %>
   Coronavirus (COVID-19) support is available to employers and the
-  self-employed. You may be eligible for loans, tax relief and cash grants.
+  self-employed. You may be eligible for loans, tax relief and cash grants,
+  whether your business is open or closed.
 
   Use this business support finder to see what support is available for you
   and your business.


### PR DESCRIPTION
Content was added to the meta description, but missed for the description block.