### PR TITLE
Refactor questions options helper logic for clarity

### DIFF
--- a/lib/smart_answer/erb_renderer/question_options_helper.rb
+++ b/lib/smart_answer/erb_renderer/question_options_helper.rb
@@ -1,11 +1,7 @@
 module SmartAnswer
   module ErbRenderer::QuestionOptionsHelper
-    def options(options = nil)
-      if options
-        @options = options
-      else
-        @options || {}
-      end
+    def options(new_options = nil)
+      @options = new_options || @options || {}
     end
   end
 end


### PR DESCRIPTION
The logic written for the question options helper is quite confusing. This is a small refactor to make it more concise.