### PR TITLE
Allow next step button to be labelled "Continue"

### DIFF
--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -5,7 +5,7 @@ class FlowPresenter
 
   attr_reader :request, :params, :flow
 
-  delegate :need_it, to: :flow
+  delegate :need_it, :button_text, to: :flow
   delegate :title, to: :start_node
 
   def initialize(request, flow)

--- a/app/views/smart_answers/question.html.erb
+++ b/app/views/smart_answers/question.html.erb
@@ -36,7 +36,7 @@
 
         <input type="hidden" name="next" value="1" />
         <%= render "govuk_publishing_components/components/button", {
-          text: "Next step",
+          text: @presenter.button_text,
           margin_bottom: true
         } %>
       </div>

--- a/doc/smart-answers/flow-definition.md
+++ b/doc/smart-answers/flow-definition.md
@@ -53,7 +53,8 @@ module SmartAnswer
       status :published # this indicates whether or not the flow is available to be published to live gov.uk , those with `:draft` status will be available on draft gov.uk
       satisfies_need "7da2fa63-190c-446e-b3e5-94480f0e46e7" # relates the Smart Answer to a Need managed by Maslow
       external_related_links { title: "Child Maintenance Options - How much should be paid",
-                               url: "http://www.cmoptions.org/en/maintenance/how-much.asp" } # External links associated to the Smart-Answer                                      
+                               url: "http://www.cmoptions.org/en/maintenance/how-much.asp" } # External links associated to the Smart-Answer
+      button_text "Continue" # optional - replaces the default "Next step" button label with the passed in text
 
       # question & outcome definitions specified here
     end

--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -40,6 +40,10 @@ module SmartAnswer
       @name
     end
 
+    def button_text(text = "Next step")
+      @button_text ||= text
+    end
+
     def satisfies_need(need_content_id)
       self.need_content_id = need_content_id
     end

--- a/test/fixtures/smart_answer_flows/custom-button.rb
+++ b/test/fixtures/smart_answer_flows/custom-button.rb
@@ -1,0 +1,12 @@
+module SmartAnswer
+  class CustomButtonFlow < Flow
+    def define
+      name "custom-button"
+      status :draft
+      button_text "Continue"
+
+      value_question :user_input? do
+      end
+    end
+  end
+end

--- a/test/fixtures/smart_answer_flows/custom-button/questions/user_input.erb
+++ b/test/fixtures/smart_answer_flows/custom-button/questions/user_input.erb
@@ -1,0 +1,7 @@
+<% text_for :title do %>
+  User input?
+<% end %>
+
+<% text_for :label do %>
+  User input:
+<% end %>

--- a/test/integration/engine/custom_button_test.rb
+++ b/test/integration/engine/custom_button_test.rb
@@ -1,0 +1,13 @@
+require_relative "engine_test_helper"
+
+class CustomButtonTest < EngineIntegrationTest
+  setup do
+    stub_content_store_has_item("/custom-button")
+    visit "/custom-button"
+    click_on "Start now"
+  end
+
+  should "display custom button text" do
+    assert page.has_css?("button.gem-c-button", text: "Continue"), "Button does not have correct text"
+  end
+end

--- a/test/unit/flow_test.rb
+++ b/test/unit/flow_test.rb
@@ -9,6 +9,21 @@ class FlowTest < ActiveSupport::TestCase
     assert_equal "sweet-or-savoury", s.name
   end
 
+  test "Can set button text" do
+    text = "continue"
+    smart_answer = SmartAnswer::Flow.new do
+      button_text text
+    end
+
+    assert_equal text, smart_answer.button_text
+  end
+
+  test "Uses default when not set button text" do
+    smart_answer = SmartAnswer::Flow.new
+
+    assert_equal "Next step", smart_answer.button_text
+  end
+
   test "Can set the start page content_id" do
     s = SmartAnswer::Flow.new do
       start_page_content_id "587920ff-b854-4adb-9334-451b45652467"


### PR DESCRIPTION
- Adds `button_text` setter/getter to `Flow`
- Updates `FlowPresenter` to pass through `button_text` from flow
- Uses `@presenter.button_text` to define button text in view
- Adds integration and unit test of this functionality

[trello ticket](https://trello.com/c/WFH0TtG2/372-change-next-step-buttons-to-continue)
