### PR TITLE
Remove notice about closed workplaces

### DIFF
--- a/lib/smart_answer_flows/coronavirus-employee-risk-assessment/outcomes/you_should_not_be_going_to_work.erb
+++ b/lib/smart_answer_flows/coronavirus-employee-risk-assessment/outcomes/you_should_not_be_going_to_work.erb
@@ -13,5 +13,11 @@
     If your salary is reduced because of these changes, [check if you’re eligible for Universal Credit](https://www.gov.uk/universal-credit/eligibility).
   $CTA
 
+  $CTA
+    ## If there is still work to do
+
+    Your employer might ask you to work from home or come into work.
+  $CTA
+
   <%= render "come_back" %>
 <% end %>


### PR DESCRIPTION
This added confusion for users in the coronavirus employee risk assessment.

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.
