### PR TITLE
Remove deprecated methods from sick pay flow

### DIFF
--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -228,10 +228,6 @@ module SmartAnswer
         option :eight_weeks_less
         option :before_payday
 
-        precalculate :sick_start_date_for_awe do
-          calculator.sick_start_date_for_awe
-        end
-
         on_response do |response|
           calculator.eight_weeks_earnings = response
         end
@@ -274,10 +270,6 @@ module SmartAnswer
         to { Calculators::StatutorySickPayCalculator.year_of_sickness }
         validate_in_range
 
-        precalculate :sick_start_date_for_awe do
-          calculator.sick_start_date_for_awe
-        end
-
         on_response do |response|
           calculator.relevant_period_to = response
         end
@@ -297,10 +289,6 @@ module SmartAnswer
         to { Calculators::StatutorySickPayCalculator.year_of_sickness }
         validate_in_range
 
-        precalculate :pay_day_offset do
-          calculator.pay_day_offset
-        end
-
         on_response do |response|
           calculator.relevant_period_from = response + 1.day
         end
@@ -316,14 +304,6 @@ module SmartAnswer
 
       # Question 9.2
       money_question :total_employee_earnings? do
-        precalculate :relevant_period_from do
-          calculator.relevant_period_from
-        end
-
-        precalculate :relevant_period_to do
-          calculator.relevant_period_to
-        end
-
         on_response do |response|
           calculator.total_employee_earnings = response
         end
@@ -335,10 +315,6 @@ module SmartAnswer
 
       # Question 10
       money_question :pay_amount_if_not_sick? do
-        precalculate :sick_start_date_for_awe do
-          calculator.sick_start_date_for_awe
-        end
-
         on_response do |response|
           calculator.relevant_contractual_pay = response
         end
@@ -418,32 +394,13 @@ module SmartAnswer
       outcome :not_regular_schedule
 
       # Answer 5
-      outcome :not_earned_enough do
-        precalculate :lower_earning_limit do
-          calculator.lower_earning_limit
-        end
-
-        precalculate :employee_average_weekly_earnings do
-          calculator.employee_average_weekly_earnings
-        end
-      end
+      outcome :not_earned_enough
 
       # Answer 6
-      outcome :entitled_to_sick_pay do
-        precalculate :ssp_payment do
-          calculator.ssp_payment
-        end
-
-        precalculate(:days_paid) { calculator.days_paid }
-        precalculate(:normal_workdays_out) { calculator.normal_workdays }
-        precalculate(:pattern_days) { calculator.pattern_days }
-        precalculate(:pattern_days_total) { calculator.pattern_days_total }
-      end
+      outcome :entitled_to_sick_pay
 
       # Answer 7
-      outcome :not_entitled_3_days_not_paid do
-        precalculate(:normal_workdays_out) { calculator.normal_workdays }
-      end
+      outcome :not_entitled_3_days_not_paid
 
       # Answer 8
       outcome :maximum_entitlement_reached

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/entitled_to_sick_pay.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/entitled_to_sick_pay.erb
@@ -1,7 +1,7 @@
 <% govspeak_for :body do %>
   ##Statutory Sick Pay (SSP)
 
-  Your employee is entitled to SSP for <%= days_paid %> days out of <%= normal_workdays_out %> working days taken off sick between <%= format_date(calculator.sick_start_date) %> and <%= format_date(calculator.sick_end_date) %>
+  Your employee is entitled to SSP for <%= calculator.days_paid %> days out of <%= calculator.normal_workdays %> working days taken off sick between <%= format_date(calculator.sick_start_date) %> and <%= format_date(calculator.sick_end_date) %>
 
   <% unless calculator.enough_notice_of_absence %>
     You don’t have to pay until your employee tells you that they’re ill. You’ll have to pay any withheld amounts by the end of your employee's entitlement to sick pay if your employee is sick for more than 28 weeks.
@@ -13,7 +13,7 @@
   <% calculator.weekly_payments.each do |week_ending, ssp_amount| %>
     <%= format_date(week_ending) %>|<%= format_money(ssp_amount) %>
   <% end %>
-   | **Total SSP: <%= format_money(ssp_payment) %>**
+   | **Total SSP: <%= format_money(calculator.ssp_payment) %>**
 
   ##What you need to know
 
@@ -21,7 +21,7 @@
     ^ Your employee will not be able to collect Statutory Shared Parental Pay, Statutory Paternity Pay, Statutory Parental Bereavement Pay or Statutory Adoption Pay while collecting Statutory Sick Pay. ^
   <% end %>
 
-  SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of <%= pattern_days_total %> days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. <% if calculator.enough_notice_of_absence %>They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).<% end %>
+  SSP can be paid for up to 28 weeks of an employee’s normal workdays. For this employee that equals a total of <%= calculator.pattern_days_total %> days. After that you must give them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) within 7 days of SSP ending. <% if calculator.enough_notice_of_absence %>They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).<% end %>
 
 
 

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/not_earned_enough.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/not_earned_enough.erb
@@ -1,5 +1,5 @@
 <% govspeak_for :body do %>
-  Your employee isn’t entitled to Statutory Sick Pay because their average weekly earnings must be at least <%= format_money(lower_earning_limit) %>. Their average weekly earnings are <%= format_money(employee_average_weekly_earnings) %>.
+  Your employee isn’t entitled to Statutory Sick Pay because their average weekly earnings must be at least <%= format_money(calculator.lower_earning_limit) %>. Their average weekly earnings are <%= format_money(calculator.employee_average_weekly_earnings) %>.
 
   You must send them [form SSP1](/employers-sick-pay/eligibility-and-form-ssp1) no more than 7 days after they’ve told you they’re sick. They may be able to get [Employment Support Allowance (ESA)](/employment-support-allowance).
 <% end %>

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/not_entitled_3_days_not_paid.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/not_entitled_3_days_not_paid.erb
@@ -1,5 +1,5 @@
 <% govspeak_for :body do %>
   Your employee isn’t entitled to Statutory Sick Pay because the first 3 days of illness aren’t paid.
 
-  This employee has taken <%= normal_workdays_out %> working days off sick between <%= format_date(calculator.sick_start_date) %> and <%= format_date(calculator.sick_end_date) %>.
+  This employee has taken <%= calculator.normal_workdays %> working days off sick between <%= format_date(calculator.sick_start_date) %> and <%= format_date(calculator.sick_end_date) %>.
 <% end %>

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/questions/last_payday_before_offset.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/questions/last_payday_before_offset.erb
@@ -1,7 +1,7 @@
 <% text_for :title do %>
-  What was the last normal payday on or before <%= format_date(pay_day_offset) %>?
+  What was the last normal payday on or before <%= format_date(calculator.pay_day_offset) %>?
 <% end %>
 
 <% text_for :error_message do %>
-  You must enter a date on or before <%= format_date(pay_day_offset) %>
+  You must enter a date on or before <%= format_date(calculator.pay_day_offset) %>
 <% end %>

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/questions/last_payday_before_sickness.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/questions/last_payday_before_sickness.erb
@@ -1,5 +1,5 @@
 <% text_for :title do %>
-  What was the last normal payday before <%= format_date(sick_start_date_for_awe) %>?
+  What was the last normal payday before <%= format_date(calculator.sick_start_date_for_awe) %>?
 <% end %>
 
 <% text_for :hint do %>
@@ -7,5 +7,5 @@
 <% end %>
 
 <% text_for :error_message do %>
-  You must enter a date before <%= format_date(sick_start_date_for_awe) %>
+  You must enter a date before <%= format_date(calculator.sick_start_date_for_awe) %>
 <% end %>

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/questions/paid_at_least_8_weeks.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/questions/paid_at_least_8_weeks.erb
@@ -1,5 +1,5 @@
 <% text_for :title do %>
-  On <%= format_date(sick_start_date_for_awe) %> had you paid your employee at least 8 weeks of earnings?
+  On <%= format_date(calculator.sick_start_date_for_awe) %> had you paid your employee at least 8 weeks of earnings?
 <% end %>
 
 <% options(

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/questions/total_earnings_before_sick_period.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/questions/total_earnings_before_sick_period.erb
@@ -1,3 +1,3 @@
 <% text_for :title do %>
-  Enter the total earnings paid before <%= format_date(sick_start_date_for_awe) %>.
+  Enter the total earnings paid before <%= format_date(calculator.sick_start_date_for_awe) %>.
 <% end %>

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/questions/total_employee_earnings.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/questions/total_employee_earnings.erb
@@ -1,5 +1,5 @@
 <% text_for :title do %>
-  Enter the total amount (before deductions like Income Tax and National Insurance) of your employee’s earnings on paydays between <%= format_date(relevant_period_from) %> and <%= format_date(relevant_period_to) %>.
+  Enter the total amount (before deductions like Income Tax and National Insurance) of your employee’s earnings on paydays between <%= format_date(calculator.relevant_period_from) %> and <%= format_date(calculator.relevant_period_to) %>.
 <% end %>
 
 <% govspeak_for :body do %>


### PR DESCRIPTION
Pre-calculate methods have been deprecated and have been removed from the flow in favour of just calling the calculator directly from the view.

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.
