### PR TITLE
Add Future Fund scheme

### DIFF
--- a/lib/smart_answer/calculators/business_coronavirus_support_finder_calculator.rb
+++ b/lib/smart_answer/calculators/business_coronavirus_support_finder_calculator.rb
@@ -60,6 +60,9 @@ module SmartAnswer::Calculators
       bounce_back_loan: lambda { |calculator|
         %w[under_85k 85k_to_45m].include?(calculator.annual_turnover)
       },
+      future_fund: lambda { |calculator|
+        calculator.annual_turnover == "pre_revenue"
+      },
     }.freeze
 
     def show?(result_id)

--- a/lib/smart_answer_flows/business-coronavirus-support-finder.rb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder.rb
@@ -40,6 +40,7 @@ module SmartAnswer
         option :"45m_to_500m"
         option :"85k_to_45m"
         option :under_85k
+        option :pre_revenue
 
         on_response do |response|
           calculator.annual_turnover = response

--- a/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.govspeak.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.govspeak.erb
@@ -312,6 +312,28 @@
     $CTA
   <% end %>
 
+  <% if calculator.show?(:future_fund) %>
+    $CTA
+    ### Future Fund
+    
+    The Future Fund scheme will issue convertible loans between £125,000 to £5 million to innovative companies facing financing difficulties due to the coronavirus outbreak.
+
+    Your business is eligible if:
+
+    - it is UK-incorporated (if your business is part of a corporate group, only the parent company is eligible)
+    - it has raised at least £250,000 in equity investment from third-party investors in the last 5 years
+    - none of its shares are traded on a regulated market, multilateral trading facility or other listing venue
+    - it was incorporated on or before 31 December 2019
+    - half or more employees are UK-based or half or more revenues are from UK sales
+
+    <a data-module="track-click"
+       data-track-category="Internal Link Clicked"
+       data-track-action="/guidance/future-fund"
+       data-track-label="Find out how to apply"
+       href="/guidance/future-fund">Find out how to apply</a>
+    $CTA
+  <% end %>
+
   <% if calculator.business_based == "scotland" %>
     $CTA
     Find out [what support is available in Scotland](https://findbusinesssupport.gov.scot/coronavirus-advice).

--- a/lib/smart_answer_flows/business-coronavirus-support-finder/questions/annual_turnover.govspeak.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/questions/annual_turnover.govspeak.erb
@@ -7,4 +7,5 @@
   "45m_to_500m": "£45 million to £500 million",
   "85k_to_45m": "£85,000 to £45 million",
   "under_85k": "Under £85,000",
+  "pre_revenue": "My business is a start-up and is pre-revenue",
 ) %>

--- a/test/unit/calculators/business_coronavirus_support_calculator_test.rb
+++ b/test/unit/calculators/business_coronavirus_support_calculator_test.rb
@@ -264,6 +264,18 @@ module SmartAnswer::Calculators
           assert_not @calculator.show?(:bounce_back_loan)
         end
       end
+
+      context "future_fund" do
+        should "return true when annual turnover is pre-prevenue" do
+          @calculator.annual_turnover = "pre_revenue"
+          assert @calculator.show?(:future_fund)
+        end
+
+        should "return false when annual turnover not pre-prevenue" do
+          @calculator.annual_turnover = "45m_to_500m"
+          assert_not @calculator.show?(:future_fund)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This adds a new scheme to the business coronavirus support finder's results page. This also adds a new option to the annual turnover question to determine whether the user is eligible.