### PR TITLE
Adds Production example for flow visualisation

### DIFF
--- a/doc/debugging/visualising-flows.md
+++ b/doc/debugging/visualising-flows.md
@@ -1,6 +1,6 @@
 # Visualising flows
 
-To see an interactive visualisation of a smart answer flow, append `/y/visualise` to the root of a smartanswer URL e.g. `http://smartanswers.dev.gov.uk/<my-flow>/y/visualise/`
+To see an interactive visualisation of a smart answer flow, append `/y/visualise` to the root of a smart answer URL e.g. `http://smartanswers.dev.gov.uk/<smart-answer>/y/visualise` or `https://www.gov.uk/<smart-answer>/y/visualise`
 
 To see a static visualisation of a smart answer flow, using Graphviz:
 


### PR DESCRIPTION
This adds an example URL from the Production site, to help non-developers understand how to access the flow visualisation


[Trello](https://trello.com/c/65jLhWvK/1739-help-content-designers-understand-process-of-removing-content-from-pay-leave-for-parents)