### PR TITLE
Add reopening guidance for hotels

### DIFF
--- a/lib/smart_answer_flows/coronavirus-business-reopening.rb
+++ b/lib/smart_answer_flows/coronavirus-business-reopening.rb
@@ -9,6 +9,7 @@ module SmartAnswer
       checkbox_question :sectors? do
         option :construction
         option :factories
+        option :hotels
         option :labs
         option :offices
         option :hospitality

--- a/lib/smart_answer_flows/coronavirus-business-reopening/outcomes/_cleaning.erb
+++ b/lib/smart_answer_flows/coronavirus-business-reopening/outcomes/_cleaning.erb
@@ -49,6 +49,15 @@ There may be a risk of the virus coming into the workplace through goods, mercha
 - work out how to clean expensive equipment that cannot be washed down and design protection around machines and equipment
 - make sure you have adequate disposal arrangements
 
+<% if calculator.sector?("hotels") %>
+For guests in hotels, hostels, B&Bs, caravan parks and campsites you should:
+
+- assign shared shower facilities to just one household group, or run a reservation-and-clean process (allowing just one household to exclusively use shared facilities for a fixed time, cleaning it thoroughly, before allowing the next household)
+- set clear use and cleaning guidance for shared toilets, including asking guests to remove their personal items and maintaining social distancing
+- inform guests about the increased risk of using these facilities
+- make sure that shared facilities like water points, waste points or washing up points are cleaned regularly
+<% end %>
+
 ### Ventilation
 
 Before you reopen you should:

--- a/lib/smart_answer_flows/coronavirus-business-reopening/outcomes/_main.erb
+++ b/lib/smart_answer_flows/coronavirus-business-reopening/outcomes/_main.erb
@@ -114,7 +114,17 @@ This guidance is to help you prepare to open your business.
   - operate the ventilation system 24 hours a day 
   - increase the frequency of filter changes
 
+  <% if calculator.sector?("hotels") %>
+    ### Room Service
 
+    You should:
+
+    - encourage customers to order over the phone
+    - minimise contact between kitchen employees and front of house staff by arranging drop off and pick up points
+    - take measures such as dropping butler’s trays outside door, and encouraging tips to be added to the bill
+    - make staff accessible to guests via phone, emails and guest apps
+
+  <% end %>
   ---
 <% end %>
 

--- a/lib/smart_answer_flows/coronavirus-business-reopening/questions/sectors.erb
+++ b/lib/smart_answer_flows/coronavirus-business-reopening/questions/sectors.erb
@@ -11,6 +11,9 @@
     label: "Factories, plants, warehouses",
     hint_text: "For example, manufacturing and chemical plants, food and other large processing plants, warehouses, port operations",
   },
+  "hotels": {
+    label: "Hotels and other guest accommodation",
+  },
   "labs": {
     label: "Labs and research facilities",
     hint_text: "For example, engineering centres, clean rooms, prototyping centres, wet labs, wind tunnels, computer labs, simulators, material development labs, specialist testing rooms",


### PR DESCRIPTION
This adds a new sector choice for hotels and conditional displays additional guidance for those in that sector.

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.

<img width="754" alt="image" src="https://user-images.githubusercontent.com/11051676/87778495-33ff4780-c823-11ea-8a18-f823ee8958b8.png">
<img width="754" alt="image" src="https://user-images.githubusercontent.com/11051676/87778543-46798100-c823-11ea-8ca9-86f9f0920431.png">
<img width="754" alt="image" src="https://user-images.githubusercontent.com/11051676/87778592-55603380-c823-11ea-9447-a82e116c445c.png">
