### PR TITLE
Add exception page for Coronavirus employee risk assessment flow

### DIFF
--- a/lib/smart_answer_flows/coronavirus-employee-risk-assessment.rb
+++ b/lib/smart_answer_flows/coronavirus-employee-risk-assessment.rb
@@ -38,6 +38,7 @@ module SmartAnswer
           when
             "food_and_drink",
             "retail",
+            "driving_schools",
             "holiday_accommodation",
             "libraries",
             "community_centre",

--- a/lib/smart_answer_flows/coronavirus-employee-risk-assessment/questions/is_your_workplace_an_exception.govspeak.erb
+++ b/lib/smart_answer_flows/coronavirus-employee-risk-assessment/questions/is_your_workplace_an_exception.govspeak.erb
@@ -1,7 +1,7 @@
 <%
   workplace = calculator.where_do_you_work
   case workplace
-  when "museums_or_galleries", "cinema", "indoor_attraction", "retail"
+  when "driving_schools", "museums_or_galleries", "cinema", "indoor_attraction", "retail"
     options = {
       "yes": "Yes",
       "no": "No",
@@ -45,6 +45,9 @@
   <% end %>
 
   <% case workplace %>
+  <% when "driving_schools" %>
+    - driving schools or instructors providing lessions to key workers preparing for an emergency driving test
+    - test centres running emergency driving tests for key workers
   <% when "food_and_drink" %>
     - food delivery and takeaway - this can be a new activity; this covers the provision of hot and cold food that’s been prepared for consumers for collection or delivery to be consumed, reheated or cooked off the premises
     - room services in hotels and accommodation


### PR DESCRIPTION
This adds an exceptions page for driving schools.
<img width="865" alt="image" src="https://user-images.githubusercontent.com/11051676/85851464-a3df5c80-b7a6-11ea-83af-2a64f8afd2e0.png">

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.