### PR TITLE
Add workplace opening soon notice

### DIFF
--- a/lib/smart_answer/calculators/coronavirus_employee_risk_assessment_calculator.rb
+++ b/lib/smart_answer/calculators/coronavirus_employee_risk_assessment_calculator.rb
@@ -2,13 +2,16 @@ module SmartAnswer::Calculators
   class CoronavirusEmployeeRiskAssessmentCalculator
     WORKPLACES_CLOSED_TO_PUBLIC = %w[
       food_and_drink
-      beauty_parlour
       retail
       auction_house
       nightclubs_or_gambling
       leisure_centre
       indoor_recreation
     ].freeze
+
+    WORKPLACES_OPENING_SOON_TO_PUBLIC = {
+      "beauty_parlour" => "13 July 2020",
+    }.freeze
 
     attr_accessor :where_do_you_work,
                   :workplace_is_exception,
@@ -18,6 +21,10 @@ module SmartAnswer::Calculators
 
     def workplace_should_be_closed_to_public
       WORKPLACES_CLOSED_TO_PUBLIC.include?(where_do_you_work) && !workplace_is_exception
+    end
+
+    def workplace_opening_date
+      WORKPLACES_OPENING_SOON_TO_PUBLIC[where_do_you_work] unless workplace_is_exception
     end
   end
 end

--- a/lib/smart_answer_flows/coronavirus-employee-risk-assessment/outcomes/go_back_to_work.erb
+++ b/lib/smart_answer_flows/coronavirus-employee-risk-assessment/outcomes/go_back_to_work.erb
@@ -62,8 +62,10 @@
 
   <% if calculator.workplace_should_be_closed_to_public %>
     ### Your workplace should be closed to the public
-    
+
     If there is still work to do despite your workplace being closed to the public, your employer might ask you to work from home or come into work.
+  <% elsif calculator.workplace_opening_date %>
+    **Your workplace can be open to the public from <%= calculator.workplace_opening_date %>**
   <% end %>
 
 

--- a/test/unit/calculators/coronavirus_employee_risk_assessment_calculator_test.rb
+++ b/test/unit/calculators/coronavirus_employee_risk_assessment_calculator_test.rb
@@ -25,5 +25,22 @@ module SmartAnswer::Calculators
         assert_not @calculator.workplace_should_be_closed_to_public
       end
     end
+
+    context "#workplace_opening_date" do
+      should "return nil when for workplace not reopening" do
+        @calculator.where_do_you_work = "retail"
+        assert_equal nil, @calculator.workplace_opening_date
+      end
+
+      should "return nil when for workplace already open" do
+        @calculator.where_do_you_work = "other"
+        assert_equal nil, @calculator.workplace_opening_date
+      end
+
+      should "return date when workplace is reopening soon" do
+        @calculator.where_do_you_work = "beauty_parlour"
+        assert_equal "13 July 2020", @calculator.workplace_opening_date
+      end
+    end
   end
 end


### PR DESCRIPTION
This adds a notice to the results page for the coronavirus employee risk assessment flow. The notice informs business when they can open to the public.

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.
