### PR TITLE
Fix typo in question

### DIFF
--- a/lib/smart_answer_flows/coronavirus-business-reopening/questions/send_or_receive_goods.erb
+++ b/lib/smart_answer_flows/coronavirus-business-reopening/questions/send_or_receive_goods.erb
@@ -1,5 +1,5 @@
 <% text_for :title do %>
-  Do you send and receive good on your site?
+  Do you send and receive goods on your site?
 <% end %>
 
 <% options(


### PR DESCRIPTION
This fixes a typo in a question for the coronavirus business reopening flow.