### PR TITLE
Create test-dependencies.js to replace live static assets

### DIFF
--- a/app/assets/javascripts/test-dependencies.js
+++ b/app/assets/javascripts/test-dependencies.js
@@ -1,0 +1,3 @@
+// This file contains dependencies that are only needed when running in a test
+// environment. In the dev and live environment these are provided by static.
+//= require govuk_publishing_components/dependencies

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,6 +4,7 @@
     <title><%= yield :title %> - GOV.UK</title>
     <%= stylesheet_link_tag "application", :media => "all" %>
     <%= stylesheet_link_tag "print.css", media: "print" %>
+    <%= javascript_include_tag "test-dependencies" if Rails.env.test? %>
     <%= yield :head %>
     <% if @content_item %>
       <%= render "govuk_publishing_components/components/meta_tags",

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -11,4 +11,4 @@ Rails.application.config.assets.version = "1.0"
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
-# Rails.application.config.assets.precompile += %w( admin.js admin.css )
+Rails.application.config.assets.precompile += %w[test-dependencies.js]


### PR DESCRIPTION
Trello: https://trello.com/c/oNEtjIVp/99-serve-static-assets-from-www-hostname

The tests for this app were failing after GOV.UK's assets switched from
the assets hostname to www. This was because slimmer was actually
embedding links to production GOV.UK assets which were symlinked to the
latest ones. Once the assets changed path then the tests broke.

Since it is good practice for tests to be isolated I've created a
test-dependencies.js file which loads in the basic slimmer dependencies
from govuk_publishing_components. This has the advantage that this test
suite no longer has external network requirement, but does have the
disadvantage that the JS isn't the same. This trade-off seems reasonable
since there was never anything particularly realistic about the slimmer
test template [1] and it's mostly luck that it matches production.

[1]: https://github.com/alphagov/slimmer/blob/master/lib/slimmer/test_templates/wrapper.html