### PR TITLE
Remove deprecated methods from the student finance flow

### DIFF
--- a/lib/smart_answer/calculators/student_finance_calculator.rb
+++ b/lib/smart_answer/calculators/student_finance_calculator.rb
@@ -1,16 +1,17 @@
 module SmartAnswer
   module Calculators
     class StudentFinanceCalculator
-      attr_accessor(
-        :course_start,
-        :household_income,
-        :residence,
-        :course_type,
-        :part_time_credits,
-        :full_time_credits,
-        :doctor_or_dentist,
-        :uk_ft_circumstances,
-      )
+      attr_accessor :course_start,
+                    :household_income,
+                    :residence,
+                    :course_type,
+                    :course_studied,
+                    :part_time_credits,
+                    :full_time_credits,
+                    :doctor_or_dentist,
+                    :uk_ft_circumstances,
+                    :uk_all_circumstances,
+                    :tuition_fee_amount
 
       LOAN_MAXIMUMS = {
         "2019-2020" => {
@@ -172,6 +173,18 @@ module SmartAnswer
       def course_start_years
         year_matches = /(\d{4})-(\d{4})/.match(@course_start)
         [year_matches[1].to_i, year_matches[2].to_i]
+      end
+
+      def valid_tuition_fee_amount?
+        tuition_fee_amount <= tuition_fee_maximum
+      end
+
+      def valid_credit_amount?
+        part_time_credits.positive?
+      end
+
+      def valid_full_time_credit_amount?
+        full_time_credits.positive? && full_time_credits >= part_time_credits
       end
 
     private

--- a/lib/smart_answer/calculators/student_finance_calculator.rb
+++ b/lib/smart_answer/calculators/student_finance_calculator.rb
@@ -187,6 +187,10 @@ module SmartAnswer
         full_time_credits.positive? && full_time_credits >= part_time_credits
       end
 
+      def ineligible_for_extra_grants?
+        uk_all_circumstances.include?("no") && course_studied != "teacher-training" && course_studied != "social-work"
+      end
+
     private
 
       def max_loan_amount

--- a/lib/smart_answer_flows/student-finance-calculator/outcomes/_nhs_full_time_funding.erb
+++ b/lib/smart_answer_flows/student-finance-calculator/outcomes/_nhs_full_time_funding.erb
@@ -1,29 +1,29 @@
 - NHS Bursary (funding towards your fees and living costs)
 
-<% if uk_ft_circumstances.include?('has-disability') %>
+<% if calculator.uk_ft_circumstances.include?('has-disability') %>
   - Disabled Students' Allowance
 <% end %>
 
-<% if uk_ft_circumstances.include?('children-under-17') %>
+<% if calculator.uk_ft_circumstances.include?('children-under-17') %>
   - Childcare Allowance
   - Parents' Learning Allowance
 <% end %>
 
-<% if uk_ft_circumstances.include?('dependant-adult') %>
+<% if calculator.uk_ft_circumstances.include?('dependant-adult') %>
   - Dependants' Allowance
 <% end %>
 
 - Extra Weeks Allowance
 - Practice placement expenses
 
-<% if uk_ft_circumstances.include?('children-under-17') || uk_ft_circumstances.include?('low-income') %>
+<% if calculator.uk_ft_circumstances.include?('children-under-17') || calculator.uk_ft_circumstances.include?('low-income') %>
   Each year you could also get:
 
-  <% if uk_ft_circumstances.include?('children-under-17') %>
+  <% if calculator.uk_ft_circumstances.include?('children-under-17') %>
     - [Child Tax Credit](/child-tax-credit)
   <% end %>
 
-  <% if uk_ft_circumstances.include?('low-income') %>
+  <% if calculator.uk_ft_circumstances.include?('low-income') %>
     - [University and college hardship funds](/extra-money-pay-university/university-and-college-hardship-funds) (extra help with costs while studying)
   <% end %>
 <% end %>

--- a/lib/smart_answer_flows/student-finance-calculator/outcomes/_nhs_part_time_funding.erb
+++ b/lib/smart_answer_flows/student-finance-calculator/outcomes/_nhs_part_time_funding.erb
@@ -1,10 +1,10 @@
 - NHS Bursary (funding towards your fees and living costs)
-<% if all_uk_students_circumstances.include?('has-disability') %>
+<% if calculator.uk_all_circumstances.include?('has-disability') %>
   - Disabled Students' Allowance
 <% end %>
 - Extra Weeks Allowance
 - Practice placement expenses
 
-<% if all_uk_students_circumstances.include?('low-income') %>
+<% if calculator.uk_all_circumstances.include?('low-income') %>
   Each year you could also get [University and college hardship funds](/extra-money-pay-university/university-and-college-hardship-funds) (extra help with costs while studying)
 <% end %>

--- a/lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_eu_students.erb
+++ b/lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_eu_students.erb
@@ -3,11 +3,11 @@
 
   ##Tuition costs
 
-  You could get a [Tuition Fee Loan](/student-finance/eu-students) - <%= format_money(tuition_fee_amount, pounds_only: true) %> per year.
+  You could get a [Tuition Fee Loan](/student-finance/eu-students) - <%= format_money(calculator.tuition_fee_amount, pounds_only: true) %> per year.
 
   The loan pays for the cost of your course and must be paid back.
 
-  <% if course_type == 'eu-full-time' %>
+  <% if calculator.course_type == 'eu-full-time' %>
     ##Living costs
 
     Most EU full-time students don't qualify for help with living costs (known as 'maintenance').

--- a/lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_uk_all_students.erb
+++ b/lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_uk_all_students.erb
@@ -1,11 +1,11 @@
 <% govspeak_for :body do %>
   <%= render partial: 'disclaimer' %>
 
-  <% if course_studied == 'dental-medical-healthcare' %>
+  <% if calculator.course_studied == 'dental-medical-healthcare' %>
     To qualify for a Maintenance Loan you must be studying a DipHE in dental hygiene and dental therapy or operating department practice, or a Foundation Degree in dental hygiene and dental therapy.
-  <% elsif course_studied == 'teacher-training' %>
+  <% elsif calculator.course_studied == 'teacher-training' %>
     To qualify for a Maintenance Loan you must be studying an Initial Teacher Training course (if it's degree level or above).
-  <% elsif course_studied == 'none-of-the-above' %>
+  <% elsif calculator.course_studied == 'none-of-the-above' %>
     To qualify for a Maintenance Loan, you must be studying one of the following courses:
 
     - a first degree, for example BA, BSc or BEd
@@ -19,7 +19,7 @@
 
   You could get per year:
 
-  - <%= format_money(tuition_fee_amount, pounds_only: true) %> [Tuition Fee Loan](/student-finance/parttime-students)
+  - <%= format_money(calculator.tuition_fee_amount, pounds_only: true) %> [Tuition Fee Loan](/student-finance/parttime-students)
 
   <% if calculator.maintenance_loan_amount > 0 %>
     - <%= format_money(calculator.maintenance_loan_amount, pounds_only: true) %> [Maintenance Loan](/student-finance/parttime-students)
@@ -27,28 +27,28 @@
 
   ###Extra student funding
 
-  <% if all_uk_students_circumstances.include?('no') and course_studied != 'teacher-training' and course_studied != 'social-work' %>
+  <% if calculator.uk_all_circumstances.include?('no') and calculator.course_studied != 'teacher-training' and calculator.course_studied != 'social-work' %>
     You don’t qualify for extra grants and allowances.
   <% else %>
     You could get:
 
-    <% if all_uk_students_circumstances.include?('has-disability') %>
+    <% if calculator.uk_all_circumstances.include?('has-disability') %>
       - [Disabled Students' Allowances](/disabled-students-allowances-dsas)
     <% end %>
 
-    <% if all_uk_students_circumstances.include?('low-income') %>
+    <% if calculator.uk_all_circumstances.include?('low-income') %>
       - [University and college hardship funds](/extra-money-pay-university/university-and-college-hardship-funds) (extra help with costs while studying)
     <% end %>
 
-    <% if course_studied == 'teacher-training' %>
+    <% if calculator.course_studied == 'teacher-training' %>
       - [Funding for teacher training](/teacher-training-funding)
-    <% elsif course_studied == 'social-work' %>
+    <% elsif calculator.course_studied == 'social-work' %>
       - [Social Work Bursary](/social-work-bursaries) (NHS funding towards your fees and living costs)
     <% end %>
 
   <% end %>
 
-  <%= render partial: 'uk_extra_help', locals: { course_type: course_type } %>
+  <%= render partial: 'uk_extra_help', locals: { course_type: calculator.course_type } %>
 
   <%= render partial: 'next_steps' %>
 

--- a/lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_uk_all_students.erb
+++ b/lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_uk_all_students.erb
@@ -27,7 +27,7 @@
 
   ###Extra student funding
 
-  <% if calculator.uk_all_circumstances.include?('no') and calculator.course_studied != 'teacher-training' and calculator.course_studied != 'social-work' %>
+  <% if calculator.ineligible_for_extra_grants? %>
     You don’t qualify for extra grants and allowances.
   <% else %>
     You could get:

--- a/lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_uk_full_time_dental_medical_students.erb
+++ b/lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_uk_full_time_dental_medical_students.erb
@@ -6,7 +6,7 @@
 
     In each of your first 4 years, you could get:
 
-    <%= render partial: 'full_time_tuition', locals: { tuition_fee_amount: tuition_fee_amount, maintenance_loan_amount: calculator.maintenance_loan_amount, maintenance_grant_amount: calculator.maintenance_grant_amount, start_date: start_date } %>
+    <%= render partial: 'full_time_tuition', locals: { tuition_fee_amount: calculator.tuition_fee_amount, maintenance_loan_amount: calculator.maintenance_loan_amount, maintenance_grant_amount: calculator.maintenance_grant_amount, start_date: calculator.course_start } %>
 
     <% if calculator.eligible_for_childcare_grant_one_child? %>
       - up to 85% of your childcare costs (maximum <%= format_money(calculator.childcare_grant_one_child) %> a week for a single child or <%= format_money(calculator.childcare_grant_more_than_one_child) %> a week if you have more than one) in Childcare Grant
@@ -22,17 +22,17 @@
       - up to <%= format_money(calculator.adult_dependant_allowance) %> per year [Adult Dependant’s Grant](/adult-dependants-grant)
     <% end %>
 
-    <% if uk_ft_circumstances.include?('has-disability') %>
+    <% if calculator.uk_ft_circumstances.include?('has-disability') %>
       - [Disabled Students' Allowances](/disabled-students-allowances-dsas)
     <% end %>
 
     In your fifth and sixth years, you could get <%= format_money(calculator.reduced_maintenance_loan_for_healthcare, pounds_only: true) %> reduced Maintenance Loan. You can also apply for [NHS funding](/nhs-bursaries) and get the following depending on your circumstances:
 
-    <%= render partial: 'nhs_full_time_funding', locals: { uk_ft_circumstances: uk_ft_circumstances, calculator: calculator } %>
+    <%= render partial: 'nhs_full_time_funding', locals: { calculator: calculator } %>
 
     ^ If you're on a 4 year accelerated graduate course, you'll have to apply for an NHS bursary from your second year.
 
-  <%= render partial: 'uk_extra_help', locals: { course_type: course_type } %>
+  <%= render partial: 'uk_extra_help', locals: { course_type: calculator.course_type } %>
 
   <%= render partial: 'next_steps' %>
 <% end %>

--- a/lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_uk_full_time_students.erb
+++ b/lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_uk_full_time_students.erb
@@ -5,11 +5,11 @@
 
   You could get per year:
 
-  <%= render partial: 'full_time_tuition', locals: { tuition_fee_amount: tuition_fee_amount, maintenance_loan_amount: calculator.maintenance_loan_amount, maintenance_grant_amount: calculator.maintenance_grant_amount, start_date: start_date } %>
+  <%= render partial: 'full_time_tuition', locals: { tuition_fee_amount: calculator.tuition_fee_amount, maintenance_loan_amount: calculator.maintenance_loan_amount, maintenance_grant_amount: calculator.maintenance_grant_amount, start_date: calculator.course_start } %>
 
   ###Extra student funding
 
-  <% if uk_ft_circumstances.include?('no') && course_studied == 'none-of-the-above' %>
+  <% if calculator.uk_ft_circumstances.include?('no') && calculator.course_studied == 'none-of-the-above' %>
     You don’t qualify for extra grants and allowances.
   <% else %>
     Depending on your income and circumstances, you could get:
@@ -24,7 +24,7 @@
       - up to <%= format_money(calculator.parent_learning_allowance) %> per year [Parents’ Learning Allowance](/parents-learning-allowance)
     <% end %>
 
-    <% if uk_ft_circumstances.include?('children-under-17') %>
+    <% if calculator.uk_ft_circumstances.include?('children-under-17') %>
       - [Child Tax Credit](/child-tax-credit)
     <% end %>
 
@@ -32,21 +32,21 @@
       - up to <%= format_money(calculator.adult_dependant_allowance) %> per year [Adult Dependant’s Grant](/adult-dependants-grant)
     <% end %>
 
-    <% if uk_ft_circumstances.include?('has-disability') %>
+    <% if calculator.uk_ft_circumstances.include?('has-disability') %>
       - [Disabled Students' Allowances](/disabled-students-allowances-dsas)
     <% end %>
 
-    <% if uk_ft_circumstances.include?('low-income') %>
+    <% if calculator.uk_ft_circumstances.include?('low-income') %>
       - [University and college hardship funds](/extra-money-pay-university/university-and-college-hardship-funds) (extra help with costs while studying)
     <% end %>
 
-    <% if course_studied == 'teacher-training' %>
+    <% if calculator.course_studied == 'teacher-training' %>
       - [Funding for teacher training](/teacher-training-funding)
-    <% elsif course_studied == 'social-work' %>
+    <% elsif calculator.course_studied == 'social-work' %>
       - [Social Work Bursary](/social-work-bursaries) (NHS funding towards your fees and living costs)
     <% end %>
 
-    <%= render partial: 'uk_extra_help', locals: { course_type: course_type } %>
+    <%= render partial: 'uk_extra_help', locals: { course_type: calculator.course_type } %>
 
     <%= render partial: 'next_steps' %>
   <% end %>

--- a/lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_uk_part_time_dental_medical_students.erb
+++ b/lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_uk_part_time_dental_medical_students.erb
@@ -3,9 +3,9 @@
 
   Each year you could get the following [NHS funding](/nhs-bursaries):
 
-  <%= render partial: 'nhs_part_time_funding', locals: { all_uk_students_circumstances: all_uk_students_circumstances, calculator: calculator } %>
+  <%= render partial: 'nhs_part_time_funding', locals: { calculator: calculator } %>
 
-  <%= render partial: 'uk_extra_help', locals: { course_type: course_type } %>
+  <%= render partial: 'uk_extra_help', locals: { course_type: calculator.course_type } %>
 
   <%= render partial: 'next_steps' %>
 


### PR DESCRIPTION
This removes the save_input_as and calculate blocks and replaces the logic with methods in the calculator.

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.
