### PR TITLE
Remove closed workplace guidance for leisure centres

### DIFF
--- a/lib/smart_answer/calculators/coronavirus_employee_risk_assessment_calculator.rb
+++ b/lib/smart_answer/calculators/coronavirus_employee_risk_assessment_calculator.rb
@@ -5,7 +5,6 @@ module SmartAnswer::Calculators
       retail
       auction_house
       nightclubs_or_gambling
-      leisure_centre
       indoor_recreation
     ].freeze
 


### PR DESCRIPTION
This is for the coronavirus employee risk assessment.

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.
