### PR TITLE
Add link to the defer self-assesment scheme on results

### DIFF
--- a/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.govspeak.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.govspeak.erb
@@ -42,6 +42,12 @@
     The deferment is optional. If you are still able to pay your second payment on 31 July, you should do so.
 
     This is an automatic offer. You do not need to apply for the deferral, or tell HMRC. If you normally pay by Direct Debit you should contact your bank to cancel your Direct Debit as soon as you can. You do not need to contact HMRC before doing this.
+
+    <a data-module="track-click"
+       data-track-category="Internal Link Clicked"
+       data-track-action="/guidance/defer-your-self-assessment-payment-on-account-due-to-coronavirus-covid-19"
+       data-track-label="Check if you are eligible to defer your Self Assessment payment on account"
+       href="/guidance/defer-your-self-assessment-payment-on-account-due-to-coronavirus-covid-19">Check if you are eligible to defer your Self Assessment payment on account</a>
     $CTA
   <% end %>
 


### PR DESCRIPTION
This adds a link to view extra information about eligibility for deferring self assessment on the coronavirus business funding and support results.