### PR TITLE
Update oru-result.erb-remove-call-out

### DIFF
--- a/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.erb
+++ b/lib/smart_answer_flows/register-a-birth/outcomes/oru_result.erb
@@ -29,7 +29,7 @@
   s4. Post your documents and the form.
 
 
-  %The service to register a birth with the UK authorities is currently suspended. This page will be updated when it has resumed.%
+ 
 
   ##1. Check your documents
 


### PR DESCRIPTION
Removed suspension wording in call out.

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.
