### PR TITLE
Adding coronavirus information to parental pay calculators

### DIFF
--- a/lib/smart_answer_flows/maternity-paternity-calculator/questions/earnings_for_pay_period.govspeak.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/questions/earnings_for_pay_period.govspeak.erb
@@ -4,6 +4,8 @@
 
 <% content_for :hint do %>
   This is their earnings before deductions like PAYE, pension or National Insurance contributions.
+
+  If your employee is starting their leave after 25 April: if they were earning less at any time because they were ‘on furlough’ under the Coronavirus Job Retention Scheme, enter what they would have earned normally. 
 <% end %>
 
 <%= render partial: 'earnings_question_error_message.govspeak.erb' %>

--- a/lib/smart_answer_flows/maternity-paternity-calculator/questions/earnings_for_pay_period.govspeak.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/questions/earnings_for_pay_period.govspeak.erb
@@ -4,8 +4,10 @@
 
 <% content_for :hint do %>
   This is their earnings before deductions like PAYE, pension or National Insurance contributions.
-
-  If your employee is starting their leave after 25 April: if they were earning less at any time because they were ‘on furlough’ under the Coronavirus Job Retention Scheme, enter what they would have earned normally. 
 <% end %>
 
 <%= render partial: 'earnings_question_error_message.govspeak.erb' %>
+
+<% content_for :post_body do %>
+  For leave starting after 25 April 2020: if your employee earned less than usual because they were 'on furlough' under the Coronavirus Job Retention Scheme, enter what they would have earned normally. 
+<% end %>

--- a/lib/smart_answer_flows/maternity-paternity-calculator/questions/earnings_for_pay_period_adoption.govspeak.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/questions/earnings_for_pay_period_adoption.govspeak.erb
@@ -4,6 +4,8 @@
 
 <% content_for :hint do %>
   This is their earnings before deductions like PAYE, pension or National Insurance contributions.
+
+  If your employee is starting their leave after 25 April: if they were earning less at any time because they were ‘on furlough’ under the Coronavirus Job Retention Scheme, enter what they would have earned normally.
 <% end %>
 
 <%= render partial: 'earnings_question_error_message.govspeak.erb' %>

--- a/lib/smart_answer_flows/maternity-paternity-calculator/questions/earnings_for_pay_period_adoption.govspeak.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/questions/earnings_for_pay_period_adoption.govspeak.erb
@@ -4,8 +4,10 @@
 
 <% content_for :hint do %>
   This is their earnings before deductions like PAYE, pension or National Insurance contributions.
-
-  If your employee is starting their leave after 25 April: if they were earning less at any time because they were ‘on furlough’ under the Coronavirus Job Retention Scheme, enter what they would have earned normally.
 <% end %>
 
 <%= render partial: 'earnings_question_error_message.govspeak.erb' %>
+
+<% content_for :post_body do %>
+  For leave starting after 25 April 2020: if your employee earned less than usual because they were 'on furlough' under the Coronavirus Job Retention Scheme, enter what they would have earned normally. 
+<% end %>

--- a/lib/smart_answer_flows/maternity-paternity-calculator/questions/earnings_for_pay_period_paternity.govspeak.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/questions/earnings_for_pay_period_paternity.govspeak.erb
@@ -4,8 +4,10 @@
 
 <% content_for :hint do %>
   This is the earnings before deductions like PAYE, pension or National Insurance contributions.
-
-  If your employee is starting their leave after 25 April: if they were earning less at any time because they were ‘on furlough’ under the Coronavirus Job Retention Scheme, enter what they would have earned normally. 
 <% end %>
 
 <%= render partial: 'earnings_question_error_message.govspeak.erb' %>
+
+<% content_for :post_body do %>
+  For leave starting after 25 April 2020: if your employee earned less than usual because they were 'on furlough' under the Coronavirus Job Retention Scheme, enter what they would have earned normally. 
+<% end %>

--- a/lib/smart_answer_flows/maternity-paternity-calculator/questions/earnings_for_pay_period_paternity.govspeak.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/questions/earnings_for_pay_period_paternity.govspeak.erb
@@ -4,6 +4,8 @@
 
 <% content_for :hint do %>
   This is the earnings before deductions like PAYE, pension or National Insurance contributions.
+
+  If your employee is starting their leave after 25 April: if they were earning less at any time because they were ‘on furlough’ under the Coronavirus Job Retention Scheme, enter what they would have earned normally. 
 <% end %>
 
 <%= render partial: 'earnings_question_error_message.govspeak.erb' %>

--- a/lib/smart_answer_flows/pay-leave-for-parents/questions/mother_earned_at_least_390.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/questions/mother_earned_at_least_390.govspeak.erb
@@ -1,6 +1,9 @@
 <% content_for :title do %>
   Did the mother earn (or will she have earned) a total of £390 or more in any 13 weeks of this job between <%= format_date(calculator.earnings_employment_start_date) %> and <%= format_date(calculator.earnings_employment_end_date) %>?
 <% end %>
+<% content_for :hint do %>
+If starting leave after 25 April: if they were paid less than usual in any weeks because they were ‘on furlough’ under the Coronavirus Job Retention Scheme, work this out using what they would have earned normally. 
+<% end %>
 
 <% options(
   "yes": "Yes",

--- a/lib/smart_answer_flows/pay-leave-for-parents/questions/mother_earned_at_least_390.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/questions/mother_earned_at_least_390.govspeak.erb
@@ -2,7 +2,7 @@
   Did the mother earn (or will she have earned) a total of £390 or more in any 13 weeks of this job between <%= format_date(calculator.earnings_employment_start_date) %> and <%= format_date(calculator.earnings_employment_end_date) %>?
 <% end %>
 <% content_for :hint do %>
-If starting leave after 25 April: if they were paid less than usual in any weeks because they were ‘on furlough’ under the Coronavirus Job Retention Scheme, work this out using what they would have earned normally. 
+The 13 weeks do not need to be in a row. 
 <% end %>
 
 <% options(
@@ -11,5 +11,5 @@ If starting leave after 25 April: if they were paid less than usual in any weeks
 ) %>
 
 <% content_for :post_body do %>
-  The 13 weeks don’t need to be in a row.
+  For leave starting after 25 April 2020: if they earned less than usual in any weeks because they were 'on furlough' under the Coronavirus Job Retention Scheme, you can use what they would have earned normally. 
 <% end %>

--- a/lib/smart_answer_flows/pay-leave-for-parents/questions/mother_earned_more_than_lower_earnings_limit.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/questions/mother_earned_more_than_lower_earnings_limit.govspeak.erb
@@ -2,10 +2,6 @@
   Has the mother earned (or will she have earned) more than <%= format_money(calculator.lower_earnings_amount) %> per week in this job between <%= format_date(calculator.lower_earnings_start_date) %> and <%= format_date(calculator.lower_earnings_end_date) %>?
 <% end %>
 
-<% content_for :hint do %>
-The 13 weeks do not need to be in a row. 
-<% end %>
-
 <% options(
   "yes": "Yes",
   "no": "No"

--- a/lib/smart_answer_flows/pay-leave-for-parents/questions/mother_earned_more_than_lower_earnings_limit.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/questions/mother_earned_more_than_lower_earnings_limit.govspeak.erb
@@ -2,6 +2,10 @@
   Has the mother earned (or will she have earned) more than <%= format_money(calculator.lower_earnings_amount) %> per week in this job between <%= format_date(calculator.lower_earnings_start_date) %> and <%= format_date(calculator.lower_earnings_end_date) %>?
 <% end %>
 
+<% content_for :hint do %>
+If starting leave after 25 April: if they were paid less than usual in any weeks because they were ‘on furlough’ under the Coronavirus Job Retention Scheme, work this out using what they would have earned normally. 
+<% end %>
+
 <% options(
   "yes": "Yes",
   "no": "No"

--- a/lib/smart_answer_flows/pay-leave-for-parents/questions/mother_earned_more_than_lower_earnings_limit.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/questions/mother_earned_more_than_lower_earnings_limit.govspeak.erb
@@ -3,10 +3,14 @@
 <% end %>
 
 <% content_for :hint do %>
-If starting leave after 25 April: if they were paid less than usual in any weeks because they were ‘on furlough’ under the Coronavirus Job Retention Scheme, work this out using what they would have earned normally. 
+The 13 weeks do not need to be in a row. 
 <% end %>
 
 <% options(
   "yes": "Yes",
   "no": "No"
 ) %>
+
+<% content_for :post_body do %>
+  For leave starting after 25 April 2020: if they earned less than usual in any weeks because they were 'on furlough' under the Coronavirus Job Retention Scheme, you can use what they would have earned normally. 
+<% end %>

--- a/lib/smart_answer_flows/pay-leave-for-parents/questions/partner_earned_at_least_390.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/questions/partner_earned_at_least_390.govspeak.erb
@@ -1,6 +1,9 @@
 <% content_for :title do %>
   Did the mother’s partner earn (or will they have earned) a total of £390 or more in any 13 weeks of this job between <%= format_date(calculator.earnings_employment_start_date) %> and <%= format_date(calculator.earnings_employment_end_date) %>?
 <% end %>
+"<% content_for :hint do %>
+If starting leave after 25 April: if they were paid less than usual in any weeks because they were ‘on furlough’ under the Coronavirus Job Retention Scheme, work this out using what they would have earned normally. 
+<% end %>"
 
 <% options(
   "yes": "Yes",

--- a/lib/smart_answer_flows/pay-leave-for-parents/questions/partner_earned_at_least_390.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/questions/partner_earned_at_least_390.govspeak.erb
@@ -2,7 +2,7 @@
   Did the mother’s partner earn (or will they have earned) a total of £390 or more in any 13 weeks of this job between <%= format_date(calculator.earnings_employment_start_date) %> and <%= format_date(calculator.earnings_employment_end_date) %>?
 <% end %>
 <% content_for :hint do %>
-If starting leave after 25 April: if they were paid less than usual in any weeks because they were ‘on furlough’ under the Coronavirus Job Retention Scheme, work this out using what they would have earned normally. 
+The 13 weeks do not need to be in a row. 
 <% end %>
 
 <% options(
@@ -11,5 +11,5 @@ If starting leave after 25 April: if they were paid less than usual in any weeks
 ) %>
 
 <% content_for :post_body do %>
-  The 13 weeks don’t need to be in a row.
+  For leave starting after 25 April 2020: if they earned less than usual in any weeks because they were 'on furlough' under the Coronavirus Job Retention Scheme, you can use what they would have earned normally. 
 <% end %>

--- a/lib/smart_answer_flows/pay-leave-for-parents/questions/partner_earned_at_least_390.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/questions/partner_earned_at_least_390.govspeak.erb
@@ -1,9 +1,9 @@
 <% content_for :title do %>
   Did the mother’s partner earn (or will they have earned) a total of £390 or more in any 13 weeks of this job between <%= format_date(calculator.earnings_employment_start_date) %> and <%= format_date(calculator.earnings_employment_end_date) %>?
 <% end %>
-"<% content_for :hint do %>
+<% content_for :hint do %>
 If starting leave after 25 April: if they were paid less than usual in any weeks because they were ‘on furlough’ under the Coronavirus Job Retention Scheme, work this out using what they would have earned normally. 
-<% end %>"
+<% end %>
 
 <% options(
   "yes": "Yes",

--- a/lib/smart_answer_flows/pay-leave-for-parents/questions/partner_earned_more_than_lower_earnings_limit.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/questions/partner_earned_more_than_lower_earnings_limit.govspeak.erb
@@ -2,6 +2,10 @@
   Has the mother’s partner earned (or will they have earned) more than <%= format_money(calculator.lower_earnings_amount) %> per week in this job between <%= format_date(calculator.lower_earnings_start_date) %> and <%= format_date(calculator.lower_earnings_end_date) %>?
 <% end %>
 
+<% content_for :hint do %>
+If starting leave after 25 April: if they were paid less than usual in any weeks because they were ‘on furlough’ under the Coronavirus Job Retention Scheme, work this out using what they would have earned normally. 
+<% end %>
+
 <% options(
   "yes": "Yes",
   "no": "No"

--- a/lib/smart_answer_flows/pay-leave-for-parents/questions/partner_earned_more_than_lower_earnings_limit.govspeak.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/questions/partner_earned_more_than_lower_earnings_limit.govspeak.erb
@@ -2,11 +2,11 @@
   Has the mother’s partner earned (or will they have earned) more than <%= format_money(calculator.lower_earnings_amount) %> per week in this job between <%= format_date(calculator.lower_earnings_start_date) %> and <%= format_date(calculator.lower_earnings_end_date) %>?
 <% end %>
 
-<% content_for :hint do %>
-If starting leave after 25 April: if they were paid less than usual in any weeks because they were ‘on furlough’ under the Coronavirus Job Retention Scheme, work this out using what they would have earned normally. 
-<% end %>
-
 <% options(
   "yes": "Yes",
   "no": "No"
 ) %>
+
+<% content_for :post_body do %>
+  For leave starting after 25 April 2020: if they earned less than usual in any weeks because they were 'on furlough' under the Coronavirus Job Retention Scheme, you can use what they would have earned normally. 
+<% end %>


### PR DESCRIPTION
Adding hints about using normal levels of pay rather than any furloughed pay (due to COVID-19) to calculate entitlements.