### PR TITLE
Fix issue of ErbRenderer#content_for returning nil

### DIFF
--- a/lib/smart_answer/erb_renderer.rb
+++ b/lib/smart_answer/erb_renderer.rb
@@ -1,7 +1,5 @@
 module SmartAnswer
   class ErbRenderer
-    delegate :content_for, to: :rendered_view
-
     def initialize(template_directory:, template_name:, locals: {}, helpers: [])
       @template_directory = template_directory
       @template_name = template_name
@@ -27,6 +25,10 @@ module SmartAnswer
 
     def relative_erb_template_path
       erb_template_path.relative_path_from(Rails.root).to_s
+    end
+
+    def content_for(name)
+      rendered_view.content_for(name) || ""
     end
 
   private

--- a/test/unit/erb_renderer_test.rb
+++ b/test/unit/erb_renderer_test.rb
@@ -113,6 +113,16 @@ Hello world
       end
     end
 
+    test "#content_for returns an empty string when content is missing" do
+      erb_template = ""
+
+      with_erb_template_file("template-name", erb_template) do |erb_template_directory|
+        renderer = ErbRenderer.new(template_directory: erb_template_directory, template_name: "template-name")
+
+        assert_equal renderer.content_for(:key), ""
+      end
+    end
+
     test "#option_text returns option text for specified key" do
       erb_template = "<% options(option_one: 'option-one-text', option_two: 'option-two-text') %>"
 


### PR DESCRIPTION
ErbRenderer#content_for was changed in commit 87ba54b97d30d2578cd0a8d1c540c48b67450249 to be delegate to the ActiveView::Base#content_for method. However this introduced a behaviour change whereby calls for named content that were not present in rendered_view returned nil instead of "". This introduced a bug where the ContentItemSyncer sent an invalid schema to the Publishing API preventing updates to start pages.