### PR TITLE
Switch asset path and host

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -44,7 +44,11 @@ module SmartAnswers
     config.filter_parameters += [:password]
 
     # Path within public/ where assets are compiled to
-    config.assets.prefix = "/smartanswers"
+    config.assets.prefix = "/assets/smartanswers"
+
+    # allow overriding the asset host with an enironment variable, useful for
+    # when router is proxying to this app but asset proxying isn't set up.
+    config.asset_host = ENV["ASSET_HOST"]
 
     # Precompile additional assets (application.js, application.css, and all non-JS/CSS are already added)
     config.assets.precompile += %w[

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,10 +36,6 @@ Rails.application.configure do
   # number of complex assets.
   config.assets.debug = true
 
-  if ENV["GOVUK_ASSET_ROOT"].present?
-    config.asset_host = ENV["GOVUK_ASSET_ROOT"]
-  end
-
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,9 +30,6 @@ Rails.application.configure do
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 
-  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.action_controller.asset_host = "http://assets.example.com"
-
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for Apache
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
@@ -60,8 +57,6 @@ Rails.application.configure do
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
-
-  config.action_controller.asset_host = ENV["GOVUK_ASSET_HOST"]
 
   if ENV["RUNNING_ON_HEROKU"]
     # flush output to the underlying OS without buffering

--- a/config/initializers/slimmer.rb
+++ b/config/initializers/slimmer.rb
@@ -1,7 +1,3 @@
 SmartAnswers::Application.configure do
   config.slimmer.logger = Rails.logger
-
-  if Rails.env.development?
-    config.slimmer.asset_host = ENV["STATIC_DEV"] || Plek.new.find("static")
-  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/oNEtjIVp/99-serve-static-assets-from-www-hostname

This configures this app to serve assets from the current host by
default rather than the GOVUK_ASSET_ROOT environment variable. This is
to support the switch of assets from assets.publishing.service.gov.uk to
www.gov.uk.

The host for assets can be specified with an ASSET_HOST env var which is
intended to be used in development environments where router isn't set
up for proxying. Unlike GOVUK_ASSET_ROOT this is expected to be app
specific hence why it doesn't have a GOVUK prefix.