### PR TITLE
Ensure link is correctly shown

### DIFF
--- a/lib/smart_answer_flows/simplified-expenses-checker/questions/is_vehicle_green.govspeak.erb
+++ b/lib/smart_answer_flows/simplified-expenses-checker/questions/is_vehicle_green.govspeak.erb
@@ -2,7 +2,7 @@
   What are the car’s CO2 emissions?
 <% end %>
 
-<% render_content_for :hint do %>
+<% render_content_for :body do %>
   Check your car's <a href="/get-vehicle-information-from-dvla">CO2 emissions</a>.
 <% end %>
 


### PR DESCRIPTION
The link for checking the C02 emissions was not being shown correctly
on the is vehicle green page in the simplified expenses checker.
found here:
/simplified-expenses-checker/y/car/using_home_for_business/new/30000.0
 it was being shown as html instead of being changed into a hyperlink.

This is because hints are rendered as text and not html. Here the
content has been changed from hint to body so it can be processed as
html and shown correctly.

before: 
![image (1)](https://user-images.githubusercontent.com/17481621/83752300-3ab17100-a660-11ea-8c8b-f01929f3a55f.png)

after:
![image (2)](https://user-images.githubusercontent.com/17481621/83752339-4ac95080-a660-11ea-98d6-4c0f47bb3019.png)

