### PR TITLE
Add find support form

### DIFF
--- a/lib/graph_presenter.rb
+++ b/lib/graph_presenter.rb
@@ -1,5 +1,5 @@
 class GraphPresenter
-  EXEMPTIONS_LIST = %w[benefit-cap-calculator].freeze
+  EXEMPTIONS_LIST = %w[benefit-cap-calculator coronavirus-find-support].freeze
   def initialize(flow)
     @flow = flow
   end

--- a/lib/smart_answer/calculators/coronavirus_find_support_calculator.rb
+++ b/lib/smart_answer/calculators/coronavirus_find_support_calculator.rb
@@ -1,0 +1,96 @@
+module SmartAnswer::Calculators
+  class CoronavirusFindSupportCalculator
+    attr_accessor :nation,
+                  :need_help_with,
+                  :feel_safe,
+                  :afford_rent_mortgage_bills,
+                  :afford_food,
+                  :get_food,
+                  :able_to_go_out,
+                  :self_employed,
+                  :worried_about_work,
+                  :have_somewhere_to_live,
+                  :have_you_been_evicted,
+                  :are_you_off_work_ill,
+                  :have_you_been_made_unemployed,
+                  :mental_health_worries
+
+    def has_results?
+      need_help_with.present?
+    end
+
+    def needs_help_with?(given_help_item)
+      return false unless has_results?
+
+      need_help_with.split(",").include? given_help_item
+    end
+
+    def needs_help_in?(given_nation)
+      return false if nation.blank?
+
+      nation.split(",").include? given_nation
+    end
+
+    def user_feels_unsafe?
+      needs_help_with?("feeling_unsafe") && feel_safe != "yes"
+    end
+
+    def user_cannot_pay_their_bills?
+      needs_help_with?("paying_bills") && afford_rent_mortgage_bills != "no"
+    end
+
+    def user_cannot_get_food?
+      needs_help_with?("getting_food") && (afford_food != "no" && get_food != "yes")
+    end
+
+    def user_is_worried_about_going_to_work?
+      needs_help_with?("going_to_work") && worried_about_work != "no"
+    end
+
+    def user_is_unemployed?
+      needs_help_with?("being_unemployed") && (
+        (self_employed != "yes" && have_you_been_made_unemployed != "no") || are_you_off_work_ill == "yes"
+      )
+    end
+
+    def user_needs_somewhere_to_live?
+      needs_help_with?("somewhere_to_live") && (
+        have_somewhere_to_live != "yes" || have_you_been_evicted != "no"
+      )
+    end
+
+    def user_has_mental_health_worries?
+      needs_help_with?("mental_health") && mental_health_worries != "no"
+    end
+
+    def next_question(current_node)
+      nodes = %i[
+        need_help_with?
+        feel_safe?
+        afford_rent_mortgage_bills?
+        get_food?
+        are_you_off_work_ill?
+        worried_about_work?
+        have_you_been_evicted?
+      ]
+
+      if nodes.slice(0..0).include?(current_node) && needs_help_with?("feeling_unsafe")
+        :feel_safe?
+      elsif nodes.slice(0..1).include?(current_node) && needs_help_with?("paying_bills")
+        :afford_rent_mortgage_bills?
+      elsif nodes.slice(0..2).include?(current_node) && needs_help_with?("getting_food")
+        :afford_food?
+      elsif nodes.slice(0..3).include?(current_node) && needs_help_with?("being_unemployed")
+        :self_employed?
+      elsif nodes.slice(0..4).include?(current_node) && needs_help_with?("going_to_work")
+        :worried_about_work?
+      elsif nodes.slice(0..5).include?(current_node) && needs_help_with?("somewhere_to_live")
+        :have_somewhere_to_live?
+      elsif nodes.slice(0..6).include?(current_node) && needs_help_with?("mental_health")
+        :mental_health_worries?
+      else
+        :nation?
+      end
+    end
+  end
+end

--- a/lib/smart_answer_flows/coronavirus-find-support.rb
+++ b/lib/smart_answer_flows/coronavirus-find-support.rb
@@ -1,0 +1,277 @@
+module SmartAnswer
+  class CoronavirusFindSupportFlow < Flow
+    def define
+      name "coronavirus-find-support"
+      start_page_content_id "6a6ab3c9-4612-4764-8f2f-2c534c3c6b19"
+      flow_content_id "31d81949-aa15-48cf-a7f1-f0d0a670e8db"
+      status :draft
+
+      # ======================================================================
+      # What do you need help with because of coronavirus?
+      # ======================================================================
+      checkbox_question :need_help_with? do
+        option :feeling_unsafe
+        option :paying_bills
+        option :getting_food
+        option :being_unemployed
+        option :going_to_work
+        option :somewhere_to_live
+        option :mental_health
+        option :not_sure
+
+        on_response do |response|
+          self.calculator = Calculators::CoronavirusFindSupportCalculator.new
+          calculator.need_help_with = response
+        end
+
+        next_node do
+          question calculator.next_question(:need_help_with?)
+        end
+      end
+
+      # ======================================================================
+      # Do you feel safe where you live?
+      # ======================================================================
+      multiple_choice :feel_safe? do
+        option :yes
+        option :yes_but_i_am_concerned_about_others
+        option :no
+        option :not_sure
+
+        on_response do |response|
+          calculator.feel_safe = response
+        end
+
+        next_node do
+          question calculator.next_question(:feel_safe?)
+        end
+      end
+
+      # ======================================================================
+      # Are you finding it hard to afford rent, your mortgage or bills?
+      # ======================================================================
+      multiple_choice :afford_rent_mortgage_bills? do
+        option :yes
+        option :no
+        option :not_sure
+
+        on_response do |response|
+          calculator.afford_rent_mortgage_bills = response
+        end
+
+        next_node do
+          question calculator.next_question(:afford_rent_mortgage_bills?)
+        end
+      end
+
+      # ======================================================================
+      # Are you finding it hard to afford food?
+      # ======================================================================
+      multiple_choice :afford_food? do
+        option :yes
+        option :no
+        option :not_sure
+
+        on_response do |response|
+          calculator.afford_food = response
+        end
+
+        next_node do
+          question :get_food?
+        end
+      end
+
+      # ======================================================================
+      # Are your able to get food?
+      # ======================================================================
+      multiple_choice :get_food? do
+        option :yes
+        option :no
+        option :not_sure
+
+        on_response do |response|
+          calculator.get_food = response
+        end
+
+        next_node do
+          if calculator.get_food == "yes"
+            question calculator.next_question(:get_food?)
+          else
+            question :able_to_go_out?
+          end
+        end
+      end
+
+      # ======================================================================
+      # Are you able to leave your home for food, medicine, or health reasons?
+      # ======================================================================
+      multiple_choice :able_to_go_out? do
+        option :yes
+        option :no_i_have_coronavirus
+        option :no_i_have_a_medical_condition
+        option :no_i_have_a_disability
+        option :no_for_another_reason
+
+        on_response do |response|
+          calculator.able_to_go_out = response
+        end
+
+        next_node do
+          question :self_employed?
+        end
+      end
+
+      # ======================================================================
+      # Are you self-employed or a sole trader?
+      # ======================================================================
+      multiple_choice :self_employed? do
+        option :yes
+        option :no
+        option :not_sure
+
+        on_response do |response|
+          calculator.self_employed = response
+        end
+
+        next_node do
+          if calculator.self_employed == "yes"
+            question :worried_about_work?
+          else
+            question :have_you_been_made_unemployed?
+          end
+        end
+      end
+
+      # ======================================================================
+      # Have you been told to stop working?
+      # ======================================================================
+      multiple_choice :have_you_been_made_unemployed? do
+        option :yes_i_have_been_made_unemployed
+        option :yes_i_have_been_put_on_furlough
+        option :no
+        option :not_sure
+
+        on_response do |response|
+          calculator.have_you_been_made_unemployed = response
+        end
+
+        next_node do
+          if %w[yes_i_have_been_made_unemployed yes_i_have_been_put_on_furlough].include? calculator.have_you_been_made_unemployed
+            question :worried_about_work?
+          else
+            question :are_you_off_work_ill?
+          end
+        end
+      end
+
+      # ======================================================================
+      # Are you off work because you're ill or self-isolating?
+      # ======================================================================
+      multiple_choice :are_you_off_work_ill? do
+        option :yes
+        option :no
+
+        on_response do |response|
+          calculator.are_you_off_work_ill = response
+        end
+
+        next_node do
+          question calculator.next_question(:are_you_off_work_ill?)
+        end
+      end
+
+      # ======================================================================
+      # Are you worried about going in to work?
+      # ======================================================================
+      multiple_choice :worried_about_work? do
+        option :yes
+        option :no
+        option :not_sure
+
+        on_response do |response|
+          calculator.worried_about_work = response
+        end
+
+        next_node do
+          question calculator.next_question(:worried_about_work?)
+        end
+      end
+
+      # ======================================================================
+      # Do you have somewhere to live?
+      # ======================================================================
+      multiple_choice :have_somewhere_to_live? do
+        option :yes
+        option :yes_but_i_might_lose_it
+        option :no
+        option :not_sure
+
+        on_response do |response|
+          calculator.have_somewhere_to_live = response
+        end
+
+        next_node do
+          question :have_you_been_evicted?
+        end
+      end
+
+      # ======================================================================
+      # Have you been evicted?
+      # ======================================================================
+      multiple_choice :have_you_been_evicted? do
+        option :yes
+        option :yes_i_might_be_soon
+        option :no
+        option :not_sure
+
+        on_response do |response|
+          calculator.have_you_been_evicted = response
+        end
+
+        next_node do
+          question calculator.next_question(:have_you_been_evicted?)
+        end
+      end
+
+      # ======================================================================
+      # Are you worries about your mental health or someone else's mental health?
+      # ======================================================================
+      multiple_choice :mental_health_worries? do
+        option :yes
+        option :no
+        option :not_sure
+
+        on_response do |response|
+          calculator.mental_health_worries = response
+        end
+
+        next_node do
+          question :nation?
+        end
+      end
+
+      # ======================================================================
+      # Where do you live?
+      # ======================================================================
+      checkbox_question :nation? do
+        option :england
+        option :scotland
+        option :wales
+        option :northern_ireland
+
+        on_response do |response|
+          calculator.nation = response
+        end
+
+        next_node do
+          outcome :results
+        end
+      end
+
+      # ======================================================================
+      # Results
+      # ======================================================================
+      outcome :results
+    end
+  end
+end

--- a/lib/smart_answer_flows/coronavirus-find-support/coronavirus_find_support.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/coronavirus_find_support.erb
@@ -1,0 +1,21 @@
+<% text_for :title do %>
+  Find out what you can do if you're struggling bacause of coronavirus (COVID-19)
+<% end %>
+
+<% govspeak_for :body do %>
+  Use this service to find out what help and advice you can get from the government and other organisations. You can use it for yourself or someone else.
+
+  You can find support with:
+
+  * what to do if you’re feeling unsafe where you live, or if you’re worried about someone else
+  * paying bills, rent, or your mortgage
+  * getting food
+  * being made redundant or unemployed, or not having any work
+  * what to do if you’re worried about going in to work
+  * having somewhere to live
+  * mental health and wellbeing, including information for children
+
+  If you need medical help, [go to NHS 111 online](https://www.nhs.uk/conditions/coronavirus-covid-19/check-if-you-have-coronavirus-symptoms/).
+
+  You will not get direct support from the government or organisations through this service.
+<% end %>

--- a/lib/smart_answer_flows/coronavirus-find-support/outcomes/_being_unemployed.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/outcomes/_being_unemployed.erb
@@ -1,0 +1,128 @@
+## Being unemployed
+
+### If you’ve been made redundant or unemployed, or put on temporary leave (on furlough)
+
+[What to do if you’ve lost your job](https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-you-were-employed-and-have-lost-your-job)
+
+[What to do if you’ve been furloughed](https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-youre-employed-and-cannot-work)
+
+[Your rights if you’ve been made redundant, including information on how much redundancy pay you can get and your notice period](https://www.gov.uk/redundancy-your-rights)
+
+[Find out if you can get help in your local area](https://www.gov.uk/coronavirus-local-help)
+
+<% if calculator.needs_help_in?("northern_ireland") %>
+  [Find out about the financial support and benefits you might be able to get (NI direct)](https://www.nidirect.gov.uk/articles/coronavirus-covid-19-and-benefits)
+<% end %>
+
+<% if calculator.needs_help_in?("scotland") %>
+  [Check if your redundancy is fair (Citizens Advice Scotland)](https://www.citizensadvice.org.uk/scotland/work/leaving-a-job/redundancy/check-if-your-redundancy-is-fair/)
+
+  [Find help with benefits (mygov.scot)](https://www.mygov.scot/benefits-support/)
+<% end %>
+
+<% if calculator.needs_help_in?("england") %>
+  [Check if your redundancy is fair (Citizens Advice)](https://www.citizensadvice.org.uk/work/leaving-a-job/redundancy/check-if-your-redundancy-is-fair/)
+<% end %>
+
+<% if calculator.needs_help_in?("wales") %>
+  [Check if your redundancy is fair (Citizens Advice)](https://www.citizensadvice.org.uk/wales/work/leaving-a-job/redundancy/check-if-your-redundancy-is-fair/)
+
+  [Check if you’re eligible for the Discretionary Assistance Fund (Welsh Government)](https://gov.wales/discretionary-assistance-fund-daf)
+<% end %>
+
+<% unless calculator.needs_help_in?("northern_ireland") %>
+  [Search and apply for jobs](https://www.gov.uk/find-a-job)
+<% end %>
+
+#### Support and advice
+
+[What to do if your employer has ended your employment but you have not been made redundant](https://www.gov.uk/dismissal)
+
+<% if calculator.needs_help_in?("northern_ireland") %>
+  [Get help from Citizens Advice](https://www.citizensadvice.org.uk/about-us/northern-ireland/)
+
+  [Get advice on benefits (Advice NI)](https://www.adviceni.net/)
+<% end %>
+
+<% if calculator.needs_help_in?("scotland") %>
+  [Advice if you’ve been furloughed (Citizens Advice Scotland)](https://www.citizensadvice.org.uk/scotland/work/coronavirus-being-furloughed-if-you-cant-work/)
+
+  [Get advice on applying for Universal Credit (Citizens Advice Scotland)](https://www.citizensadvice.org.uk/scotland/benefits/universal-credit/)
+
+  [Get help if you’ve been made redundant (mygov.scot)](https://www.mygov.scot/help-redundancy/)
+<% end %>
+
+<% if calculator.needs_help_in?("england") %>
+  [Advice if you’ve been furloughed (Citizens Advice)](https://www.citizensadvice.org.uk/work/coronavirus-being-furloughed-if-you-cant-work/)
+
+  [Get advice on applying for Universal Credit (Citizens Advice)](https://www.citizensadvice.org.uk/benefits/universal-credit/)
+<% end %>
+
+<% if calculator.needs_help_in?("wales") %>
+  [Advice if you’ve been furloughed (Citizens Advice)](https://www.citizensadvice.org.uk/wales/work/coronavirus-being-furloughed-if-you-cant-work/)
+
+  [Get advice on applying for Universal Credit (Citizens Advice)](https://www.citizensadvice.org.uk/wales/benefits/universal-credit/)
+
+  [Contact Working Wales if you’ve been made redundant](https://workingwales.gov.wales/)
+<% end %>
+
+### If you’re off work because you’re ill or self isolating
+
+[What to do if you’re employed but cannot work](https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-youre-employed-and-cannot-work)
+
+<% if calculator.needs_help_in?("wales") %>
+  [Check if you’re eligible for the Discretionary Assistance Fund (Welsh Government)](https://gov.wales/discretionary-assistance-fund-daf)
+<% end %>
+
+#### Support and advice
+
+[Find out about the help you can get if you’re self-employed or work in the gig economy (Money Advice Service)](https://www.moneyadviceservice.org.uk/en/articles/coronavirus-what-it-means-for-you)
+
+[Find out about getting statutory sick pay if you’re self-isolating (Acas)](https://www.acas.org.uk/coronavirus/self-isolation-and-sick-pay)
+
+### If you’re self employed or a sole trader
+
+[What to do if you’re self-employed and getting less or no work](https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-youre-self-employed-and-getting-less-work-or-no-work)
+
+[Find financial support for your business](https://www.gov.uk/business-coronavirus-support-finder)
+
+[Find out if you can get help in your local area](https://www.gov.uk/coronavirus-local-help)
+
+<% if calculator.needs_help_in?("northern_ireland") %>
+  [Find out about the financial support and benefits you might be able to get (NI direct)](https://www.nidirect.gov.uk/articles/coronavirus-covid-19-and-benefits)
+
+  [Get help with your business rates and find out about coronavirus loans (nibusinessinfo)](https://www.nibusinessinfo.co.uk/content/coronavirus-support-and-advice-self-employed)
+<% end %>
+
+<% if calculator.needs_help_in?("wales") %>
+  [Check if you’re eligible for the Discretionary Assistance Fund (Welsh Government)](https://gov.wales/discretionary-assistance-fund-daf)
+<% end %>
+
+<% if calculator.needs_help_in?("scotland") %>
+  [Find financial support for your business (Scottish Government)](https://findbusinesssupport.gov.scot/coronavirus-advice)
+<% end %>
+
+#### Support and advice
+
+[What you can do if you’re self employed or a sole trader (Money Advice Service)](https://www.moneyadviceservice.org.uk/en/articles/coronavirus-if-youre-self-employed)
+
+<% if calculator.needs_help_in?("england") %>
+  [Get advice on applying for Universal Credit (Citizens Advice)](https://www.citizensadvice.org.uk/benefits/universal-credit/)
+<% end %>
+
+<% if calculator.needs_help_in?("scotland") %>
+  [Get advice on applying for Universal Credit (Citizens Advice Scotland)](https://www.citizensadvice.org.uk/scotland/benefits/universal-credit/)
+
+  [Find help with benefits (mygov.scot)](https://www.mygov.scot/benefits-support/)
+<% end %>
+
+<% if calculator.needs_help_in?("wales") %>
+  [Get advice on applying for Universal Credit (Citizens Advice)](https://www.citizensadvice.org.uk/wales/benefits/universal-credit/)
+<% end %>
+
+<% if calculator.needs_help_in?("northern_ireland") %>
+  [Get help from Citizens Advice](https://www.citizensadvice.org.uk/about-us/northern-ireland/)
+
+  [Get advice on benefits (Advice NI)](https://www.adviceni.net/)
+<% end %>
+

--- a/lib/smart_answer_flows/coronavirus-find-support/outcomes/_feeling_unsafe.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/outcomes/_feeling_unsafe.erb
@@ -1,0 +1,61 @@
+## Feeling unsafe
+
+### If you do not feel safe where you live or you’re worried about someone else
+
+If you’re in immediate danger call 999 and ask for the Police.
+
+If you’re in danger and unable to talk on the phone, call 999, then press 55 when prompted.
+
+Call the National Domestic Abuse Helpline on [0808 2000 247](tel:0808 2000 247), you can get advice in different languages. You can also [get help online](https://www.nationaldahelpline.org.uk/Chat-to-us-online).
+
+If you’re a child or young person call Childline on [0800 1111](tel:0800 1111) or [get help online](https://www.childline.org.uk).
+
+[Contact NSPCC if you’re concerned about a child.](https://www.nspcc.org.uk/keeping-children-safe/our-services/nspcc-helpline/)
+
+Call Hourglass, if you're an older person or worried about an older person on [0808 808 8141](tel:0808 808 8141), or [find out what support they offer](https://wearehourglass.org/).
+
+Call Galop, the LGBT+ helpline on [0800 999 5428](tel:0800 999 5428), or [find out what support they offer](http://www.galop.org.uk/how-we-can-help/).
+
+Call Men’s Advice Line on [0808 8010327](tel:0808 8010327) or [get help online](https://mensadviceline.org.uk/).
+
+Call Southall Black Sisters for help for black and minority women, including if you’ve got No Recourse to Public Funds on [0208 571 9595](tel:0208 571 9595). You can get advice in different languages. You can also [find out what support they offer](https://southallblacksisters.org.uk).
+
+Call [Karma Nirvana](https://karmanirvana.org.uk/help/) for help with honour-based abuse and forced marriage on [0800 5999 247](tel:0800 5999 247).
+
+[Get specialist support for Deaf people from Signhealth](https://signhealth.org.uk/with-deaf-people/domestic-abuse/domestic-abuse-service).
+
+<% if calculator.needs_help_in?("northern_ireland") %>
+  [Get help from Nexus NI](https://nexusni.org/domestic-and-sexual-abuse-24-hour-helpline/)
+<% end %>
+
+<% if calculator.needs_help_in?("scotland") %>
+  [Get help from Women’s Aid Scotland](https://womensaid.scot/)
+
+  [Get help from Scotland’s forced marriage and domestic abuse helpline](https://sdafmh.org.uk/)
+<% end %>
+
+<% if calculator.needs_help_in?("wales") %>
+  [Get help from Live Fear Free](https://gov.wales/live-fear-free)
+
+  [Find helplines if you’re an older person (Older People’s Commissioner for Wales)](https://www.olderpeoplewales.com/en/coronavirus.aspx)
+
+  [Find victim support helplines (this page is in Welsh)](https://www.victimsupport.org.uk/help-and-support/get-help/support-near-you/wales)
+<% end %>
+
+<% if calculator.needs_help_in?("wales") or calculator.needs_help_in?("england") %>
+  [Get help from Rape Crisis](https://rapecrisis.org.uk/get-help)
+<% end %>
+
+#### Support and advice
+
+[Get safety advice for survivors from Women’s Aid](https://www.womensaid.org.uk/covid-19-coronavirus-safety-and-support-resources/).
+
+You can get advice in different languages including British Sign Language.
+
+[Find specialist helplines for black and minority women (Imkaan)](https://www.imkaan.org.uk/get-help).
+
+Find additional helplines [if you’re a victim of domestic abuse or feel at risk of abuse](https://www.gov.uk/guidance/domestic-abuse-how-to-get-help" class="govuk-link), or if you are a [victim or witness of a crime](https://www.gov.uk/guidance/coronavirus-covid-19-victim-and-witness-services).
+
+<% if calculator.needs_help_in?("wales") %>
+  [Get advice for children (Children’s Commissioner for Wales)](https://www.childcomwales.org.uk/coronavirus/)
+<% end %>

--- a/lib/smart_answer_flows/coronavirus-find-support/outcomes/_getting_food.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/outcomes/_getting_food.erb
@@ -1,0 +1,67 @@
+## Getting food
+
+### If you’re finding it hard to afford food
+
+[If you need food urgently and have no other support, find out if you can get help from your council](https://www.gov.uk/coronavirus-local-help)
+
+[Find out if you’re eligible for Universal Credit](https://www.gov.uk/universal-credit/eligibility)
+
+[If you have a child, find out if they can get free school meals](https://www.gov.uk/apply-free-school-meals)
+
+<% if calculator.needs_help_in?("wales") %>
+  [Find out if you can get help from a foodbank (Citizens Advice)](https://www.citizensadvice.org.uk/wales/benefits/help-if-on-a-low-income/using-a-food-bank/)
+
+  [Check if you’re eligible for the Discretionary Assistance Fund (Welsh Government)](https://gov.wales/discretionary-assistance-fund-daf)
+<% end %>
+
+<% if calculator.needs_help_in?("england") %>
+  [Find out if you can get help from a foodbank (Citizens Advice)](https://www.citizensadvice.org.uk/benefits/help-if-on-a-low-income/using-a-food-bank/)
+<% end %>
+
+<% if calculator.needs_help_in?("northern_ireland") %>
+  [Find out about the financial support and benefits you might be able to get (NI direct)](https://www.nidirect.gov.uk/articles/coronavirus-covid-19-and-benefits)
+
+  Call the coronavirus Community Helpline for Northern Ireland on [0808 802 0020](tel:+448088020020), email [covid19@adviceni.net](mailto:covid19@adviceni.net) or text ‘ACTION’ to 81025
+<% end %>
+
+<% unless calculator.needs_help_in?("scotland") %>
+  [Find out if you can apply for Healthy Start vouchers if you’re 10 or more weeks pregnant or have a child under 4](https://www.healthystart.nhs.uk/healthy-start-vouchers/do-i-qualify/)
+<% end %>
+
+<% if calculator.needs_help_in?("scotland") %>
+  [Find out if you can apply for Best Start Grant and Best Start Foods if you have a child (mygov.scot)](https://www.mygov.scot/best-start-grant-best-start-foods/)
+
+  [Find out if you’re eligible for the Scottish Welfare Fund (mygov.scot)](https://www.mygov.scot/scottish-welfare-fund/)
+
+  [Find out if you can get a grant if you’re a parent or looking after a child (mygov.scot)](https://www.mygov.scot/best-start-grant-best-start-foods/)
+<% end %>
+
+You might be able to phone or email your local shops to get a food delivery, or get food online.
+
+[Find out if you can get help from a volunteer through the NHS Volunteer Responders programme](https://volunteering.royalvoluntaryservice.org.uk/nhs-volunteer-responders-portal/isolating)
+
+[If you need urgent help contact your local council](https://www.gov.uk/coronavirus-local-help)
+
+<% if calculator.needs_help_in?("scotland") %>
+  [Find out if you can sign up for supermarket delivery priority access if you’re clinically at high risk from coronavirus (Gov.scot)](https://www.gov.scot/publications/covid-shielding/pages/overview/)
+
+  [Find out if you can get help from the Scottish Government](https://www.gov.scot/publications/coronavirus-covid-19-help-for-vulnerable-people)
+<% end %>
+
+<% if calculator.needs_help_in?("england") %>
+  [Find out how you can pay for your shopping safely if someone else is shopping for you](https://www.gov.uk/guidance/coronavirus-covid-19-accessing-food-and-essential-supplies)
+<% end %>
+
+<% if calculator.needs_help_in?("wales") %>
+  [Find out how you can pay for your shopping safely if someone else is shopping for you](https://gov.wales/getting-food-and-essential-supplies-during-coronavirus-pandemic)
+<% end %>
+
+#### Support and advice
+
+<% if calculator.needs_help_in?("england") %>
+  [Get more information on accessing food and other essential supplies](https://www.gov.uk/guidance/coronavirus-covid-19-accessing-food-and-essential-supplies)
+<% end %>
+
+<% if calculator.needs_help_in?("wales") %>
+  [Get more information on accessing food and other essential supplies](https://gov.wales/getting-food-and-essential-supplies-during-coronavirus-pandemic)
+<% end %>

--- a/lib/smart_answer_flows/coronavirus-find-support/outcomes/_going_to_work.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/outcomes/_going_to_work.erb
@@ -1,0 +1,31 @@
+## Going in to work
+
+### If you’re worried about going in to work
+
+[Find out if you can get help paying for childcare](https://www.gov.uk/get-childcare)
+
+<% if calculator.needs_help_in?("england") %>
+  [Check if you should go back in to work](https://www.gov.uk/coronavirus-employee-risk-assessment)
+<% end %>
+
+#### Support and advice
+
+[What to do if you’re shielding because you’ve been told by a doctor you’re clinically extremely vulnerable, but you’ve been told to go back to work](https://www.gov.uk/government/publications/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19#work-and-employment-for-those-who-are-shielding)
+
+[What you can do if you’ve been told to go back to work but you need to look after someone or do child care (Acas)](https://www.acas.org.uk/coronavirus/using-holiday/time-off-work-to-look-after-someone)
+
+<% if calculator.needs_help_in?("northern_ireland") %>
+  [Get help from Citizens Advice](https://www.citizensadvice.org.uk/about-us/northern-ireland/)
+<% end %>
+
+<% if calculator.needs_help_in?("scotland") %>
+  [What to do if you’ve been told to go back in to work and you’re worried (Citizens Advice Scotland)](https://www.citizensadvice.org.uk/scotland/work/coronavirus-if-youre-worried-about-working/)
+<% end %>
+
+<% if calculator.needs_help_in?("england") %>
+  [What to do if you’ve been told to go back in to work and you’re worried (Citizens Advice)](https://www.citizensadvice.org.uk/work/coronavirus-if-youre-worried-about-working/)
+<% end %>
+
+<% if calculator.needs_help_in?("wales") %>
+  [What to do if you’ve been told to go back in to work and you’re worried (Citizens Advice)](https://www.citizensadvice.org.uk/wales/work/coronavirus-if-youre-worried-about-working/)
+<% end %>

--- a/lib/smart_answer_flows/coronavirus-find-support/outcomes/_mental_health.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/outcomes/_mental_health.erb
@@ -1,0 +1,31 @@
+## Mental health and wellbeing
+
+### If you’re worried about your mental health or someone else’s mental health
+
+[Where to get urgent help for mental health (NHS)](https://www.nhs.uk/using-the-nhs/nhs-services/mental-health-services/dealing-with-a-mental-health-crisis-or-emergency/)
+
+[How to manage specific mental health needs (Mind)](https://www.mind.org.uk/information-support/coronavirus/coronavirus-and-your-wellbeing)
+
+[Get advice on looking after your mental health during coronavirus (NHS)](https://www.nhs.uk/oneyou/every-mind-matters)
+
+[Things you can do to support the mental health and wellbeing of children and young people (Public Health England)](https://www.gov.uk/government/publications/covid-19-guidance-on-supporting-children-and-young-peoples-mental-health-and-wellbeing/guidance-for-parents-and-carers-on-supporting-children-and-young-peoples-mental-health-and-wellbeing-during-the-coronavirus-covid-19-outbreak)
+
+[Advice and guidance on where you can get help with your mental health if you’re a young person (Young Minds)](https://youngminds.org.uk/find-help/looking-after-yourself/coronavirus-and-mental-health/)
+
+#### Support and advice
+
+[Looking after your mental health during coronavirus (Public Health England)](https://www.gov.uk/government/publications/covid-19-guidance-for-the-public-on-mental-health-and-wellbeing)
+
+[Advice on supporting children’s mental health during coronavirus (Young Minds)](https://youngminds.org.uk/find-help/for-parents/supporting-your-child-during-the-coronavirus-pandemic/)
+
+<% if calculator.needs_help_in?("northern_ireland") %>
+  [Additional information about taking care of your mental health (NI direct)](https://www.nidirect.gov.uk/articles/coronavirus-covid-19-taking-care-your-mental-health-and-wellbeing)
+<% end %>
+
+<% if calculator.needs_help_in?("scotland") %>
+  [Additional information about coronavirus and your mental wellbeing from the Scottish Association for Mental Health](https://www.samh.org.uk/about-mental-health/self-help-and-wellbeing/coronavirus-and-your-mental-wellbeing)
+<% end %>
+
+<% if calculator.needs_help_in?("wales") %>
+  [Additional information about taking care of your mental health (Public Health Wales)](https://phw.nhs.wales/topics/latest-information-on-novel-coronavirus-covid-19/staying-well-at-home/how-are-you-feeling/)
+<% end %>

--- a/lib/smart_answer_flows/coronavirus-find-support/outcomes/_paying_bills.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/outcomes/_paying_bills.erb
@@ -1,0 +1,45 @@
+## Paying bills
+
+### If you’re finding it hard to pay your rent, mortgage or bills
+
+[Find out if you can get help paying for childcare](https://www.gov.uk/get-childcare)
+
+[Find out if you can get help in your local area](https://www.gov.uk/coronavirus-local-help)
+
+<% if calculator.needs_help_in?("northern_ireland") %>
+  [Get help from Citizens Advice](https://www.citizensadvice.org.uk/about-us/northern-ireland/)
+
+  [Get help from the housing and debt helpline for Northern Ireland (Housing Rights)](https://www.housingrights.org.uk/)
+<% end %>
+
+<% if calculator.needs_help_in?("scotland") %>
+  [What to do if you cannot pay your rent or mortgage (Shelter Scotland)](https://scotland.shelter.org.uk/get_advice/scottish_housing_advice_coronavirus_COVID_19)
+
+  [What to do if you cannot pay your bills or mortgage, including if you cannot go out to pay them (Citizens Advice Scotland)](https://www.citizensadvice.org.uk/scotland/debt-and-money/if-you-cant-pay-your-bills-because-of-coronavirus/)
+<% end %>
+
+<% if calculator.needs_help_in?("england") %>
+  [What to do if you cannot pay your rent or mortgage (Shelter)](https://england.shelter.org.uk/housing_advice/coronavirus)
+
+  [What to do if you cannot pay your bills or mortgage, including if you cannot go out to pay them (Citizens Advice)](https://www.citizensadvice.org.uk/debt-and-money/if-you-cant-pay-your-bills-because-of-coronavirus/)
+<% end %>
+
+<% if calculator.needs_help_in?("wales") %>
+  [What to do if you cannot pay your rent or mortgage (Shelter Cymru)](https://sheltercymru.org.uk/get-advice/coronavirus/)
+
+  [What to do if you cannot pay your bills or mortgage, including if you cannot go out to pay them (Citizens Advice)](https://www.citizensadvice.org.uk/wales/debt-and-money/if-you-cant-pay-your-bills-because-of-coronavirus/)
+<% end %>
+
+#### Support and advice
+
+[Your rights if you’re finding it hard to pay rent](https://www.gov.uk/government/publications/covid-19-and-renting-guidance-for-landlords-tenants-and-local-authorities)
+
+<% if calculator.needs_help_in?("scotland") %>
+  [Find out about your rights if you have a private landlord (mygov.scot)](https://www.mygov.scot/private-rental-rights/)
+
+  [Find out about your rights if you have a social landlord (mygov.scot)](https://www.mygov.scot/social-rental-rights/)
+<% end %>
+
+<% if calculator.needs_help_in?("wales") %>
+  [What to do if you’re finding it hard to pay rent (Welsh Government)](https://gov.wales/coronavirus-covid-19-guidance-for-tenants-in-the-private-rented-sector-html)
+<% end %>

--- a/lib/smart_answer_flows/coronavirus-find-support/outcomes/_somewhere_to_live.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/outcomes/_somewhere_to_live.erb
@@ -1,0 +1,83 @@
+## Having somewhere to live
+
+### If you do not have somewhere to live or might become homeless
+
+[Find out if you can get help in your local area](https://www.gov.uk/coronavirus-local-help)
+
+[Get specialist advice for LGBT+ people (Stonewall Housing)](https://stonewallhousing.org/services/advice/)
+
+[Get help if you’re aged 16 to 25 (Centrepoint)](https://centrepoint.org.uk/youth-homelessness/get-help-now/)
+
+<% if calculator.needs_help_in?("northern_ireland") %>
+  Call the Northern Ireland Housing Executive on [03448 920 908](tel:+443448920908)
+<% end %>
+
+<% if calculator.needs_help_in?("scotland") %>
+  [Get help if you’re homeless (mygov.scot)](https://www.mygov.scot/homelessness/)
+<% end %>
+
+<% if calculator.needs_help_in?("england") %>
+  [Get help if you’re homeless, including advice for EU nationals, refugees and asylum seekers, and disabled people (Shelter)](https://england.shelter.org.uk/housing_advice/homelessness)
+<% end %>
+
+<% if calculator.needs_help_in?("wales") %>
+  [Get help if you’re homeless, including advice for refugees and asylum seekers and EU nationals (Shelter Cymru)](https://sheltercymru.org.uk/get-advice/homelessness/)
+<% end %>
+
+#### Support and advice
+
+<% if calculator.needs_help_in?("northern_ireland") %>
+  [Get help from Housing Rights housing and debt helpline](https://www.housingadviceni.org/homeless/coronavirus)
+<% end %>
+
+<% if calculator.needs_help_in?("scotland") %>
+  [Get help if you’re homeless from Shelter Scotland](https://scotland.shelter.org.uk/get_advice/advice_topics/homelessness)
+<% end %>
+
+### If you’ve been evicted or might be soon
+
+[Find out if you can get help in your local area](https://www.gov.uk/coronavirus-local-help)
+
+<% if calculator.needs_help_in?("northern_ireland") %>
+  Call the Northern Ireland Housing Executive on [03448 920 908](tel:+443448920908)
+<% end %>
+
+<% if calculator.needs_help_in?("scotland") %>
+  [Find out how to get help if you’re being evicted (mygov.scot)](https://www.mygov.scot/private-tenant-eviction/getting-help/)
+
+  [Get advice and find out about your rights if you’re a Gypsy or Traveller and you’re being evicted (Shelter Scotland)](https://scotland.shelter.org.uk/get_advice/advice_topics/eviction/eviction_of_gypsiestravellers)
+<% end %>
+
+<% if calculator.needs_help_in?("england") %>
+  [Get coronavirus housing advice (Shelter)](https://england.shelter.org.uk/housing_advice/coronavirus)
+
+  [Get advice and find out about your rights if you’re a Gypsy or Traveller and you’re being evicted (Shelter)](https://england.shelter.org.uk/housing_advice/eviction/gypsies_and_travellers_facing_eviction_from_a_site)
+<% end %>
+
+<% if calculator.needs_help_in?("wales") %>
+  [Get coronavirus housing advice for Wales (Shelter Cymru)](https://sheltercymru.org.uk/get-advice/coronavirus/)
+<% end %>
+
+#### Support and advice
+
+<% if calculator.needs_help_in?("northern_ireland") %>
+  [Find advice from the Housing Executive](https://www.nihe.gov.uk/My-Housing-Executive/Advice-for-Housing-Executive-Tenants/Covid-19-(Coronavirus))
+
+  [Get advice from Housing Rights](https://www.housingadviceni.org/coronavirus)
+<% end %>
+
+<% if calculator.needs_help_in?("scotland") %>
+  [Find out about your rights if you have a private landlord (mygov.scot)](https://www.mygov.scot/private-rental-rights/)
+
+  [Find out about your rights if you have a social landlord (mygov.scot)](https://www.mygov.scot/social-rental-rights/)
+
+  [Get coronavirus housing advice (Shelter Scotland)](https://scotland.shelter.org.uk/get_advice/scottish_housing_advice_coronavirus_COVID_19)
+<% end %>
+
+<% if calculator.needs_help_in?("england") %>
+  [Find information about your rights as a tenant](https://www.gov.uk/government/publications/covid-19-and-renting-guidance-for-landlords-tenants-and-local-authorities)
+<% end %>
+
+<% if calculator.needs_help_in?("wales") %>
+  [Get information on evictions (Welsh Government)](https://gov.wales/coronavirus-covid-19-guidance-for-tenants-in-the-private-rented-sector-html)
+<% end %>

--- a/lib/smart_answer_flows/coronavirus-find-support/outcomes/results.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/outcomes/results.erb
@@ -1,0 +1,55 @@
+<% text_for :title do %>
+  <% if calculator.has_results? %>
+    Information based on your answers
+  <% else %>
+    Information based on your answers - no specific information
+  <% end %>
+<% end %>
+
+<% govspeak_for :body do %>
+  <% if calculator.has_results? %>
+
+    <%= render("feeling_unsafe", calculator: calculator) if calculator.user_feels_unsafe? %>
+    <%= render("paying_bills", calculator: calculator) if calculator.user_cannot_pay_their_bills? %>
+    <%= render("getting_food", calculator: calculator) if calculator.user_cannot_get_food? %>
+    <%= render("being_unemployed", calculator: calculator) if calculator.user_is_unemployed? %>
+    <%= render("going_to_work", calculator: calculator) if calculator.user_is_worried_about_going_to_work? %>
+    <%= render("somewhere_to_live", calculator: calculator) if calculator.user_needs_somewhere_to_live? %>
+    <%= render("mental_health", calculator: calculator) if calculator.user_has_mental_health_worries? %>
+
+  <% else %>
+    Based on your answers, there’s no specific information for you in this service at the moment. It will be updated regularly.
+
+    [Find all information on coronavirus, including how to protect yourself and get financial support](https://www.gov.uk/coronavirus)
+
+    <% if calculator.needs_help_in?("england") %>
+      [Find information about what you can do from Citizens Advice](https://www.citizensadvice.org.uk/health/coronavirus-what-it-means-for-you/)
+    <% end %>
+
+    <% if calculator.needs_help_in?("northern_ireland") %>
+      [Additional information for Northern Ireland](https://www.nidirect.gov.uk/campaigns/coronavirus-covid-19)
+
+      [Get advice from Citizens Advice](https://www.citizensadvice.org.uk/about-us/northern-ireland/)
+    <% end %>
+
+    <% if calculator.needs_help_in?("scotland") %>
+      [Additional information for Scotland (mygov.scot)](https://www.mygov.scot/coronavirus-covid-19/)
+
+      [Find other organisations who might be able to help you (Ready Scotland)](https://www.readyscotland.org/coronavirus/where-to-find-additional-support/)
+
+      [Get advice from Citizens Advice Scotland](https://www.citizensadvice.org.uk/scotland/health/coronavirus-what-it-means-for-you-s/)
+    <% end %>
+
+    <% if calculator.needs_help_in?("wales") %>
+      [Additional information for Wales](https://gov.wales/coronavirus)
+
+      [Get advice from Citizens Advice](https://www.citizensadvice.org.uk/wales/health/coronavirus-what-it-means-for-you/)
+    <% end %>
+  <% end %>
+
+  $CTA
+    ### Help us improve
+
+    [Give feedback on this service](https://www.gov.uk/done/find-coronavirus-support)
+  $CTA
+<% end %>

--- a/lib/smart_answer_flows/coronavirus-find-support/questions/able_to_go_out.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/questions/able_to_go_out.erb
@@ -1,0 +1,15 @@
+<% text_for :hint do %>
+  Getting food
+<% end %>
+
+<% text_for :title do %>
+  Are you able to leave your home for food, medicine, or health reasons?
+<% end %>
+
+<% options(
+  "yes": "Yes",
+  "no_i_have_coronavirus": "No, I should not go out because I have coronavirus, or someone in my household does",
+  "no_i_have_a_medical_condition": "No, I should not go out because I have a medical condition which means I’m extremely vulnerable to coronavirus",
+  "no_i_have_a_disability": "No, I’m unable to go out because I have a disability",
+  "no_for_another_reason": "No, I’m unable to go out for another reason",
+) %>

--- a/lib/smart_answer_flows/coronavirus-find-support/questions/afford_food.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/questions/afford_food.erb
@@ -1,0 +1,13 @@
+<% text_for :hint do %>
+  Getting food
+<% end %>
+
+<% text_for :title do %>
+  Are you finding it hard to afford food?
+<% end %>
+
+<% options(
+  "yes": "Yes",
+  "no": "No",
+  "not_sure": "Not sure",
+) %>

--- a/lib/smart_answer_flows/coronavirus-find-support/questions/afford_rent_mortgage_bills.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/questions/afford_rent_mortgage_bills.erb
@@ -1,0 +1,13 @@
+<% text_for :hint do %>
+  Paying bills
+<% end %>
+
+<% text_for :title do %>
+  Are you finding it hard to afford rent, your mortgage or bills?
+<% end %>
+
+<% options(
+  "yes": "Yes",
+  "no": "No",
+  "not_sure": "Not sure",
+) %>

--- a/lib/smart_answer_flows/coronavirus-find-support/questions/are_you_off_work_ill.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/questions/are_you_off_work_ill.erb
@@ -1,0 +1,12 @@
+<% text_for :hint do %>
+  Being made redundant or unemployed, or not having any work
+<% end %>
+
+<% text_for :title do %>
+  Are you off work because you’re ill or self-isolating?
+<% end %>
+
+<% options(
+  "yes": "Yes",
+  "no": "No",
+) %>

--- a/lib/smart_answer_flows/coronavirus-find-support/questions/feel_safe.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/questions/feel_safe.erb
@@ -1,0 +1,14 @@
+<% text_for :hint do %>
+  Feeling unsafe
+<% end %>
+
+<% text_for :title do %>
+  Do you feel safe where you live?
+<% end %>
+
+<% options(
+  "yes": "Yes",
+  "yes_but_i_am_concerned_about_others": "Yes, but I’m worried about the safety of another adult or a child",
+  "no": "No",
+  "not_sure": "Not sure",
+) %>

--- a/lib/smart_answer_flows/coronavirus-find-support/questions/get_food.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/questions/get_food.erb
@@ -1,0 +1,13 @@
+<% text_for :hint do %>
+  Getting food
+<% end %>
+
+<% text_for :title do %>
+  Are you able to get food?
+<% end %>
+
+<% options(
+  "yes": "Yes",
+  "no": "No",
+  "not_sure": "Not sure",
+) %>

--- a/lib/smart_answer_flows/coronavirus-find-support/questions/going_in_to_work.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/questions/going_in_to_work.erb
@@ -1,0 +1,13 @@
+<% text_for :hint do %>
+  Going in to work
+<% end %>
+
+<% text_for :title do %>
+  Are you worried about going in to work?
+<% end %>
+
+<% options(
+  "yes": "Yes",
+  "no": "No",
+  "not_sure": "Not sure",
+) %>

--- a/lib/smart_answer_flows/coronavirus-find-support/questions/have_somewhere_to_live.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/questions/have_somewhere_to_live.erb
@@ -1,0 +1,14 @@
+<% text_for :hint do %>
+  Having somewhere to live
+<% end %>
+
+<% text_for :title do %>
+  Do you have somewhere to live?
+<% end %>
+
+<% options(
+  "yes": "Yes",
+  "yes_but_i_might_lose_it": "I do now but I might lose it",
+  "no": "No",
+  "not_sure": "Not sure",
+) %>

--- a/lib/smart_answer_flows/coronavirus-find-support/questions/have_you_been_evicted.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/questions/have_you_been_evicted.erb
@@ -1,0 +1,14 @@
+<% text_for :hint do %>
+  Having somewhere to live
+<% end %>
+
+<% text_for :title do %>
+  Have you been evicted?
+<% end %>
+
+<% options(
+  "yes": "Yes",
+  "yes_i_might_be_soon": "I might be evicted soon",
+  "no": "No",
+  "not_sure": "Not sure",
+) %>

--- a/lib/smart_answer_flows/coronavirus-find-support/questions/have_you_been_made_unemployed.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/questions/have_you_been_made_unemployed.erb
@@ -1,0 +1,14 @@
+<% text_for :hint do %>
+  Being made redundant or unemployed, or not having any work
+<% end %>
+
+<% text_for :title do %>
+  Have you been made redundant or told to stop working?
+<% end %>
+
+<% options(
+  "yes_i_have_been_made_unemployed": "Yes, I’ve been made unemployed, or might be soon",
+  "yes_i_have_been_put_on_furlough": "Yes, I’ve been put on temporary leave (on furlough), or might be soon",
+  "no": "No",
+  "not_sure": "Not sure",
+) %>

--- a/lib/smart_answer_flows/coronavirus-find-support/questions/mental_health_worries.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/questions/mental_health_worries.erb
@@ -1,0 +1,13 @@
+<% text_for :hint do %>
+  Mental health and wellbeing
+<% end %>
+
+<% text_for :title do %>
+  Are you worried about your mental health, or another adult or child’s mental health?
+<% end %>
+
+<% options(
+  "yes": "Yes, I am",
+  "no": "No, I'm not",
+  "not_sure": "Not sure",
+) %>

--- a/lib/smart_answer_flows/coronavirus-find-support/questions/nation.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/questions/nation.erb
@@ -1,0 +1,10 @@
+<% text_for :title do %>
+  Where do you live?
+<% end %>
+
+<% options(
+  "england": "England",
+  "scotland": "Scotland",
+  "wales": "Wales",
+  "northern_ireland": "Northern Ireland",
+) %>

--- a/lib/smart_answer_flows/coronavirus-find-support/questions/need_help_with.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/questions/need_help_with.erb
@@ -1,0 +1,18 @@
+<% text_for :title do %>
+  What do you need help with because of coronavirus?
+<% end %>
+
+<% text_for :hint do %>
+  Select all that apply
+<% end %>
+
+<% options(
+  "feeling_unsafe": "Feeling unsafe where you live, or being worried about someone else",
+  "paying_bills": "Paying bills",
+  "getting_food": "Getting food",
+  "being_unemployed": "Being unemployed or not having any work",
+  "going_to_work": "Going in to work",
+  "somewhere_to_live": "Having somewhere to live",
+  "mental_health": "Mental health and wellbeing",
+  "not_sure": "I'm not sure",
+) %>

--- a/lib/smart_answer_flows/coronavirus-find-support/questions/self_employed.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/questions/self_employed.erb
@@ -1,0 +1,13 @@
+<% text_for :hint do %>
+  Being made redundant or unemployed, or not having any work
+<% end %>
+
+<% text_for :title do %>
+  Are you self-employed or a sole trader?
+<% end %>
+
+<% options(
+  "yes": "Yes",
+  "no": "No",
+  "not_sure": "Not sure",
+) %>

--- a/lib/smart_answer_flows/coronavirus-find-support/questions/worried_about_work.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/questions/worried_about_work.erb
@@ -1,0 +1,13 @@
+<% text_for :hint do %>
+  Going in to work
+<% end %>
+
+<% text_for :title do %>
+  Are you worried about going in to work?
+<% end %>
+
+<% options(
+  "yes": "Yes",
+  "no": "No",
+  "not_sure": "Not sure",
+) %>

--- a/test/integration/smart_answer_flows/coronavirus_find_support_test.rb
+++ b/test/integration/smart_answer_flows/coronavirus_find_support_test.rb
@@ -1,0 +1,106 @@
+require_relative "../../test_helper"
+require_relative "flow_test_helper"
+
+require "smart_answer_flows/coronavirus-find-support.rb"
+
+class CoronavirusFindSupportFlowTest < ActiveSupport::TestCase
+  include FlowTestHelper
+
+  setup do
+    setup_for_testing_flow SmartAnswer::CoronavirusFindSupportFlow
+  end
+
+  context "specific outcomes" do
+    should "show results for a user that can get food and is self-employed" do
+      assert_current_node :need_help_with?
+      add_response "being_unemployed,feeling_unsafe,getting_food,going_to_work,mental_health,paying_bills,somewhere_to_live"
+      assert_current_node :feel_safe?
+      add_response "no"
+      assert_current_node :afford_rent_mortgage_bills?
+      add_response "no"
+      assert_current_node :afford_food?
+      add_response "no"
+
+      assert_current_node :get_food?
+      add_response "yes"
+      assert_current_node :self_employed?
+      add_response "yes"
+
+      assert_current_node :worried_about_work?
+      add_response "yes"
+      assert_current_node :have_somewhere_to_live?
+      add_response "no"
+      assert_current_node :have_you_been_evicted?
+      add_response "yes"
+      assert_current_node :mental_health_worries?
+      add_response "yes"
+      assert_current_node :nation?
+      add_response "england,scotland,wales,northern_ireland"
+      assert_current_node :results
+    end
+
+    should "show results for a user that cannot get food, is not self-employed, and has been made unemployed" do
+      assert_current_node :need_help_with?
+      add_response "being_unemployed,feeling_unsafe,getting_food,going_to_work,mental_health,paying_bills,somewhere_to_live"
+      assert_current_node :feel_safe?
+      add_response "no"
+      assert_current_node :afford_rent_mortgage_bills?
+      add_response "no"
+      assert_current_node :afford_food?
+      add_response "no"
+
+      assert_current_node :get_food?
+      add_response "no"
+      assert_current_node :able_to_go_out?
+      add_response "yes"
+      assert_current_node :self_employed?
+      add_response "no"
+      assert_current_node :have_you_been_made_unemployed?
+      add_response "yes_i_have_been_made_unemployed"
+
+      assert_current_node :worried_about_work?
+      add_response "yes"
+      assert_current_node :have_somewhere_to_live?
+      add_response "no"
+      assert_current_node :have_you_been_evicted?
+      add_response "yes"
+      assert_current_node :mental_health_worries?
+      add_response "yes"
+      assert_current_node :nation?
+      add_response "england,scotland,wales,northern_ireland"
+      assert_current_node :results
+    end
+
+    should "show results for a user that can get food, is not self-employed, and has not been made unemployed" do
+      assert_current_node :need_help_with?
+      add_response "being_unemployed,feeling_unsafe,getting_food,going_to_work,mental_health,paying_bills,somewhere_to_live"
+      assert_current_node :feel_safe?
+      add_response "no"
+      assert_current_node :afford_rent_mortgage_bills?
+      add_response "no"
+      assert_current_node :afford_food?
+      add_response "no"
+
+      assert_current_node :get_food?
+      add_response "yes"
+      assert_current_node :self_employed?
+      add_response "no"
+      assert_current_node :have_you_been_made_unemployed?
+      add_response "no"
+      assert_current_node :are_you_off_work_ill?
+      add_response "no"
+
+      assert_current_node :worried_about_work?
+      add_response "yes"
+      assert_current_node :have_somewhere_to_live?
+      add_response "no"
+      assert_current_node :have_you_been_evicted?
+      add_response "yes"
+      assert_current_node :mental_health_worries?
+      add_response "yes"
+      assert_current_node :nation?
+      add_response "england,scotland,wales,northern_ireland"
+      assert_current_node :results
+    end
+  end
+end

--- a/test/unit/calculators/coronavirus_find_support_calculator_test.rb
+++ b/test/unit/calculators/coronavirus_find_support_calculator_test.rb
@@ -1,0 +1,725 @@
+require_relative "../../test_helper"
+
+module SmartAnswer::Calculators
+  class CoronavirusFindSupportCalculatorTest < ActiveSupport::TestCase
+    setup do
+      @calculator = CoronavirusFindSupportCalculator.new
+    end
+
+    context "#next_question" do
+      context "user is on the need_help_with? node" do
+        should "return feel_safe? when paying_bills has been chosen" do
+          @calculator.need_help_with = "feeling_unsafe"
+          assert_equal @calculator.next_question(:need_help_with?), :feel_safe?
+        end
+
+        should "return afford_rent_mortgage_bills? when paying_bills has been chosen" do
+          @calculator.need_help_with = "paying_bills"
+          assert_equal @calculator.next_question(:need_help_with?), :afford_rent_mortgage_bills?
+        end
+
+        should "return self_employed? when getting_food has been chosen" do
+          @calculator.need_help_with = "getting_food"
+          assert_equal @calculator.next_question(:need_help_with?), :afford_food?
+        end
+
+        should "return self_employed? when being_unemployed has been chosen" do
+          @calculator.need_help_with = "being_unemployed"
+          assert_equal @calculator.next_question(:need_help_with?), :self_employed?
+        end
+
+        should "return worried_about_work? when going_to_work has been chosen" do
+          @calculator.need_help_with = "going_to_work"
+          assert_equal @calculator.next_question(:need_help_with?), :worried_about_work?
+        end
+
+        should "return have_somewhere_to_live? when somewhere_to_live has been chosen" do
+          @calculator.need_help_with = "somewhere_to_live"
+          assert_equal @calculator.next_question(:need_help_with?), :have_somewhere_to_live?
+        end
+
+        should "return mental_health_worries? when mental_health has been chosen" do
+          @calculator.need_help_with = "mental_health"
+          assert_equal @calculator.next_question(:need_help_with?), :mental_health_worries?
+        end
+
+        should "return nation? when there are no other selected options" do
+          @calculator.need_help_with = ""
+          assert_equal @calculator.next_question(:need_help_with?), :nation?
+        end
+      end
+
+      context "user is on the feel_safe? node" do
+        should "return afford_rent_mortgage_bills? when paying_bills has been chosen" do
+          @calculator.need_help_with = "paying_bills"
+          assert_equal @calculator.next_question(:feel_safe?), :afford_rent_mortgage_bills?
+        end
+
+        should "return self_employed? when getting_food has been chosen" do
+          @calculator.need_help_with = "getting_food"
+          assert_equal @calculator.next_question(:feel_safe?), :afford_food?
+        end
+
+        should "return self_employed? when being_unemployed has been chosen" do
+          @calculator.need_help_with = "being_unemployed"
+          assert_equal @calculator.next_question(:feel_safe?), :self_employed?
+        end
+
+        should "return worried_about_work? when going_to_work has been chosen" do
+          @calculator.need_help_with = "going_to_work"
+          assert_equal @calculator.next_question(:feel_safe?), :worried_about_work?
+        end
+
+        should "return have_somewhere_to_live? when somewhere_to_live has been chosen" do
+          @calculator.need_help_with = "somewhere_to_live"
+          assert_equal @calculator.next_question(:feel_safe?), :have_somewhere_to_live?
+        end
+
+        should "return mental_health_worries? when mental_health has been chosen" do
+          @calculator.need_help_with = "mental_health"
+          assert_equal @calculator.next_question(:feel_safe?), :mental_health_worries?
+        end
+
+        should "return nation? when there are no other selected options" do
+          @calculator.need_help_with = ""
+          assert_equal @calculator.next_question(:feel_safe?), :nation?
+        end
+      end
+
+      context "user is on the afford_rent_mortgage_bills? node" do
+        should "return self_employed? when getting_food has been chosen" do
+          @calculator.need_help_with = "getting_food"
+          assert_equal @calculator.next_question(:afford_rent_mortgage_bills?), :afford_food?
+        end
+
+        should "return self_employed? when being_unemployed has been chosen" do
+          @calculator.need_help_with = "being_unemployed"
+          assert_equal @calculator.next_question(:afford_rent_mortgage_bills?), :self_employed?
+        end
+
+        should "return worried_about_work? when going_to_work has been chosen" do
+          @calculator.need_help_with = "going_to_work"
+          assert_equal @calculator.next_question(:afford_rent_mortgage_bills?), :worried_about_work?
+        end
+
+        should "return have_somewhere_to_live? when somewhere_to_live has been chosen" do
+          @calculator.need_help_with = "somewhere_to_live"
+          assert_equal @calculator.next_question(:afford_rent_mortgage_bills?), :have_somewhere_to_live?
+        end
+
+        should "return mental_health_worries? when mental_health has been chosen" do
+          @calculator.need_help_with = "mental_health"
+          assert_equal @calculator.next_question(:afford_rent_mortgage_bills?), :mental_health_worries?
+        end
+
+        should "return nation? when there are no other selected options" do
+          @calculator.need_help_with = ""
+          assert_equal @calculator.next_question(:afford_rent_mortgage_bills?), :nation?
+        end
+      end
+
+      context "user is on the get_food? node" do
+        should "return self_employed? when being_unemployed has been chosen" do
+          @calculator.need_help_with = "being_unemployed"
+          assert_equal @calculator.next_question(:get_food?), :self_employed?
+        end
+
+        should "return worried_about_work? when going_to_work has been chosen" do
+          @calculator.need_help_with = "going_to_work"
+          assert_equal @calculator.next_question(:get_food?), :worried_about_work?
+        end
+
+        should "return have_somewhere_to_live? when somewhere_to_live has been chosen" do
+          @calculator.need_help_with = "somewhere_to_live"
+          assert_equal @calculator.next_question(:get_food?), :have_somewhere_to_live?
+        end
+
+        should "return mental_health_worries? when mental_health has been chosen" do
+          @calculator.need_help_with = "mental_health"
+          assert_equal @calculator.next_question(:get_food?), :mental_health_worries?
+        end
+
+        should "return nation? when there are no other selected options" do
+          @calculator.need_help_with = ""
+          assert_equal @calculator.next_question(:get_food?), :nation?
+        end
+      end
+
+      context "user is on the are_you_off_work_ill? node" do
+        should "return worried_about_work? when going_to_work has been chosen" do
+          @calculator.need_help_with = "going_to_work"
+          assert_equal @calculator.next_question(:are_you_off_work_ill?), :worried_about_work?
+        end
+
+        should "return have_somewhere_to_live? when somewhere_to_live has been chosen" do
+          @calculator.need_help_with = "somewhere_to_live"
+          assert_equal @calculator.next_question(:are_you_off_work_ill?), :have_somewhere_to_live?
+        end
+
+        should "return mental_health_worries? when mental_health has been chosen" do
+          @calculator.need_help_with = "mental_health"
+          assert_equal @calculator.next_question(:are_you_off_work_ill?), :mental_health_worries?
+        end
+
+        should "return nation? when there are no other selected options" do
+          @calculator.need_help_with = ""
+          assert_equal @calculator.next_question(:are_you_off_work_ill?), :nation?
+        end
+      end
+
+      context "user is on the worried_about_work? node" do
+        should "return have_somewhere_to_live? when somewhere_to_live has been chosen" do
+          @calculator.need_help_with = "somewhere_to_live"
+          assert_equal @calculator.next_question(:worried_about_work?), :have_somewhere_to_live?
+        end
+
+        should "return mental_health_worries? when mental_health has been chosen" do
+          @calculator.need_help_with = "mental_health"
+          assert_equal @calculator.next_question(:worried_about_work?), :mental_health_worries?
+        end
+
+        should "return nation? when there are no other selected options" do
+          @calculator.need_help_with = ""
+          assert_equal @calculator.next_question(:worried_about_work?), :nation?
+        end
+      end
+
+      context "user is on the have_you_been_evicted? node" do
+        should "return mental_health_worries? when mental_health has been chosen" do
+          @calculator.need_help_with = "mental_health"
+          assert_equal @calculator.next_question(:have_you_been_evicted?), :mental_health_worries?
+        end
+
+        should "return nation? when there are no other selected options" do
+          @calculator.need_help_with = ""
+          assert_equal @calculator.next_question(:have_you_been_evicted?), :nation?
+        end
+      end
+    end
+
+    context "#needs_help_with?" do
+      should "return true if the given help item has been chosen" do
+        @calculator.need_help_with = "one,two,three,four"
+        assert_equal @calculator.needs_help_with?("one"), true
+      end
+
+      should "return false if the given help item has not been chosen" do
+        @calculator.need_help_with = "one,two,three,four"
+        assert_equal @calculator.needs_help_with?("five"), false
+      end
+
+      should "return false if need_help_with is an empty string" do
+        @calculator.need_help_with = ""
+        assert_equal @calculator.needs_help_with?("one"), false
+      end
+
+      should "return false if need_help_with is nil" do
+        @calculator.need_help_with = nil
+        assert_equal @calculator.needs_help_with?("one"), false
+      end
+    end
+
+    context "#has_results?" do
+      should "return true if at least one help item has been chosen" do
+        @calculator.need_help_with = "one"
+        assert_equal @calculator.has_results?, true
+      end
+
+      should "return false if need_help_with is an empty string" do
+        @calculator.need_help_with = ""
+        assert_equal @calculator.has_results?, false
+      end
+
+      should "return false if need_help_with is nil" do
+        @calculator.need_help_with = nil
+        assert_equal @calculator.has_results?, false
+      end
+    end
+
+    context "#needs_help_in?" do
+      should "return true if the given nation has been chosen" do
+        @calculator.nation = "one,two,three,four"
+        assert_equal @calculator.needs_help_in?("one"), true
+      end
+
+      should "return false if the given nation has not been chosen" do
+        @calculator.nation = "one,two,three,four"
+        assert_equal @calculator.needs_help_in?("five"), false
+      end
+
+      should "return false if nation is an empty string" do
+        @calculator.nation = ""
+        assert_equal @calculator.needs_help_in?("one"), false
+      end
+
+      should "return false if nation is nil" do
+        @calculator.nation = nil
+        assert_equal @calculator.needs_help_in?("one"), false
+      end
+    end
+
+    context "#user_feels_unsafe?" do
+      context "user has selected feeling_unsafe" do
+        setup do
+          @calculator.need_help_with = "feeling_unsafe"
+        end
+
+        should "return false if the user feels safe" do
+          @calculator.feel_safe = "yes"
+          assert_equal @calculator.user_feels_unsafe?, false
+        end
+
+        should "return true if the user feels safe but not completely" do
+          @calculator.feel_safe = "yes_but"
+          assert_equal @calculator.user_feels_unsafe?, true
+        end
+
+        should "return true if the user does not feel safe" do
+          @calculator.feel_safe = "no"
+          assert_equal @calculator.user_feels_unsafe?, true
+        end
+
+        should "return true if the user is unsure about feeling safe" do
+          @calculator.feel_safe = "not_sure"
+          assert_equal @calculator.user_feels_unsafe?, true
+        end
+      end
+
+      context "user has not selected feeling_unsafe" do
+        should "return false" do
+          @calculator.need_help_with = ""
+          @calculator.feel_safe = "no"
+          assert_equal @calculator.user_feels_unsafe?, false
+        end
+      end
+    end
+
+    context "#user_cannot_pay_their_bills?" do
+      context "user has selected paying_bills" do
+        setup do
+          @calculator.need_help_with = "paying_bills"
+        end
+
+        should "return true if the user is finding it hard to pay their bills" do
+          @calculator.afford_rent_mortgage_bills = "yes"
+          assert_equal @calculator.user_cannot_pay_their_bills?, true
+        end
+
+        should "return false if the user is not finding it hard to pay their bills" do
+          @calculator.afford_rent_mortgage_bills = "no"
+          assert_equal @calculator.user_cannot_pay_their_bills?, false
+        end
+
+        should "return true if the user is unsure if they are finding it hard to pay their bills" do
+          @calculator.afford_rent_mortgage_bills = "not_sure"
+          assert_equal @calculator.user_cannot_pay_their_bills?, true
+        end
+      end
+
+      context "user has not selected paying_bills" do
+        should "return false" do
+          @calculator.need_help_with = ""
+          @calculator.afford_rent_mortgage_bills = "yes"
+          assert_equal @calculator.user_cannot_pay_their_bills?, false
+        end
+      end
+    end
+
+    context "#user_cannot_get_food?" do
+      context "user has selected getting_food" do
+        setup do
+          @calculator.need_help_with = "getting_food"
+        end
+
+        context "user is finding it hard to afford food" do
+          setup do
+            @calculator.afford_food = "yes"
+          end
+
+          should "return false if the user can get food" do
+            @calculator.get_food = "yes"
+            assert_equal @calculator.user_cannot_get_food?, false
+          end
+
+          should "return true if the user cannot get food" do
+            @calculator.get_food = "no"
+            assert_equal @calculator.user_cannot_get_food?, true
+          end
+
+          should "return true if the user is unsure if they can get food" do
+            @calculator.get_food = "not_sure"
+            assert_equal @calculator.user_cannot_get_food?, true
+          end
+        end
+
+        context "user is unsure if they are finding it hard afford food" do
+          setup do
+            @calculator.afford_food = "not_sure"
+          end
+
+          should "return false if the user can get food" do
+            @calculator.get_food = "yes"
+            assert_equal @calculator.user_cannot_get_food?, false
+          end
+
+          should "return true if the user cannot get food" do
+            @calculator.get_food = "no"
+            assert_equal @calculator.user_cannot_get_food?, true
+          end
+
+          should "return true if the user is unsure if they can get food" do
+            @calculator.get_food = "not_sure"
+            assert_equal @calculator.user_cannot_get_food?, true
+          end
+        end
+
+        context "user is not finding it hard to afford food" do
+          setup do
+            @calculator.afford_food = "no"
+          end
+
+          should "return false if the user can get food" do
+            @calculator.get_food = "yes"
+            assert_equal @calculator.user_cannot_get_food?, false
+          end
+
+          should "return false if the user cannot get food" do
+            @calculator.get_food = "no"
+            assert_equal @calculator.user_cannot_get_food?, false
+          end
+
+          should "return false if the user is unsure if they can get food" do
+            @calculator.get_food = "not_sure"
+            assert_equal @calculator.user_cannot_get_food?, false
+          end
+        end
+      end
+
+      context "user has not selected getting_food" do
+        should "return false" do
+          @calculator.need_help_with = ""
+          @calculator.afford_food = "yes"
+          @calculator.get_food = "no"
+          assert_equal @calculator.user_cannot_get_food?, false
+        end
+      end
+    end
+
+    context "#user_is_worried_about_going_to_work?" do
+      context "user has selected going_to_work" do
+        setup do
+          @calculator.need_help_with = "going_to_work"
+        end
+
+        should "return true if the user is worried about work" do
+          @calculator.worried_about_work = "yes"
+          assert_equal @calculator.user_is_worried_about_going_to_work?, true
+        end
+
+        should "return false if the user is not worried about work" do
+          @calculator.worried_about_work = "no"
+          assert_equal @calculator.user_is_worried_about_going_to_work?, false
+        end
+
+        should "return true if the user is unsure about being worried about work" do
+          @calculator.worried_about_work = "not_sure"
+          assert_equal @calculator.user_is_worried_about_going_to_work?, true
+        end
+      end
+
+      context "user has not selected going_to_work" do
+        should "return false" do
+          @calculator.need_help_with = ""
+          @calculator.worried_about_work = "yes"
+          assert_equal @calculator.user_is_worried_about_going_to_work?, false
+        end
+      end
+    end
+
+    context "#user_is_unemployed?" do
+      context "user has selected being_unemployed" do
+        setup do
+          @calculator.need_help_with = "being_unemployed"
+        end
+
+        context "user is not ill" do
+          setup do
+            @calculator.are_you_off_work_ill = "no"
+          end
+
+          context "user is not self-employed" do
+            setup do
+              @calculator.self_employed = "no"
+            end
+
+            should "return true if the user has been made unemployed" do
+              @calculator.have_you_been_made_unemployed = "yes_1"
+              assert_equal @calculator.user_is_unemployed?, true
+            end
+
+            should "return true if the user is going to be made unemployed" do
+              @calculator.have_you_been_made_unemployed = "yes_2"
+              assert_equal @calculator.user_is_unemployed?, true
+            end
+
+            should "return true if the user is unsure if they are going to be made unemployed" do
+              @calculator.have_you_been_made_unemployed = "not_sure"
+              assert_equal @calculator.user_is_unemployed?, true
+            end
+
+            should "return false if the user has not been made unemployed" do
+              @calculator.have_you_been_made_unemployed = "no"
+              assert_equal @calculator.user_is_unemployed?, false
+            end
+          end
+
+          context "user is self-employed" do
+            setup do
+              @calculator.self_employed = "yes"
+            end
+
+            should "return false if the user has been made unemployed" do
+              @calculator.have_you_been_made_unemployed = "yes_1"
+              assert_equal @calculator.user_is_unemployed?, false
+            end
+
+            should "return false if the user is going to be made unemployed" do
+              @calculator.have_you_been_made_unemployed = "yes_2"
+              assert_equal @calculator.user_is_unemployed?, false
+            end
+
+            should "return false if the user is unsure if they are going to be made unemployed" do
+              @calculator.have_you_been_made_unemployed = "not_sure"
+              assert_equal @calculator.user_is_unemployed?, false
+            end
+
+            should "return false if the user has not been made unemployed" do
+              @calculator.have_you_been_made_unemployed = "no"
+              assert_equal @calculator.user_is_unemployed?, false
+            end
+          end
+        end
+
+        context "user is ill" do
+          setup do
+            @calculator.are_you_off_work_ill = "yes"
+          end
+
+          context "user is not self-employed" do
+            setup do
+              @calculator.self_employed = "no"
+            end
+
+            should "return true if the user has been made unemployed" do
+              @calculator.have_you_been_made_unemployed = "yes_1"
+              assert_equal @calculator.user_is_unemployed?, true
+            end
+
+            should "return true if the user is going to be made unemployed" do
+              @calculator.have_you_been_made_unemployed = "yes_2"
+              assert_equal @calculator.user_is_unemployed?, true
+            end
+
+            should "return true if the user is unsure if they are going to be made unemployed" do
+              @calculator.have_you_been_made_unemployed = "not_sure"
+              assert_equal @calculator.user_is_unemployed?, true
+            end
+
+            should "return true if the user has not been made unemployed" do
+              @calculator.have_you_been_made_unemployed = "no"
+              assert_equal @calculator.user_is_unemployed?, true
+            end
+          end
+
+          context "user is self-employed" do
+            setup do
+              @calculator.self_employed = "yes"
+            end
+
+            should "return true if the user has been made unemployed" do
+              @calculator.have_you_been_made_unemployed = "yes_1"
+              assert_equal @calculator.user_is_unemployed?, true
+            end
+
+            should "return true if the user is going to be made unemployed" do
+              @calculator.have_you_been_made_unemployed = "yes_2"
+              assert_equal @calculator.user_is_unemployed?, true
+            end
+
+            should "return true if the user is unsure if they are going to be made unemployed" do
+              @calculator.have_you_been_made_unemployed = "not_sure"
+              assert_equal @calculator.user_is_unemployed?, true
+            end
+
+            should "return true if the user has not been made unemployed" do
+              @calculator.have_you_been_made_unemployed = "no"
+              assert_equal @calculator.user_is_unemployed?, true
+            end
+          end
+        end
+      end
+
+      context "user has not selected being_unemployed" do
+        should "return false" do
+          @calculator.need_help_with = ""
+          @calculator.are_you_off_work_ill = "yes"
+          @calculator.self_employed = "no"
+          @calculator.have_you_been_made_unemployed = "yes"
+          assert_equal @calculator.user_is_unemployed?, false
+        end
+      end
+    end
+
+    context "#user_needs_somewhere_to_live?" do
+      context "user has selected somewhere_to_live" do
+        setup do
+          @calculator.need_help_with = "somewhere_to_live"
+        end
+
+        context "user does have somewhere to live" do
+          setup do
+            @calculator.have_somewhere_to_live = "yes"
+          end
+
+          should "return true if the user has been evicted" do
+            @calculator.have_you_been_evicted = "yes"
+            assert_equal @calculator.user_needs_somewhere_to_live?, true
+          end
+
+          should "return true if the user going to be evicted" do
+            @calculator.have_you_been_evicted = "soon"
+            assert_equal @calculator.user_needs_somewhere_to_live?, true
+          end
+
+          should "return false if the user is not going to be evicted" do
+            @calculator.have_you_been_evicted = "no"
+            assert_equal @calculator.user_needs_somewhere_to_live?, false
+          end
+
+          should "return true if the user is unsure if they are going to be evicted" do
+            @calculator.have_you_been_evicted = "not_sure"
+            assert_equal @calculator.user_needs_somewhere_to_live?, true
+          end
+        end
+
+        context "user may not have somewhere to live" do
+          setup do
+            @calculator.have_somewhere_to_live = "yes_but"
+          end
+
+          should "return true if the user has been evicted" do
+            @calculator.have_you_been_evicted = "yes"
+            assert_equal @calculator.user_needs_somewhere_to_live?, true
+          end
+
+          should "return true if the user going to be evicted" do
+            @calculator.have_you_been_evicted = "soon"
+            assert_equal @calculator.user_needs_somewhere_to_live?, true
+          end
+
+          should "return true if the user is not going to be evicted" do
+            @calculator.have_you_been_evicted = "no"
+            assert_equal @calculator.user_needs_somewhere_to_live?, true
+          end
+
+          should "return true if the user is unsure if they are going to be evicted" do
+            @calculator.have_you_been_evicted = "not_sure"
+            assert_equal @calculator.user_needs_somewhere_to_live?, true
+          end
+        end
+
+        context "user does not have somewhere to live" do
+          setup do
+            @calculator.have_somewhere_to_live = "no"
+          end
+
+          should "return true if the user has been evicted" do
+            @calculator.have_you_been_evicted = "yes"
+            assert_equal @calculator.user_needs_somewhere_to_live?, true
+          end
+
+          should "return true if the user going to be evicted" do
+            @calculator.have_you_been_evicted = "soon"
+            assert_equal @calculator.user_needs_somewhere_to_live?, true
+          end
+
+          should "return true if the user is not going to be evicted" do
+            @calculator.have_you_been_evicted = "no"
+            assert_equal @calculator.user_needs_somewhere_to_live?, true
+          end
+
+          should "return true if the user is unsure if they are going to be evicted" do
+            @calculator.have_you_been_evicted = "not_sure"
+            assert_equal @calculator.user_needs_somewhere_to_live?, true
+          end
+        end
+
+        context "user unsure if they have somewhere to live" do
+          setup do
+            @calculator.have_somewhere_to_live = "not_sure"
+          end
+
+          should "return true if the user has been evicted" do
+            @calculator.have_you_been_evicted = "yes"
+            assert_equal @calculator.user_needs_somewhere_to_live?, true
+          end
+
+          should "return true if the user going to be evicted" do
+            @calculator.have_you_been_evicted = "soon"
+            assert_equal @calculator.user_needs_somewhere_to_live?, true
+          end
+
+          should "return true if the user is not going to be evicted" do
+            @calculator.have_you_been_evicted = "no"
+            assert_equal @calculator.user_needs_somewhere_to_live?, true
+          end
+
+          should "return true if the user is unsure if they are going to be evicted" do
+            @calculator.have_you_been_evicted = "not_sure"
+            assert_equal @calculator.user_needs_somewhere_to_live?, true
+          end
+        end
+      end
+
+      context "user has not selected somewhere_to_live" do
+        should "return false" do
+          @calculator.need_help_with = ""
+          @calculator.have_somewhere_to_live = "no"
+          @calculator.have_you_been_evicted = "yes"
+          assert_equal @calculator.user_needs_somewhere_to_live?, false
+        end
+      end
+    end
+
+    context "#user_has_mental_health_worries?" do
+      context "user has selected mental_health" do
+        setup do
+          @calculator.need_help_with = "mental_health"
+        end
+
+        should "return true if the user has mental health worries" do
+          @calculator.mental_health_worries = "yes"
+          assert_equal @calculator.user_has_mental_health_worries?, true
+        end
+
+        should "return true if the user is unsure if they have mental health worries" do
+          @calculator.mental_health_worries = "not_sure"
+          assert_equal @calculator.user_has_mental_health_worries?, true
+        end
+
+        should "return false if the user does not have any mental health worries" do
+          @calculator.mental_health_worries = "no"
+          assert_equal @calculator.user_has_mental_health_worries?, false
+        end
+      end
+
+      context "user has not selected mental_health" do
+        should "return false" do
+          @calculator.need_help_with = ""
+          @calculator.mental_health_worries = "yes"
+          assert_equal @calculator.user_has_mental_health_worries?, false
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Convert the coronavirus find support service (otherwise known as the triage tool) from a standalone service to a smart answer service.

[Trello](https://trello.com/c/vlwPnMuk/394-convert-existing-triage-tool-to-smart-answers-format)