### PR TITLE
Remove redundant RuboCop exclusions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,15 +14,10 @@ AllCops:
 Style/CommentedKeyword:
   Enabled: false
 
-Style/FormatStringToken:
-  Enabled: false
-
 Metrics/BlockLength:
   Exclude:
     - 'lib/tasks/**/*.rake'
     - 'lib/smart_answer_flows/**/*.rb'
-    - 'test/**/*.rb'
-    - 'spec/**/*.rb'
 
 Rails/OutputSafety:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,5 +21,3 @@ Metrics/BlockLength:
 
 Rails/OutputSafety:
   Enabled: false
-Rails/HelperInstanceVariable:
-  Enabled: false

--- a/app/helpers/layouts_helper.rb
+++ b/app/helpers/layouts_helper.rb
@@ -10,7 +10,7 @@ module LayoutsHelper
   #     <% parent_layout "parent" %>
   #
   def parent_layout(layout)
-    @view_flow.set(:layout, output_buffer)
+    @view_flow.set(:layout, output_buffer) # rubocop:disable Rails/HelperInstanceVariable
     output = render(template: "layouts/#{layout}")
     self.output_buffer = ActionView::OutputBuffer.new(output)
   end


### PR DESCRIPTION
Removing these doesn't cause any issues and makes this app less 'special'.