### PR TITLE
Remove deprecated methods from am I getting the minimum wage flow

### DIFF
--- a/lib/smart_answer_flows/am-i-getting-minimum-wage.rb
+++ b/lib/smart_answer_flows/am-i-getting-minimum-wage.rb
@@ -14,15 +14,11 @@ module SmartAnswer
         option "current_payment"
         option "past_payment"
 
-        calculate :calculator do |response|
-          if response == "past_payment"
-            Calculators::MinimumWageCalculator.new(date: Date.parse("2019-04-01"))
-          else
-            Calculators::MinimumWageCalculator.new
-          end
+        on_response do |response|
+          date = Date.parse("2019-04-01") if response == "past_payment"
+          self.calculator = Calculators::MinimumWageCalculator.new(date: date)
+          self.accommodation_charge = nil
         end
-
-        calculate :accommodation_charge
 
         next_node do |response|
           case response
@@ -36,10 +32,6 @@ module SmartAnswer
 
       # Q3
       value_question :how_old_are_you?, parse: Integer do
-        precalculate :age_title do
-          "How old are you?"
-        end
-
         validate do |response|
           calculator.valid_age?(response)
         end

--- a/lib/smart_answer_flows/am-i-getting-minimum-wage/questions/how_old_are_you.erb
+++ b/lib/smart_answer_flows/am-i-getting-minimum-wage/questions/how_old_are_you.erb
@@ -1,5 +1,5 @@
 <% text_for :title do %>
-  <%= age_title %>
+  How old are you?
 <% end %>
 
 <% text_for :suffix_label do %>


### PR DESCRIPTION
Calculate and pre-calculate methods have been deprecated. Here we replace them with logic within the on_response method block.

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.
