### PR TITLE
Add tracking to links for coronavirus business results

### DIFF
--- a/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.govspeak.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.govspeak.erb
@@ -11,7 +11,11 @@
 
     This applies to employees who have been asked to stop working because of coronavirus, but are being kept on the payroll. They are known as ‘furloughed workers’. HMRC will pay 80% of their wages, up to £2,500 per month.
 
-    [Check if you are eligible for the Coronavirus Job Retention Scheme ](https://www.gov.uk/guidance/claim-for-wage-costs-through-the-coronavirus-job-retention-scheme)
+    <a data-module="track-click"
+       data-track-category="Click - Financial Support links"
+       data-track-action="Link clicked"
+       data-track-label="/guidance/claim-for-wage-costs-through-the-coronavirus-job-retention-scheme"
+       href="/guidance/claim-for-wage-costs-through-the-coronavirus-job-retention-scheme">Check if you are eligible for the Coronavirus Job Retention Scheme</a>
     $CTA
   <% end %>
 
@@ -20,7 +24,11 @@
 
   If you’re a UK VAT registered business and have a VAT payment due between 20 March 2020 and 30 June 2020, you have the option to defer payment until 31 March 2021.
 
-  [Check if you are eligible to defer your VAT payment](https://www.gov.uk/guidance/deferral-of-vat-payments-due-to-coronavirus-covid-19)
+  <a data-module="track-click"
+     data-track-category="Click - Financial Support links"
+     data-track-action="Link clicked"
+     data-track-label="/guidance/deferral-of-vat-payments-due-to-coronavirus-covid-19"
+     href="/guidance/deferral-of-vat-payments-due-to-coronavirus-covid-19">Check if you are eligible to defer your VAT payment</a>
   $CTA
 
   <% if calculator.show?(:self_assessment_payments) %>
@@ -50,7 +58,11 @@
     - UK based
     - small or medium-sized and employs fewer than 250 employees as of 28 February 2020
 
-    [Claim back Statutory Sick Pay paid to employees due to coronavirus (COVID-19)](https://www.gov.uk/guidance/claim-back-statutory-sick-pay-paid-to-employees-due-to-coronavirus-covid-19)
+    <a data-module="track-click"
+       data-track-category="Click - Financial Support links"
+       data-track-action="Link clicked"
+       data-track-label="/guidance/claim-back-statutory-sick-pay-paid-to-employees-due-to-coronavirus-covid-19"
+       href="/guidance/claim-back-statutory-sick-pay-paid-to-employees-due-to-coronavirus-covid-19">Claim back Statutory Sick Pay paid to employees due to coronavirus (COVID-19)</a>
     $CTA
   <% end %>
 
@@ -72,9 +84,24 @@
 
     ^Trading profits do not include dividends paid from your own company to yourself.^
 
-    If you are not eligible for Self-Employed Income Support Scheme, you may be eligible for [Universal Credit](https://www.gov.uk/universal-credit) or [Employment and Support Allowance](https://www.gov.uk/employment-support-allowance/eligibility).
+    If you are not eligible for Self-Employed Income Support Scheme, you may be eligible for
+    <a data-module="track-click"
+       data-track-category="Click - Financial Support links"
+       data-track-action="Link clicked"
+       data-track-label="/universal-credit"
+       href="/universal-credit">Universal Credit</a>
+    or
+    <a data-module="track-click"
+       data-track-category="Click - Financial Support links"
+       data-track-action="Link clicked"
+       data-track-label="/employment-support-allowance/eligibility"
+       href="/employment-support-allowance/eligibility">Employment and Support Allowance</a>.
 
-    [Claim a grant through the Self-Employment Income Support Scheme](https://www.gov.uk/guidance/claim-a-grant-through-the-coronavirus-covid-19-self-employment-income-support-scheme)
+    <a data-module="track-click"
+       data-track-category="Click - Financial Support links"
+       data-track-action="Link clicked"
+       data-track-label="/guidance/claim-a-grant-through-the-coronavirus-covid-19-self-employment-income-support-scheme"
+       href="/guidance/claim-a-grant-through-the-coronavirus-covid-19-self-employment-income-support-scheme">Claim a grant through the Self-Employment Income Support Scheme</a>
     $CTA
   <% end %>
 
@@ -94,7 +121,11 @@
     - assembly or leisure property - for example, a sports club, a gym or a spa
     - hospitality property - for example, a hotel, a guest house or self-catering accommodation
 
-    [Check if your retail, hospitality or leisure business is eligible for business rates relief due to coronavirus (COVID-19)](https://www.gov.uk/guidance/check-if-your-retail-hospitality-or-leisure-business-is-eligible-for-business-rates-relief-due-to-coronavirus-covid-19)
+    <a data-module="track-click"
+       data-track-category="Click - Financial Support links"
+       data-track-action="Link clicked"
+       data-track-label="/guidance/check-if-your-retail-hospitality-or-leisure-business-is-eligible-for-business-rates-relief-due-to-coronavirus-covid-19"
+       href="/guidance/check-if-your-retail-hospitality-or-leisure-business-is-eligible-for-business-rates-relief-due-to-coronavirus-covid-19">Check if your retail, hospitality or leisure business is eligible for business rates relief due to coronavirus (COVID-19)</a>
     $CTA
   <% end %>
 
@@ -116,7 +147,11 @@
 
     Contact your local council if you think you are eligible for a grant but have not yet received it.
 
-    [Coronavirus guidance on business support grant funding](https://www.gov.uk/government/publications/coronavirus-covid-19-business-support-grant-funding-guidance-for-businesses)
+    <a data-module="track-click"
+       data-track-category="Click - Financial Support links"
+       data-track-action="Link clicked"
+       data-track-label="/government/publications/coronavirus-covid-19-business-support-grant-funding-guidance-for-businesses"
+       href="/government/publications/coronavirus-covid-19-business-support-grant-funding-guidance-for-businesses">Coronavirus guidance on business support grant funding</a>
     $CTA
   <% end %>
 
@@ -130,7 +165,11 @@
 
     Local authority-run nurseries are not eligible.
 
-    [Check if your nursery is eligible for business rates relief due to coronavirus (COVID-19)](https://www.gov.uk/guidance/check-if-your-nursery-is-eligible-for-business-rates-relief-due-to-coronavirus-covid-19)
+    <a data-module="track-click"
+       data-track-category="Click - Financial Support links"
+       data-track-action="Link clicked"
+       data-track-label="/guidance/check-if-your-nursery-is-eligible-for-business-rates-relief-due-to-coronavirus-covid-19"
+       href="/guidance/check-if-your-nursery-is-eligible-for-business-rates-relief-due-to-coronavirus-covid-19">Check if your nursery is eligible for business rates relief due to coronavirus (COVID-19)</a>
     $CTA
   <% end %>
 
@@ -152,7 +191,11 @@
 
     Contact your local council if you think you are eligible for a grant but have not yet received it.
 
-    [Coronavirus: business support grant funding guidance for businesses](https://www.gov.uk/government/publications/coronavirus-covid-19-business-support-grant-funding-guidance-for-businesses)
+    <a data-module="track-click"
+       data-track-category="Click - Financial Support links"
+       data-track-action="Link clicked"
+       data-track-label="/government/publications/coronavirus-covid-19-business-support-grant-funding-guidance-for-businesses"
+       href="/government/publications/coronavirus-covid-19-business-support-grant-funding-guidance-for-businesses">Coronavirus: business support grant funding guidance for businesses</a>
     $CTA
   <% end %>
 
@@ -172,7 +215,11 @@
     - you have a borrowing proposal which would be considered viable by the lender, if not for the current pandemic
     - you can self-certify that coronavirus (COVID-19) has adversely impacted your business
 
-    [Apply for the Coronavirus Business Interruption Loan Scheme](https://www.gov.uk/guidance/apply-for-the-coronavirus-business-interruption-loan-scheme)
+    <a data-module="track-click"
+       data-track-category="Click - Financial Support links"
+       data-track-action="Link clicked"
+       data-track-label="/guidance/apply-for-the-coronavirus-business-interruption-loan-scheme"
+       href="/guidance/apply-for-the-coronavirus-business-interruption-loan-scheme">Apply for the Coronavirus Business Interruption Loan Scheme</a>
     $CTA
   <% end %>
 
@@ -191,7 +238,11 @@
 
     This includes self-employed people.
 
-    [Apply for a Coronavirus Bounce Back loan](https://www.gov.uk/guidance/apply-for-a-coronavirus-bounce-back-loan)
+    <a data-module="track-click"
+       data-track-category="Click - Financial Support links"
+       data-track-action="Link clicked"
+       data-track-label="/guidance/apply-for-a-coronavirus-bounce-back-loan"
+       href="/guidance/apply-for-a-coronavirus-bounce-back-loan">Apply for a Coronavirus Bounce Back loan</a>
     $CTA
   <% end %>
 
@@ -205,7 +256,11 @@
   - pays tax to the UK government
   - has outstanding tax liabilities
 
-  [If you cannot pay your tax bill on time](https://www.gov.uk/difficulties-paying-hmrc)
+  <a data-module="track-click"
+     data-track-category="Click - Financial Support links"
+     data-track-action="Link clicked"
+     data-track-label="/difficulties-paying-hmrc"
+     href="/difficulties-paying-hmrc">If you cannot pay your tax bill on time</a>
   $CTA
 
   <% if calculator.show?(:large_business_loan_scheme) %>
@@ -227,29 +282,56 @@
 
     The scheme is delivered through commercial lenders, supported by the Government-backed British Business Bank. Facilities backed by a guarantee under CLBILS are offered at commercial rates of interest.
 
-    [Apply for the Coronavirus Large Business Interruption Loan Scheme](https://www.gov.uk/guidance/apply-for-the-coronavirus-large-business-interruption-loan-scheme)
+    <a data-module="track-click"
+       data-track-category="Click - Financial Support links"
+       data-track-action="Link clicked"
+       data-track-label="/guidance/apply-for-the-coronavirus-large-business-interruption-loan-scheme"
+       href="/guidance/apply-for-the-coronavirus-large-business-interruption-loan-scheme">Apply for the Coronavirus Large Business Interruption Loan Scheme</a>
     $CTA
   <% end %>
 
   <% if calculator.business_based == "scotland" %>
     $CTA
-    Find out [what support is available in Scotland](https://findbusinesssupport.gov.scot/coronavirus-advice). You can be eligible for both Scottish and UK-wide schemes.
+    Find out
+    <a data-module="track-click"
+       data-track-category="Click - Financial Support links"
+       data-track-action="Link clicked"
+       data-track-label="https://findbusinesssupport.gov.scot/coronavirus-advice"
+       href="https://findbusinesssupport.gov.scot/coronavirus-advice">what support is available in Scotland</a>.
+    You can be eligible for both Scottish and UK-wide schemes.
     $CTA
   <% end %>
 
   <% if calculator.business_based == "wales" %>
     $CTA
-    Find out [what support is available in Wales](https://businesswales.gov.wales/coronavirus-advice). You can be eligible for both Welsh and UK-wide schemes.
+    Find out
+    <a data-module="track-click"
+       data-track-category="Click - Financial Support links"
+       data-track-action="Link clicked"
+       data-track-label="https://businesswales.gov.wales/coronavirus-advice"
+       href="https://businesswales.gov.wales/coronavirus-advice">what support is available in Wales</a>.
+    You can be eligible for both Welsh and UK-wide schemes.
     $CTA
   <% end %>
 
   <% if calculator.business_based == "northern_ireland" %>
     $CTA
-    Find out [what support is available in Northern Ireland](https://www.nibusinessinfo.co.uk/business-support/coronavirus). You can be eligible for both Northern Ireland and UK-wide schemes.
+    Find out
+    <a data-module="track-click"
+       data-track-category="Click - Financial Support links"
+       data-track-action="Link clicked"
+       data-track-label="https://www.nibusinessinfo.co.uk/business-support/coronavirus"
+       href="https://www.nibusinessinfo.co.uk/business-support/coronavirus">what support is available in Northern Ireland</a>.
+    You can be eligible for both Northern Ireland and UK-wide schemes.
     $CTA
   <% end %>
 
   Please note that you may be eligible for more than one scheme, whether your business is open or closed.
 
-  For detailed information about different types of business support schemes, check the [coronavirus business support page](https://www.gov.uk/coronavirus/business-support).
+  For detailed information about different types of business support schemes, check the
+  <a data-module="track-click"
+     data-track-category="Click - Financial Support links"
+     data-track-action="Link clicked"
+     data-track-label="/coronavirus/business-support"
+     href="/coronavirus/business-support">coronavirus business support page</a>.
 <% end %>


### PR DESCRIPTION
This add HTML anchor tags to markdown to support the attributes needed to enable click tracking. These attributes are automatically picked up the trackClicks loaded from Static, which send click events to GA. This will helps us know which links users are using from the results page.