### PR TITLE
Extend default rake task with rubocop linting

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,4 +9,4 @@ SmartAnswers::Application.load_tasks
 # Delete the current "default" rake task and redefine it. This allow us to use:
 # - `rake test` to only run minitest tests
 Rake::Task["default"].clear
-task default: %i[test]
+task default: %i[test lint]

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,0 +1,4 @@
+desc "Lint Ruby"
+task lint: [:environment] do
+  sh "bundle exec rubocop"
+end


### PR DESCRIPTION
[Trello card](https://trello.com/c/5Gob6WUL/147-for-everyone-ensure-that-rubocop-runs-as-part-of-bundle-exec-rake-as-one-of-the-default-tasks)