### PR TITLE
Add driving schools to business re-entry flow

### DIFF
--- a/lib/smart_answer_flows/coronavirus-employee-risk-assessment.rb
+++ b/lib/smart_answer_flows/coronavirus-employee-risk-assessment.rb
@@ -11,6 +11,7 @@ module SmartAnswer
         option :food_and_drink
         option :salon_parlour
         option :retail
+        option :driving_schools
         option :auction_house
         option :holiday_accommodation
         option :libraries

--- a/lib/smart_answer_flows/coronavirus-employee-risk-assessment/questions/where_do_you_work.govspeak.erb
+++ b/lib/smart_answer_flows/coronavirus-employee-risk-assessment/questions/where_do_you_work.govspeak.erb
@@ -8,6 +8,7 @@
   "retail": "Retail",
   "auction_house": "Auction houses",
   "holiday_accommodation": "Holiday accommodation or caravan parks",
+  "driving_schools": "Driving schools and instructors",
   "libraries": "Libraries",
   "community_centre": "Community centres",
   "places_of_worship": "Places of worship",


### PR DESCRIPTION
This adds driving schools and instructors to the list options for the "Where do you work?" question.

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.
