### PR TITLE
Tax Credit Office changed to HMRC

### DIFF
--- a/lib/smart_answer_flows/childcare-costs-for-tax-credits/outcomes/call_helpline_plain.erb
+++ b/lib/smart_answer_flows/childcare-costs-for-tax-credits/outcomes/call_helpline_plain.erb
@@ -1,3 +1,3 @@
 <% text_for :title do %>
-  Contact the Tax Credit Office for help in working out your costs.
+  Contact [HM Revenue and Customs (HMRC)](/government/organisations/hm-revenue-customs/contact/tax-credits-enquiries) for help in working out your costs.
 <% end %>

--- a/lib/smart_answer_flows/childcare-costs-for-tax-credits/outcomes/cost_changed.erb
+++ b/lib/smart_answer_flows/childcare-costs-for-tax-credits/outcomes/cost_changed.erb
@@ -5,13 +5,13 @@
 <% govspeak_for :body do %>
   <% if ten_or_more %>
     <% if cost_change_4_weeks %>
-      Call the Tax Credit Office if you expect this to last for 4 weeks in a row or more.
+      Call [HM Revenue and Customs (HMRC)](/government/organisations/hm-revenue-customs/contact/tax-credits-enquiries) if you expect this to last for 4 weeks in a row or more.
 
-      You don’t need to report it if this won’t last 4 weeks in a row or more.
+      You do not need to report it if this will not last 4 weeks in a row or more.
     <% else %>
-      Tell the Tax Credit Office so they can adjust your tax credit.
+      Tell [HM Revenue and Customs (HMRC)](/government/organisations/hm-revenue-customs/contact/tax-credits-enquiries) so they can adjust your tax credit.
     <% end %>
   <% else %>
-    This doesn’t affect your tax credits. You don’t need to report it.
+    This does not affect your tax credits. You do not need to report it.
   <% end %>
 <% end %>

--- a/lib/smart_answer_flows/childcare-costs-for-tax-credits/outcomes/no_change.erb
+++ b/lib/smart_answer_flows/childcare-costs-for-tax-credits/outcomes/no_change.erb
@@ -3,5 +3,5 @@
 <% end %>
 
 <% govspeak_for :body do %>
-  You don’t have to report anything to the Tax Credit Office.
+  You do not have to report anything to [HM Revenue and Customs (HMRC)](/government/organisations/hm-revenue-customs/contact/tax-credits-enquiries).
 <% end %>

--- a/lib/smart_answer_flows/childcare-costs-for-tax-credits/outcomes/no_longer_paying.erb
+++ b/lib/smart_answer_flows/childcare-costs-for-tax-credits/outcomes/no_longer_paying.erb
@@ -3,5 +3,5 @@
 <% end %>
 
 <% govspeak_for :body do %>
-  If you expect this to last for 4 weeks or more, tell the [Tax Credit Office](/contact-the-tax-credit-office "Contact the Tax Credit Office").
+  If you expect this to last for 4 weeks or more, tell [HM Revenue and Customs (HMRC)](/government/organisations/hm-revenue-customs/contact/tax-credits-enquiries).
 <% end %>


### PR DESCRIPTION
https://trello.com/c/46i9xfoj/2979-tax-credits-work-out-your-childcare-costs

Updated 4 outcome files to tell users they should contact HMRC rather than the Tax Credit Office.