### PR TITLE
Add tracking to change your answer links

### DIFF
--- a/app/views/smart_answers/_previous_answer.html.erb
+++ b/app/views/smart_answers/_previous_answer.html.erb
@@ -3,16 +3,23 @@
   <td class="govuk-table__cell">
     <% if question.multiple_responses? %>
       <ul class="govuk-list">
-        <% question.response_labels(@presenter.accepted_responses[number_questions_so_far]).each do |label| %>
+        <% question.response_labels(accepted_response).each do |label| %>
           <li><%= label %></li>
         <% end %>
       </ul>
     <% else %>
-      <%= question.response_label(@presenter.accepted_responses[number_questions_so_far]) %>
+      <%= question.response_label(accepted_response) %>
     <% end %>
   </td>
   <td class="govuk-table__cell">
-    <%= link_to @presenter.change_collapsed_question_link(number_questions_so_far + 1), class: "govuk-link" do %>
+    <%= link_to question_link,
+      class: "govuk-link",
+      data: {
+        "module": "track-click",
+        "track-category": "Smart Answer Change Link",
+        "track-action":  "Link clicked",
+        "track-label": "#{question.title} / #{question.response_label(accepted_response)}"
+    } do %>
       Change<span class="govuk-visually-hidden"> answer to "<%= question.title %>"</span>
     <% end %>
   </td>

--- a/app/views/smart_answers/_previous_answers.html.erb
+++ b/app/views/smart_answers/_previous_answers.html.erb
@@ -13,7 +13,13 @@
     </thead>
     <tbody class="govuk-table__body">
       <% @presenter.collapsed_questions.each_with_index do |question, number_questions_so_far| %>
-        <%= render partial: 'previous_answer', locals: {question: question, number_questions_so_far: number_questions_so_far} %>
+        <%= render partial: 'previous_answer',
+          locals: {
+            question: question,
+            accepted_response: @presenter.accepted_responses[number_questions_so_far],
+            question_link: @presenter.change_collapsed_question_link(number_questions_so_far + 1),
+          }
+        %>
       <% end %>
     </tbody>
   </table>


### PR DESCRIPTION
This adds the necessary data attributes for the trackClick modules from Static to send events to GA. This will allows us to see which answers users are changing.