### PR TITLE
Remove deprecated methods from state pension flow

### DIFF
--- a/lib/smart_answer_flows/state-pension-age.rb
+++ b/lib/smart_answer_flows/state-pension-age.rb
@@ -12,7 +12,9 @@ module SmartAnswer
         option :age
         option :bus_pass
 
-        save_input_as :which_calculation
+        on_response do |response|
+          self.which_calculation = response
+        end
 
         next_node do
           question :dob_age?
@@ -25,8 +27,8 @@ module SmartAnswer
 
         validate { |response| response <= Time.zone.today }
 
-        calculate :calculator do |response|
-          Calculators::StatePensionAgeCalculator.new(dob: response)
+        on_response do |response|
+          self.calculator = Calculators::StatePensionAgeCalculator.new(dob: response)
         end
 
         next_node do


### PR DESCRIPTION
Calculate and pre-calculate methods have been deprecated and have been replaced with logic within the on_response method block.

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.
