### PR TITLE
Fix issue with unused option key from risk assessment flow

### DIFF
--- a/lib/smart_answer_flows/coronavirus-employee-risk-assessment.rb
+++ b/lib/smart_answer_flows/coronavirus-employee-risk-assessment.rb
@@ -10,7 +10,6 @@ module SmartAnswer
       multiple_choice :where_do_you_work? do
         option :food_and_drink
         option :hairdressers
-        option :beauty_parlour
         option :retail
         option :driving_schools
         option :auction_house


### PR DESCRIPTION
This was meant to be removed as a part of #e080f10a. This is causing 500 errors to be thrown for coronavirus employee risk assessment flow.

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.
