### PR TITLE
Fix order of the sector options for business reopening flow

### DIFF
--- a/lib/smart_answer_flows/coronavirus-business-reopening.rb
+++ b/lib/smart_answer_flows/coronavirus-business-reopening.rb
@@ -8,12 +8,12 @@ module SmartAnswer
 
       checkbox_question :sectors? do
         option :construction
+        option :close_contact
         option :factories
         option :hotels
         option :labs
         option :offices
         option :hospitality
-        option :close_contact
         option :shops
         option :homes
         option :vehicles


### PR DESCRIPTION
The list should be in alphabetical order.

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.

<img width="746" alt="image" src="https://user-images.githubusercontent.com/11051676/87780226-31eab800-c826-11ea-979c-c523ccfb05e6.png">
