### PR TITLE
Update search descriptions for coronavirus flows

### DIFF
--- a/lib/smart_answer_flows/business-coronavirus-support-finder/business_coronavirus_support_finder.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/business_coronavirus_support_finder.erb
@@ -3,10 +3,7 @@
 <% end %>
 
 <% text_for :meta_description do %>
-  Coronavirus (COVID‑19) support is available to employers and the
-  self-employed, including sole traders and limited company directors.
-  You may be eligible for loans, tax relief and cash grants, whether your
-  business is open or closed.
+  Coronavirus support is available to employers and the self-employed. You may be eligible for loans, tax relief and cash grants, whether your business is open or closed. Use this business support finder to see what support is available for you and your business.
 <% end %>
 
 <% govspeak_for :body do %>

--- a/lib/smart_answer_flows/coronavirus-business-reopening/coronavirus_business_reopening.erb
+++ b/lib/smart_answer_flows/coronavirus-business-reopening/coronavirus_business_reopening.erb
@@ -3,15 +3,7 @@
 <% end %>
 
 <% text_for :meta_description do %>
-  Employers that want to reopen their business have a legal responsibility to protect their employees and other people on site.
-
-  Use this guidance to help you carry out a risk assessment and make sensible adjustments to the site and workforce.
-
-  If you do not carry out a risk assessment, the Health and Safety Executive (HSE) or your local council can issue an enforcement notice.
-
-  Employees can use this guidance to check what their workplace needs to do to keep people safe.
-
-  This guidance is only for businesses that are allowed to reopen in England.
+  Use this guidance to help you carry out a risk assessment for your business and make sensible adjustments to the site and workforce.
 <% end %>
 
 <% govspeak_for :body do %>


### PR DESCRIPTION
This is for the coronavirus business support, coronavirus employee risk assessment and the business reopening flows. Makes the description the appear in search results more concise.

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.
