### PR TITLE
Add internal link tracking helper

### DIFF
--- a/app/assets/javascripts/helpers.js
+++ b/app/assets/javascripts/helpers.js
@@ -19,3 +19,34 @@ function linkToTemplatesOnGithub() {
     element.removeAttr('data-debug-template-path');
   });
 };
+
+function trackInternalLinks (rootSelector) {
+  rootSelector = rootSelector || 'body';
+  var currentHost = document.location.protocol + '//' + document.location.hostname;
+  var internalLinkSelector = 'a[href^="' + currentHost + '"], a[href^="/"]';
+
+  $(rootSelector).find(internalLinkSelector).on('click', trackClickEvent);
+
+  function trackClickEvent (evt) {
+    var $link = getLinkFromEvent(evt);
+    var options = {transport: 'beacon'};
+    var href = $link.attr('href');
+    var linkText = $.trim($link.text());
+
+    if (linkText) {
+      options.label = linkText;
+    }
+
+    GOVUK.analytics.trackEvent('Internal Link Clicked', href, options);
+  };
+
+  function getLinkFromEvent (evt) {
+    var $target = $(evt.target);
+
+    if (!$target.is('a')) {
+      $target = $target.parents('a');
+    }
+
+    return $target;
+  };
+};

--- a/app/views/smart_answers/result.html.erb
+++ b/app/views/smart_answers/result.html.erb
@@ -11,7 +11,7 @@
 
     <% outcome = @presenter.current_node %>
 
-    <div class="govuk-!-margin-bottom-6" data-debug-template-path="<%= outcome.relative_erb_template_path %>">
+    <div class="govuk-!-margin-bottom-6 result-body" data-debug-template-path="<%= outcome.relative_erb_template_path %>">
       <% if outcome.title.present? %>
         <%= render "govuk_publishing_components/components/heading", {
           text: outcome.title,
@@ -43,6 +43,7 @@
           page: page
         };
         GOVUK.analytics.trackEvent('Smart Answer', 'Completed', options);
+        trackInternalLinks('.result-body');
       });
     </script>
 

--- a/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.govspeak.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.govspeak.erb
@@ -13,11 +13,7 @@
 
     You must have agreed with your employee to put them on furlough by 10 June 2020. You must claim wages for your furloughed employee by 31 July 2020.
 
-    <a data-module="track-click"
-       data-track-category="Internal Link Clicked"
-       data-track-action="/guidance/claim-for-wage-costs-through-the-coronavirus-job-retention-scheme"
-       data-track-label="Check if you are eligible for the Coronavirus Job Retention Scheme"
-       href="/guidance/claim-for-wage-costs-through-the-coronavirus-job-retention-scheme">Check if you are eligible for the Coronavirus Job Retention Scheme</a>
+    [Check if you are eligible for the Coronavirus Job Retention Scheme](/guidance/claim-for-wage-costs-through-the-coronavirus-job-retention-scheme)
     $CTA
   <% end %>
 
@@ -26,11 +22,7 @@
 
   If you’re a UK VAT registered business and have a VAT payment due between 20 March 2020 and 30 June 2020, you have the option to defer payment until 31 March 2021.
 
-  <a data-module="track-click"
-     data-track-category="Internal Link Clicked"
-     data-track-action="/guidance/deferral-of-vat-payments-due-to-coronavirus-covid-19"
-     data-track-label="Check if you are eligible to defer your VAT payment"
-     href="/guidance/deferral-of-vat-payments-due-to-coronavirus-covid-19">Check if you are eligible to defer your VAT payment</a>
+  [Check if you are eligible to defer your VAT payment](/guidance/deferral-of-vat-payments-due-to-coronavirus-covid-19)
   $CTA
 
   <% if calculator.show?(:self_assessment_payments) %>
@@ -45,11 +37,7 @@
 
     This is an automatic offer. You do not need to apply for the deferral, or tell HMRC. If you normally pay by Direct Debit you should contact your bank to cancel your Direct Debit as soon as you can. You do not need to contact HMRC before doing this.
 
-    <a data-module="track-click"
-       data-track-category="Internal Link Clicked"
-       data-track-action="/guidance/defer-your-self-assessment-payment-on-account-due-to-coronavirus-covid-19"
-       data-track-label="Check if you are eligible to defer your Self Assessment payment on account"
-       href="/guidance/defer-your-self-assessment-payment-on-account-due-to-coronavirus-covid-19">Check if you are eligible to defer your Self Assessment payment on account</a>
+    [Check if you are eligible to defer your Self Assessment payment on account](/guidance/defer-your-self-assessment-payment-on-account-due-to-coronavirus-covid-19)
     $CTA
   <% end %>
 
@@ -66,11 +54,7 @@
     - UK based
     - small or medium-sized and employs fewer than 250 employees as of 28 February 2020
 
-    <a data-module="track-click"
-       data-track-category="Internal Link Clicked"
-       data-track-action="/guidance/claim-back-statutory-sick-pay-paid-to-employees-due-to-coronavirus-covid-19"
-       data-track-label="Claim back Statutory Sick Pay paid to employees due to coronavirus (COVID-19)"
-       href="/guidance/claim-back-statutory-sick-pay-paid-to-employees-due-to-coronavirus-covid-19">Claim back Statutory Sick Pay paid to employees due to coronavirus (COVID-19)</a>
+    [Claim back Statutory Sick Pay paid to employees due to coronavirus (COVID-19)](/guidance/claim-back-statutory-sick-pay-paid-to-employees-due-to-coronavirus-covid-19)
     $CTA
   <% end %>
 
@@ -92,24 +76,9 @@
 
     ^Trading profits do not include dividends paid from your own company to yourself.^
 
-    If you are not eligible for Self-Employed Income Support Scheme, you may be eligible for
-    <a data-module="track-click"
-       data-track-category="Internal Link Clicked"
-       data-track-action="/universal-credit"
-       data-track-label="Universal Credit"
-       href="/universal-credit">Universal Credit</a>
-    or
-    <a data-module="track-click"
-       data-track-category="Internal Link Clicked"
-       data-track-action="/employment-support-allowance/eligibility"
-       data-track-label="Employment and Support Allowance"
-       href="/employment-support-allowance/eligibility">Employment and Support Allowance</a>.
+    If you are not eligible for Self-Employed Income Support Scheme, you may be eligible for [Universal Credit](/universal-credit) or [Employment and Support Allowance](/employment-support-allowance/eligibility).
 
-    <a data-module="track-click"
-       data-track-category="Internal Link Clicked"
-       data-track-action="/guidance/claim-a-grant-through-the-coronavirus-covid-19-self-employment-income-support-scheme"
-       data-track-label="Claim a grant through the Self-Employment Income Support Scheme"
-       href="/guidance/claim-a-grant-through-the-coronavirus-covid-19-self-employment-income-support-scheme">Claim a grant through the Self-Employment Income Support Scheme</a>
+    [Claim a grant through the Self-Employment Income Support Scheme](/guidance/claim-a-grant-through-the-coronavirus-covid-19-self-employment-income-support-scheme)
     $CTA
   <% end %>
 
@@ -129,11 +98,7 @@
     - assembly or leisure property - for example, a sports club, a gym or a spa
     - hospitality property - for example, a hotel, a guest house or self-catering accommodation
 
-    <a data-module="track-click"
-       data-track-category="Internal Link Clicked"
-       data-track-action="/guidance/check-if-your-retail-hospitality-or-leisure-business-is-eligible-for-business-rates-relief-due-to-coronavirus-covid-19"
-       data-track-label="Check if your retail, hospitality or leisure business is eligible for business rates relief due to coronavirus (COVID-19)"
-       href="/guidance/check-if-your-retail-hospitality-or-leisure-business-is-eligible-for-business-rates-relief-due-to-coronavirus-covid-19">Check if your retail, hospitality or leisure business is eligible for business rates relief due to coronavirus (COVID-19)</a>
+    [Check if your retail, hospitality or leisure business is eligible for business rates relief due to coronavirus (COVID-19)](/guidance/check-if-your-retail-hospitality-or-leisure-business-is-eligible-for-business-rates-relief-due-to-coronavirus-covid-19)
     $CTA
   <% end %>
 
@@ -155,11 +120,7 @@
 
     Contact your local council if you think you are eligible for a grant but have not yet received it.
 
-    <a data-module="track-click"
-       data-track-category="Internal Link Clicked"
-       data-track-action="/government/publications/coronavirus-covid-19-business-support-grant-funding-guidance-for-businesses"
-       data-track-label="Coronavirus guidance on business support grant funding"
-       href="/government/publications/coronavirus-covid-19-business-support-grant-funding-guidance-for-businesses">Coronavirus guidance on business support grant funding</a>
+    [Coronavirus guidance on business support grant funding](/government/publications/coronavirus-covid-19-business-support-grant-funding-guidance-for-businesses)
     $CTA
   <% end %>
 
@@ -173,11 +134,7 @@
 
     Local authority-run nurseries are not eligible.
 
-    <a data-module="track-click"
-       data-track-category="Internal Link Clicked"
-       data-track-action="/guidance/check-if-your-nursery-is-eligible-for-business-rates-relief-due-to-coronavirus-covid-19"
-       data-track-label="Check if your nursery is eligible for business rates relief due to coronavirus (COVID-19)"
-       href="/guidance/check-if-your-nursery-is-eligible-for-business-rates-relief-due-to-coronavirus-covid-19">Check if your nursery is eligible for business rates relief due to coronavirus (COVID-19)</a>
+    [Check if your nursery is eligible for business rates relief due to coronavirus (COVID-19)](/guidance/check-if-your-nursery-is-eligible-for-business-rates-relief-due-to-coronavirus-covid-19)
     $CTA
   <% end %>
 
@@ -199,11 +156,7 @@
 
     Contact your local council if you think you are eligible for a grant but have not yet received it.
 
-    <a data-module="track-click"
-       data-track-category="Internal Link Clicked"
-       data-track-action="/government/publications/coronavirus-covid-19-business-support-grant-funding-guidance-for-businesses"
-       data-track-label="Coronavirus: business support grant funding guidance for businesses"
-       href="/government/publications/coronavirus-covid-19-business-support-grant-funding-guidance-for-businesses">Coronavirus: business support grant funding guidance for businesses</a>
+    [Coronavirus: business support grant funding guidance for businesses](/government/publications/coronavirus-covid-19-business-support-grant-funding-guidance-for-businesses)
     $CTA
   <% end %>
 
@@ -215,11 +168,7 @@
 
     You can get a grant of £25,000, £10,000 or any amount under £10,000.
 
-    <a data-module="track-click"
-       data-track-category="Internal Link Clicked"
-       data-track-action="/guidance/apply-for-the-coronavirus-local-authority-discretionary-grants-fund"
-       data-track-label="Check if your business is eligible for the Discretionary Grant Fund"
-       href="/guidance/apply-for-the-coronavirus-local-authority-discretionary-grants-fund">Check if your business is eligible for the Discretionary Grant Fund</a>
+    [Check if your business is eligible for the Discretionary Grant Fund](/guidance/apply-for-the-coronavirus-local-authority-discretionary-grants-fund)
     $CTA
   <% end %>
 
@@ -239,11 +188,7 @@
     - you have a borrowing proposal which would be considered viable by the lender, if not for the current pandemic
     - you can self-certify that coronavirus (COVID-19) has adversely impacted your business
 
-    <a data-module="track-click"
-       data-track-category="Internal Link Clicked"
-       data-track-action="/guidance/apply-for-the-coronavirus-business-interruption-loan-scheme"
-       data-track-label="Apply for the Coronavirus Business Interruption Loan Scheme"
-       href="/guidance/apply-for-the-coronavirus-business-interruption-loan-scheme">Apply for the Coronavirus Business Interruption Loan Scheme</a>
+    [Apply for the Coronavirus Business Interruption Loan Scheme](/guidance/apply-for-the-coronavirus-business-interruption-loan-scheme)
     $CTA
   <% end %>
 
@@ -262,11 +207,7 @@
 
     This includes self-employed people.
 
-    <a data-module="track-click"
-       data-track-category="Internal Link Clicked"
-       data-track-action="/guidance/apply-for-a-coronavirus-bounce-back-loan"
-       data-track-label="Apply for a Coronavirus Bounce Back loan"
-       href="/guidance/apply-for-a-coronavirus-bounce-back-loan">Apply for a Coronavirus Bounce Back loan</a>
+    [Apply for a Coronavirus Bounce Back loan](/guidance/apply-for-a-coronavirus-bounce-back-loan)
     $CTA
   <% end %>
 
@@ -280,11 +221,7 @@
   - pays tax to the UK government
   - has outstanding tax liabilities
 
-  <a data-module="track-click"
-     data-track-category="Internal Link Clicked"
-     data-track-action="/difficulties-paying-hmrc"
-     data-track-label="If you cannot pay your tax bill on time"
-     href="/difficulties-paying-hmrc">If you cannot pay your tax bill on time</a>
+  [If you cannot pay your tax bill on time](/difficulties-paying-hmrc)
   $CTA
 
   <% if calculator.show?(:large_business_loan_scheme) %>
@@ -301,11 +238,7 @@
 
     The scheme is delivered through commercial lenders, supported by the Government-backed British Business Bank. Facilities backed by a guarantee under CLBILS are offered at commercial rates of interest.
 
-    <a data-module="track-click"
-       data-track-category="Internal Link Clicked"
-       data-track-action="/guidance/apply-for-the-coronavirus-large-business-interruption-loan-scheme"
-       data-track-label="Apply for the Coronavirus Large Business Interruption Loan Scheme"
-       href="/guidance/apply-for-the-coronavirus-large-business-interruption-loan-scheme">Apply for the Coronavirus Large Business Interruption Loan Scheme</a>
+    [Apply for the Coronavirus Large Business Interruption Loan Scheme](/guidance/apply-for-the-coronavirus-large-business-interruption-loan-scheme)
     $CTA
   <% end %>
 
@@ -323,11 +256,7 @@
     - it was incorporated on or before 31 December 2019
     - half or more employees are UK-based or half or more revenues are from UK sales
 
-    <a data-module="track-click"
-       data-track-category="Internal Link Clicked"
-       data-track-action="/guidance/future-fund"
-       data-track-label="Find out how to apply"
-       href="/guidance/future-fund">Find out how to apply</a>
+    [Find out how to apply](/guidance/future-fund)
     $CTA
   <% end %>
 
@@ -355,11 +284,7 @@
   Please note that you may be eligible for more than one scheme, whether your business is open or closed.
 
   For detailed information about different types of business support schemes, check the
-  <a data-module="track-click"
-     data-track-category="Internal Link Clicked"
-     data-track-action="/coronavirus/business-support"
-     data-track-label="coronavirus business support page"
-     href="/coronavirus/business-support">coronavirus business support page</a>.
+  [coronavirus business support page](/coronavirus/business-support).
 <% end %>
 
 <% render_content_for :body, format: :html do %>
@@ -368,11 +293,6 @@
       <path fill="black" d="M177.216 404.514c-.001.12-.009.239-.009.359 0 30.078 24.383 54.461 54.461 54.461s54.461-24.383 54.461-54.461c0-.12-.008-.239-.009-.359H175.216zM403.549 336.438l-49.015-72.002v-89.83c0-60.581-43.144-111.079-100.381-122.459V24.485C254.152 10.963 243.19 0 229.667 0s-24.485 10.963-24.485 24.485v27.663c-57.237 11.381-100.381 61.879-100.381 122.459v89.83l-49.015 72.002a24.76 24.76 0 0 0 20.468 38.693H383.08a24.761 24.761 0 0 0 20.469-38.694z"></path>
     </svg>
     <h3 class="govuk-heading-s app-c-email-link__title">Stay up to date</h3>
-    <a class="govuk-body govuk-link"
-       data-module="track-click"
-       data-track-category="Internal Link Clicked"
-       data-track-action="/email-signup/?topic=/coronavirus-taxon/funding-and-support"
-       data-track-label="Sign up for email updates about business funding and support"
-       href="/email-signup/?topic=/coronavirus-taxon/funding-and-support">Sign up for email updates about business funding and support</a>
+    <a class="govuk-body govuk-link" href="/email-signup/?topic=/coronavirus-taxon/funding-and-support">Sign up for email updates about business funding and support</a>
   </div>
 <% end %>


### PR DESCRIPTION
This adds a JS function that sets up GA tracking for internal links i.e. links within the same domain. It add an event listener to each link with a relevant href and sends a GA event if clicked. This is called on results pages to track user clicks and is needed by certain smart answer flows e.g.
business-coronavirus-support-finder.

This helper function makes it easier to enable internal link tracker, instead of having to manually add the correct data attribute to links to enable tracking. It will also help prevent future links from being missing in tracking, if the data attribute are forgotten to be added.