### PR TITLE
Add links to UC and support allowance for self-employment scheme

### DIFF
--- a/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.govspeak.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.govspeak.erb
@@ -72,6 +72,8 @@
 
     ^Trading profits do not include dividends paid from your own company to yourself.^
 
+    If you are not eligible for Self-Employed Income Support Scheme, you may be eligible for [Universal Credit](https://www.gov.uk/universal-credit) or [Employment and Support Allowance](https://www.gov.uk/employment-support-allowance/eligibility).
+
     [Claim a grant through the Self-Employment Income Support Scheme](https://www.gov.uk/guidance/claim-a-grant-through-the-coronavirus-covid-19-self-employment-income-support-scheme)
     $CTA
   <% end %>


### PR DESCRIPTION
This adds extra links in the description for the Self-Employment Income Support Scheme in the Coronavirus business support results.