### PR TITLE
Move arrested abroad flow logic to calculator class

### DIFF
--- a/lib/smart_answer/calculators/arrested_abroad.rb
+++ b/lib/smart_answer/calculators/arrested_abroad.rb
@@ -3,12 +3,10 @@ module SmartAnswer::Calculators
     # created for the help-if-you-are-arrested-abroad calculator
     attr_reader :data
 
-    def initialize
-      @data = self.class.prisoner_packs
-    end
+    PRISONER_PACKS = YAML.load_file(Rails.root.join("config/smart_answers/prisoner_packs.yml")).freeze
 
     def generate_url_for_download(country, field, text)
-      country_data = @data.find { |c| c["slug"] == country }
+      country_data = PRISONER_PACKS.find { |c| c["slug"] == country }
       return "" unless country_data
 
       url = country_data[field]
@@ -26,16 +24,12 @@ module SmartAnswer::Calculators
       end
     end
 
-    def self.prisoner_packs
-      @prisoner_packs ||= YAML.load_file(Rails.root.join("config/smart_answers/prisoner_packs.yml"))
-    end
-
     def countries_with_regions
       %w[cyprus]
     end
 
     def get_country_regions(slug)
-      @data.find { |c| c["slug"] == slug }["regions"]
+      PRISONER_PACKS.find { |c| c["slug"] == slug }["regions"]
     end
   end
 end

--- a/lib/smart_answer/calculators/arrested_abroad.rb
+++ b/lib/smart_answer/calculators/arrested_abroad.rb
@@ -81,9 +81,9 @@ module SmartAnswer::Calculators
     end
 
     def has_extra_downloads
-      [police, judicial, consul, prison, lawyer, benefits, doc, pdf].count { |x|
-        x != ""
-      }.positive? || countries_with_regions.include?(country)
+      extra_downloads = [police, judicial, consul, prison, lawyer, benefits, doc, pdf]
+
+      extra_downloads.any?(&:present?) || countries_with_regions.include?(country)
     end
 
     def region_downloads

--- a/lib/smart_answer/calculators/arrested_abroad.rb
+++ b/lib/smart_answer/calculators/arrested_abroad.rb
@@ -85,13 +85,12 @@ module SmartAnswer::Calculators
     end
 
     def region_downloads
-      links = []
-      if COUNTRIES_WITH_REGIONS.include?(country)
-        regions = get_country_regions
-        regions.each_value do |val|
-          links << "- [#{val['url_text']}](#{val['link']})"
-        end
+      return "" unless COUNTRIES_WITH_REGIONS.include?(country)
+
+      links = get_country_regions.values.map do |region|
+        "- [#{region['url_text']}](#{region['link']})"
       end
+
       links.join("\n")
     end
 

--- a/lib/smart_answer/calculators/arrested_abroad.rb
+++ b/lib/smart_answer/calculators/arrested_abroad.rb
@@ -1,35 +1,104 @@
 module SmartAnswer::Calculators
   class ArrestedAbroad
     # created for the help-if-you-are-arrested-abroad calculator
-    attr_reader :data
+    attr_reader :country
 
     PRISONER_PACKS = YAML.load_file(Rails.root.join("config/smart_answers/prisoner_packs.yml")).freeze
 
-    def generate_url_for_download(country, field, text)
-      country_data = PRISONER_PACKS.find { |c| c["slug"] == country }
-      return "" unless country_data
+    def initialize(country)
+      @country = country
+    end
 
-      url = country_data[field]
-      output = []
-      if url
-        urls = url.split(" ")
-        urls.each do |u|
-          new_link = "- [#{text}](#{u})"
-          new_link += '{:rel="external"}' if u.include? "http"
-          output.push(new_link)
-        end
-        output.join("\n")
-      else
-        ""
+    def country_data
+      @country_data ||= PRISONER_PACKS.find { |c| c["slug"] == country }
+    end
+
+    def generate_url_for_download(field, text)
+      return "" unless country_data && country_data[field]
+
+      urls = country_data[field].split(" ")
+      output = urls.map do |url|
+        new_link = "- [#{text}](#{url})"
+        new_link += '{:rel="external"}' if url.include? "http"
+        new_link
       end
+      output.join("\n")
     end
 
     def countries_with_regions
       %w[cyprus]
     end
 
-    def get_country_regions(slug)
-      PRISONER_PACKS.find { |c| c["slug"] == slug }["regions"]
+    def get_country_regions
+      country_data["regions"]
+    end
+
+    def location
+      @location ||= WorldLocation.find(country)
+      raise InvalidResponse unless @location
+
+      @location
+    end
+
+    def organisation
+      location.fco_organisation
+    end
+
+    def country_name
+      location.name
+    end
+
+    def pdf
+      generate_url_for_download("pdf", "Prisoner pack for #{country_name}")
+    end
+
+    def doc
+      generate_url_for_download("doc", "Prisoner pack for #{country_name}")
+    end
+
+    def benefits
+      generate_url_for_download("benefits", "Benefits or legal aid in #{country_name}")
+    end
+
+    def prison
+      generate_url_for_download("prison", "Information on prisons and prison procedures in #{country_name}")
+    end
+
+    def judicial
+      generate_url_for_download("judicial", "Information on the judicial system and procedures in #{country_name}")
+    end
+
+    def police
+      generate_url_for_download("police", "Information on the police and police procedures in #{country_name}")
+    end
+
+    def consul
+      generate_url_for_download("consul", "Consul help available in #{country_name}")
+    end
+
+    def lawyer
+      generate_url_for_download("lawyer", "English speaking lawyers and translators/interpreters in #{country_name}")
+    end
+
+    def has_extra_downloads
+      [police, judicial, consul, prison, lawyer, benefits, doc, pdf].count { |x|
+        x != ""
+      }.positive? || countries_with_regions.include?(country)
+    end
+
+    def region_downloads
+      links = []
+      if countries_with_regions.include?(country)
+        regions = get_country_regions
+        regions.each_value do |val|
+          links << "- [#{val['url_text']}](#{val['link']})"
+        end
+      end
+      links.join("\n")
+    end
+
+    def transfer_back
+      %w[austria belgium croatia denmark finland hungary italy latvia luxembourg malta netherlands slovakia].exclude?(country)
     end
   end
 end

--- a/lib/smart_answer/calculators/arrested_abroad.rb
+++ b/lib/smart_answer/calculators/arrested_abroad.rb
@@ -4,6 +4,8 @@ module SmartAnswer::Calculators
     attr_reader :country
 
     PRISONER_PACKS = YAML.load_file(Rails.root.join("config/smart_answers/prisoner_packs.yml")).freeze
+    COUNTRIES_WITH_REGIONS = %w[cyprus].freeze
+    COUNTRIES_WITHOUT_TRANFSERS_BACK = %w[austria belgium croatia denmark finland hungary italy latvia luxembourg malta netherlands slovakia].freeze
 
     def initialize(country)
       @country = country
@@ -23,10 +25,6 @@ module SmartAnswer::Calculators
         new_link
       end
       output.join("\n")
-    end
-
-    def countries_with_regions
-      %w[cyprus]
     end
 
     def get_country_regions
@@ -83,12 +81,12 @@ module SmartAnswer::Calculators
     def has_extra_downloads
       extra_downloads = [police, judicial, consul, prison, lawyer, benefits, doc, pdf]
 
-      extra_downloads.any?(&:present?) || countries_with_regions.include?(country)
+      extra_downloads.any?(&:present?) || COUNTRIES_WITH_REGIONS.include?(country)
     end
 
     def region_downloads
       links = []
-      if countries_with_regions.include?(country)
+      if COUNTRIES_WITH_REGIONS.include?(country)
         regions = get_country_regions
         regions.each_value do |val|
           links << "- [#{val['url_text']}](#{val['link']})"
@@ -98,7 +96,7 @@ module SmartAnswer::Calculators
     end
 
     def transfer_back
-      %w[austria belgium croatia denmark finland hungary italy latvia luxembourg malta netherlands slovakia].exclude?(country)
+      COUNTRIES_WITHOUT_TRANFSERS_BACK.exclude?(country)
     end
   end
 end

--- a/lib/smart_answer_flows/help-if-you-are-arrested-abroad.rb
+++ b/lib/smart_answer_flows/help-if-you-are-arrested-abroad.rb
@@ -7,76 +7,13 @@ module SmartAnswer
       status :published
       satisfies_need "de7bf117-408b-4b26-8e08-7aa51415b4e2"
 
-      arrested_calc = Calculators::ArrestedAbroad.new
       exclude_countries = %w[holy-see british-antarctic-territory]
       british_overseas_territories = %w[anguilla bermuda british-indian-ocean-territory british-virgin-islands cayman-islands falkland-islands gibraltar montserrat pitcairn-island st-helena-ascension-and-tristan-da-cunha south-georgia-and-the-south-sandwich-islands turks-and-caicos-islands]
 
       # Q1
       country_select :which_country?, exclude_countries: exclude_countries do
-        save_input_as :country
-
-        calculate :location do
-          loc = WorldLocation.find(country)
-          raise InvalidResponse unless loc
-
-          loc
-        end
-
-        calculate :organisation do
-          location.fco_organisation
-        end
-
-        calculate :country_name do
-          location.name
-        end
-
-        calculate :pdf do
-          arrested_calc.generate_url_for_download(country, "pdf", "Prisoner pack for #{country_name}")
-        end
-
-        calculate :doc do
-          arrested_calc.generate_url_for_download(country, "doc", "Prisoner pack for #{country_name}")
-        end
-
-        calculate :benefits do
-          arrested_calc.generate_url_for_download(country, "benefits", "Benefits or legal aid in #{country_name}")
-        end
-
-        calculate :prison do
-          arrested_calc.generate_url_for_download(country, "prison", "Information on prisons and prison procedures in #{country_name}")
-        end
-
-        calculate :judicial do
-          arrested_calc.generate_url_for_download(country, "judicial", "Information on the judicial system and procedures in #{country_name}")
-        end
-
-        calculate :police do
-          arrested_calc.generate_url_for_download(country, "police", "Information on the police and police procedures in #{country_name}")
-        end
-
-        calculate :consul do
-          arrested_calc.generate_url_for_download(country, "consul", "Consul help available in #{country_name}")
-        end
-
-        calculate :lawyer do
-          arrested_calc.generate_url_for_download(country, "lawyer", "English speaking lawyers and translators/interpreters in #{country_name}")
-        end
-
-        calculate :has_extra_downloads do
-          [police, judicial, consul, prison, lawyer, benefits, doc, pdf].count { |x|
-            x != ""
-          }.positive? || arrested_calc.countries_with_regions.include?(country)
-        end
-
-        calculate :region_links do
-          links = []
-          if arrested_calc.countries_with_regions.include?(country)
-            regions = arrested_calc.get_country_regions(country)
-            regions.each_value do |val|
-              links << "- [#{val['url_text']}](#{val['link']})"
-            end
-          end
-          links
+        on_response do |response|
+          self.calculator = Calculators::ArrestedAbroad.new(response)
         end
 
         next_node do |response|
@@ -90,19 +27,7 @@ module SmartAnswer
         end
       end
 
-      outcome :answer_one_generic do
-        precalculate :iran do
-          country_name == "Iran"
-        end
-
-        precalculate :transfers_back_to_uk_treaty_change_countries do
-          %w[austria belgium croatia denmark finland hungary italy latvia luxembourg malta netherlands slovakia]
-        end
-
-        precalculate :region_downloads do
-          region_links.join("\n")
-        end
-      end
+      outcome :answer_one_generic
 
       outcome :answer_three_syria
 

--- a/lib/smart_answer_flows/help-if-you-are-arrested-abroad/outcomes/answer_one_generic.erb
+++ b/lib/smart_answer_flows/help-if-you-are-arrested-abroad/outcomes/answer_one_generic.erb
@@ -33,27 +33,27 @@
   - helping British prisoners apply for a transfer to UK where possible
   - visiting prisoners when needed
 
-  <% if has_extra_downloads %>
+  <% if calculator.has_extra_downloads %>
     ##Download prisoner packs and other helpful information
 
     The FCDO has produced guides explaining the legal and prison system in different countries for British nationals arrested abroad.
 
-    <%= pdf %>
-    <%= doc %>
-    <%= benefits %>
-    <%= judicial %>
-    <%= prison %>
-    <%= police %>
-    <%= consul %>
-    <%= lawyer %>
+    <%= calculator.pdf %>
+    <%= calculator.doc %>
+    <%= calculator.benefits %>
+    <%= calculator.judicial %>
+    <%= calculator.prison %>
+    <%= calculator.police %>
+    <%= calculator.consul %>
+    <%= calculator.lawyer %>
 
-    <%= region_downloads %>
+    <%= calculator.region_downloads %>
   <% end %>
 
-  <% if iran %>
-    <%= render partial: 'iran_downloads', locals: { transfer_back: transfers_back_to_uk_treaty_change_countries.exclude?(country) } %>
+  <% if calculator.country_name == "Iran" %>
+    <%= render partial: 'iran_downloads', locals: { transfer_back: calculator.transfer_back } %>
   <% else %>
-    <%= render partial: 'common_downloads', locals: { transfer_back: transfers_back_to_uk_treaty_change_countries.exclude?(country) } %>
+    <%= render partial: 'common_downloads', locals: { transfer_back: calculator.transfer_back } %>
   <% end %>
 
   ##What the FCDO and British consulate can’t do

--- a/test/integration/smart_answer_flows/help_if_you_are_arrested_abroad_test.rb
+++ b/test/integration/smart_answer_flows/help_if_you_are_arrested_abroad_test.rb
@@ -7,7 +7,7 @@ class HelpIfYouAreArrestedAbroadTest < ActiveSupport::TestCase
   include FlowTestHelper
 
   setup do
-    @location_slugs = %w[aruba belgium greece iran syria democratic-republic-of-the-congo]
+    @location_slugs = %w[aruba belgium bermuda greece iran syria democratic-republic-of-the-congo]
     stub_world_locations(@location_slugs)
     setup_for_testing_flow SmartAnswer::HelpIfYouAreArrestedAbroadFlow
   end
@@ -18,56 +18,41 @@ class HelpIfYouAreArrestedAbroadTest < ActiveSupport::TestCase
 
   context "In a country with a prisoner pack" do
     context "Answering with a country without any specific downloads / information" do
-      context "Answering Aruba" do
-        setup do
-          add_response :aruba
-        end
-
-        should "take the user to the generic answer" do
-          assert_current_node :answer_one_generic
-        end
-
-        should "correctly calculate and store the country variables" do
-          assert_state_variable :country, "aruba"
-          assert_state_variable :country_name, "Aruba"
-        end
-
-        should "correctly set up phrase lists" do
-          assert_state_variable :has_extra_downloads, false
-        end
-      end # context: Andorra
-    end # context: country without specific info
+      should "take the user to the generic answer" do
+        add_response :aruba
+        assert_current_node :answer_one_generic
+      end
+    end
 
     context "Answering with a country that has specific downloads / information" do
       context "Answering Democratic Republic of the Congo" do
-        setup do
-          add_response :"democratic-republic-of-the-congo"
-        end
-
         should "take the user to the generic answer" do
+          add_response :"democratic-republic-of-the-congo"
           assert_current_node :answer_one_generic
-        end
-
-        should "set up the country specific downloads" do
-          assert_state_variable :has_extra_downloads, true
+          assert_select outcome_body, "h2", /Download prisoner packs/
         end
       end
 
       context "Answering Greece" do
-        setup do
-          add_response :greece
-        end
-
         should "take the user to the generic answer" do
+          add_response :greece
           assert_current_node :answer_one_generic
-        end
-
-        should "set up the country specific downloads" do
-          assert_state_variable :has_extra_downloads, true
+          assert_select outcome_body, "h2", /Download prisoner packs/
         end
       end
-    end # context: country with specific info
-  end # context: non special case
+    end
+  end
+
+  context "In Iran" do
+    setup do
+      add_response :iran
+    end
+
+    should "take the user to the generic anwser with Iran specific downloads" do
+      assert_current_node :answer_one_generic
+      assert_select outcome_body, "a", /imprisoned in Iran/
+    end
+  end
 
   context "In Syria" do
     setup do
@@ -76,6 +61,13 @@ class HelpIfYouAreArrestedAbroadTest < ActiveSupport::TestCase
 
     should "take the user to the Syria answer" do
       assert_current_node :answer_three_syria
+    end
+  end
+
+  context "In a British overseas territory" do
+    setup do
+      add_response :bermuda
+      assert_current_node :answer_three_british_overseas_territories
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -43,6 +43,7 @@ class ActiveSupport::TestCase
   include GdsApi::TestHelpers::Imminence
   include GdsApi::TestHelpers::PublishingApi
   include GdsApi::TestHelpers::Worldwide
+  include ActionDispatch::Assertions
   parallelize workers: 6
 end
 

--- a/test/unit/calculators/arrested_abroad_calculator_test.rb
+++ b/test/unit/calculators/arrested_abroad_calculator_test.rb
@@ -3,31 +3,31 @@ require_relative "../../test_helper"
 module SmartAnswer::Calculators
   class ArrestedAbroadCalculatorTest < ActiveSupport::TestCase
     context ArrestedAbroad do
-      setup do
-        @calc = ArrestedAbroad.new
-      end
-
       context "generating a URL" do
         should "not error if the country doesn't exist" do
           assert_nothing_raised do
-            @calc.generate_url_for_download("doesntexist", "pdf", "hello world")
+            calc = ArrestedAbroad.new("doesntexist")
+            calc.generate_url_for_download("pdf", "hello world")
           end
         end
 
         should "generate link if country exists" do
-          link = @calc.generate_url_for_download("argentina", "pdf", "Prisoner pack")
+          calc = ArrestedAbroad.new("argentina")
+          link = calc.generate_url_for_download("pdf", "Prisoner pack")
           assert_equal "- [Prisoner pack](/government/publications/argentina-prisoner-pack)", link
         end
 
         should "not include external tag if URL is internal" do
-          link = @calc.generate_url_for_download("israel", "pdf", "Foo")
+          calc = ArrestedAbroad.new("israel")
+          link = calc.generate_url_for_download("pdf", "Foo")
           assert_not link.include?("{:rel=\"external\"}")
         end
       end
 
       context "countries with regions" do
         should "pull out regions of the YML for Cyprus" do
-          resp = @calc.get_country_regions("cyprus")
+          calc = ArrestedAbroad.new("cyprus")
+          resp = calc.get_country_regions
           assert resp["north"]
           assert resp["north_lawyer"]
           assert resp["republic"]
@@ -35,7 +35,8 @@ module SmartAnswer::Calculators
         end
 
         should "pull the regions out of the YML for Cyprus" do
-          resp = @calc.get_country_regions("cyprus")["north"]
+          calc = ArrestedAbroad.new("cyprus")
+          resp = calc.get_country_regions["north"]
           expected = {
             "link" => "/government/publications/cyprus-north-prisoner-pack",
             "url_text" => "Prisoner pack for the north of Cyprus",

--- a/test/unit/calculators/arrested_abroad_calculator_test.rb
+++ b/test/unit/calculators/arrested_abroad_calculator_test.rb
@@ -44,6 +44,22 @@ module SmartAnswer::Calculators
         end
       end
 
+      context "region downloads" do
+        should "return list of region links for countries with regions" do
+          calc = ArrestedAbroad.new("cyprus")
+          calc.stubs(:get_country_regions).returns({
+            "a": { "url_text" => "Text 1", "link" => "link1" },
+            "b": { "url_text" => "Text 2", "link" => "link2" },
+          })
+          assert_equal calc.region_downloads, "- [Text 1](link1)\n- [Text 2](link2)"
+        end
+
+        should "return empty for countries without regions" do
+          calc = ArrestedAbroad.new("bermuda")
+          assert_equal calc.region_downloads, ""
+        end
+      end
+
       context "countries with regions" do
         should "pull out regions of the YML for Cyprus" do
           calc = ArrestedAbroad.new("cyprus")

--- a/test/unit/calculators/arrested_abroad_calculator_test.rb
+++ b/test/unit/calculators/arrested_abroad_calculator_test.rb
@@ -24,6 +24,26 @@ module SmartAnswer::Calculators
         end
       end
 
+      context "has extra downloads" do
+        should "return true for countries with regions" do
+          calc = ArrestedAbroad.new("cyprus")
+          calc.stubs(:country_name).returns("Cyprus")
+          assert calc.has_extra_downloads
+        end
+
+        should "return false if not a country with regions nor has extra download links" do
+          calc = ArrestedAbroad.new("bermuda")
+          calc.stubs(:country_name).returns("Bermuda")
+          assert_not calc.has_extra_downloads
+        end
+
+        should "return true if country has extra download links" do
+          calc = ArrestedAbroad.new("australia")
+          calc.stubs(:country_name).returns("Australia")
+          assert calc.has_extra_downloads
+        end
+      end
+
       context "countries with regions" do
         should "pull out regions of the YML for Cyprus" do
           calc = ArrestedAbroad.new("cyprus")


### PR DESCRIPTION
This removes deprecated calculate, pre-calculate and save_input_as methods from the flow definition.

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.
