### PR TITLE
Add print link to coronavirus business reopening results

### DIFF
--- a/lib/smart_answer_flows/coronavirus-business-reopening/outcomes/_main.erb
+++ b/lib/smart_answer_flows/coronavirus-business-reopening/outcomes/_main.erb
@@ -84,3 +84,5 @@ You should also consider the security implications of any decisions and control 
 
 [Read the detailed guidance for your sector](https://www.gov.uk/guidance/working-safely-during-coronavirus-covid-19).
 This guidance can help you carry out your risk assessment to make sure you keep employees and other people on site safe when opening during coronavirus (COVID‑19).
+
+<%= render "govuk_publishing_components/components/print_link", text: "Print this page" %>


### PR DESCRIPTION
We've seen the user need to print this results page, this print link aims to help users understand how to print.
