### PR TITLE
Removed VAT deferral callout

### DIFF
--- a/lib/smart_answer_flows/vat-payment-deadlines/vat_payment_deadlines.erb
+++ b/lib/smart_answer_flows/vat-payment-deadlines/vat_payment_deadlines.erb
@@ -12,7 +12,5 @@
   You can't use this calculator if you make payments on account or use the annual
   accounting scheme.
 
-^ Because of coronavirus (COVID‑19), you can delay (defer) any VAT payments due between 20 March 2020 and 30 June 2020. If you choose to defer a VAT payment, you will have until 31 March 2021 to pay it.
-
   Most businesses must [keep digital VAT records and use software to submit VAT Returns](/guidance/check-when-a-business-must-follow-the-rules-for-making-tax-digital-for-vat).
 <% end %>


### PR DESCRIPTION
https://trello.com/c/yytlF5dW/1776-removing-vat-deferral-content-from-vat-deadline-calculator

Removal of callout advising you can defer VAT payments as the deadline has now passed.
