### PR TITLE
Add link to reopening flow from "You can go back to work" outcome

### DIFF
--- a/lib/smart_answer_flows/coronavirus-employee-risk-assessment/outcomes/go_back_to_work.erb
+++ b/lib/smart_answer_flows/coronavirus-employee-risk-assessment/outcomes/go_back_to_work.erb
@@ -56,7 +56,7 @@
     $CTA
       You can go back into work, but your employer must make arrangements for you to work safely.
 
-      Check the guidance on working safely, and what you will need to do.
+      Check the [guidance on working safely, and what you will need to do.](/coronavirus-business-reopening)
     $CTA
   <% end %>
 


### PR DESCRIPTION
For the Coronavirus employee risk assessment we are adding a link to the Coronavirus business reopening flow on the results page informing users they can go back to work.

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.
