### PR TITLE
Remove last updated date on pages

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,10 +1,4 @@
 module ApplicationHelper
-  def last_updated_date
-    File.mtime(Rails.root.join("REVISION")).to_date
-  rescue StandardError
-    Time.zone.today
-  end
-
   def current_path_without_query_string
     request.original_fullpath.split("?", 2).first
   end

--- a/app/views/layouts/smart_answers.html.erb
+++ b/app/views/layouts/smart_answers.html.erb
@@ -10,8 +10,6 @@
 
 <main id="content" role="main">
   <%= yield %>
-
-  <%= render 'smartanswer_metadata' %>
 </main>
 
 <% parent_layout 'application' %>

--- a/app/views/smart_answers/_smartanswer_metadata.html.erb
+++ b/app/views/smart_answers/_smartanswer_metadata.html.erb
@@ -1,3 +1,0 @@
-<p class="app-c-meta-data">
-  Last updated: <%= last_updated_date.strftime('%e %B %Y') %>
-</p>


### PR DESCRIPTION
This removes "Last updated" date on the bottom of smart answer pages as it is inaccurate and potentially confusing for user.

This feature was implemented to show the last updated date to be the date when the application was last deployed. This means the last_updated date reflected any change to any smart answer and may have not even been a user facing change. This may give the user a false sense of confidence that the content in the smart answer is up to date.