### PR TITLE
Remove redundant RuboCop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,18 +7,17 @@ inherit_mode:
   merge:
     - Exclude
 
+# It is a convention of this app that the files
+# that define a smart answer have a name that matches
+# its (hyphenated) URL.
 Naming/FileName:
   Exclude:
     - lib/smart_answer_flows/*.rb
     - test/fixtures/smart_answer_flows/*.rb
 
+# Long conditionals are inherent in smart answers, due
+# to the complexity of the problem they represent. It is
+# a convention of this app to comment the ending of these
+# conditionals, to clarify which branches we are on.
 Style/CommentedKeyword:
-  Enabled: false
-
-Metrics/BlockLength:
-  Exclude:
-    - 'lib/tasks/**/*.rake'
-    - 'lib/smart_answer_flows/**/*.rb'
-
-Rails/OutputSafety:
   Enabled: false


### PR DESCRIPTION
https://github.com/alphagov/rubocop-govuk/issues/73

This also adds explanations to justify the config that remains.