### PR TITLE
Move none option label to question template

### DIFF
--- a/app/presenters/checkbox_question_presenter.rb
+++ b/app/presenters/checkbox_question_presenter.rb
@@ -20,32 +20,14 @@ class CheckboxQuestionPresenter < QuestionWithOptionsPresenter
   end
 
   def checkboxes
-    checkboxes = []
-
-    options.each do |option|
-      checkboxes << {
+    options.map do |option|
+      {
         label: option[:label],
         value: option[:value],
         hint: option[:hint_text],
         checked: prefill_value_includes?(self, option[:value]),
+        exclusive: option[:value] == "none" || nil,
       }
     end
-
-    if none_option_label.present?
-      checkboxes << {
-        label: none_option_label,
-        value: "none",
-        exclusive: true,
-        checked: prefill_value_is?("none"),
-      }
-    end
-
-    checkboxes
-  end
-
-private
-
-  def none_option_label
-    @node.none_option_label
   end
 end

--- a/app/presenters/checkbox_question_presenter.rb
+++ b/app/presenters/checkbox_question_presenter.rb
@@ -16,7 +16,7 @@ class CheckboxQuestionPresenter < QuestionWithOptionsPresenter
   end
 
   def hint_text
-    none_option_prefix.presence || hint
+    hint
   end
 
   def checkboxes
@@ -47,9 +47,5 @@ private
 
   def none_option_label
     @node.none_option_label
-  end
-
-  def none_option_prefix
-    @node.none_option_prefix
   end
 end

--- a/doc/smart-answers/question-types.md
+++ b/doc/smart-answers/question-types.md
@@ -4,6 +4,7 @@
   * User input: Choose zero to many options from a list of options.
   * Validation: Must be in the list of options.
   * Response: String containing comma-separated list of chosen options.
+  * Can specify `none_option` in flow definition to represent a "none" answer. This ensures the user has selected at least one checkbox before continuing.
 
 ## `country_select`
   * Options:

--- a/lib/smart_answer/question/checkbox.rb
+++ b/lib/smart_answer/question/checkbox.rb
@@ -45,7 +45,7 @@ module SmartAnswer
         @options.include?(NONE_OPTION)
       end
 
-      def set_none_option
+      def none_option
         @options << NONE_OPTION
       end
     end

--- a/lib/smart_answer/question/checkbox.rb
+++ b/lib/smart_answer/question/checkbox.rb
@@ -3,11 +3,10 @@ module SmartAnswer
     class Checkbox < Base
       NONE_OPTION = "none".freeze
 
-      attr_reader :options, :none_option_label
+      attr_reader :options
 
       def initialize(flow, name, &block)
         @options = []
-        @none_option = false
         super
       end
 
@@ -25,7 +24,7 @@ module SmartAnswer
       def parse_input(raw_input)
         if raw_input.blank?
           # Raise on for blank input when showing a 'none' option as input is required.
-          raise SmartAnswer::InvalidResponse, "No option specified", caller if has_none_option?
+          raise SmartAnswer::InvalidResponse, "No option specified", caller if none_option?
 
           return NONE_OPTION
         end
@@ -42,12 +41,12 @@ module SmartAnswer
         input.split(",").reject { |v| v == NONE_OPTION }
       end
 
-      def has_none_option?
-        none_option_label.present?
+      def none_option?
+        @options.include?(NONE_OPTION)
       end
 
-      def set_none_option(label:)
-        @none_option_label = label
+      def set_none_option
+        @options << NONE_OPTION
       end
     end
   end

--- a/lib/smart_answer/question/checkbox.rb
+++ b/lib/smart_answer/question/checkbox.rb
@@ -3,7 +3,7 @@ module SmartAnswer
     class Checkbox < Base
       NONE_OPTION = "none".freeze
 
-      attr_reader :options, :none_option_label, :none_option_prefix
+      attr_reader :options, :none_option_label
 
       def initialize(flow, name, &block)
         @options = []
@@ -46,9 +46,8 @@ module SmartAnswer
         none_option_label.present?
       end
 
-      def set_none_option(label:, prefix: nil)
+      def set_none_option(label:)
         @none_option_label = label
-        @none_option_prefix = prefix
       end
     end
   end

--- a/lib/smart_answer_flows/business-coronavirus-support-finder.rb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder.rb
@@ -98,7 +98,7 @@ module SmartAnswer
       checkbox_question :sectors? do
         option :retail_hospitality_or_leisure
         option :nurseries
-        set_none_option(label: "None of the above")
+        set_none_option
 
         on_response do |response|
           calculator.sectors = response.split(",")

--- a/lib/smart_answer_flows/business-coronavirus-support-finder.rb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder.rb
@@ -98,7 +98,7 @@ module SmartAnswer
       checkbox_question :sectors? do
         option :retail_hospitality_or_leisure
         option :nurseries
-        set_none_option
+        none_option
 
         on_response do |response|
           calculator.sectors = response.split(",")

--- a/lib/smart_answer_flows/business-coronavirus-support-finder/questions/sectors.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/questions/sectors.erb
@@ -5,4 +5,5 @@
 <% options(
   "retail_hospitality_or_leisure": "Retail, Hospitality or Leisure",
   "nurseries": "Nurseries",
+  "none": "None of the above",
 ) %>

--- a/lib/smart_answer_flows/coronavirus-business-reopening.rb
+++ b/lib/smart_answer_flows/coronavirus-business-reopening.rb
@@ -17,7 +17,7 @@ module SmartAnswer
         option :shops
         option :homes
         option :vehicles
-        set_none_option(label: "None of the above")
+        set_none_option
 
         on_response do |response|
           self.calculator = Calculators::CoronavirusBusinessReopeningCalculator.new

--- a/lib/smart_answer_flows/coronavirus-business-reopening.rb
+++ b/lib/smart_answer_flows/coronavirus-business-reopening.rb
@@ -17,7 +17,7 @@ module SmartAnswer
         option :shops
         option :homes
         option :vehicles
-        set_none_option
+        none_option
 
         on_response do |response|
           self.calculator = Calculators::CoronavirusBusinessReopeningCalculator.new

--- a/lib/smart_answer_flows/coronavirus-business-reopening/questions/sectors.erb
+++ b/lib/smart_answer_flows/coronavirus-business-reopening/questions/sectors.erb
@@ -39,4 +39,7 @@
     label: "Working in other people’s homes",
     hint_text: "For example, repair services, fitters, meter readers, plumbers, cleaners, cooks, surveyors, delivery drivers who come to the door",
   },
+  "none": {
+    label: "None of the above",
+  },
 ) %>

--- a/test/fixtures/smart_answer_flows/checkbox-sample.rb
+++ b/test/fixtures/smart_answer_flows/checkbox-sample.rb
@@ -29,7 +29,7 @@ module SmartAnswer
       checkbox_question :confirm_no_toppings? do
         option :ask_me_again
 
-        set_none_option
+        none_option
 
         next_node do |response|
           if response == "none"

--- a/test/fixtures/smart_answer_flows/checkbox-sample.rb
+++ b/test/fixtures/smart_answer_flows/checkbox-sample.rb
@@ -29,7 +29,7 @@ module SmartAnswer
       checkbox_question :confirm_no_toppings? do
         option :ask_me_again
 
-        set_none_option(label: "Definitely no toppings")
+        set_none_option
 
         next_node do |response|
           if response == "none"

--- a/test/fixtures/smart_answer_flows/checkbox-sample/questions/confirm_no_toppings.erb
+++ b/test/fixtures/smart_answer_flows/checkbox-sample/questions/confirm_no_toppings.erb
@@ -4,4 +4,5 @@
 
 <% options(
   "ask_me_again": "Hmm I'm not sure, ask me again please",
+  "none": "Definitely no toppings",
 ) %>

--- a/test/unit/checkbox_question_test.rb
+++ b/test/unit/checkbox_question_test.rb
@@ -76,11 +76,11 @@ module SmartAnswer
 
       context "with an explicitly set 'none' option" do
         setup do
-          @question.set_none_option(label: "None")
+          @question.set_none_option
         end
 
-        should "set the none option label" do
-          assert_equal("None", @question.none_option_label)
+        should "enable the none option" do
+          assert @question.none_option?
         end
 
         should "raise if the response is blank" do

--- a/test/unit/checkbox_question_test.rb
+++ b/test/unit/checkbox_question_test.rb
@@ -76,15 +76,11 @@ module SmartAnswer
 
       context "with an explicitly set 'none' option" do
         setup do
-          @question.set_none_option(label: "None", prefix: "or")
+          @question.set_none_option(label: "None")
         end
 
         should "set the none option label" do
           assert_equal("None", @question.none_option_label)
-        end
-
-        should "set the none option prefix" do
-          assert_equal("or", @question.none_option_prefix)
         end
 
         should "raise if the response is blank" do

--- a/test/unit/checkbox_question_test.rb
+++ b/test/unit/checkbox_question_test.rb
@@ -76,7 +76,7 @@ module SmartAnswer
 
       context "with an explicitly set 'none' option" do
         setup do
-          @question.set_none_option
+          @question.none_option
         end
 
         should "enable the none option" do


### PR DESCRIPTION
This PR refactors the code to improve separation of concerns. Currently we set the text for the none option in the flow definition and set the text for all other question in the question template. Now the none option text can be set in the question template along with all the other options, making it more consistent and removes presentation logic from the flow definition.

Additionally this PR does following:
- renames set_none_option to none_option to be less confusing
- remove none_option_prefix as this feature wasn't used and appeared to be broken

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.
