### PR TITLE
Remove deprecated methods in plan adoption leave flow

### DIFF
--- a/lib/smart_answer/calculators/plan_adoption_leave.rb
+++ b/lib/smart_answer/calculators/plan_adoption_leave.rb
@@ -3,25 +3,29 @@ module SmartAnswer::Calculators
     include ActionView::Helpers::DateHelper
     include SmartAnswer::DateHelper
 
-    attr_reader :formatted_match_date, :formatted_arrival_date, :formatted_start_date
+    attr_accessor :match_date, :arrival_date, :start_date
 
-    def initialize(options = {})
-      @match_date = options[:match_date]
-      @formatted_match_date = formatted_date(@match_date)
-      @arrival_date = options[:arrival_date]
-      @formatted_arrival_date = formatted_date(@arrival_date)
-      @start_date = options[:start_date]
-      @formatted_start_date = formatted_date(@start_date)
+    def valid_arrival_date?
+      arrival_date > match_date
+    end
+
+    def valid_start_date?
+      dist = (arrival_date - start_date).to_i
+      (1..14).include? dist
     end
 
     def distance_start
-      distance_of_time_in_words(@arrival_date, @start_date)
+      distance_of_time_in_words(arrival_date, start_date)
+    end
+
+    def arrival_date_formatted
+      formatted_date(arrival_date)
     end
 
     ## borrowed methods
 
     def earliest_start
-      @arrival_date - 14
+      arrival_date - 14
     end
 
     def earliest_start_formatted
@@ -29,7 +33,7 @@ module SmartAnswer::Calculators
     end
 
     def expected_week
-      sunday = @match_date - @match_date.wday
+      sunday = match_date - match_date.wday
       saturday = sunday + 6
       SmartAnswer::DateRange.new begins_on: sunday, ends_on: saturday
     end
@@ -43,7 +47,7 @@ module SmartAnswer::Calculators
     end
 
     def period_of_ordinary_leave
-      SmartAnswer::DateRange.new begins_on: @start_date, ends_on: @start_date + 26 * 7
+      SmartAnswer::DateRange.new begins_on: start_date, ends_on: start_date + 26 * 7
     end
 
     def period_of_additional_leave

--- a/lib/smart_answer_flows/plan-adoption-leave/outcomes/adoption_leave_details.erb
+++ b/lib/smart_answer_flows/plan-adoption-leave/outcomes/adoption_leave_details.erb
@@ -5,14 +5,14 @@
 <% govspeak_for :body do %>
   You can take up to 52 weeks Statutory Adoption Leave.
 
-  The dates below are based on this and the date the child starts to live with you: <%= arrival_date_formatted %>.
+  The dates below are based on this and the date the child starts to live with you: <%= calculator.arrival_date_formatted %>.
 
   Leave | Key dates
   - | -
-  Ordinary Adoption Leave (first 26 weeks): | <%= period_of_ordinary_leave %>
-  Additional Adoption Leave (last 26 weeks): | <%= period_of_additional_leave %>
-  Earliest leave can start: | <%= earliest_start_formatted %>
-  Latest date to give notice: | <%= last_qualifying_week_formatted %>
+  Ordinary Adoption Leave (first 26 weeks): | <%= calculator.period_of_ordinary_leave %>
+  Additional Adoption Leave (last 26 weeks): | <%= calculator.period_of_additional_leave %>
+  Earliest leave can start: | <%= calculator.earliest_start_formatted %>
+  Latest date to give notice: | <%= calculator.last_qualifying_week_formatted %>
 
   You could get more time off if your employer has a company adoption leave scheme.
 

--- a/test/unit/calculators/plan_adoption_leave_test.rb
+++ b/test/unit/calculators/plan_adoption_leave_test.rb
@@ -4,38 +4,29 @@ module SmartAnswer::Calculators
   class PlanAdoptionLeaveTest < ActiveSupport::TestCase
     context PlanAdoptionLeave do
       setup do
-        @match_date = Date.parse("2012-06-25")
+        @calculator = PlanAdoptionLeave.new
+        @calculator.match_date = Date.parse("2012-06-25")
       end
 
       context "formatted dates (start date 5 days)" do
         setup do
-          @calculator = PlanAdoptionLeave.new(
-            match_date: @match_date, arrival_date: Date.parse("2012-12-25"), start_date: Date.parse("2012-12-20"),
-          )
+          @calculator.arrival_date = Date.parse("2012-12-25")
+          @calculator.start_date = Date.parse("2012-12-20")
         end
 
-        should "show formatted due date" do
-          assert_equal "25 June 2012", @calculator.formatted_match_date
-          assert_equal "25 December 2012", @calculator.formatted_arrival_date
-        end
-
-        should "format start date " do
-          assert_equal "20 December 2012", @calculator.formatted_start_date
+        should "show formatted arrival date" do
+          assert_equal "25 December 2012", @calculator.arrival_date_formatted
         end
 
         should "distance from start (days 05)" do
           assert_equal "5 days", @calculator.distance_start
         end
       end
+
       context "formatted dates (start_date 2 weeks)" do
         setup do
-          @calculator = PlanAdoptionLeave.new(
-            match_date: @match_date, arrival_date: Date.parse("2012-12-25"), start_date: Date.parse("2012-12-11"),
-          )
-        end
-
-        should "format start date" do
-          assert_equal "11 December 2012", @calculator.formatted_start_date
+          @calculator.arrival_date = Date.parse("2012-12-25")
+          @calculator.start_date = Date.parse("2012-12-11")
         end
 
         should "distance from start " do
@@ -67,6 +58,30 @@ module SmartAnswer::Calculators
           should "period_of_additional_leave give range of 10 December 2012 - 10 June 2013" do
             assert_equal "11 June 2013 to 10 December 2013", @calculator.period_of_additional_leave.to_s
           end
+        end
+      end
+
+      context "test validators" do
+        should "arrival date before match date should be invalid" do
+          @calculator.arrival_date = Date.parse("2012-05-25")
+          assert_not @calculator.valid_arrival_date?
+        end
+
+        should "arrival date after match date should be valid" do
+          @calculator.arrival_date = Date.parse("2012-07-25")
+          assert @calculator.valid_arrival_date?
+        end
+
+        should "start date can be less than 14 days before arrival date" do
+          @calculator.arrival_date = Date.parse("2012-07-25")
+          @calculator.start_date = Date.parse("2012-07-15")
+          assert @calculator.valid_start_date?
+        end
+
+        should "start date cannot be longer than 14 days before arrival date" do
+          @calculator.arrival_date = Date.parse("2012-07-25")
+          @calculator.start_date = Date.parse("2012-07-10")
+          assert_not @calculator.valid_start_date?
         end
       end
     end


### PR DESCRIPTION
This moves the validation and state into the calculator class to remove the deprecated pre-calculate, calculate and save_input_as methods.

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.
