### PR TITLE
Fix tracking events on coronavirus business support results

### DIFF
--- a/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.govspeak.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.govspeak.erb
@@ -12,9 +12,9 @@
     This applies to employees who have been asked to stop working because of coronavirus, but are being kept on the payroll. They are known as ‘furloughed workers’. HMRC will pay 80% of their wages, up to £2,500 per month.
 
     <a data-module="track-click"
-       data-track-category="Click - Financial Support links"
-       data-track-action="Link clicked"
-       data-track-label="/guidance/claim-for-wage-costs-through-the-coronavirus-job-retention-scheme"
+       data-track-category="Internal Link Clicked"
+       data-track-action="/guidance/claim-for-wage-costs-through-the-coronavirus-job-retention-scheme"
+       data-track-label="Check if you are eligible for the Coronavirus Job Retention Scheme"
        href="/guidance/claim-for-wage-costs-through-the-coronavirus-job-retention-scheme">Check if you are eligible for the Coronavirus Job Retention Scheme</a>
     $CTA
   <% end %>
@@ -25,9 +25,9 @@
   If you’re a UK VAT registered business and have a VAT payment due between 20 March 2020 and 30 June 2020, you have the option to defer payment until 31 March 2021.
 
   <a data-module="track-click"
-     data-track-category="Click - Financial Support links"
-     data-track-action="Link clicked"
-     data-track-label="/guidance/deferral-of-vat-payments-due-to-coronavirus-covid-19"
+     data-track-category="Internal Link Clicked"
+     data-track-action="/guidance/deferral-of-vat-payments-due-to-coronavirus-covid-19"
+     data-track-label="Check if you are eligible to defer your VAT payment"
      href="/guidance/deferral-of-vat-payments-due-to-coronavirus-covid-19">Check if you are eligible to defer your VAT payment</a>
   $CTA
 
@@ -59,9 +59,9 @@
     - small or medium-sized and employs fewer than 250 employees as of 28 February 2020
 
     <a data-module="track-click"
-       data-track-category="Click - Financial Support links"
-       data-track-action="Link clicked"
-       data-track-label="/guidance/claim-back-statutory-sick-pay-paid-to-employees-due-to-coronavirus-covid-19"
+       data-track-category="Internal Link Clicked"
+       data-track-action="/guidance/claim-back-statutory-sick-pay-paid-to-employees-due-to-coronavirus-covid-19"
+       data-track-label="Claim back Statutory Sick Pay paid to employees due to coronavirus (COVID-19)"
        href="/guidance/claim-back-statutory-sick-pay-paid-to-employees-due-to-coronavirus-covid-19">Claim back Statutory Sick Pay paid to employees due to coronavirus (COVID-19)</a>
     $CTA
   <% end %>
@@ -86,21 +86,21 @@
 
     If you are not eligible for Self-Employed Income Support Scheme, you may be eligible for
     <a data-module="track-click"
-       data-track-category="Click - Financial Support links"
-       data-track-action="Link clicked"
-       data-track-label="/universal-credit"
+       data-track-category="Internal Link Clicked"
+       data-track-action="/universal-credit"
+       data-track-label="Universal Credit"
        href="/universal-credit">Universal Credit</a>
     or
     <a data-module="track-click"
-       data-track-category="Click - Financial Support links"
-       data-track-action="Link clicked"
-       data-track-label="/employment-support-allowance/eligibility"
+       data-track-category="Internal Link Clicked"
+       data-track-action="/employment-support-allowance/eligibility"
+       data-track-label="Employment and Support Allowance"
        href="/employment-support-allowance/eligibility">Employment and Support Allowance</a>.
 
     <a data-module="track-click"
-       data-track-category="Click - Financial Support links"
-       data-track-action="Link clicked"
-       data-track-label="/guidance/claim-a-grant-through-the-coronavirus-covid-19-self-employment-income-support-scheme"
+       data-track-category="Internal Link Clicked"
+       data-track-action="/guidance/claim-a-grant-through-the-coronavirus-covid-19-self-employment-income-support-scheme"
+       data-track-label="Claim a grant through the Self-Employment Income Support Scheme"
        href="/guidance/claim-a-grant-through-the-coronavirus-covid-19-self-employment-income-support-scheme">Claim a grant through the Self-Employment Income Support Scheme</a>
     $CTA
   <% end %>
@@ -122,9 +122,9 @@
     - hospitality property - for example, a hotel, a guest house or self-catering accommodation
 
     <a data-module="track-click"
-       data-track-category="Click - Financial Support links"
-       data-track-action="Link clicked"
-       data-track-label="/guidance/check-if-your-retail-hospitality-or-leisure-business-is-eligible-for-business-rates-relief-due-to-coronavirus-covid-19"
+       data-track-category="Internal Link Clicked"
+       data-track-action="/guidance/check-if-your-retail-hospitality-or-leisure-business-is-eligible-for-business-rates-relief-due-to-coronavirus-covid-19"
+       data-track-label="Check if your retail, hospitality or leisure business is eligible for business rates relief due to coronavirus (COVID-19)"
        href="/guidance/check-if-your-retail-hospitality-or-leisure-business-is-eligible-for-business-rates-relief-due-to-coronavirus-covid-19">Check if your retail, hospitality or leisure business is eligible for business rates relief due to coronavirus (COVID-19)</a>
     $CTA
   <% end %>
@@ -148,9 +148,9 @@
     Contact your local council if you think you are eligible for a grant but have not yet received it.
 
     <a data-module="track-click"
-       data-track-category="Click - Financial Support links"
-       data-track-action="Link clicked"
-       data-track-label="/government/publications/coronavirus-covid-19-business-support-grant-funding-guidance-for-businesses"
+       data-track-category="Internal Link Clicked"
+       data-track-action="/government/publications/coronavirus-covid-19-business-support-grant-funding-guidance-for-businesses"
+       data-track-label="Coronavirus guidance on business support grant funding"
        href="/government/publications/coronavirus-covid-19-business-support-grant-funding-guidance-for-businesses">Coronavirus guidance on business support grant funding</a>
     $CTA
   <% end %>
@@ -166,9 +166,9 @@
     Local authority-run nurseries are not eligible.
 
     <a data-module="track-click"
-       data-track-category="Click - Financial Support links"
-       data-track-action="Link clicked"
-       data-track-label="/guidance/check-if-your-nursery-is-eligible-for-business-rates-relief-due-to-coronavirus-covid-19"
+       data-track-category="Internal Link Clicked"
+       data-track-action="/guidance/check-if-your-nursery-is-eligible-for-business-rates-relief-due-to-coronavirus-covid-19"
+       data-track-label="Check if your nursery is eligible for business rates relief due to coronavirus (COVID-19)"
        href="/guidance/check-if-your-nursery-is-eligible-for-business-rates-relief-due-to-coronavirus-covid-19">Check if your nursery is eligible for business rates relief due to coronavirus (COVID-19)</a>
     $CTA
   <% end %>
@@ -192,9 +192,9 @@
     Contact your local council if you think you are eligible for a grant but have not yet received it.
 
     <a data-module="track-click"
-       data-track-category="Click - Financial Support links"
-       data-track-action="Link clicked"
-       data-track-label="/government/publications/coronavirus-covid-19-business-support-grant-funding-guidance-for-businesses"
+       data-track-category="Internal Link Clicked"
+       data-track-action="/government/publications/coronavirus-covid-19-business-support-grant-funding-guidance-for-businesses"
+       data-track-label="Coronavirus: business support grant funding guidance for businesses"
        href="/government/publications/coronavirus-covid-19-business-support-grant-funding-guidance-for-businesses">Coronavirus: business support grant funding guidance for businesses</a>
     $CTA
   <% end %>
@@ -216,9 +216,9 @@
     - you can self-certify that coronavirus (COVID-19) has adversely impacted your business
 
     <a data-module="track-click"
-       data-track-category="Click - Financial Support links"
-       data-track-action="Link clicked"
-       data-track-label="/guidance/apply-for-the-coronavirus-business-interruption-loan-scheme"
+       data-track-category="Internal Link Clicked"
+       data-track-action="/guidance/apply-for-the-coronavirus-business-interruption-loan-scheme"
+       data-track-label="Apply for the Coronavirus Business Interruption Loan Scheme"
        href="/guidance/apply-for-the-coronavirus-business-interruption-loan-scheme">Apply for the Coronavirus Business Interruption Loan Scheme</a>
     $CTA
   <% end %>
@@ -239,9 +239,9 @@
     This includes self-employed people.
 
     <a data-module="track-click"
-       data-track-category="Click - Financial Support links"
-       data-track-action="Link clicked"
-       data-track-label="/guidance/apply-for-a-coronavirus-bounce-back-loan"
+       data-track-category="Internal Link Clicked"
+       data-track-action="/guidance/apply-for-a-coronavirus-bounce-back-loan"
+       data-track-label="Apply for a Coronavirus Bounce Back loan"
        href="/guidance/apply-for-a-coronavirus-bounce-back-loan">Apply for a Coronavirus Bounce Back loan</a>
     $CTA
   <% end %>
@@ -257,9 +257,9 @@
   - has outstanding tax liabilities
 
   <a data-module="track-click"
-     data-track-category="Click - Financial Support links"
-     data-track-action="Link clicked"
-     data-track-label="/difficulties-paying-hmrc"
+     data-track-category="Internal Link Clicked"
+     data-track-action="/difficulties-paying-hmrc"
+     data-track-label="If you cannot pay your tax bill on time"
      href="/difficulties-paying-hmrc">If you cannot pay your tax bill on time</a>
   $CTA
 
@@ -283,45 +283,30 @@
     The scheme is delivered through commercial lenders, supported by the Government-backed British Business Bank. Facilities backed by a guarantee under CLBILS are offered at commercial rates of interest.
 
     <a data-module="track-click"
-       data-track-category="Click - Financial Support links"
-       data-track-action="Link clicked"
-       data-track-label="/guidance/apply-for-the-coronavirus-large-business-interruption-loan-scheme"
+       data-track-category="Internal Link Clicked"
+       data-track-action="/guidance/apply-for-the-coronavirus-large-business-interruption-loan-scheme"
+       data-track-label="Apply for the Coronavirus Large Business Interruption Loan Scheme"
        href="/guidance/apply-for-the-coronavirus-large-business-interruption-loan-scheme">Apply for the Coronavirus Large Business Interruption Loan Scheme</a>
     $CTA
   <% end %>
 
   <% if calculator.business_based == "scotland" %>
     $CTA
-    Find out
-    <a data-module="track-click"
-       data-track-category="Click - Financial Support links"
-       data-track-action="Link clicked"
-       data-track-label="https://findbusinesssupport.gov.scot/coronavirus-advice"
-       href="https://findbusinesssupport.gov.scot/coronavirus-advice">what support is available in Scotland</a>.
+    Find out [what support is available in Scotland](https://findbusinesssupport.gov.scot/coronavirus-advice).
     You can be eligible for both Scottish and UK-wide schemes.
     $CTA
   <% end %>
 
   <% if calculator.business_based == "wales" %>
     $CTA
-    Find out
-    <a data-module="track-click"
-       data-track-category="Click - Financial Support links"
-       data-track-action="Link clicked"
-       data-track-label="https://businesswales.gov.wales/coronavirus-advice"
-       href="https://businesswales.gov.wales/coronavirus-advice">what support is available in Wales</a>.
+    Find out [what support is available in Wales](https://businesswales.gov.wales/coronavirus-advice).
     You can be eligible for both Welsh and UK-wide schemes.
     $CTA
   <% end %>
 
   <% if calculator.business_based == "northern_ireland" %>
     $CTA
-    Find out
-    <a data-module="track-click"
-       data-track-category="Click - Financial Support links"
-       data-track-action="Link clicked"
-       data-track-label="https://www.nibusinessinfo.co.uk/business-support/coronavirus"
-       href="https://www.nibusinessinfo.co.uk/business-support/coronavirus">what support is available in Northern Ireland</a>.
+    Find out [what support is available in Northern Ireland](https://www.nibusinessinfo.co.uk/business-support/coronavirus).
     You can be eligible for both Northern Ireland and UK-wide schemes.
     $CTA
   <% end %>
@@ -330,8 +315,8 @@
 
   For detailed information about different types of business support schemes, check the
   <a data-module="track-click"
-     data-track-category="Click - Financial Support links"
-     data-track-action="Link clicked"
-     data-track-label="/coronavirus/business-support"
+     data-track-category="Internal Link Clicked"
+     data-track-action="/coronavirus/business-support"
+     data-track-label="coronavirus business support page"
      href="/coronavirus/business-support">coronavirus business support page</a>.
 <% end %>


### PR DESCRIPTION
This removes tracking attribute from external links, as they are already tracked via the external-link module from Static. We also make the tracking events for internal links consistent with that modules where the URL is the action and the label includes the link text. Following the pattern used [here](https://github.com/alphagov/static/blob/master/doc/analytics.md#external-link-tracking-external-link-trackerjs).