### PR TITLE
Remove deprecated methods from married couples allowance flow

### DIFF
--- a/lib/smart_answer_flows/calculate-married-couples-allowance.rb
+++ b/lib/smart_answer_flows/calculate-married-couples-allowance.rb
@@ -151,17 +151,9 @@ module SmartAnswer
         end
       end
 
-      outcome :husband_done do
-        precalculate :allowance do
-          calculator.calculate_allowance
-        end
-      end
+      outcome :husband_done
 
-      outcome :highest_earner_done do
-        precalculate :allowance do
-          calculator.calculate_allowance
-        end
-      end
+      outcome :highest_earner_done
 
       outcome :sorry
     end

--- a/lib/smart_answer_flows/calculate-married-couples-allowance/outcomes/highest_earner_done.erb
+++ b/lib/smart_answer_flows/calculate-married-couples-allowance/outcomes/highest_earner_done.erb
@@ -1,5 +1,5 @@
 <% text_for :title do %>
-  The highest earner qualifies for Married Couple's Allowance - they'll get <%= format_money(allowance) %> off their tax bill.
+  The highest earner qualifies for Married Couple's Allowance - they'll get <%= format_money(calculator.calculate_allowance) %> off their tax bill.
 <% end %>
 
 <% govspeak_for :body do %>

--- a/lib/smart_answer_flows/calculate-married-couples-allowance/outcomes/husband_done.erb
+++ b/lib/smart_answer_flows/calculate-married-couples-allowance/outcomes/husband_done.erb
@@ -1,5 +1,5 @@
 <% text_for :title do %>
-  The husband qualifies for Married Couple's Allowance - he'll get <%= format_money(allowance) %> off his tax bill.
+  The husband qualifies for Married Couple's Allowance - he'll get <%= format_money(calculator.calculate_allowance) %> off his tax bill.
 <% end %>
 
 <% govspeak_for :body do %>

--- a/test/integration/smart_answer_flows/calculate_married_couples_allowance_test.rb
+++ b/test/integration/smart_answer_flows/calculate_married_couples_allowance_test.rb
@@ -101,14 +101,6 @@ class CalculateMarriedCouplesAllowanceTest < ActiveSupport::TestCase
                 should "end at husband_done" do
                   assert_current_node :husband_done
                 end
-
-                should "calculate allowance using calculators" do
-                  SmartAnswer::Calculators::MarriedCouplesAllowanceCalculator.any_instance
-                    .expects(:calculate_allowance)
-                    .returns("Calculated allowance")
-
-                  assert_state_variable :allowance, "Calculated allowance"
-                end
               end # donating 100 with gift aid
             end # paying 500 with tax relief
           end # paying 1000 before tax
@@ -133,15 +125,6 @@ class CalculateMarriedCouplesAllowanceTest < ActiveSupport::TestCase
               add_response "0"
               assert_current_node :husband_done
             end
-
-            should "calculate allowance using calculators" do
-              SmartAnswer::Calculators::MarriedCouplesAllowanceCalculator.any_instance
-                .expects(:calculate_allowance)
-                .returns("Calculated allowance")
-
-              add_response "0"
-              assert_state_variable :allowance, "Calculated allowance"
-            end
           end
         end # paying into a pension
 
@@ -162,14 +145,6 @@ class CalculateMarriedCouplesAllowanceTest < ActiveSupport::TestCase
             should "end at husband_done" do
               assert_current_node :husband_done
             end
-
-            should "calculate allowance using calculators" do
-              SmartAnswer::Calculators::MarriedCouplesAllowanceCalculator.any_instance
-                .expects(:calculate_allowance)
-                .returns("Calculated allowance")
-
-              assert_state_variable :allowance, "Calculated allowance"
-            end
           end # donating 100 with gift aid
 
           context "donating 0 with gift aid" do
@@ -179,14 +154,6 @@ class CalculateMarriedCouplesAllowanceTest < ActiveSupport::TestCase
 
             should "end at husband_done" do
               assert_current_node :husband_done
-            end
-
-            should "calculate allowance using calculators" do
-              SmartAnswer::Calculators::MarriedCouplesAllowanceCalculator.any_instance
-                .expects(:calculate_allowance)
-                .returns("Calculated allowance")
-
-              assert_state_variable :allowance, "Calculated allowance"
             end
           end # donating 0 with gift aid
         end # not paying into a pension
@@ -200,14 +167,6 @@ class CalculateMarriedCouplesAllowanceTest < ActiveSupport::TestCase
 
         should "end at husband_done" do
           assert_current_node :husband_done
-        end
-
-        should "calculate allowance using calculators" do
-          SmartAnswer::Calculators::MarriedCouplesAllowanceCalculator.any_instance
-            .expects(:calculate_allowance)
-            .returns("Calculated allowance")
-
-          assert_state_variable :allowance, "Calculated allowance"
         end
       end # income < 25400
     end # before 2005
@@ -271,14 +230,6 @@ class CalculateMarriedCouplesAllowanceTest < ActiveSupport::TestCase
                 should "end at highest_earner_done" do
                   assert_current_node :highest_earner_done
                 end
-
-                should "calculate allowance using calculators" do
-                  SmartAnswer::Calculators::MarriedCouplesAllowanceCalculator.any_instance
-                    .expects(:calculate_allowance)
-                    .returns("Calculated allowance")
-
-                  assert_state_variable :allowance, "Calculated allowance"
-                end
               end # donating 100 with gift aid
             end # paying 500 with tax relief
           end # paying 1000 before tax
@@ -311,14 +262,6 @@ class CalculateMarriedCouplesAllowanceTest < ActiveSupport::TestCase
             should "end at highest_earner_done" do
               assert_current_node :highest_earner_done
             end
-
-            should "calculate allowance using calculators" do
-              SmartAnswer::Calculators::MarriedCouplesAllowanceCalculator.any_instance
-                .expects(:calculate_allowance)
-                .returns("Calculated allowance")
-
-              assert_state_variable :allowance, "Calculated allowance"
-            end
           end # donating 100 with gift aid
 
           context "donating 0 with gift aid" do
@@ -328,14 +271,6 @@ class CalculateMarriedCouplesAllowanceTest < ActiveSupport::TestCase
 
             should "end at highest_earner_done" do
               assert_current_node :highest_earner_done
-            end
-
-            should "calculate allowance using calculators" do
-              SmartAnswer::Calculators::MarriedCouplesAllowanceCalculator.any_instance
-                .expects(:calculate_allowance)
-                .returns("Calculated allowance")
-
-              assert_state_variable :allowance, "Calculated allowance"
             end
           end # donating 0 with gift aid
         end # not paying into a pension
@@ -347,16 +282,6 @@ class CalculateMarriedCouplesAllowanceTest < ActiveSupport::TestCase
           add_response "13850.50"
 
           assert_current_node :highest_earner_done
-        end
-
-        should "calculate allowance using calculators" do
-          SmartAnswer::Calculators::MarriedCouplesAllowanceCalculator.any_instance
-            .expects(:calculate_allowance)
-            .returns("Calculated allowance")
-
-          add_response "1930-05-14"
-          add_response "13850.50"
-          assert_state_variable :allowance, "Calculated allowance"
         end
       end # income < 25400
     end # after 2005


### PR DESCRIPTION
Pre-calculate methods have been deprecated and have been removed from the flow in favour of just calling the calculator directly from the view.

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.
