### PR TITLE
Update staff travel question with false option

### DIFF
--- a/lib/smart_answer/calculators/coronavirus_business_reopening_calculator.rb
+++ b/lib/smart_answer/calculators/coronavirus_business_reopening_calculator.rb
@@ -18,7 +18,7 @@ module SmartAnswer::Calculators
         calculator.staff_meetings == "yes"
       },
       staff_travel: lambda { |calculator|
-        calculator.staff_travel == "yes"
+        calculator.staff_travel == "for_work"
       },
       send_or_receive_goods: lambda { |calculator|
         calculator.send_or_receive_goods == "yes"

--- a/lib/smart_answer_flows/coronavirus-business-reopening.rb
+++ b/lib/smart_answer_flows/coronavirus-business-reopening.rb
@@ -69,7 +69,8 @@ module SmartAnswer
       end
 
       multiple_choice :staff_travel? do
-        option :yes
+        option :to_work
+        option :for_work
         option :no
 
         on_response do |response|

--- a/lib/smart_answer_flows/coronavirus-business-reopening/questions/staff_travel.erb
+++ b/lib/smart_answer_flows/coronavirus-business-reopening/questions/staff_travel.erb
@@ -1,12 +1,9 @@
 <% text_for :title do %>
-  Do your employees need to travel for work? (besides their normal commute from home to work)
-<% end %>
-
-<% text_for :hint do %>
-  If your business requires employees to travel to different places (such as construction workers, or those who travel to client sites) then select 'yes'.
+  Do your employees need to travel for work?
 <% end %>
 
 <% options(
-  "yes": "Yes",
+  "to_work": "Yes, but only to commute to the workplace",
+  "for_work": "Yes, they work on-site, visit clients or take business trips",
   "no": "No",
 ) %>

--- a/test/integration/smart_answer_flows/coronavirus_business_reopening_test.rb
+++ b/test/integration/smart_answer_flows/coronavirus_business_reopening_test.rb
@@ -21,7 +21,7 @@ class CoronavirusBusinessReopeningFlowTest < ActiveSupport::TestCase
       assert_current_node :staff_meetings?
       add_response "yes"
       assert_current_node :staff_travel?
-      add_response "yes"
+      add_response "for_work"
       assert_current_node :send_or_receive_goods?
       add_response "yes"
       assert_current_node :results

--- a/test/unit/calculators/coronavirus_business_reopening_calculator_test.rb
+++ b/test/unit/calculators/coronavirus_business_reopening_calculator_test.rb
@@ -45,7 +45,7 @@ module SmartAnswer::Calculators
 
       context "staff_travel" do
         should "return true when criteria met" do
-          @calculator.staff_travel = "yes"
+          @calculator.staff_travel = "for_work"
           assert @calculator.show?(:staff_travel)
         end
 


### PR DESCRIPTION
This adds another option to the staff travel question for the coronavirus business reopening flow. This new option is to help users understand the question, that we are asking if their employees travel as part of their work and not just their normal commute to the workplace.

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.

After:
<img width="629" alt="image" src="https://user-images.githubusercontent.com/11051676/87956330-d1b67900-caa6-11ea-81df-301b0de21e5a.png">

Before:
<img width="695" alt="image" src="https://user-images.githubusercontent.com/11051676/87956386-e561df80-caa6-11ea-8549-d429e44fd117.png">

