### PR TITLE
Use individual component CSS/JS

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,5 +1,11 @@
+//= require govuk_publishing_components/lib
+//= require govuk_publishing_components/components/button
+//= require govuk_publishing_components/components/checkboxes
+//= require govuk_publishing_components/components/feedback
+//= require govuk_publishing_components/components/govspeak
+//= require govuk_publishing_components/components/radio
+//= require govuk_publishing_components/components/step-by-step-nav
 //= require helpers
-//= require govuk_publishing_components/all_components
 
 $(document).ready(function() {
   $('#current-error').focus();

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,29 @@
 $govuk-compatibility-govuktemplate: true;
 $govuk-use-legacy-palette: false;
 
-@import "govuk_publishing_components/all_components";
+@import "govuk_publishing_components/govuk_frontend_support";
+@import "govuk_publishing_components/component_support";
+@import "govuk_publishing_components/components/button";
+@import "govuk_publishing_components/components/checkboxes";
+@import "govuk_publishing_components/components/contextual-sidebar";
+@import "govuk_publishing_components/components/date-input";
+@import "govuk_publishing_components/components/error-message";
+@import "govuk_publishing_components/components/feedback";
+@import "govuk_publishing_components/components/fieldset";
+@import "govuk_publishing_components/components/govspeak";
+@import "govuk_publishing_components/components/heading";
+@import "govuk_publishing_components/components/hint";
+@import "govuk_publishing_components/components/input";
+@import "govuk_publishing_components/components/label";
+@import "govuk_publishing_components/components/phase-banner";
+@import "govuk_publishing_components/components/radio";
+@import "govuk_publishing_components/components/related-navigation";
+@import "govuk_publishing_components/components/select";
+@import "govuk_publishing_components/components/step-by-step-nav";
+@import "govuk_publishing_components/components/step-by-step-nav-related";
+@import "govuk_publishing_components/components/title";
+
+// not in suggested sass from component gem but still needed
+@import "govuk_publishing_components/components/table";
+
 @import "smart_answers";

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -1,4 +1,9 @@
-@import "govuk_publishing_components/all_components_print";
+@import "govuk_publishing_components/govuk_frontend_support";
+@import "govuk_publishing_components/components/print/button";
+@import "govuk_publishing_components/components/print/feedback";
+@import "govuk_publishing_components/components/print/govspeak";
+@import "govuk_publishing_components/components/print/step-by-step-nav";
+@import "govuk_publishing_components/components/print/title";
 
 .smart_answer {
   margin-left: 0;

--- a/app/assets/stylesheets/visualise.css.scss
+++ b/app/assets/stylesheets/visualise.css.scss
@@ -1,6 +1,26 @@
 $govuk-compatibility-govuktemplate: true;
 
-@import "govuk_publishing_components/all_components";
+@import "govuk_publishing_components/govuk_frontend_support";
+@import "govuk_publishing_components/component_support";
+@import "govuk_publishing_components/components/button";
+@import "govuk_publishing_components/components/checkboxes";
+@import "govuk_publishing_components/components/contextual-sidebar";
+@import "govuk_publishing_components/components/date-input";
+@import "govuk_publishing_components/components/error-message";
+@import "govuk_publishing_components/components/feedback";
+@import "govuk_publishing_components/components/fieldset";
+@import "govuk_publishing_components/components/govspeak";
+@import "govuk_publishing_components/components/heading";
+@import "govuk_publishing_components/components/hint";
+@import "govuk_publishing_components/components/input";
+@import "govuk_publishing_components/components/label";
+@import "govuk_publishing_components/components/phase-banner";
+@import "govuk_publishing_components/components/radio";
+@import "govuk_publishing_components/components/related-navigation";
+@import "govuk_publishing_components/components/select";
+@import "govuk_publishing_components/components/step-by-step-nav";
+@import "govuk_publishing_components/components/step-by-step-nav-related";
+@import "govuk_publishing_components/components/title";
 
 .warning {
   border-left: 6px solid red;


### PR DESCRIPTION
:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.

---

Update smart-answers to import the sass and Javascript for only the components it is using, instead of all components, as [documented here](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/install-and-use.md#import-sass-for-individual-components) and [here](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/install-and-use.md#import-javascript-for-individual-components).

## Filesize comparison

CSS before: **936 KB** and after: **453 KB**

<img width="436" alt="Screenshot 2020-07-14 at 08 52 56" src="https://user-images.githubusercontent.com/861310/87400987-7588bc00-c5b1-11ea-8685-0ef8964a7dc6.png">

<img width="435" alt="Screenshot 2020-07-14 at 11 54 50" src="https://user-images.githubusercontent.com/861310/87417988-e38cad80-c5c8-11ea-9f86-5c5caac1c3e6.png">

JS before: **471 KB** and after: **244 KB**

<img width="435" alt="Screenshot 2020-07-14 at 08 53 16" src="https://user-images.githubusercontent.com/861310/87401072-8fc29a00-c5b1-11ea-8d65-ac98fc7acca5.png">

<img width="436" alt="Screenshot 2020-07-14 at 11 54 33" src="https://user-images.githubusercontent.com/861310/87418021-f1423300-c5c8-11ea-9237-375fa44694a2.png">

Trello card: https://trello.com/c/GWttlBxs/228-upgrade-applications-to-use-individual-component-sass

