### PR TITLE
Remove soon to be opening date message for beauty parlours

### DIFF
--- a/lib/smart_answer/calculators/coronavirus_employee_risk_assessment_calculator.rb
+++ b/lib/smart_answer/calculators/coronavirus_employee_risk_assessment_calculator.rb
@@ -9,9 +9,7 @@ module SmartAnswer::Calculators
       indoor_recreation
     ].freeze
 
-    WORKPLACES_OPENING_SOON_TO_PUBLIC = {
-      "beauty_parlour" => "13 July 2020",
-    }.freeze
+    WORKPLACES_OPENING_SOON_TO_PUBLIC = {}.freeze
 
     attr_accessor :where_do_you_work,
                   :workplace_is_exception,

--- a/lib/smart_answer_flows/coronavirus-employee-risk-assessment/questions/where_do_you_work.erb
+++ b/lib/smart_answer_flows/coronavirus-employee-risk-assessment/questions/where_do_you_work.erb
@@ -8,8 +8,7 @@
 
 <% options(
   "food_and_drink": "Restaurant, pub, wine bar, café or canteen, or other food and drink establishment",
-  "hairdressers": "Hairdressers and barbers",
-  "beauty_parlour": "Beauty or nail salon, piercing and tattoo parlour, spa or massage parlour",
+  "hairdressers": "Hairdressers, barbers, beauty or nail salons, piercing and tattoo parlours, spas or massage parlours",
   "retail": "Retail",
   "auction_house": "Auction houses",
   "holiday_accommodation": "Holiday accommodation or caravan parks",

--- a/test/unit/calculators/coronavirus_employee_risk_assessment_calculator_test.rb
+++ b/test/unit/calculators/coronavirus_employee_risk_assessment_calculator_test.rb
@@ -36,11 +36,6 @@ module SmartAnswer::Calculators
         @calculator.where_do_you_work = "other"
         assert_nil @calculator.workplace_opening_date
       end
-
-      should "return date when workplace is reopening soon" do
-        @calculator.where_do_you_work = "beauty_parlour"
-        assert_equal "13 July 2020", @calculator.workplace_opening_date
-      end
     end
   end
 end


### PR DESCRIPTION
This removes the custom message shown to beauty parlours about reopening on the 13 of July as the date has passed.

Re-merged the option with "Hairdressers and barbers" option to reduce the list of options. 

Kept the WORKPLACES_OPENING_SOON_TO_PUBLIC constant, in case new guidance is published.

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.
