### PR TITLE
Fix error thrown for invalid request format in URL

### DIFF
--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -26,7 +26,7 @@ class SmartAnswersController < ApplicationController
   def show
     @title = @presenter.title
 
-    render page_type
+    render page_type, formats: [:html]
 
     set_expiry
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,10 +9,10 @@ Rails.application.routes.draw do
   constraints id: /[a-z0-9-]+/i do
     get "/:id/y/visualise(.:format)", to: "smart_answers#visualise", as: :visualise
 
-    get "/:id(/:started(/*responses)).:format",
+    get "/:id(/:started(/*responses))",
         to: "smart_answers#show",
         as: :formatted_smart_answer,
-        constraints: { format: /[a-zA-Z]+/ }
+        format: false
 
     get "/:id(/:started(/*responses))",
         to: "smart_answers#show",


### PR DESCRIPTION
This fixes an issues where an 500 error is returned if users request a url with a format that is not `html` i.e. `ics`. The only possible format for landing, question and result pages is HTML.

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.
