### PR TITLE
Enable parallel linting for rubocop

### DIFF
--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,4 +1,4 @@
 desc "Lint Ruby"
 task lint: [:environment] do
-  sh "bundle exec rubocop"
+  sh "bundle exec rubocop --parallel"
 end


### PR DESCRIPTION
Improves times taken to lint.

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.
