### PR TITLE
Remove part of hint text on "Where do you work?"

### DIFF
--- a/lib/smart_answer_flows/coronavirus-employee-risk-assessment/questions/where_do_you_work.erb
+++ b/lib/smart_answer_flows/coronavirus-employee-risk-assessment/questions/where_do_you_work.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% text_for :hint do %>
-  This list does not include all types of businesses that are currently open or allowed to open soon. If your workplace is not in the list, please select the last option 'None of these'.
+  If your workplace is not in the list, please select the last option 'None of these'.
 <% end %>
 
 <% options(


### PR DESCRIPTION
This is simplifies the hint text for users on the "Where do you work?" question for the coronavirus employee risk assessment tool.

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.
