### PR TITLE
Improve print styles

### DIFF
--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -1,1 +1,23 @@
 @import "govuk_publishing_components/all_components_print";
+
+.smart_answer {
+  margin-left: 0;
+  margin-right: 0;
+  max-width: none;
+
+  .outcome {
+    width: 100%;
+  }
+
+  .previous-answers-table {
+    th:last-child,
+    td:last-child {
+      display: none;
+    }
+
+    .govuk-table__cell,
+    .govuk-table__header {
+      padding: govuk-spacing(2);
+    }
+  }
+}

--- a/app/assets/stylesheets/smart_answers.scss
+++ b/app/assets/stylesheets/smart_answers.scss
@@ -4,6 +4,15 @@ $is-ie: false !default;
 // The more generic SmartAnswer CSS is in Static _multi_step.scss
 
 .smart_answer {
+  @include govuk-media-query($media-type: print) {
+    .previous-answers-table {
+      th:last-child,
+      td:last-child {
+        display: none;
+      }
+    }
+  }
+
   a:not(.govuk-button):focus {
     @include govuk-focused-text;
   }

--- a/app/assets/stylesheets/smart_answers.scss
+++ b/app/assets/stylesheets/smart_answers.scss
@@ -4,23 +4,6 @@ $is-ie: false !default;
 // The more generic SmartAnswer CSS is in Static _multi_step.scss
 
 .smart_answer {
-  @include govuk-media-query($media-type: print) {
-    max-width: none;
-    margin-right: 0;
-    margin-left: 0;
-
-    .outcome {
-      width: 100%;
-    }
-
-    .previous-answers-table {
-      th:last-child,
-      td:last-child {
-        display: none;
-      }
-    }
-  }
-
   a:not(.govuk-button):focus {
     @include govuk-focused-text;
   }

--- a/app/assets/stylesheets/smart_answers.scss
+++ b/app/assets/stylesheets/smart_answers.scss
@@ -5,6 +5,14 @@ $is-ie: false !default;
 
 .smart_answer {
   @include govuk-media-query($media-type: print) {
+    max-width: none;
+    margin-right: 0;
+    margin-left: 0;
+
+    .outcome {
+      width: 100%;
+    }
+
     .previous-answers-table {
       th:last-child,
       td:last-child {

--- a/app/views/smart_answers/_previous_answers.html.erb
+++ b/app/views/smart_answers/_previous_answers.html.erb
@@ -1,5 +1,5 @@
 <% if @presenter.current_question_number > 1 %>
-  <table class="govuk-table">
+  <table class="govuk-table previous-answers-table">
     <caption class="govuk-table__caption">
       <h2 class="govuk-heading-m">Previous answers</h2>
       <p class="govuk-body"><%= link_to "Start again", smart_answer_path(params[:id]), :class => "govuk-link" %></p>


### PR DESCRIPTION
## What
This PR improves the page styles for printing by:
- hiding the "change your answer" column in the previous answers table
- add consistent padding to cells of the previous answers table
- spans body text of result to the full width of the page

## Visual changes
<img width="1270" alt="image" src="https://user-images.githubusercontent.com/11051676/85595037-63fe6500-b640-11ea-977b-55f1b3f4156f.png">

<img width="1282" alt="image" src="https://user-images.githubusercontent.com/11051676/85595303-9f009880-b640-11ea-846c-ebce1c98ca9e.png">

