### PR TITLE
Fix missing workplace closure messages for restaurants

### DIFF
--- a/lib/smart_answer/calculators/coronavirus_employee_risk_assessment_calculator.rb
+++ b/lib/smart_answer/calculators/coronavirus_employee_risk_assessment_calculator.rb
@@ -1,6 +1,7 @@
 module SmartAnswer::Calculators
   class CoronavirusEmployeeRiskAssessmentCalculator
     WORKPLACES_CLOSED_TO_PUBLIC = %w[
+      food_and_drink
       beauty_parlour
       retail
       auction_house


### PR DESCRIPTION
This is for the Coronavirus employee risk assessment.

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.
