### PR TITLE
Update hint text and start page for coronavirus business support

### DIFF
--- a/lib/smart_answer_flows/business-coronavirus-support-finder/business_coronavirus_support_finder.govspeak.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/business_coronavirus_support_finder.govspeak.erb
@@ -4,14 +4,16 @@
 
 <% render_content_for :meta_description do %>
   Coronavirus (COVID-19) support is available to employers and the
-  self-employed. You may be eligible for loans, tax relief and cash grants,
-  whether your business is open or closed.
+  self-employed, including sole traders and limited company directors.
+  You may be eligible for loans, tax relief and cash grants, whether your
+  business is open or closed.
 <% end %>
 
 <% render_content_for :body do %>
   Coronavirus (COVID-19) support is available to employers and the
-  self-employed. You may be eligible for loans, tax relief and cash grants,
-  whether your business is open or closed.
+  self-employed, including sole traders and limited company directors.
+  You may be eligible for loans, tax relief and cash grants, whether your
+  business is open or closed.
 
   Use this business support finder to see what support is available for you
   and your business.

--- a/lib/smart_answer_flows/business-coronavirus-support-finder/questions/non_domestic_property.govspeak.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/questions/non_domestic_property.govspeak.erb
@@ -2,6 +2,10 @@
   What is the rateable value of your business' non-domestic property?
 <% end %>
 
+<% render_content_for :hint do %>
+  The rateable value of your property is used by your local council to calculate your business rates bill.
+<% end %>
+
 <% options(
   "51k_and_over": "£51,000 and over",
   "under_51k": "Under £51,000",

--- a/lib/smart_answer_flows/business-coronavirus-support-finder/questions/self_employed.govspeak.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/questions/self_employed.govspeak.erb
@@ -2,6 +2,10 @@
   Are you self-employed?
 <% end %>
 
+<% render_content_for :hint do %>
+  For this question, limited company directors are not considered self-employed.
+<% end %>
+
 <% options(
   "yes": "Yes",
   "no": "No",


### PR DESCRIPTION
Hint text is added to the "are you self-employed" and "non-domestic property" questions to help clarify what they mean. Also added a line to the start page to further explain who this is smart answer is relevant too.