### PR TITLE
Update guidance link for employee risk tool

### DIFF
--- a/lib/smart_answer_flows/coronavirus-employee-risk-assessment/outcomes/go_back_to_work.govspeak.erb
+++ b/lib/smart_answer_flows/coronavirus-employee-risk-assessment/outcomes/go_back_to_work.govspeak.erb
@@ -3,7 +3,7 @@
     ## You can go back to work
     You can go back into work, but your employer must make arrangements for you to work safely.
 
-    [Check the guidance on working safely, and what you will need to do](https://www.gov.uk/guidance/working-safely-during-coronavirus-covid-19)
+    [Check the guidance on working safely, and what you will need to do](https://www.gov.uk/coronavirus-business-reopening)
   $CTA
   <%= render "come_back" %>
 <% end %>

--- a/lib/smart_answer_flows/coronavirus-employee-risk-assessment/outcomes/keep_your_household_safe.govspeak.erb
+++ b/lib/smart_answer_flows/coronavirus-employee-risk-assessment/outcomes/keep_your_household_safe.govspeak.erb
@@ -1,7 +1,7 @@
 <% render_content_for :body do %>
   $CTA
     ## Get advice on how to socially distance at work and keep your household safe
-    If you cannot work from home, you should make sure your employer is following guidance on [how to work safely during the coronavirus pandemic](https://www.gov.uk/guidance/working-safely-during-coronavirus-covid-19).
+    If you cannot work from home, you should make sure your employer is following guidance on [how to work safely during the coronavirus pandemic](https://www.gov.uk/coronavirus-business-reopening).
 
     Employers should pay particular attention to people who live with clinically extremely vulnerable individuals.
 

--- a/lib/smart_answer_flows/coronavirus-employee-risk-assessment/outcomes/vulnerable_work_arrangements.govspeak.erb
+++ b/lib/smart_answer_flows/coronavirus-employee-risk-assessment/outcomes/vulnerable_work_arrangements.govspeak.erb
@@ -8,7 +8,7 @@
 
     If you have to spend time within 2 metres of others, employers should carefully assess whether this involves an acceptable level of risk. As for any workplace risk, employers must take into account specific duties to those with protected characteristics, including, for example, pregnant women who are entitled to a suspension on full pay if suitable roles cannot be found.
 
-    [Find out more about how to work safely in your workplace](https://www.gov.uk/guidance/working-safely-during-coronavirus-covid-19).
+    [Find out more about how to work safely in your workplace](https://www.gov.uk/coronavirus-business-reopening).
   $CTA
   <%= render "come_back" %>
 <% end %>


### PR DESCRIPTION
## What
In the employee re-entry tool, we are changing the link from: https://www.gov.uk/guidance/working-safely-during-coronavirus-covid-19
to
https://www.gov.uk/coronavirus-business-reopening

## Why
So that we show employees the correct version of guidance

