### PR TITLE
Remove render_content_for

### DIFF
--- a/lib/smart_answer/erb_renderer/format_capture_helper.rb
+++ b/lib/smart_answer/erb_renderer/format_capture_helper.rb
@@ -1,7 +1,5 @@
 module SmartAnswer
   module ErbRenderer::FormatCaptureHelper
-    class InvalidFormatType < RuntimeError; end
-
     TEXT_CONTENT = [
       :title,
       :meta_description,
@@ -10,21 +8,6 @@ module SmartAnswer
       :suffix_label,
       /^error_/,
     ].freeze
-
-    def render_content_for(name, options = {}, &block)
-      format = options.fetch(:format, default_format(name))
-
-      case format
-      when :govspeak
-        govspeak_for(name, &block)
-      when :html
-        html_for(name, &block)
-      when :text
-        text_for(name, &block)
-      else
-        raise InvalidFormatType
-      end
-    end
 
     def text_for(name, &block)
       content = capture_content(&block)

--- a/test/unit/erb_renderer_test.rb
+++ b/test/unit/erb_renderer_test.rb
@@ -3,7 +3,7 @@ require_relative "../test_helper"
 module SmartAnswer
   class ErbRendererTest < ActiveSupport::TestCase
     test "can render a template" do
-      erb_template = render_content_for(:key, "content")
+      erb_template = %{<%= text_for(:key) { "content" } %>}
       with_erb_template_file("template-name", erb_template) do |erb_template_directory|
         renderer = ErbRenderer.new(
           template_directory: erb_template_directory,
@@ -14,7 +14,7 @@ module SmartAnswer
     end
 
     test "can render a template with a .govspeak name" do
-      erb_template = render_content_for(:key, "content")
+      erb_template = %{<%= text_for(:key) { "content" } %>}
       with_erb_template_file("template-name.govspeak", erb_template) do |erb_template_directory|
         renderer = ErbRenderer.new(
           template_directory: erb_template_directory,
@@ -41,8 +41,7 @@ module SmartAnswer
     end
 
     test "#content_for makes local variables available to the ERB template" do
-      erb_template = render_content_for(:key, "<%= state_variable %>")
-
+      erb_template = %{<%= text_for(:key) { %><%= state_variable %> <% } %>}
       with_erb_template_file("template-name", erb_template) do |erb_template_directory|
         renderer = ErbRenderer.new(template_directory: erb_template_directory, template_name: "template-name", locals: { state_variable: "state-variable" })
 
@@ -51,8 +50,7 @@ module SmartAnswer
     end
 
     test "#content_for raises an exception if the ERB template references a non-existent state variable" do
-      erb_template = render_content_for(:key, "<%= non_existent_state_variable %>")
-
+      erb_template = %{<%= text_for(:key) { %><%= non_existent_state_variable %> <% } %>}
       with_erb_template_file("template-name", erb_template) do |erb_template_directory|
         renderer = ErbRenderer.new(template_directory: erb_template_directory, template_name: "template-name", locals: {})
 
@@ -109,10 +107,6 @@ module SmartAnswer
     end
 
   private
-
-    def render_content_for(key, template)
-      "<% render_content_for #{key.inspect} do %>\n#{template}\n<% end %>"
-    end
 
     def with_erb_template_file(outcome_name, erb_template)
       erb_template_filename = "#{outcome_name}.erb"

--- a/test/unit/format_capture_helper_test.rb
+++ b/test/unit/format_capture_helper_test.rb
@@ -96,38 +96,5 @@ module SmartAnswer
                      error.message
       end
     end
-
-    context "#render_content_for" do
-      should "render govspeak when specified" do
-        @test_obj.render_content_for(:name, format: :govspeak) { "content" }
-        assert_match @test_obj.content_for(:name), "<govspeak><p>content</p>\n</govspeak>"
-      end
-
-      should "render html when specified" do
-        @test_obj.render_content_for(:name, format: :html) { "<p>content</p>" }
-        assert_equal @test_obj.content_for(:name), "<p>content</p>"
-      end
-
-      should "render text when specified" do
-        @test_obj.render_content_for(:name, format: :text) { "text" }
-        assert_equal @test_obj.content_for(:name), "text"
-      end
-
-      should "default to rendering govspeak" do
-        @test_obj.render_content_for(:name) { "content" }
-        assert_match @test_obj.content_for(:name), "<govspeak><p>content</p>\n</govspeak>"
-      end
-
-      should "render text when the field defaults to text" do
-        @test_obj.render_content_for(:title) { "content" }
-        assert_match @test_obj.content_for(:title), "content"
-      end
-
-      should "raise an error when given an unknown format" do
-        assert_raises SmartAnswer::ErbRenderer::FormatCaptureHelper::InvalidFormatType do
-          @test_obj.render_content_for(:title, { format: :invalid }) { "content" }
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
Since https://github.com/alphagov/smart-answers/pull/4527 was merged we no longer use the `render_content_for` method in smart answers and can now safely remove it.

