### PR TITLE
Fix wrapping of COVID-19 to not break on wrapping

### DIFF
--- a/lib/smart_answer_flows/business-coronavirus-support-finder/business_coronavirus_support_finder.govspeak.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/business_coronavirus_support_finder.govspeak.erb
@@ -3,14 +3,14 @@
 <% end %>
 
 <% render_content_for :meta_description do %>
-  Coronavirus (COVID-19) support is available to employers and the
+  Coronavirus (COVID‑19) support is available to employers and the
   self-employed, including sole traders and limited company directors.
   You may be eligible for loans, tax relief and cash grants, whether your
   business is open or closed.
 <% end %>
 
 <% render_content_for :body do %>
-  Coronavirus (COVID-19) support is available to employers and the
+  Coronavirus (COVID‑19) support is available to employers and the
   self-employed, including sole traders and limited company directors.
   You may be eligible for loans, tax relief and cash grants, whether your
   business is open or closed.

--- a/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.govspeak.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.govspeak.erb
@@ -45,7 +45,7 @@
     $CTA
     ### Statutory Sick Pay rebate
 
-    Employers can reclaim Statutory Sick Pay (SSP) paid for sickness absence due to COVID-19. This scheme will cover up to 2 weeks of SSP for every eligible employee.
+    Employers can reclaim Statutory Sick Pay (SSP) paid for sickness absence due to COVID‑19. This scheme will cover up to 2 weeks of SSP for every eligible employee.
 
     Employers must maintain records of staff absences and payments for SSP. Employees will not have to provide a GP fit note.
 
@@ -54,7 +54,7 @@
     - UK based
     - small or medium-sized and employs fewer than 250 employees as of 28 February 2020
 
-    [Claim back Statutory Sick Pay paid to employees due to coronavirus (COVID-19)](/guidance/claim-back-statutory-sick-pay-paid-to-employees-due-to-coronavirus-covid-19)
+    [Claim back Statutory Sick Pay paid to employees due to coronavirus (COVID‑19)](/guidance/claim-back-statutory-sick-pay-paid-to-employees-due-to-coronavirus-covid-19)
     $CTA
   <% end %>
 
@@ -98,7 +98,7 @@
     - assembly or leisure property - for example, a sports club, a gym or a spa
     - hospitality property - for example, a hotel, a guest house or self-catering accommodation
 
-    [Check if your retail, hospitality or leisure business is eligible for business rates relief due to coronavirus (COVID-19)](/guidance/check-if-your-retail-hospitality-or-leisure-business-is-eligible-for-business-rates-relief-due-to-coronavirus-covid-19)
+    [Check if your retail, hospitality or leisure business is eligible for business rates relief due to coronavirus (COVID‑19)](/guidance/check-if-your-retail-hospitality-or-leisure-business-is-eligible-for-business-rates-relief-due-to-coronavirus-covid-19)
     $CTA
   <% end %>
 
@@ -134,7 +134,7 @@
 
     Local authority-run nurseries are not eligible.
 
-    [Check if your nursery is eligible for business rates relief due to coronavirus (COVID-19)](/guidance/check-if-your-nursery-is-eligible-for-business-rates-relief-due-to-coronavirus-covid-19)
+    [Check if your nursery is eligible for business rates relief due to coronavirus (COVID‑19)](/guidance/check-if-your-nursery-is-eligible-for-business-rates-relief-due-to-coronavirus-covid-19)
     $CTA
   <% end %>
 
@@ -186,7 +186,7 @@
 
     - your business is UK-based, with a turnover of no more than £45 million per year
     - you have a borrowing proposal which would be considered viable by the lender, if not for the current pandemic
-    - you can self-certify that coronavirus (COVID-19) has adversely impacted your business
+    - you can self-certify that coronavirus (COVID‑19) has adversely impacted your business
 
     [Apply for the Coronavirus Business Interruption Loan Scheme](/guidance/apply-for-the-coronavirus-business-interruption-loan-scheme)
     $CTA

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/questions/coronavirus_related.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/questions/coronavirus_related.govspeak.erb
@@ -1,5 +1,5 @@
 <% render_content_for :title do %>
-  Is your employee off work because of coronavirus (COVID-19)?
+  Is your employee off work because of coronavirus (COVID‑19)?
 <% end %>
 
 <% options(

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/questions/coronavirus_self_or_cohabitant.govspeak.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/questions/coronavirus_self_or_cohabitant.govspeak.erb
@@ -1,5 +1,5 @@
 <% render_content_for :title do %>
-  Has your employee or someone they live with got symptoms of coronavirus (COVID-19)?
+  Has your employee or someone they live with got symptoms of coronavirus (COVID‑19)?
 <% end %>
 
 <% options(

--- a/lib/smart_answer_flows/coronavirus-business-reopening/coronavirus_business_reopening.erb
+++ b/lib/smart_answer_flows/coronavirus-business-reopening/coronavirus_business_reopening.erb
@@ -1,5 +1,5 @@
 <% text_for :title do %>
-  Reopen your business safely during coronavirus (COVID-19)
+  Reopen your business safely during coronavirus (COVID‑19)
 <% end %>
 
 <% text_for :meta_description do %>

--- a/lib/smart_answer_flows/coronavirus-business-reopening/outcomes/_cleaning.erb
+++ b/lib/smart_answer_flows/coronavirus-business-reopening/outcomes/_cleaning.erb
@@ -1,6 +1,6 @@
 ## Cleaning
 
-% If someone has symptoms follow the [specific instructions for cleaning after a case of COVID-19](/government/publications/covid-19-decontamination-in-non-healthcare-settings/covid-19-decontamination-in-non-healthcare-settings).  %
+% If someone has symptoms follow the [specific instructions for cleaning after a case of COVID‑19](/government/publications/covid-19-decontamination-in-non-healthcare-settings/covid-19-decontamination-in-non-healthcare-settings).  %
 
 To minimise the risk of the virus spreading you should:
 

--- a/lib/smart_answer_flows/coronavirus-business-reopening/outcomes/_main.erb
+++ b/lib/smart_answer_flows/coronavirus-business-reopening/outcomes/_main.erb
@@ -1,4 +1,4 @@
-This guidance can help you carry out your risk assessment to make sure you keep employees and other people on site safe when opening during coronavirus (COVID-19).
+This guidance can help you carry out your risk assessment to make sure you keep employees and other people on site safe when opening during coronavirus (COVID‑19).
 
 You should also consider the security implications of any decisions and control measures you intend to put in place, as any revisions could present new or altered security risks that may require mitigation.
 
@@ -83,4 +83,4 @@ You should also consider the security implications of any decisions and control 
 ## More help with your risk assessment
 
 [Read the detailed guidance for your sector](https://www.gov.uk/guidance/working-safely-during-coronavirus-covid-19).
-This guidance can help you carry out your risk assessment to make sure you keep employees and other people on site safe when opening during coronavirus (COVID-19).
+This guidance can help you carry out your risk assessment to make sure you keep employees and other people on site safe when opening during coronavirus (COVID‑19).

--- a/lib/smart_answer_flows/landlord-immigration-check/landlord_immigration_check.govspeak.erb
+++ b/lib/smart_answer_flows/landlord-immigration-check/landlord_immigration_check.govspeak.erb
@@ -15,7 +15,7 @@
 
   If you’ve bought a property that already has tenants, you need proof that their last landlord did the check. You’ll still be responsible for carrying out [further checks](/check-tenant-right-to-rent-documents/further-checks) on your tenants in future.
 
-  Because of coronavirus (COVID-19) there are [temporary changes to the way you can check documents](/guidance/coronavirus-covid-19-landlord-right-to-rent-checks). These changes include asking for documents digitally, making checks on a video call, and what to do if someone cannot provide any accepted documents.
+  Because of coronavirus (COVID‑19) there are [temporary changes to the way you can check documents](/guidance/coronavirus-covid-19-landlord-right-to-rent-checks). These changes include asking for documents digitally, making checks on a video call, and what to do if someone cannot provide any accepted documents.
 
   ^Read more about the [right to rent documents](/government/publications/right-to-rent-document-checks-a-user-guide) you can accept.^
 

--- a/lib/smart_answer_flows/vat-payment-deadlines/vat_payment_deadlines.govspeak.erb
+++ b/lib/smart_answer_flows/vat-payment-deadlines/vat_payment_deadlines.govspeak.erb
@@ -12,7 +12,7 @@
   You can't use this calculator if you make payments on account or use the annual
   accounting scheme.
 
-^ Because of coronavirus (COVID-19), you can delay (defer) any VAT payments due between 20 March 2020 and 30 June 2020. If you choose to defer a VAT payment, you will have until 31 March 2021 to pay it.
+^ Because of coronavirus (COVID‑19), you can delay (defer) any VAT payments due between 20 March 2020 and 30 June 2020. If you choose to defer a VAT payment, you will have until 31 March 2021 to pay it.
 
   Most businesses must [keep digital VAT records and use software to submit VAT Returns](/guidance/check-when-a-business-must-follow-the-rules-for-making-tax-digital-for-vat).
 <% end %>


### PR DESCRIPTION
This replaces the hyphen with a unicode non-breaking hyphen to prevent wrapping in the middle of the word COVID-19.