### PR TITLE
Remove deprecated methods from childcare credits flow

### DIFF
--- a/lib/smart_answer/calculators/childcare_cost_calculator.rb
+++ b/lib/smart_answer/calculators/childcare_cost_calculator.rb
@@ -1,29 +1,53 @@
 module SmartAnswer::Calculators
   class ChildcareCostCalculator
+    attr_accessor :cost_change_4_weeks,
+                  :weekly_cost,
+                  :new_weekly_costs,
+                  :old_weekly_costs,
+                  :weekly_difference
+
+    delegate :abs, to: :weekly_difference, prefix: true
+
+    def initialize
+      @cost_change_4_weeks = false
+    end
+
     # C1, C2, C4, C8, C9
-    def self.weekly_cost(annual_cost)
+    def weekly_cost_from_annual(annual_cost)
       (Float(annual_cost) / 52.0).ceil
     end
 
     # C3, C7
-    def self.weekly_cost_from_monthly(monthly_cost)
-      weekly_cost(monthly_cost * 12.0)
+    def weekly_cost_from_monthly(monthly_cost)
+      weekly_cost_from_annual(monthly_cost * 12.0)
     end
 
     # C5
-    def self.weekly_cost_from_fortnightly(fortnightly_cost)
+    def weekly_cost_from_fortnightly(fortnightly_cost)
       (fortnightly_cost / 2.0).ceil
     end
 
     # C6
-    def self.weekly_cost_from_four_weekly(four_weekly_cost)
+    def weekly_cost_from_four_weekly(four_weekly_cost)
       (four_weekly_cost / 4.0).ceil
     end
 
     # C10
-    def self.cost_change(new_weekly_cost, old_weekly_tax)
+    def cost_change(new_weekly_cost, old_weekly_tax)
       # all childcare costs are always rounded up to the nearest pound before calculations
       (Float(new_weekly_cost) - Float(old_weekly_tax).ceil)
+    end
+
+    def ten_or_more
+      weekly_difference_abs >= 10
+    end
+
+    def title_change_text
+      weekly_difference >= 10 ? "increased" : "decreased"
+    end
+
+    def difference_money
+      SmartAnswer::Money.new(weekly_difference_abs)
     end
   end
 end

--- a/lib/smart_answer_flows/childcare-costs-for-tax-credits/outcomes/cost_changed.erb
+++ b/lib/smart_answer_flows/childcare-costs-for-tax-credits/outcomes/cost_changed.erb
@@ -1,10 +1,10 @@
 <% text_for :title do %>
-  Your average weekly childcare costs have <%= title_change_text %> by <%= format_money(difference_money) %>.
+  Your average weekly childcare costs have <%= calculator.title_change_text %> by <%= format_money(calculator.difference_money) %>.
 <% end %>
 
 <% govspeak_for :body do %>
-  <% if ten_or_more %>
-    <% if cost_change_4_weeks %>
+  <% if calculator.ten_or_more %>
+    <% if calculator.cost_change_4_weeks %>
       Call [HM Revenue and Customs (HMRC)](/government/organisations/hm-revenue-customs/contact/tax-credits-enquiries) if you expect this to last for 4 weeks in a row or more.
 
       You do not need to report it if this will not last 4 weeks in a row or more.

--- a/test/integration/smart_answer_flows/childcare_costs_for_tax_credits_test.rb
+++ b/test/integration/smart_answer_flows/childcare_costs_for_tax_credits_test.rb
@@ -131,7 +131,7 @@ class ChildcareCostsForTaxCreditsTest < ActiveSupport::TestCase
             should "calculate the weekly cost and take user to outcome" do
               add_response 52
               assert_current_node :weekly_costs_are_x
-              assert_state_variable :weekly_cost, 1
+              assert_calculator_attr :weekly_cost, 1
             end
           end # Q7
 
@@ -145,7 +145,7 @@ class ChildcareCostsForTaxCreditsTest < ActiveSupport::TestCase
             end
 
             should "calculate the weekly cost" do
-              assert_state_variable :weekly_cost, 1
+              assert_calculator_attr :weekly_cost, 1
             end
           end # Q6
         end # Q4
@@ -164,7 +164,7 @@ class ChildcareCostsForTaxCreditsTest < ActiveSupport::TestCase
 
       should "calculate the weekly cost" do
         add_response 4 # Q10
-        assert_state_variable :weekly_cost, 1
+        assert_calculator_attr :weekly_cost, 1
         assert_current_node :weekly_costs_are_x
       end
     end
@@ -178,7 +178,7 @@ class ChildcareCostsForTaxCreditsTest < ActiveSupport::TestCase
 
       should "ask you how much you pay fortnightly" do
         add_response 10 # Answer Q13
-        assert_state_variable :weekly_cost, 5
+        assert_calculator_attr :weekly_cost, 5
         assert_current_node :weekly_costs_are_x
       end
     end # Q13
@@ -193,7 +193,7 @@ class ChildcareCostsForTaxCreditsTest < ActiveSupport::TestCase
 
       should "calculate the weekly cost" do
         add_response 20 # Q14
-        assert_state_variable :weekly_cost, 5
+        assert_calculator_attr :weekly_cost, 5
         assert_current_node :weekly_costs_are_x
       end
     end # Q14
@@ -208,7 +208,7 @@ class ChildcareCostsForTaxCreditsTest < ActiveSupport::TestCase
 
       should "calculate the weekly cost" do
         add_response 52 # Q14
-        assert_state_variable :weekly_cost, 1
+        assert_calculator_attr :weekly_cost, 1
         assert_current_node :weekly_costs_are_x
       end
     end # Q15
@@ -233,16 +233,16 @@ class ChildcareCostsForTaxCreditsTest < ActiveSupport::TestCase
 
       should "calculate weekly_cost from Q8" do
         add_response 52 # Q8
-        assert_state_variable :weekly_cost, 1
+        assert_calculator_attr :weekly_cost, 1
       end
 
       should "calculate diff after answering Q18" do
         add_response 52 # Q8
         add_response 2 # Q18
-        assert_state_variable :old_weekly_cost, 2
-        assert_state_variable :weekly_difference, -1
-        assert_state_variable :weekly_difference_abs, 1
-        assert_state_variable :cost_change_4_weeks, false
+        assert_calculator_attr :old_weekly_costs, 2
+        assert_calculator_attr :weekly_difference, -1
+        assert_calculator_attr :weekly_difference_abs, 1
+        assert_calculator_attr :cost_change_4_weeks, false
         assert_current_node :cost_changed
       end
     end # Q18
@@ -266,7 +266,7 @@ class ChildcareCostsForTaxCreditsTest < ActiveSupport::TestCase
 
     should "take user to Q20 if they give an answer" do
       add_response 1
-      assert_state_variable :new_weekly_costs, 1
+      assert_calculator_attr :new_weekly_costs, 1
       assert_current_node :old_weekly_amount_2?
     end
 
@@ -277,16 +277,16 @@ class ChildcareCostsForTaxCreditsTest < ActiveSupport::TestCase
       end
 
       should "calculate the old costs based on user answer" do
-        assert_state_variable :old_weekly_costs, 11
-        assert_state_variable :weekly_difference, -10
-        assert_state_variable :weekly_difference_abs, 10
-        assert_state_variable :ten_or_more, true
-        assert_state_variable :cost_change_4_weeks, true
+        assert_calculator_attr :old_weekly_costs, 11
+        assert_calculator_attr :weekly_difference, -10
+        assert_calculator_attr :weekly_difference_abs, 10
+        assert_calculator_attr :ten_or_more, true
+        assert_calculator_attr :cost_change_4_weeks, true
         assert_current_node :cost_changed
       end
 
       should "show correct phrases" do
-        assert_state_variable :title_change_text, "decreased"
+        assert_calculator_attr :title_change_text, "decreased"
       end
     end # Q20
   end # Q17
@@ -309,7 +309,7 @@ class ChildcareCostsForTaxCreditsTest < ActiveSupport::TestCase
 
     should "take the user to Q21 if they give an answer" do
       add_response 4
-      assert_state_variable :new_weekly_costs, 1
+      assert_calculator_attr :new_weekly_costs, 1
       assert_current_node :old_monthly_amount?
     end
 
@@ -320,11 +320,11 @@ class ChildcareCostsForTaxCreditsTest < ActiveSupport::TestCase
       end
 
       should "calculate old costs and difference" do
-        assert_state_variable :old_weekly_costs, 10
-        assert_state_variable :weekly_difference, -9
-        assert_state_variable :ten_or_more, false
-        assert_state_variable :title_change_text, "decreased"
-        assert_state_variable :cost_change_4_weeks, false
+        assert_calculator_attr :old_weekly_costs, 10
+        assert_calculator_attr :weekly_difference, -9
+        assert_calculator_attr :ten_or_more, false
+        assert_calculator_attr :title_change_text, "decreased"
+        assert_calculator_attr :cost_change_4_weeks, false
         assert_current_node :cost_changed
       end
     end
@@ -343,7 +343,7 @@ class ChildcareCostsForTaxCreditsTest < ActiveSupport::TestCase
 
     should "take user to weekly outcome" do
       add_response 52
-      assert_state_variable :weekly_cost, 1
+      assert_calculator_attr :weekly_cost, 1
       assert_current_node :weekly_costs_are_x
     end
   end

--- a/test/integration/smart_answer_flows/flow_test_helper.rb
+++ b/test/integration/smart_answer_flows/flow_test_helper.rb
@@ -64,4 +64,9 @@ module FlowTestHelper
     end
     assert_equal expected, actual
   end
+
+  def assert_calculator_attr(name, expected)
+    actual = current_state.calculator.send(name)
+    assert_equal expected, actual
+  end
 end

--- a/test/unit/calculators/childcare_cost_calculator_test.rb
+++ b/test/unit/calculators/childcare_cost_calculator_test.rb
@@ -4,39 +4,43 @@ require_relative "../../test_helper"
 
 module SmartAnswer::Calculators
   class ChildcareCostCalculatorTest < ActiveSupport::TestCase
+    setup do
+      @calculator = ChildcareCostCalculator.new
+    end
+
     context ".weekly_cost" do
       should "return the weekly cost based on the annual cost" do
-        assert_equal 12, ChildcareCostCalculator.weekly_cost(600)
+        assert_equal 12, @calculator.weekly_cost_from_annual(600)
       end
     end
 
     context ".weekly_cost" do
       should "return the weekly cost based on the annual cost - rounding up test" do
-        assert_equal 56, ChildcareCostCalculator.weekly_cost(2880)
+        assert_equal 56, @calculator.weekly_cost_from_annual(2880)
       end
     end
 
     context ".weekly_cost_from_monthly" do
       should "return the weekly cost based on the monthly cost" do
-        assert_equal 14, ChildcareCostCalculator.weekly_cost_from_monthly(60)
+        assert_equal 14, @calculator.weekly_cost_from_monthly(60)
       end
     end
 
     context ".weekly_cost_from_fortnightly" do
       should "return the weekly cost based on the fortnightly cost" do
-        assert_equal 14, ChildcareCostCalculator.weekly_cost_from_fortnightly(27)
+        assert_equal 14, @calculator.weekly_cost_from_fortnightly(27)
       end
     end
 
     context ".weekly_cost_from_four_weekly" do
       should "return the weekly cost based on the four weekly cost" do
-        assert_equal 20, ChildcareCostCalculator.weekly_cost_from_four_weekly(77)
+        assert_equal 20, @calculator.weekly_cost_from_four_weekly(77)
       end
     end
 
     context ".cost_change" do
       should "return the difference between weekly cost and tax" do
-        assert_equal 3, ChildcareCostCalculator.cost_change(10, 7)
+        assert_equal 3, @calculator.cost_change(10, 7)
       end
     end
   end


### PR DESCRIPTION
Pre-calculate and calculate methods have been deprecated and have been removed from the flow in favour of storing attributes on the calculator and calling calculator methods directly from the views.

A new assertion helper has been added to check calculator attribute values. This makes it easier to migrate existing tests which checked state values.

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.
