### PR TITLE
Fix error for empty render_content_for blocks

### DIFF
--- a/lib/smart_answer/erb_renderer/format_capture_helper.rb
+++ b/lib/smart_answer/erb_renderer/format_capture_helper.rb
@@ -8,12 +8,14 @@ module SmartAnswer
     }.freeze
 
     def render_content_for(name, options = {}, &block)
-      content = capture(&block)
+      if block_given?
+        content = capture(&block) || ""
 
-      format = options.delete(:format) || default_format(name)
-      content = render_content(format, content)
+        format = options.delete(:format) || default_format(name)
+        content = render_content(format, content)
 
-      content_for(name, content, options, &nil)
+        content_for(name, content, options, &nil)
+      end
     end
 
   private

--- a/test/integration/smart_answer_flows/check_uk_visa_test.rb
+++ b/test/integration/smart_answer_flows/check_uk_visa_test.rb
@@ -7,7 +7,7 @@ class CheckUkVisaTest < ActiveSupport::TestCase
   include FlowTestHelper
 
   setup do
-    @location_slugs = %w[andorra anguilla armenia bolivia canada china colombia croatia estonia hong-kong latvia macao mexico south-africa stateless-or-refugee syria turkey democratic-republic-of-the-congo oman united-arab-emirates qatar taiwan venezuela afghanistan yemen]
+    @location_slugs = %w[andorra anguilla armenia austria bolivia canada china colombia croatia estonia hong-kong latvia macao mexico south-africa stateless-or-refugee syria turkey democratic-republic-of-the-congo oman united-arab-emirates qatar taiwan venezuela afghanistan yemen]
     stub_world_locations(@location_slugs)
     setup_for_testing_flow SmartAnswer::CheckUkVisaFlow
   end
@@ -183,6 +183,16 @@ class CheckUkVisaTest < ActiveSupport::TestCase
       should "show outcome no visa needed" do
         assert_current_node :outcome_no_visa_needed
       end
+    end
+  end
+
+  context "choose an EEA country" do
+    setup do
+      add_response "austria"
+    end
+
+    should "go to outcome no visa needed" do
+      assert_current_node :outcome_no_visa_needed
     end
   end
 

--- a/test/unit/format_capture_helper_test.rb
+++ b/test/unit/format_capture_helper_test.rb
@@ -35,6 +35,18 @@ module SmartAnswer
         @test_obj.extend(SmartAnswer::ErbRenderer::FormatCaptureHelper)
       end
 
+      should "ignore missing blocks" do
+        @test_obj.expects(:content_for).never
+
+        @test_obj.render_content_for(:title)
+      end
+
+      should "return empty string for empty blocks" do
+        @test_obj.expects(:content_for).with(:title, "", {})
+
+        @test_obj.render_content_for(:title) {}
+      end
+
       should "pass all arguments to content_for" do
         @test_obj.expects(:content_for).with(:title, "contents", { option: :option })
 
@@ -86,7 +98,7 @@ module SmartAnswer
       end
 
       should "not wrap empty content with govspeak html tags" do
-        assert_captured_content("", :govspeak, "")
+        assert_captured_content("  ", :govspeak, "")
       end
     end
   end


### PR DESCRIPTION
This fixes the case when a template has render_content_for block that is empty or just has whitespace.

```erb
<% render_content_for :body %>

<% end %>
```

This was seen for for UK Visa smart answer where the body content is empty for certain EEA citizens. `render_content_for` expected the block to always be present and return a String. However the ERB templating engine passes a block that evaluates to a nil value instead of an empty string.