### PR TITLE
Add email link to the business coronavirus support results

### DIFF
--- a/app/assets/stylesheets/smart_answers.scss
+++ b/app/assets/stylesheets/smart_answers.scss
@@ -80,3 +80,21 @@ $is-ie: false !default;
   @include govuk-font($size: 16);
   color: $govuk-secondary-text-colour;
 }
+
+.app-c-email-link {
+  display: block;
+  @include govuk-responsive-margin(8, "top");
+  padding: govuk-spacing(6);
+  background-color: govuk-colour("light-grey", $legacy: "grey-4");
+}
+
+.app-c-email-link__icon {
+  position: relative;
+  float: left;
+  margin-right: .5em;
+  top: 2px;
+}
+
+.app-c-email-link__title {
+  margin-bottom: govuk-spacing(2);
+}

--- a/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.govspeak.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.govspeak.erb
@@ -326,3 +326,18 @@
      data-track-label="coronavirus business support page"
      href="/coronavirus/business-support">coronavirus business support page</a>.
 <% end %>
+
+<% render_content_for :body, format: :html do %>
+  <div class="app-c-email-link">
+    <svg class="app-c-email-link__icon" xmlns="http://www.w3.org/2000/svg" height="18" width="18" viewBox="0 0 459.334 459.334">
+      <path fill="black" d="M177.216 404.514c-.001.12-.009.239-.009.359 0 30.078 24.383 54.461 54.461 54.461s54.461-24.383 54.461-54.461c0-.12-.008-.239-.009-.359H175.216zM403.549 336.438l-49.015-72.002v-89.83c0-60.581-43.144-111.079-100.381-122.459V24.485C254.152 10.963 243.19 0 229.667 0s-24.485 10.963-24.485 24.485v27.663c-57.237 11.381-100.381 61.879-100.381 122.459v89.83l-49.015 72.002a24.76 24.76 0 0 0 20.468 38.693H383.08a24.761 24.761 0 0 0 20.469-38.694z"></path>
+    </svg>
+    <h3 class="govuk-heading-s app-c-email-link__title">Stay up to date</h3>
+    <a class="govuk-body govuk-link"
+       data-module="track-click"
+       data-track-category="Internal Link Clicked"
+       data-track-action="/email-signup/?topic=/coronavirus-taxon/funding-and-support"
+       data-track-label="Sign up for email updates about business funding and support"
+       href="/email-signup/?topic=/coronavirus-taxon/funding-and-support">Sign up for email updates about business funding and support</a>
+  </div>
+<% end %>


### PR DESCRIPTION
This adds a link for users to sign up to email alerts for all coronavirus business funding and support. This re-uses styling from the transition page and add custom CSS for the email-link app component.