### PR TITLE
Update none option in sector question

### DIFF
--- a/lib/smart_answer_flows/coronavirus-business-reopening.rb
+++ b/lib/smart_answer_flows/coronavirus-business-reopening.rb
@@ -18,7 +18,7 @@ module SmartAnswer
         option :fitness
         option :homes
         option :vehicles
-        none_option
+        option :any
 
         on_response do |response|
           self.calculator = Calculators::CoronavirusBusinessReopeningCalculator.new

--- a/lib/smart_answer_flows/coronavirus-business-reopening/questions/sectors.erb
+++ b/lib/smart_answer_flows/coronavirus-business-reopening/questions/sectors.erb
@@ -42,7 +42,7 @@
     label: "Working in other people’s homes",
     hint_text: "For example, repair services, fitters, meter readers, plumbers, cleaners, cooks, surveyors, delivery drivers who come to the door",
   },
-  "none": {
-    label: "None of the above",
+  "any": {
+    label: "Any other type of workplace",
   },
 ) %>


### PR DESCRIPTION
This changes the none option to non-exclusive option with the label "Any other type of workplace" to help users feel not left out when completing the coronavirus business reopening flow.

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.
