### PR TITLE
Deploy 3 August. Edit-register-birth-remove-call-out

### DIFF
--- a/lib/smart_answer_flows/register-a-birth/register_a_birth.erb
+++ b/lib/smart_answer_flows/register-a-birth/register_a_birth.erb
@@ -22,5 +22,4 @@
 
 ^If you’re a member of HM Armed Forces or you work with them, you may be able to register a birth abroad. Email <dbs-jcccgroupmailbox@mod.gov.uk> to check if you’re eligible.^
 
-  %The service to register a birth with the UK authorities is currently suspended. This page will be updated when it has resumed.%
 <% end %>


### PR DESCRIPTION
Publish on 3 August. 
Removed: %The service to register a birth with the UK authorities is currently suspended. This page will be updated when it has resumed.% as service has resumed

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.
