### PR TITLE
Fix name of tests job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,7 @@
 name: CI
 on: [push, pull_request]
 jobs:
-  tests:
-    name: Test
+  test:
     runs-on: ubuntu-latest
     env:
       RAILS_ENV: test


### PR DESCRIPTION
It needs to be named `test` to match the requires branch protection rules: https://github.com/alphagov/govuk-saas-config/blob/aebb18d9cd32664c94d2bb63d832804ffec222b8/github/lib/configure_repo.rb#L104

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.
