### PR TITLE
Use production GOV.UK for heroku

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,12 +4,11 @@
   "repository": "https://github.com/alphagov/smart-answers",
   "success_url": "/",
   "env": {
-    "GOVUK_APP_DOMAIN": "integration.publishing.service.gov.uk",
+    "GOVUK_APP_DOMAIN": "www.gov.uk",
     "GOVUK_WEBSITE_ROOT": "https://www.gov.uk",
     "PLEK_SERVICE_CONTENT_STORE_URI": "https://www.gov.uk/api" ,
-    "PLEK_SERVICE_STATIC_URI": "https://assets.integration.publishing.service.gov.uk/",
-    "RUNNING_ON_HEROKU": "true",
-    "ERRBIT_ENV": "integration"
+    "PLEK_SERVICE_STATIC_URI": "https://assets.publishing.service.gov.uk/",
+    "RUNNING_ON_HEROKU": "true"
   },
   "image": "heroku/ruby",
   "buildpacks": [ { "url": "heroku/ruby" } ],


### PR DESCRIPTION
This app is configured to use integration for the heroku preview
environment. This is inconsistent with other frontend apps (such as
government-frontend [1]) which use production.

Using integration presents us with some problems loading assets as
integration is behind basic authentication - this problem wasn't present
before changing assets to the www hostname as we don't (oddly) have
basic authentication on assets.integration.publishing.service.gov.uk.

[1]: https://github.com/alphagov/government-frontend/blob/38d12b68809953131ba008f55a02ea6db9464cf7/app.json