### PR TITLE
Allows the previous answers section to be hidden

### DIFF
--- a/app/views/smart_answers/question.html.erb
+++ b/app/views/smart_answers/question.html.erb
@@ -42,6 +42,8 @@
       </div>
     <% end %>
 
-    <%= render 'previous_answers' %>
+    <% if @presenter.flow.show_previous_answers %>
+      <%= render 'previous_answers' %>
+    <% end %>
   </div>
 </div>

--- a/app/views/smart_answers/result.html.erb
+++ b/app/views/smart_answers/result.html.erb
@@ -47,7 +47,9 @@
       });
     </script>
 
-    <%= render 'previous_answers' %>
+    <% if @presenter.flow.show_previous_answers %>
+      <%= render 'previous_answers' %>
+    <% end %>
   </div>
 
   <% if defined?(@presenter.finished?) and @presenter.finished? %>

--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -15,6 +15,7 @@ module SmartAnswer
     def initialize(&block)
       @nodes = []
       status(:draft)
+      show_previous_answers(true)
       instance_eval(&block) if block_given?
     end
 
@@ -38,6 +39,11 @@ module SmartAnswer
     def name(name = nil)
       @name = name unless name.nil?
       @name
+    end
+
+    def show_previous_answers(show_answers = nil)
+      @show_previous_answers = show_answers unless show_answers.nil?
+      @show_previous_answers
     end
 
     def satisfies_need(need_content_id)


### PR DESCRIPTION
Allow the previous answers display to be hidden via configuration in the smart answers Flow class.  

Defaults to `true` unless overridden.

For example...

```
module SmartAnswer
  class MySmartAnswerFlow < Flow
    def define
      # ...
      show_previous_answers false
      # ...
    end
  end
end
```

[Trello](https://trello.com/c/KLGRL90U/386-allow-previous-answers-section-to-be-shown-hidden-as-needed)