### PR TITLE
Allow 'Next step' button text to be changed

### DIFF
--- a/app/views/smart_answers/question.html.erb
+++ b/app/views/smart_answers/question.html.erb
@@ -36,7 +36,7 @@
 
         <input type="hidden" name="next" value="1" />
         <%= render "govuk_publishing_components/components/button", {
-          text: "Next step",
+          text: @presenter.flow.next_button_text,
           margin_bottom: true
         } %>
       </div>

--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -15,6 +15,7 @@ module SmartAnswer
     def initialize(&block)
       @nodes = []
       status(:draft)
+      next_button_text("Next step")
       instance_eval(&block) if block_given?
     end
 
@@ -38,6 +39,11 @@ module SmartAnswer
     def name(name = nil)
       @name = name unless name.nil?
       @name
+    end
+
+    def next_button_text(button_text = nil)
+      @next_button_text = button_text unless button_text.nil?
+      @next_button_text
     end
 
     def satisfies_need(need_content_id)


### PR DESCRIPTION
Allow the text on the `Next step` button to be changed via configuration in the smart answers Flow class.  

Defaults to `Next step` unless overridden.

For example...

```
module SmartAnswer
  class MySmartAnswerFlow < Flow
    def define
      # ...
      next_button_text Continue
      # ...
    end
  end
end
```

[Trello](https://trello.com/c/WFH0TtG2/372-change-next-step-buttons-to-continue)