### PR TITLE
Move close contact section in Coronavirus business reopening

### DIFF
--- a/lib/smart_answer_flows/coronavirus-business-reopening/outcomes/_main.erb
+++ b/lib/smart_answer_flows/coronavirus-business-reopening/outcomes/_main.erb
@@ -1,3 +1,7 @@
+This guidance can help you carry out your risk assessment to make sure you keep employees and other people on site safe when opening during coronavirus (COVID‑19).
+
+You should also consider the security implications of any decisions and control measures you intend to put in place, as any revisions could present new or altered security risks that may require mitigation.
+
 <% if calculator.sector?("close_contact") %>
   Close contact services include:
 
@@ -21,10 +25,6 @@
 
   The other services outlined above will remain closed until further notice subject to the [5 tests](/government/publications/our-plan-to-rebuild-the-uk-governments-covid-19-recovery-strategy/our-plan-to-rebuild-the-uk-governments-covid-19-recovery-strategy#moving-to-the-next-phase), but this guidance will help you prepare for reopening.
 <% end %>
-
-This guidance can help you carry out your risk assessment to make sure you keep employees and other people on site safe when opening during coronavirus (COVID‑19).
-
-You should also consider the security implications of any decisions and control measures you intend to put in place, as any revisions could present new or altered security risks that may require mitigation.
 
 <% if calculator.sector?("hospitality") %>
 This guidance is to help you prepare to open your business from 4 July 2020.


### PR DESCRIPTION
This moves the conditional guidance for close contact under the generic statement for results page in the Coronavirus business reopening tool.

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.
