### PR TITLE
Refactor headers in the Coronavirus business reopening flow

### DIFF
--- a/app/assets/stylesheets/smart_answers.scss
+++ b/app/assets/stylesheets/smart_answers.scss
@@ -21,6 +21,10 @@ $is-ie: false !default;
       @extend %govuk-heading-m;
     }
 
+    h4 {
+      @extend %govuk-heading-s;
+    }
+
     p {
       @extend %govuk-body-m;
     }

--- a/lib/smart_answer_flows/coronavirus-business-reopening/outcomes/_cleaning.erb
+++ b/lib/smart_answer_flows/coronavirus-business-reopening/outcomes/_cleaning.erb
@@ -37,10 +37,8 @@ There may be a risk of the virus coming into the workplace through goods, mercha
 - clean things like reusable delivery boxes regularly
 - minimising client contact with testers
 
----
-
 <% if calculator.sector?("construction") %>
-  ## Construction and outdoor work: cleaning the workplace
+  ### Construction and outdoor work
 
   When handling equipment you should:
 
@@ -54,12 +52,10 @@ There may be a risk of the virus coming into the workplace through goods, mercha
 
   - clean goods and merchandise entering the site
   - regularly clean vehicles, for example pallet trucks and forklift trucks
-
-  ---
 <% end %>
 
 <% if calculator.sector?("factories") %>
-  ## Factories: cleaning the workplace
+  ### Factories
 
   Before you reopen you should:
 
@@ -74,12 +70,10 @@ There may be a risk of the virus coming into the workplace through goods, mercha
   - clean parts of shared equipment that you touch after each use, such as tools and vehicles, for example pallet trucks, forklift trucks
   - clean goods and vehicles that come on to the site
   - take special care when cleaning portable toilets
-
-  ---
 <% end %>
 
 <% if calculator.sector?("labs") %>
-  ## Labs and research facilities: cleaning the workplace
+  ### Labs and research facilities
 
   Before you reopen you should:
 
@@ -96,12 +90,10 @@ There may be a risk of the virus coming into the workplace through goods, mercha
   - work out how to clean expensive equipment that cannot be washed down and design protection around machines and equipment
   - make sure you have adequate disposal arrangements
   - restrict non-business deliveries, for example personal deliveries to workers to cut the risk of the virus coming into the workplace.
-
-  ---
 <% end %>
 
 <% if calculator.sector?("offices") %>
-  ## Offices: cleaning the workplace
+  ### Offices
 
   Before you reopen you should:
 
@@ -114,12 +106,10 @@ There may be a risk of the virus coming into the workplace through goods, mercha
   - frequently clean objects and surfaces that are touched regularly
   - limit or restrict the use of ‘high-touch’ items such as printers or whiteboards
   - restrict non-business deliveries, for example personal deliveries to workers
-
-  ---
 <% end %>
 
 <% if calculator.sector?("homes") %>
-  ## Other people’s homes: cleaning the work area
+  ### Other people’s homes
 
   If you work in people’s homes you need to minimise the risk of passing infection on to other people.
 
@@ -133,12 +123,10 @@ There may be a risk of the virus coming into the workplace through goods, mercha
   - collect materials in bulk to reduce how often you visit shops to buy or collect materials
   - get rid of waste in bulk if possible
   - remove all waste and belongings at the end of a job and arrange with the householder how to safely dispose of the waste.
-
-  ---
 <% end %>
 
 <% if calculator.sector?("hospitality") %>
-  ## Restaurants, pubs, bars and takeaway services: cleaning the workplace
+  ### Restaurants, pubs, bars and takeaway services
 
   ^ You should follow [government guidance on cleaning food preparation and service areas](/government/publications/covid-19-guidance-for-food-businesses/guidance-for-food-businesses-on-coronavirus-covid-19) at all times.  ^
 
@@ -162,12 +150,10 @@ There may be a risk of the virus coming into the workplace through goods, mercha
   - have bins for collecting used towels and employees overalls
   - clean the parts of shared equipment you touch after each use
   - handle laundry in a way that prevents contaminating surrounding surfaces, raising dust or dispersing the virus
-
-  ---
 <% end %>
 
 <% if calculator.sector?("shops") %>
-  ## Shops and branches: cleaning the workplace
+  ### Shops and branches
 
   Before you reopen you should:
   
@@ -183,9 +169,8 @@ There may be a risk of the virus coming into the workplace through goods, mercha
 
   You need to make sure you have adequate disposal arrangements.
 
-  ### Customer fitting rooms
+  #### Customer fitting rooms
  
-
   You should:
 
   - consider very carefully if you want to keep fitting rooms open
@@ -193,7 +178,7 @@ There may be a risk of the virus coming into the workplace through goods, mercha
   - create procedures to manage clothes that have been tried on, for example delaying their return to the shop floor
   - limit contact between customers and employees during fitting, for example by suspending fitting help
 
-  ### Handling goods, merchandise and other materials
+  #### Handling goods, merchandise and other materials
 
   You should:
 
@@ -204,18 +189,16 @@ There may be a risk of the virus coming into the workplace through goods, mercha
   - try to do contactless refunds
   - keep returned goods separate from displayed goods and stock
   - give workers guidance on how they can safely help customers when selling large items
-
-  ---
 <% end %>
 
 <% if calculator.sector?("vehicles") %>
-  ## Vehicles: cleaning the workplace
+  ### Vehicles
 
   You should:
 
   - encourage workers to wash their hands before getting in their vehicles
   - keep enough hand sanitiser or wipes inside so that they can clean their hands after each delivery or drop off
   - make sure drivers can get to toilets during their journeys and when they arrive at their destinations, for example use prior booking in
-
-  ---
 <% end %>
+
+---

--- a/lib/smart_answer_flows/coronavirus-business-reopening/outcomes/_social_distancing.erb
+++ b/lib/smart_answer_flows/coronavirus-business-reopening/outcomes/_social_distancing.erb
@@ -30,20 +30,6 @@ Where you cannot stay 2 metres apart (or 1 metre with risk mitigation where 2 me
 - work side by side or back-to-back rather than face-to-face
 - have fixed teams to minimise exposure
 
-<% if calculator.sector?("hospitality") %>
-### Managing service of food and drink
-
-You should:
-
-- maintain social distancing (2 metres apart, or 1 metre with risk mitigation where 2m is not viable) from customers when taking orders from customers
-- minimise customers’ self-service of food, cutlery and condiments to reduce risk of transmission
-- encourage contactless payments where possible and adjust the location of card readers to follow social distancing guidelines
-- provide only disposable condiments or cleaning non-disposable condiment containers after each use.
-- reducing the number of surfaces touched by both staff and customers
-- minimise contact between front-of-house workers and customers at points of service where appropriate
-- ensure all outdoor areas, especially covered areas, have sufficient ventilation
-
-<% end %>
 ### Entrances and exits
 
 You should:
@@ -70,22 +56,17 @@ You should:
 - stagger break times and, if possible, have breaks outdoors
 - arrange seating in break areas 2 metres apart (or 1 metre with risk mitigation)
 
----
-
 <% if calculator.sector?("construction") %>
-  ## Construction and outdoor work: social distancing
+  ### Construction and outdoor work
 
   You should:
 
   - plan how people access the site and ‘areas of safety’ points to make sure they can stay 2 meters apart
   - keep the number of people to a minimum for site inductions and have them outdoors where possible
-
-  
-  ---
 <% end %>
 
 <% if calculator.sector?("labs") %>
-  ## Labs and research facilities: social distancing
+  ### Labs and research facilities
 
   You should:
 
@@ -97,26 +78,20 @@ You should:
   - reduce the number of people using a lab at one time, for example by booking it
   - limit the number of people handling equipment
   - make sure air filters in high-risk areas are installed and maintained to reduce the risk from airborne particles
-
-  
-  ---
 <% end %>
 
 <% if calculator.sector?("offices") %>
-  ## Offices and contact centres: social distancing
+  ### Offices and contact centres
 
   You should:
 
   - avoid hotdesking as much as possible
   - sanitise workstations between occupants where people share
   - rearrange desks to avoid face-to-face working
-
-  
-  ---
 <% end %>
 
 <% if calculator.sector?("homes") %>
-  ## Working in other people’s homes: social distancing
+  ### Working in other people’s homes
 
   To minimise risk from travelling to the home you should:
 
@@ -133,26 +108,32 @@ You should:
   - avoid busy spaces like corridors where possible
   - bring your own food to avoid going outside
   - not share things like pens and devices
-
-  
-  ---
 <% end %>
 
 <% if calculator.sector?("hospitality") %>
-  ## Restaurants with takeaway and delivery: social distancing
+  ### Managing service of food and drink
+
+  You should:
+
+  - maintain social distancing (2 metres apart, or 1 metre with risk mitigation where 2m is not viable) from customers when taking orders from customers
+  - minimise customers’ self-service of food, cutlery and condiments to reduce risk of transmission
+  - encourage contactless payments where possible and adjust the location of card readers to follow social distancing guidelines
+  - provide only disposable condiments or cleaning non-disposable condiment containers after each use.
+  - reducing the number of surfaces touched by both staff and customers
+  - minimise contact between front-of-house workers and customers at points of service where appropriate
+  - ensure all outdoor areas, especially covered areas, have sufficient ventilation
+
+  ### Restaurants with takeaway and delivery
 
   You should:
 
   - encourage customers to order online or over the phone
   - minimise contact between kitchen employees and front-of-house or delivery drivers by arranging drop-off and pick up points
   - set out floor markings and signs to encourage takeaway customers and delivery drivers to maintain social distancing (see government guidance on food safety for food delivery)
-
-  
-  ---
 <% end %>
 
 <% if calculator.sector?("shops") %>
-  ## Retail: social distancing
+  ### Retail
 
   You should:
 
@@ -161,13 +142,10 @@ You should:
   - minimise contact when customers are paying, for example by using contactless
   - think about how to display promotional materials to allow employees and customers to stay 2 meters apart
   - encourage employees to stay on site during the day - if they go out, for example for lunch, they should social distance
-
-  
-  ---
 <% end %>
 
 <% if calculator.sector?("vehicles") %>
-  ## Using vehicles: social distancing
+  ### Using vehicles
 
   You should: 
 
@@ -177,7 +155,6 @@ You should:
   - have collection slots for picking up goods
   - load vehicles without contact with the driver
   - avoid having 2 people for deliveries, for example by delaying bigger orders, or have fixed pairs if this is not possible
-
-  
-  ---
 <% end %>
+
+---


### PR DESCRIPTION
This removes separate H2 headings for sector specific advice for social distance and cleaning. The sector specific advice is shown under the general H2 heading with a H3 for the sector.

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.
