### PR TITLE
Update state pension age question and statement for some users

### DIFF
--- a/lib/smart_answer/calculators/state_pension_age_calculator.rb
+++ b/lib/smart_answer/calculators/state_pension_age_calculator.rb
@@ -72,6 +72,10 @@ module SmartAnswer::Calculators
       dob.between?(Date.parse("6 April 1970"), Date.parse("5 April 1978"))
     end
 
+    def pension_age_based_on_gender?
+      dob < Date.parse("6 December 1953")
+    end
+
   private
 
     def earliest_application_date

--- a/lib/smart_answer_flows/state-pension-age.rb
+++ b/lib/smart_answer_flows/state-pension-age.rb
@@ -33,7 +33,13 @@ module SmartAnswer
 
         next_node do
           if which_calculation == "age"
-            question :gender?
+            if calculator.pension_age_based_on_gender?
+              question :gender?
+            elsif calculator.before_state_pension_date?
+              outcome :not_yet_reached_sp_age
+            else
+              outcome :has_reached_sp_age
+            end
           else
             outcome :bus_pass_result
           end

--- a/lib/smart_answer_flows/state-pension-age/outcomes/not_yet_reached_sp_age.erb
+++ b/lib/smart_answer_flows/state-pension-age/outcomes/not_yet_reached_sp_age.erb
@@ -8,8 +8,6 @@
 
   <% if calculator.rolling_increase_period? %>
     ^This may increase by up to a year following [review of the State Pension age](/government/news/proposed-new-timetable-for-state-pension-age-increases).^
-  <% else %>
-    ^[The State Pension age is under review](/government/news/proposed-new-timetable-for-state-pension-age-increases) and may change in the future.^
   <% end %>
 
   <% if calculator.can_apply? %>

--- a/lib/smart_answer_flows/state-pension-age/questions/dob_age.erb
+++ b/lib/smart_answer_flows/state-pension-age/questions/dob_age.erb
@@ -2,6 +2,10 @@
   What is your date of birth?
 <% end %>
 
+<% text_for :hint do %>
+  For example, 14 10 1968
+<% end %>
+
 <% text_for :error_message do %>
   Enter your date of birth
 <% end %>

--- a/test/integration/smart_answer_flows/state_pension_age_test.rb
+++ b/test/integration/smart_answer_flows/state_pension_age_test.rb
@@ -37,13 +37,26 @@ class StatePensionAgeTest < ActiveSupport::TestCase
 
   # Calculating State Pension Age
   context "gender question" do
-    setup do
-      add_response :age
-      add_response Date.parse("5th Dec 1975")
+    context "when born before 6th December 1953" do
+      setup do
+        add_response :age
+        add_response Date.parse("5th Dec 1953")
+      end
+
+      should "ask for your gender" do
+        assert_current_node :gender?
+      end
     end
 
-    should "ask for your gender" do
-      assert_current_node :gender?
+    context "when born after 6th December 1953" do
+      setup do
+        add_response :age
+        add_response Date.parse("6th December 1953")
+      end
+
+      should "display the outcome" do
+        assert_current_node :has_reached_sp_age
+      end
     end
   end
 
@@ -52,7 +65,6 @@ class StatePensionAgeTest < ActiveSupport::TestCase
     setup do
       add_response :age
       add_response Date.parse("5th December 1975")
-      add_response :male
     end
 
     should "show you have not yet reached state pension age" do

--- a/test/unit/calculators/state_pension_age_calculator_test.rb
+++ b/test/unit/calculators/state_pension_age_calculator_test.rb
@@ -366,5 +366,17 @@ module SmartAnswer::Calculators
         assert_equal false, @calculator.rolling_increase_period?
       end
     end
+
+    context "#pension_age_based_on_gender?" do
+      should "be true for a date that is before 06/12/1953" do
+        @calculator = StatePensionAgeCalculator.new(dob: Date.parse("5 December 1953"))
+        assert_equal true, @calculator.pension_age_based_on_gender?
+      end
+
+      should "be false for a date after 06/12/1953" do
+        @calculator = StatePensionAgeCalculator.new(dob: Date.parse("6 December 1953"))
+        assert_equal false, @calculator.pension_age_based_on_gender?
+      end
+    end
   end
 end


### PR DESCRIPTION
State pension age for people born on or after 6th December 1953 is no longer based on being male or female, so this smart-answer no longer asks in this case and instead directs straight to the outcome.

This PR also removes some outcome text regarding the state pension age being under review for dates of birth that are outside the review.

[Trello](https://trello.com/c/ykYW1UoP/2052-3-remove-question-and-statement-for-some-users-state-pension-age-calculator)