### PR TITLE
Remove redundant eligibility requirement from bounce back scheme

### DIFF
--- a/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.govspeak.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.govspeak.erb
@@ -186,7 +186,6 @@
 
     You may be eligible for this scheme if your business:
 
-    - is based in the UK
     - has been negatively affected by coronavirus
     - was not an ‘undertaking in difficulty’ on 31 December 2019
 


### PR DESCRIPTION
We re-stated that the scheme was only available for UK based businesses in the coronavirus business support flow results.