### PR TITLE
Use content ids to associate Smart Answers with needs

### DIFF
--- a/app/presenters/flow_registration_presenter.rb
+++ b/app/presenters/flow_registration_presenter.rb
@@ -7,8 +7,8 @@ class FlowRegistrationPresenter
     @flow.name
   end
 
-  def need_id
-    @flow.need_id
+  def need_content_id
+    @flow.need_content_id
   end
 
   def start_page_content_id

--- a/doc/smart-answers/flow-definition.md
+++ b/doc/smart-answers/flow-definition.md
@@ -51,7 +51,7 @@ module SmartAnswer
       name 'example-smart-answer' # this is the path where the Smart Answer will be registered on gov.uk (via the publishing-api)
       content_id "bfda3b4f-166b-48e7-9aaf-21bfbd606207" # a UUID used by v2 of the Publishing API (?)
       status :published # this indicates whether or not the flow is available to be published to live gov.uk , those with `:draft` status will be available on draft gov.uk
-      satisfies_need "123456" # may relate the Smart Answer to the original user need in the Need-o-tron app (?)
+      satisfies_need "7da2fa63-190c-446e-b3e5-94480f0e46e7" # relates the Smart Answer to a Need managed by Maslow
       external_related_links { title: "Child Maintenance Options - How much should be paid",
                                url: "http://www.cmoptions.org/en/maintenance/how-much.asp" } # External links associated to the Smart-Answer                                      
 

--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -3,7 +3,7 @@ require "ostruct"
 module SmartAnswer
   class Flow
     attr_reader :nodes
-    attr_accessor :need_id
+    attr_accessor :need_content_id
     attr_writer :status
 
     def self.build
@@ -40,8 +40,8 @@ module SmartAnswer
       @name
     end
 
-    def satisfies_need(need_id)
-      self.need_id = need_id
+    def satisfies_need(need_content_id)
+      self.need_content_id = need_content_id
     end
 
     def external_related_links(external_related_links = nil)

--- a/lib/smart_answer_flows/additional-commodity-code.rb
+++ b/lib/smart_answer_flows/additional-commodity-code.rb
@@ -6,7 +6,7 @@ module SmartAnswer
       name "additional-commodity-code"
 
       status :published
-      satisfies_need "100233"
+      satisfies_need "835da435-b6ea-4c76-a584-75c1082d86f5"
 
       # Q1
       multiple_choice :how_much_starch_glucose? do

--- a/lib/smart_answer_flows/am-i-getting-minimum-wage.rb
+++ b/lib/smart_answer_flows/am-i-getting-minimum-wage.rb
@@ -7,7 +7,7 @@ module SmartAnswer
       flow_content_id "43cc9c0c-4210-4643-b045-53a388bbc36f"
       name "am-i-getting-minimum-wage"
       status :published
-      satisfies_need "100145"
+      satisfies_need "6f764f56-01af-415f-8bfb-60bda489c015"
 
       # Q1
       multiple_choice :what_would_you_like_to_check? do

--- a/lib/smart_answer_flows/benefit-cap-calculator.rb
+++ b/lib/smart_answer_flows/benefit-cap-calculator.rb
@@ -5,7 +5,7 @@ module SmartAnswer
       flow_content_id "d2593a1a-441b-4751-8bf7-ed04a8fd8689"
       name "benefit-cap-calculator"
       status :published
-      satisfies_need "100696"
+      satisfies_need "8474ef2f-6bc2-44be-8883-8a795d728c51"
 
       config = Calculators::BenefitCapCalculatorConfiguration.new
 

--- a/lib/smart_answer_flows/calculate-agricultural-holiday-entitlement.rb
+++ b/lib/smart_answer_flows/calculate-agricultural-holiday-entitlement.rb
@@ -5,7 +5,7 @@ module SmartAnswer
       flow_content_id "5fc369c1-87fa-4935-a96a-ee0321beeaed"
       name "calculate-agricultural-holiday-entitlement"
       status :published
-      satisfies_need "100143"
+      satisfies_need "a22c3cfa-0590-4a00-9846-f67df3df0071"
 
       multiple_choice :work_the_same_number_of_days_each_week? do
         option "same-number-of-days"

--- a/lib/smart_answer_flows/calculate-employee-redundancy-pay.rb
+++ b/lib/smart_answer_flows/calculate-employee-redundancy-pay.rb
@@ -8,7 +8,7 @@ module SmartAnswer
       name "calculate-employee-redundancy-pay"
 
       status :published
-      satisfies_need "100138"
+      satisfies_need "7b64d692-db45-428a-8767-131bb6d5b118"
 
       append(Shared::RedundancyPayFlow.build)
     end

--- a/lib/smart_answer_flows/calculate-married-couples-allowance.rb
+++ b/lib/smart_answer_flows/calculate-married-couples-allowance.rb
@@ -5,7 +5,7 @@ module SmartAnswer
       flow_content_id "cb4649de-e0b7-42e3-a43a-b98e4415555a"
       name "calculate-married-couples-allowance"
       status :published
-      satisfies_need "101007"
+      satisfies_need "39e28d41-a13b-441d-8bf2-f1fc54992aea"
 
       multiple_choice :were_you_or_your_partner_born_on_or_before_6_april_1935? do
         option :yes

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay.rb
@@ -6,7 +6,7 @@ module SmartAnswer
       name "calculate-statutory-sick-pay"
 
       status :published
-      satisfies_need "100262"
+      satisfies_need "4784e91e-359c-4f88-aa9e-316392945c85"
 
       # Question 1
       checkbox_question :is_your_employee_getting? do

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement.rb
@@ -5,7 +5,7 @@ module SmartAnswer
       flow_content_id "ebc97e28-85be-4f9f-8637-b2d43be9f0a6"
       name "calculate-your-holiday-entitlement"
       status :published
-      satisfies_need "100143"
+      satisfies_need "a22c3cfa-0590-4a00-9846-f67df3df0071"
 
       # Q1
       multiple_choice :basis_of_calculation? do

--- a/lib/smart_answer_flows/calculate-your-redundancy-pay.rb
+++ b/lib/smart_answer_flows/calculate-your-redundancy-pay.rb
@@ -8,7 +8,7 @@ module SmartAnswer
       name "calculate-your-redundancy-pay"
 
       status :published
-      satisfies_need "100135"
+      satisfies_need "0165fbcc-e7a1-4c42-b6fa-a459384086f1"
 
       append(Shared::RedundancyPayFlow.build)
     end

--- a/lib/smart_answer_flows/check-uk-visa.rb
+++ b/lib/smart_answer_flows/check-uk-visa.rb
@@ -6,7 +6,7 @@ module SmartAnswer
       flow_content_id "34b852ce-9045-4431-9a16-6609d307cdb7"
       name "check-uk-visa"
       status :published
-      satisfies_need "100982"
+      satisfies_need "5f714149-da26-46f9-9a87-d1bf75dd778a"
 
       additional_countries = UkbaCountry.all
 

--- a/lib/smart_answer_flows/childcare-costs-for-tax-credits.rb
+++ b/lib/smart_answer_flows/childcare-costs-for-tax-credits.rb
@@ -5,7 +5,7 @@ module SmartAnswer
       flow_content_id "5f606f33-a3e9-47ff-bc1d-2a6444e7b54c"
       name "childcare-costs-for-tax-credits"
       status :published
-      satisfies_need "100422"
+      satisfies_need "e2826e36-a66a-4970-955c-3767674ae82e"
 
       # Q1
       multiple_choice :currently_claiming? do

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
@@ -5,7 +5,7 @@ module SmartAnswer
       flow_content_id "14244ee4-6d7d-4e05-90a7-aaf1a776d312"
       name "estimate-self-assessment-penalties"
       status :published
-      satisfies_need "100615"
+      satisfies_need "e220b484-a097-4ed4-ae3d-ac982b10c8cd"
 
       multiple_choice :which_year? do
         option :"2012-13"

--- a/lib/smart_answer_flows/help-if-you-are-arrested-abroad.rb
+++ b/lib/smart_answer_flows/help-if-you-are-arrested-abroad.rb
@@ -5,7 +5,7 @@ module SmartAnswer
       flow_content_id "d5074786-f3cc-410e-bc3d-d52008f0a692"
       name "help-if-you-are-arrested-abroad"
       status :published
-      satisfies_need "100220"
+      satisfies_need "de7bf117-408b-4b26-8e08-7aa51415b4e2"
 
       arrested_calc = Calculators::ArrestedAbroad.new
       exclude_countries = %w[holy-see british-antarctic-territory]

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will.rb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will.rb
@@ -5,7 +5,7 @@ module SmartAnswer
       flow_content_id "c1e50aff-67b7-4841-b0d8-33a66bec9807"
       name "inherits-someone-dies-without-will"
       status :published
-      satisfies_need "100988"
+      satisfies_need "cb6ea8b6-e8ed-4832-a7c1-5a1bf99cd2e1"
 
       # The case & if blocks in this file are organised to be read in the same order
       # as the flow chart rather than to minimise repetition.

--- a/lib/smart_answer_flows/landlord-immigration-check.rb
+++ b/lib/smart_answer_flows/landlord-immigration-check.rb
@@ -5,7 +5,7 @@ module SmartAnswer
       flow_content_id "61334174-53a3-4112-b6ea-1608d875ced8"
       name "landlord-immigration-check"
       status :published
-      satisfies_need "102373"
+      satisfies_need "02c8d20b-6742-4494-8e17-e2c34bc8c21f"
 
       # Q0
       postcode_question :property? do

--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -14,7 +14,7 @@ module SmartAnswer
       flow_content_id "92c0a193-3b3b-4378-ba43-279e7274b7e7"
       name "marriage-abroad"
       status :published
-      satisfies_need "101000"
+      satisfies_need "463773ea-3629-4386-8511-06ec12351303"
 
       exclude_countries = %w[congo holy-see british-antarctic-territory the-occupied-palestinian-territories]
 

--- a/lib/smart_answer_flows/maternity-paternity-calculator.rb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator.rb
@@ -10,7 +10,7 @@ module SmartAnswer
       flow_content_id "38c0b111-e9be-40f3-915b-ad1d9bbf3b2b"
       name "maternity-paternity-calculator"
       status :published
-      satisfies_need "100990"
+      satisfies_need "ee96f915-9dbd-4bf9-a6fc-21ad237de88b"
 
       ## Q1
       multiple_choice :what_type_of_leave? do

--- a/lib/smart_answer_flows/minimum-wage-calculator-employers.rb
+++ b/lib/smart_answer_flows/minimum-wage-calculator-employers.rb
@@ -7,7 +7,7 @@ module SmartAnswer
       flow_content_id "fe2a4b16-bd8c-42c7-bd89-8c5f825673e2"
       name "minimum-wage-calculator-employers"
       status :published
-      satisfies_need "100145"
+      satisfies_need "6f764f56-01af-415f-8bfb-60bda489c015"
 
       # Q1
       multiple_choice :what_would_you_like_to_check? do

--- a/lib/smart_answer_flows/part-year-profit-tax-credits.rb
+++ b/lib/smart_answer_flows/part-year-profit-tax-credits.rb
@@ -4,7 +4,7 @@ module SmartAnswer
       name "part-year-profit-tax-credits"
 
       status :published
-      satisfies_need "103438"
+      satisfies_need "2aa5527c-8626-492a-83de-9654e250eda0"
       start_page_content_id "de6723a5-7256-4bfd-aad3-82b04b06b73e"
       flow_content_id "a0720c77-f45d-437c-a867-405d5f5dd40c"
 

--- a/lib/smart_answer_flows/pay-leave-for-parents.rb
+++ b/lib/smart_answer_flows/pay-leave-for-parents.rb
@@ -5,7 +5,7 @@ module SmartAnswer
       flow_content_id "177cde4d-e52f-4629-bbbe-ec85a18ed944"
       name "pay-leave-for-parents"
       status :published
-      satisfies_need "101018"
+      satisfies_need "558b11d4-e164-40e2-96a2-f20643fe4539"
 
       multiple_choice :two_carers do
         option "yes"

--- a/lib/smart_answer_flows/plan-adoption-leave.rb
+++ b/lib/smart_answer_flows/plan-adoption-leave.rb
@@ -5,7 +5,7 @@ module SmartAnswer
       flow_content_id "a2ae6c66-ce83-4da1-b758-f7f12acc4c39"
       name "plan-adoption-leave"
       status :published
-      satisfies_need "101018"
+      satisfies_need "558b11d4-e164-40e2-96a2-f20643fe4539"
 
       date_question :child_match_date? do
         save_input_as :match_date

--- a/lib/smart_answer_flows/register-a-birth.rb
+++ b/lib/smart_answer_flows/register-a-birth.rb
@@ -5,7 +5,7 @@ module SmartAnswer
       flow_content_id "68e9c4da-2edb-4859-8793-17ebc92fc01b"
       name "register-a-birth"
       status :published
-      satisfies_need "101003"
+      satisfies_need "7b4cffa5-c82b-41be-9092-e61bf3a19f5b"
 
       # Q1
       country_select :country_of_birth?, exclude_countries: Calculators::RegisterABirthCalculator::EXCLUDE_COUNTRIES do

--- a/lib/smart_answer_flows/register-a-death.rb
+++ b/lib/smart_answer_flows/register-a-death.rb
@@ -5,7 +5,7 @@ module SmartAnswer
       flow_content_id "16230cbd-9c81-44ae-9d24-7d8bbabddf88"
       name "register-a-death"
       status :published
-      satisfies_need "101006"
+      satisfies_need "d2c1fda5-92d4-4368-a8d0-307290989887"
 
       # Q1
       multiple_choice :where_did_the_death_happen? do

--- a/lib/smart_answer_flows/report-a-lost-or-stolen-passport.rb
+++ b/lib/smart_answer_flows/report-a-lost-or-stolen-passport.rb
@@ -5,7 +5,7 @@ module SmartAnswer
       flow_content_id "ba17a50d-611e-4df5-aa35-9339c4e20162"
       name "report-a-lost-or-stolen-passport"
       status :published
-      satisfies_need "100221"
+      satisfies_need "1de5292b-6696-4149-94b9-1e0b6f8b7119"
 
       multiple_choice :where_was_the_passport_lost_or_stolen? do
         option :in_the_uk

--- a/lib/smart_answer_flows/simplified-expenses-checker.rb
+++ b/lib/smart_answer_flows/simplified-expenses-checker.rb
@@ -5,7 +5,7 @@ module SmartAnswer
       flow_content_id "09f5f2b6-dc09-4594-8c2a-d907fed427d5"
       name "simplified-expenses-checker"
       status :published
-      satisfies_need "100119"
+      satisfies_need "f59b3c90-a1a8-4fa9-a593-2b218b25c0fd"
 
       # Q1 - vehicle expense
       multiple_choice :vehicle_expense? do

--- a/lib/smart_answer_flows/state-pension-age.rb
+++ b/lib/smart_answer_flows/state-pension-age.rb
@@ -5,7 +5,7 @@ module SmartAnswer
       flow_content_id "cdca2cab-da55-4184-abb3-af27764dd756"
       name "state-pension-age"
       status :published
-      satisfies_need "100245"
+      satisfies_need "b91945bf-56f6-46aa-b25f-0066bc2377b6"
 
       # Q1
       multiple_choice :which_calculation? do

--- a/lib/smart_answer_flows/state-pension-through-partner.rb
+++ b/lib/smart_answer_flows/state-pension-through-partner.rb
@@ -5,7 +5,7 @@ module SmartAnswer
       flow_content_id "8e80445f-b987-4f71-bc86-282b2779a4de"
       name "state-pension-through-partner"
       status :published
-      satisfies_need "100578"
+      satisfies_need "50721588-6952-4280-be7b-30d5402e715d"
 
       # Q1
       multiple_choice :what_is_your_marital_status? do

--- a/lib/smart_answer_flows/student-finance-calculator.rb
+++ b/lib/smart_answer_flows/student-finance-calculator.rb
@@ -5,7 +5,7 @@ module SmartAnswer
       flow_content_id "92631e38-206a-4785-82b2-4f544db16040"
       name "student-finance-calculator"
       status :published
-      satisfies_need "100133"
+      satisfies_need "7389628a-b288-45c4-a8c3-f4d9de7f8873"
 
       sf_calculator = Calculators::StudentFinanceCalculator.new
 

--- a/lib/smart_answer_flows/towing-rules.rb
+++ b/lib/smart_answer_flows/towing-rules.rb
@@ -5,7 +5,7 @@ module SmartAnswer
       flow_content_id "94eb2af7-beb4-4657-b8b9-885dd86cbe3f"
       name "towing-rules"
       status :published
-      satisfies_need "101014"
+      satisfies_need "965810bf-bbe7-4945-bbe5-f37af459d2fe"
 
       ## Cars and light vehicles
       ##

--- a/lib/smart_answer_flows/uk-benefits-abroad.rb
+++ b/lib/smart_answer_flows/uk-benefits-abroad.rb
@@ -5,7 +5,7 @@ module SmartAnswer
       flow_content_id "99f0e249-aaf2-43da-8e5e-7a8de934fc64"
       name "uk-benefits-abroad"
       status :published
-      satisfies_need "100490"
+      satisfies_need "5327577e-9a37-42c6-b43a-105772d11dbd"
 
       exclude_countries = %w[british-antarctic-territory french-guiana guadeloupe holy-see martinique mayotte reunion st-maarten]
       additional_countries = [OpenStruct.new(slug: "jersey", name: "Jersey"), OpenStruct.new(slug: "guernsey", name: "Guernsey")]

--- a/lib/smart_answer_flows/vat-payment-deadlines.rb
+++ b/lib/smart_answer_flows/vat-payment-deadlines.rb
@@ -5,7 +5,7 @@ module SmartAnswer
       flow_content_id "f0868a94-5b24-4141-a1c2-73b53b842b44"
       name "vat-payment-deadlines"
       status :published
-      satisfies_need "100624"
+      satisfies_need "2c24c7e6-93c7-4290-9a1f-d5f8f3f112bb"
 
       date_question :when_does_your_vat_accounting_period_end? do
         default_day { -1 }

--- a/test/fixtures/smart_answer_flows/flow-sample.rb
+++ b/test/fixtures/smart_answer_flows/flow-sample.rb
@@ -2,7 +2,7 @@ module SmartAnswer
   class FlowSampleFlow < Flow
     def define
       name "flow-sample"
-      satisfies_need 4242
+      satisfies_need "dccab509-bd3b-4f92-9af6-30f88485ac41"
       start_page_content_id "f26e566e-2557-4921-b944-9373c32255f1"
 
       multiple_choice :hotter_or_colder? do

--- a/test/fixtures/smart_answer_flows/smart-answers-controller-sample.rb
+++ b/test/fixtures/smart_answer_flows/smart-answers-controller-sample.rb
@@ -2,7 +2,7 @@ module SmartAnswer
   class SmartAnswersControllerSampleFlow < Flow
     def define
       name "smart-answers-controller-sample"
-      satisfies_need 1337
+      satisfies_need "7da2fa63-190c-446e-b3e5-94480f0e46e7"
 
       multiple_choice :do_you_like_chocolate? do
         option :yes

--- a/test/unit/flow_registration_presenter_test.rb
+++ b/test/unit/flow_registration_presenter_test.rb
@@ -34,9 +34,9 @@ class FlowRegistrationPresenterTest < ActiveSupport::TestCase
     end
   end
 
-  context "need_id" do
-    should "use the flow's need_id" do
-      assert_equal 4242, @presenter.need_id
+  context "need_content_id" do
+    should "use the flow's need_content_id" do
+      assert_equal "dccab509-bd3b-4f92-9af6-30f88485ac41", @presenter.need_content_id
     end
   end
 

--- a/test/unit/flow_test.rb
+++ b/test/unit/flow_test.rb
@@ -173,12 +173,12 @@ class FlowTest < ActiveSupport::TestCase
     assert_instance_of SmartAnswer::Question::Postcode, question
   end
 
-  test "should have a need ID" do
+  test "should have a need content ID" do
     s = SmartAnswer::Flow.new do
-      satisfies_need 1337
+      satisfies_need "dccab509-bd3b-4f92-9af6-30f88485ac41"
     end
 
-    assert_equal 1337, s.need_id
+    assert_equal "dccab509-bd3b-4f92-9af6-30f88485ac41", s.need_content_id
   end
 
   test "should default to a draft status" do


### PR DESCRIPTION
This follows on from some work done a long time ago to move needs from
the Need API to the Publishing API [1]. At this time, the identifiers
for needs transitioned from being numbers, to UUIDs, because the
Publishing API uses UUIDs.

1: https://github.com/alphagov/maslow/pull/160

I don't think this change alone will actually have an effect beyond
smart answers, but it may enable linking the smart answers content
items to the relevant need content item in the future.

To map the need ids here to content ids, I just queried the Publishing
API database with a query like the following, where XXX is the numeric
need id:

```
  SELECT DISTINCT editions.details->'need_id', documents.content_id
  FROM editions
  INNER JOIN documents
    ON editions.document_id = documents.id
  WHERE document_type = 'need'
    AND editions.details->>'need_id' = 'XXX';
```

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.
