### PR TITLE
Add escape button

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ end
 
 group :development, :test do
   gem "byebug"
+  gem "jasmine", "~> 3.6.0"
   gem "pry"
   gem "rubocop-govuk"
 end
@@ -43,6 +44,7 @@ end
 group :test do
   gem "ci_reporter"
   gem "govuk_test"
+  gem "jasmine_selenium_runner", "~> 3.0.0", require: false
   gem "minitest"
   gem "minitest-focus"
   gem "mocha", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,6 +139,15 @@ GEM
       domain_name (~> 0.5)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
+    jasmine (3.6.0)
+      jasmine-core (~> 3.6.0)
+      phantomjs
+      rack (>= 1.2.1)
+      rake
+    jasmine-core (3.6.0)
+    jasmine_selenium_runner (3.0.0)
+      jasmine (~> 3.0)
+      selenium-webdriver (~> 3.8)
     json (2.3.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
@@ -183,6 +192,7 @@ GEM
     parallel (1.19.2)
     parser (2.7.1.4)
       ast (~> 2.4.1)
+    phantomjs (2.1.1.0)
     plek (4.0.0)
     pry (0.13.1)
       coderay (~> 1.1)
@@ -365,6 +375,8 @@ DEPENDENCIES
   govuk_publishing_components
   govuk_test
   htmlentities
+  jasmine (~> 3.6.0)
+  jasmine_selenium_runner (~> 3.0.0)
   json
   listen
   method_source

--- a/Rakefile
+++ b/Rakefile
@@ -9,4 +9,4 @@ SmartAnswers::Application.load_tasks
 # Delete the current "default" rake task and redefine it. This allow us to use:
 # - `rake test` to only run minitest tests
 Rake::Task["default"].clear
-task default: %i[test lint security]
+task default: %i[test js_test lint security]

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -7,7 +7,9 @@
 //= require govuk_publishing_components/components/radio
 //= require govuk_publishing_components/components/step-by-step-nav
 //= require helpers
+//= require components/escape-link
 
-$(document).ready(function() {
-  $('#current-error').focus();
-});
+window.addEventListener('DOMContentLoaded', function () {
+  var error = document.getElementById('current-error');
+  if (error) { error.focus() };
+})

--- a/app/assets/javascripts/components/escape-link.js
+++ b/app/assets/javascripts/components/escape-link.js
@@ -1,0 +1,37 @@
+/* global ga:readonly */
+
+function EscapeLink ($module) {
+  this.$module = $module
+}
+
+EscapeLink.prototype.init = function () {
+  var $module = this.$module
+
+  if (!$module) {
+    return
+  }
+  $module.addEventListener('click', this.handleClick.bind(this))
+}
+
+EscapeLink.prototype.handleClick = function (event) {
+  event.preventDefault()
+
+  var url = event.target.getAttribute('href')
+  var rel = event.target.getAttribute('rel')
+  var trackLabel = event.target.getAttribute('data-track-label')
+
+  this.openNewPage(url, rel)
+  this.replaceCurrentPage(url)
+}
+
+EscapeLink.prototype.openNewPage = function (url, rel) {
+  var newWindow = window.open(url, rel)
+  newWindow.opener = null
+}
+
+EscapeLink.prototype.replaceCurrentPage = function (url) {
+  window.location.replace(url)
+}
+
+var $escapeLink = document.querySelector('[data-module="app-escape-link"]')
+new EscapeLink($escapeLink).init()

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -28,3 +28,4 @@ $govuk-use-legacy-palette: false;
 @import "govuk_publishing_components/components/table";
 
 @import "smart_answers";
+@import "components/escape-link";

--- a/app/assets/stylesheets/components/_escape-link.scss
+++ b/app/assets/stylesheets/components/_escape-link.scss
@@ -1,0 +1,23 @@
+.app-c-escape-link {
+  @include govuk-font($size: 19, $weight: bold);
+
+  bottom: 0;
+  float: right;
+  padding: govuk-spacing(4) govuk-spacing(3);
+  position: fixed;
+  position: sticky; // scss-lint:disable DuplicateProperty
+  right: 0;
+
+  &:link,
+  &:visited,
+  &:hover,
+  &:active {
+    background-color: govuk-colour('black');
+    color: govuk-colour('white');
+  }
+
+  &:focus {
+    background-color: $govuk-focus-colour;
+    color: $govuk-focus-text-colour;
+  }
+}

--- a/app/assets/stylesheets/smart_answers.scss
+++ b/app/assets/stylesheets/smart_answers.scss
@@ -101,3 +101,7 @@ $is-ie: false !default;
 .app-c-email-link__title {
   margin-bottom: govuk-spacing(2);
 }
+
+.gem-c-feedback {
+  clear: both;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,11 @@ class ApplicationController < ActionController::Base
 
 protected
 
+  def heroku?
+    request.host.include? "herokuapp"
+  end
+  helper_method :heroku?
+
   def error_403
     error(403)
   end

--- a/app/controllers/session_answers_controller.rb
+++ b/app/controllers/session_answers_controller.rb
@@ -1,4 +1,6 @@
 class SessionAnswersController < ApplicationController
+  before_action :set_cache_headers
+
   def show
     @title = presenter.title
     @content_item = ContentItemRetriever.fetch(name) if presenter.finished?
@@ -10,7 +12,23 @@ class SessionAnswersController < ApplicationController
     redirect_to session_flow_path(id: params[:id], node_name: next_node_name)
   end
 
+  def destroy
+    session.delete(:responses)
+
+    if params[:ext_r] == "true"
+      redirect_to "https://bbc.co.uk/news"
+    else
+      redirect_to "/#{params[:id]}"
+    end
+  end
+
 private
+
+  def set_cache_headers
+    response.headers["Cache-Control"] = "no-cache, no-store"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "Mon, 01 Jan 1990 00:00:00 GMT"
+  end
 
   def presenter
     @presenter ||= begin

--- a/app/controllers/session_answers_controller.rb
+++ b/app/controllers/session_answers_controller.rb
@@ -67,6 +67,7 @@ private
 
     :question
   end
+  helper_method :page_type
 
   def next_node_name
     presenter.current_state.current_node.to_s

--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -48,11 +48,6 @@ class SmartAnswersController < ApplicationController
 
 private
 
-  def heroku?
-    request.host.include? "herokuapp"
-  end
-  helper_method :heroku?
-
   def debug?
     Rails.env.development? && params[:debug]
   end
@@ -79,6 +74,7 @@ private
       :landing
     end
   end
+  helper_method :page_type
 
   def redirect_response_to_canonical_url
     if params[:next] && !@presenter.current_state.error

--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -5,7 +5,7 @@ class FlowPresenter
 
   attr_reader :params, :flow
 
-  delegate :need_it, :button_text, :use_session?, :questions, to: :flow
+  delegate :need_it, :button_text, :use_session?, :questions, :use_escape_button?, :show_escape_link?, to: :flow
   delegate :title, to: :start_node
 
   def initialize(params, flow)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,6 +19,7 @@
     <%= stylesheet_link_tag "application", :media => "all" %>
     <%= stylesheet_link_tag "print.css", media: "print" %>
     <%= javascript_include_tag "test-dependencies" if Rails.env.test? %>
+    <%= javascript_include_tag "application", defer: true %>
     <%= yield :head %>
     <% if @content_item %>
       <%= render "govuk_publishing_components/components/meta_tags",
@@ -29,7 +30,9 @@
   </head>
   <body class="govuk-template__body">
     <div class="govuk-width-container smart_answer" id="wrapper">
+      <%= render partial: "smart_answers/heroku_alert" if heroku? %>
       <%= yield %>
+      <%= yield :escape_link %>
       <%= render "govuk_publishing_components/components/feedback" %>
     </div>
   </body>

--- a/app/views/layouts/smart_answers.html.erb
+++ b/app/views/layouts/smart_answers.html.erb
@@ -2,12 +2,6 @@
   <%= @title %>
 <% end %>
 
-<% content_for :head do %>
-  <%= javascript_include_tag "application", defer: true %>
-<% end %>
-
-<%= render partial: "smart_answers/heroku_alert" if heroku? %>
-
 <main id="content" role="main">
   <%= yield %>
 </main>

--- a/app/views/smart_answers/_escape-link.html.erb
+++ b/app/views/smart_answers/_escape-link.html.erb
@@ -1,0 +1,5 @@
+<%
+  data_attributes ||= {}
+  data_attributes[:module] = 'app-escape-link'
+%>
+<%= link_to "Leave this site", destroy_session_flow_path(ext_r: "true"), class: "app-c-escape-link govuk-link", rel: "nofollow noreferrer noopener", target: "_blank", data: data_attributes %>

--- a/app/views/smart_answers/question.html.erb
+++ b/app/views/smart_answers/question.html.erb
@@ -4,6 +4,12 @@
   <meta name="robots" content="noindex">
 <% end %>
 
+<% content_for :escape_link do %>
+  <% if @presenter.show_escape_link? %>
+    <%= render "smart_answers/escape-link" %>
+  <% end %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render 'smart_answers/debug' %>

--- a/app/views/smart_answers/result.html.erb
+++ b/app/views/smart_answers/result.html.erb
@@ -6,6 +6,12 @@
   <meta name="robots" content="noindex">
 <% end %>
 
+<% content_for :escape_link do %>
+  <% if @presenter.show_escape_link? %>
+    <%= render "smart_answers/escape-link" %>
+  <% end %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div id="result-info" class="govuk-grid-column-two-thirds outcome">
     <%= render 'smart_answers/debug' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
         format: false
   end
 
+  get "/:id/destroy_session", to: "session_answers#destroy", as: :destroy_session_flow
   get "/:id/:node_name", to: "session_answers#show", as: :session_flow
   get "/:id/:node_name/next", to: "session_answers#update", as: :update_session_flow
 end

--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -2,6 +2,8 @@ require "ostruct"
 
 module SmartAnswer
   class Flow
+    class NonSessionBasedFlow < StandardError; end
+
     attr_reader :nodes
     attr_accessor :need_content_id
     attr_writer :status
@@ -46,6 +48,20 @@ module SmartAnswer
 
     def use_session?
       ActiveModel::Type::Boolean.new.cast(@use_session)
+    end
+
+    def use_escape_button(use_escape_button) # rubocop:disable Style/TrivialAccessors
+      @use_escape_button = use_escape_button
+    end
+
+    def use_escape_button?
+      raise NonSessionBasedFlow, "This flow is not session-based" unless use_session?
+
+      ActiveModel::Type::Boolean.new.cast(@use_escape_button)
+    end
+
+    def show_escape_link?
+      use_session? && use_escape_button?
     end
 
     def button_text(text = "Next step")

--- a/lib/smart_answer_flows/coronavirus-find-support.rb
+++ b/lib/smart_answer_flows/coronavirus-find-support.rb
@@ -6,6 +6,7 @@ module SmartAnswer
       flow_content_id "31d81949-aa15-48cf-a7f1-f0d0a670e8db"
       status :draft
       use_session true
+      use_escape_button true
       button_text "Continue"
 
       # ======================================================================

--- a/lib/tasks/js_test.rake
+++ b/lib/tasks/js_test.rake
@@ -1,0 +1,4 @@
+desc "Run Javascript tests"
+task js_test: [:environment] do
+  sh "rake jasmine:ci"
+end

--- a/spec/javascripts/components/escape-link.spec.js
+++ b/spec/javascripts/components/escape-link.spec.js
@@ -1,0 +1,36 @@
+/* eslint-env jasmine */
+/* global EscapeLink */
+
+describe('Escape link component', function () {
+  'use strict'
+
+  var container
+  var escapeLinkElement
+  var escapeLinkModule
+
+  beforeEach(function () {
+    container = document.createElement('div')
+    container.innerHTML = '<a class="app-c-escape-link govuk-link" rel="nofollow noreferrer noopener" target="_blank" data-module="app-escape-link" data-track-label="need-help-with" href="https://www.gov.uk/">Leave this site</a>'
+    document.body.appendChild(container)
+    escapeLinkElement = document.querySelector('[data-module="app-escape-link"]')
+    escapeLinkModule = new EscapeLink(escapeLinkElement)
+    escapeLinkModule.replaceCurrentPage = function () {}
+    escapeLinkModule.init()
+  })
+
+  afterEach(function () {
+    document.body.removeChild(container)
+  })
+
+  it('opens a new page', function () {
+    spyOn(escapeLinkModule, 'openNewPage')
+    escapeLinkElement.click()
+    expect(escapeLinkModule.openNewPage).toHaveBeenCalledWith('https://www.gov.uk/', 'nofollow noreferrer noopener')
+  })
+
+  it('replaces the original page', function () {
+    spyOn(escapeLinkModule, 'replaceCurrentPage')
+    escapeLinkElement.click()
+    expect(escapeLinkModule.replaceCurrentPage).toHaveBeenCalledWith('https://www.gov.uk/')
+  })
+})

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -1,0 +1,139 @@
+# src_files
+#
+# Return an array of filepaths relative to src_dir to include before jasmine specs.
+# Default: []
+#
+# EXAMPLE:
+#
+# src_files:
+#   - lib/source1.js
+#   - lib/source2.js
+#   - 'dist/**/*.js'
+#
+src_files:
+  - assets/application.js
+
+# stylesheets
+#
+# Return an array of stylesheet filepaths relative to src_dir to include before jasmine specs.
+# Default: []
+#
+# EXAMPLE:
+#
+# stylesheets:
+#   - css/style.css
+#   - 'stylesheets/*.css'
+#
+stylesheets:
+  - assets/application.css
+
+# helpers
+#
+# Return an array of filepaths relative to spec_dir to include before jasmine specs.
+# Default: ["helpers/**/*.js"]
+#
+# EXAMPLE:
+#
+# helpers:
+#   - 'helpers/**/*.js'
+#
+helpers:
+  - 'helpers/**/*.js'
+
+# spec_files
+#
+# Return an array of filepaths relative to spec_dir to include.
+# Default: ["**/*[sS]pec.js"]
+#
+# EXAMPLE:
+#
+# spec_files:
+#   - '**/*[sS]pec.js'
+#
+spec_files:
+  - '**/*[Ss]pec.js'
+
+# src_dir
+#
+# Source directory path. Your src_files must be returned relative to this path. Will use root if left blank.
+# Default: project root
+#
+# EXAMPLE:
+#
+# src_dir: public
+#
+src_dir: "app/assets/javascripts"
+
+# spec_dir
+#
+# Spec directory path. Your spec_files must be returned relative to this path.
+# Default: spec/javascripts
+#
+# EXAMPLE:
+#
+# spec_dir: spec/javascripts
+#
+spec_dir:
+
+# spec_helper
+#
+# Ruby file that Jasmine server will require before starting.
+# Returned relative to your root path
+# Default spec/javascripts/support/jasmine_helper.rb
+#
+# EXAMPLE:
+#
+# spec_helper: spec/javascripts/support/jasmine_helper.rb
+#
+spec_helper: spec/javascripts/support/jasmine_helper.rb
+
+# boot_dir
+#
+# Boot directory path. Your boot_files must be returned relative to this path.
+# Default: Built in boot file
+#
+# EXAMPLE:
+#
+# boot_dir: spec/javascripts/support/boot
+#
+boot_dir:
+
+# boot_files
+#
+# Return an array of filepaths relative to boot_dir to include in order to boot Jasmine
+# Default: Built in boot file
+#
+# EXAMPLE
+#
+# boot_files:
+#   - '**/*.js'
+#
+boot_files:
+
+tmp_dir: "tmp/jasmine"
+
+use_phantom_gem: false
+
+# rack_options
+#
+# Extra options to be passed to the rack server
+# by default, Port and AccessLog are passed.
+#
+# This is an advanced options, and left empty by default
+#
+# EXAMPLE
+#
+# rack_options:
+#   server: 'thin'
+
+# phantom_cli_options
+#
+# Extra options to be passed to the phantomjs cli,
+# e.g. to enable localStorage in PhantomJs 2.5
+#
+# EXAMPLE
+#
+# phantom_cli_options:
+#   local-storage-quota: 5000
+
+random: false

--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -1,0 +1,27 @@
+# Use this file to set/override Jasmine configuration options
+# You can remove it if you don't need it.
+# This file is loaded *after* jasmine.yml is interpreted.
+#
+# Example: using a different boot file.
+# Jasmine.configure do |config|
+#    config.boot_dir = '/absolute/path/to/boot_dir'
+#    config.boot_files = lambda { ['/absolute/path/to/boot_dir/file.js'] }
+# end
+#
+# Example: prevent PhantomJS auto install, uses PhantomJS already on your path.
+
+require "jasmine/runners/selenium"
+require "webdrivers/chromedriver"
+
+Jasmine.configure do |config|
+  config.prevent_phantom_js_auto_install = true
+
+  config.runner = lambda { |formatter, jasmine_server_url|
+    options = Selenium::WebDriver::Chrome::Options.new
+    options.headless!
+    options.add_argument("--no-sandbox")
+
+    webdriver = Selenium::WebDriver.for(:chrome, options: options)
+    Jasmine::Runners::Selenium.new(formatter, jasmine_server_url, webdriver, 50)
+  }
+end

--- a/test/unit/flow_test.rb
+++ b/test/unit/flow_test.rb
@@ -39,6 +39,52 @@ class FlowTest < ActiveSupport::TestCase
     assert_not smart_answer.use_session?
   end
 
+  test "cannot set a flag to use the escape button if the use session flag is not also set" do
+    smart_answer = SmartAnswer::Flow.new do
+      use_session false
+      use_escape_button true
+    end
+
+    assert_raises SmartAnswer::Flow::NonSessionBasedFlow do
+      smart_answer.use_escape_button?
+    end
+  end
+
+  test "can set a flag to use the escape button when the use session flag is also set" do
+    smart_answer = SmartAnswer::Flow.new do
+      use_session true
+      use_escape_button true
+    end
+
+    assert smart_answer.use_escape_button?
+  end
+
+  test "can set a flag to use the escape button with a string" do
+    smart_answer = SmartAnswer::Flow.new do
+      use_session true
+      use_escape_button "yes"
+    end
+
+    assert smart_answer.use_escape_button?
+  end
+
+  test "can set a flag not to use the escape button with a string" do
+    smart_answer = SmartAnswer::Flow.new do
+      use_session true
+      use_escape_button "false"
+    end
+
+    assert_not smart_answer.use_escape_button?
+  end
+
+  test "defaults to not use the escape button" do
+    smart_answer = SmartAnswer::Flow.new do
+      use_session true
+    end
+
+    assert_not smart_answer.use_escape_button?
+  end
+
   test "Can set button text" do
     text = "continue"
     smart_answer = SmartAnswer::Flow.new do


### PR DESCRIPTION
Add escape button for vulnerable users.  When clicked, the user is taken to the BBC News website and the session data is removed.

Page caching is disabled so that any attempt to return to the smart answer returns no stored or cached data.

The button is only enabled if the flow is session-based and the `use_escape_button` flow variable is set to true.

- Add route and tests to remove session data
- Add escape button to flow pages
- Add configuration option to show button if flow is session-based

[Trello](https://trello.com/c/9cxZlrUr/367-add-leave-this-site-button-to-triage-tool-smart-answer-prototype)