### PR TITLE
Remove deprecated methods from uk benefits abroad

### DIFF
--- a/lib/list_validator.rb
+++ b/lib/list_validator.rb
@@ -1,11 +1,18 @@
 class ListValidator
+  def self.call(constraint: {}, test: [])
+    test.map!(&:to_sym)
+    new(constraint.keys).all_valid?(test)
+  end
+
+  attr_reader :list
+
   def initialize(list)
     @list = list
   end
 
   def all_valid?(elements)
-    elements.present? &&
-      elements.is_a?(Array) &&
-      elements.all? { |element| @list.include?(element) }
+    return false unless elements.present? && elements.is_a?(Array)
+
+    (elements - list).empty?
   end
 end

--- a/lib/smart_answer/calculators/uk_benefits_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/uk_benefits_abroad_calculator.rb
@@ -4,7 +4,7 @@ module SmartAnswer::Calculators
 
     attr_accessor :country, :benefits, :dispute_criteria, :partner_premiums
     attr_accessor :possible_impairments, :impairment_periods, :tax_credits
-    attr_accessor :going_abroad
+    attr_accessor :going_abroad, :benefit
 
     COUNTRIES_OF_FORMER_YUGOSLAVIA = %w[bosnia-and-herzegovina kosovo montenegro north-macedonia serbia].freeze
     STATE_BENEFITS = {
@@ -187,6 +187,16 @@ module SmartAnswer::Calculators
 
     def already_abroad_text_two
       " or permanently" if already_abroad
+    end
+
+    def how_long_question_titles
+      if benefit == "disability_benefits"
+        "How long will you be abroad for?"
+      elsif going_abroad
+        "How long are you going abroad for?"
+      else
+        "How long will you be living abroad for?"
+      end
     end
   end
 end

--- a/lib/smart_answer/calculators/uk_benefits_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/uk_benefits_abroad_calculator.rb
@@ -43,8 +43,6 @@ module SmartAnswer::Calculators
       industrial_injuries_disablement_benefit: "Industrial Injuries Disablement Benefit",
       contribution_based_employment_support_allowance: "contribution-based Employment and Support Allowance",
     }.freeze
-    private_constant :STATE_BENEFITS, :DISPUTE_CRITERIA, :PREMIUMS, :IMPAIRMENTS
-    private_constant :PERIODS_OF_IMPAIRMENT, :TAX_CREDITS_BENEFITS
 
     def eea_country?
       %w[austria
@@ -99,68 +97,48 @@ module SmartAnswer::Calculators
       %w[barbados bermuda canada guernsey jersey israel jamaica mauritius new-zealand philippines turkey usa]).include?(country)
     end
 
-    def state_benefits
-      STATE_BENEFITS
-    end
-
-    def all_dispute_criteria
-      DISPUTE_CRITERIA
-    end
-
-    def premiums
-      PREMIUMS
-    end
-
-    def impairments
-      IMPAIRMENTS
-    end
-
-    def periods_of_impairment
-      PERIODS_OF_IMPAIRMENT
-    end
-
-    def tax_credits_benefits
-      TAX_CREDITS_BENEFITS
+    def employer_paying_ni_not_ssp_country_entitled?
+      (COUNTRIES_OF_FORMER_YUGOSLAVIA + %w[barbados guernsey jersey israel turkey]).include?(country)
     end
 
     def benefits?
       ListValidator.call(
-        constraint: state_benefits,
+        constraint: STATE_BENEFITS,
         test: benefits,
       )
     end
 
     def dispute_criteria?
       ListValidator.call(
-        constraint: all_dispute_criteria,
+        constraint: DISPUTE_CRITERIA,
         test: dispute_criteria,
       )
     end
 
     def partner_premiums?
       ListValidator.call(
-        constraint: premiums,
+        constraint: PREMIUMS,
         test: partner_premiums,
       )
     end
 
     def getting_income_support?
       ListValidator.call(
-        constraint: impairments,
+        constraint: IMPAIRMENTS,
         test: possible_impairments,
       )
     end
 
     def not_getting_sick_pay?
       ListValidator.call(
-        constraint: periods_of_impairment,
+        constraint: PERIODS_OF_IMPAIRMENT,
         test: impairment_periods,
       )
     end
 
     def tax_credits?
       ListValidator.call(
-        constraint: tax_credits_benefits,
+        constraint: TAX_CREDITS_BENEFITS,
         test: tax_credits,
       )
     end

--- a/lib/smart_answer/calculators/uk_benefits_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/uk_benefits_abroad_calculator.rb
@@ -2,7 +2,7 @@ module SmartAnswer::Calculators
   class UkBenefitsAbroadCalculator
     include ActiveModel::Model
 
-    attr_accessor :country, :benefits, :dispute_criteria, :partner_premiums
+    attr_accessor :country, :country_name, :benefits, :dispute_criteria, :partner_premiums
     attr_accessor :possible_impairments, :impairment_periods, :tax_credits
     attr_accessor :going_abroad, :benefit
 

--- a/lib/smart_answer/calculators/uk_benefits_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/uk_benefits_abroad_calculator.rb
@@ -4,6 +4,7 @@ module SmartAnswer::Calculators
 
     attr_accessor :country, :benefits, :dispute_criteria, :partner_premiums
     attr_accessor :possible_impairments, :impairment_periods, :tax_credits
+    attr_accessor :going_abroad
 
     COUNTRIES_OF_FORMER_YUGOSLAVIA = %w[bosnia-and-herzegovina kosovo montenegro north-macedonia serbia].freeze
     STATE_BENEFITS = {
@@ -123,33 +124,69 @@ module SmartAnswer::Calculators
     end
 
     def benefits?
-      ListValidator.new(state_benefits.keys)
-        .all_valid?(benefits.map(&:to_sym))
+      ListValidator.call(
+        constraint: state_benefits,
+        test: benefits,
+      )
     end
 
     def dispute_criteria?
-      ListValidator.new(all_dispute_criteria.keys)
-        .all_valid?(dispute_criteria.map(&:to_sym))
+      ListValidator.call(
+        constraint: all_dispute_criteria,
+        test: dispute_criteria,
+      )
     end
 
     def partner_premiums?
-      ListValidator.new(premiums.keys)
-        .all_valid?(partner_premiums.map(&:to_sym))
+      ListValidator.call(
+        constraint: premiums,
+        test: partner_premiums,
+      )
     end
 
     def getting_income_support?
-      ListValidator.new(impairments.keys)
-        .all_valid?(possible_impairments.map(&:to_sym))
+      ListValidator.call(
+        constraint: impairments,
+        test: possible_impairments,
+      )
     end
 
     def not_getting_sick_pay?
-      ListValidator.new(periods_of_impairment.keys)
-        .all_valid?(impairment_periods.map(&:to_sym))
+      ListValidator.call(
+        constraint: periods_of_impairment,
+        test: impairment_periods,
+      )
     end
 
     def tax_credits?
-      ListValidator.new(tax_credits_benefits.keys)
-        .all_valid?(tax_credits.map(&:to_sym))
+      ListValidator.call(
+        constraint: tax_credits_benefits,
+        test: tax_credits,
+      )
+    end
+
+    def already_abroad
+      !going_abroad
+    end
+
+    def country_question_title
+      if going_abroad
+        "Which country are you moving to?"
+      else
+        "Which country are you living in?"
+      end
+    end
+
+    def why_abroad_question_title
+      if going_abroad
+        "Why are you going abroad?"
+      else
+        "Why have you gone abroad?"
+      end
+    end
+
+    def already_abroad_text_two
+      " or permanently" if already_abroad
     end
   end
 end

--- a/lib/smart_answer_flows/uk-benefits-abroad.rb
+++ b/lib/smart_answer_flows/uk-benefits-abroad.rb
@@ -86,10 +86,7 @@ module SmartAnswer
       country_select :which_country?, additional_countries: additional_countries, exclude_countries: exclude_countries do
         on_response do |response|
           calculator.country = response
-        end
-
-        calculate :country_name do
-          (WorldLocation.all + additional_countries).find { |c| c.slug == calculator.country }.name
+          self.country_name = (WorldLocation.all + additional_countries).find { |c| c.slug == calculator.country }.name
         end
 
         next_node do |response|

--- a/lib/smart_answer_flows/uk-benefits-abroad.rb
+++ b/lib/smart_answer_flows/uk-benefits-abroad.rb
@@ -10,16 +10,13 @@ module SmartAnswer
       exclude_countries = %w[british-antarctic-territory french-guiana guadeloupe holy-see martinique mayotte reunion st-maarten]
       additional_countries = [OpenStruct.new(slug: "jersey", name: "Jersey"), OpenStruct.new(slug: "guernsey", name: "Guernsey")]
 
-      countries_of_former_yugoslavia = Calculators::UkBenefitsAbroadCalculator::COUNTRIES_OF_FORMER_YUGOSLAVIA
-      uk_benefits_abroad_calculator = Calculators::UkBenefitsAbroadCalculator.new
-
       # Q1
       multiple_choice :going_or_already_abroad? do
         option :going_abroad
         option :already_abroad
 
         on_response do |response|
-          self.calculator = uk_benefits_abroad_calculator
+          self.calculator = Calculators::UkBenefitsAbroadCalculator.new
           calculator.going_abroad = (response == "going_abroad")
         end
 
@@ -267,7 +264,7 @@ module SmartAnswer
           # not SSP benefits
           elsif response == "yes"
             question :eligible_for_smp? # Q9 going_abroad and Q8 already_abroad
-          elsif (countries_of_former_yugoslavia + %w[barbados guernsey jersey israel turkey]).include?(calculator.country)
+          elsif calculator.employer_paying_ni_not_ssp_country_entitled?
             if calculator.already_abroad
               outcome :maternity_benefits_social_security_already_abroad_outcome # A10 already_abroad
             else
@@ -281,7 +278,7 @@ module SmartAnswer
 
       # Q13 going_abroad and Q12 already_abroad
       checkbox_question :do_either_of_the_following_apply? do
-        uk_benefits_abroad_calculator.state_benefits.each_key do |benefit|
+        Calculators::UkBenefitsAbroadCalculator::STATE_BENEFITS.each_key do |benefit|
           option benefit
         end
 
@@ -355,7 +352,7 @@ module SmartAnswer
 
       # Q20 already_abroad
       checkbox_question :tax_credits_currently_claiming? do
-        uk_benefits_abroad_calculator.tax_credits_benefits.each_key do |credit|
+        Calculators::UkBenefitsAbroadCalculator::TAX_CREDITS_BENEFITS.each_key do |credit|
           option credit
         end
 
@@ -427,7 +424,7 @@ module SmartAnswer
 
       # Q33 going_abroad
       checkbox_question :is_claiming_benefits? do
-        uk_benefits_abroad_calculator.premiums.each_key do |premium|
+        Calculators::UkBenefitsAbroadCalculator::PREMIUMS.each_key do |premium|
           option premium
         end
 
@@ -446,7 +443,7 @@ module SmartAnswer
 
       # Q34 going_abroad
       checkbox_question :is_either_of_the_following? do
-        uk_benefits_abroad_calculator.impairments.each_key do |impairment|
+        Calculators::UkBenefitsAbroadCalculator::IMPAIRMENTS.each_key do |impairment|
           option impairment
         end
 
@@ -480,7 +477,7 @@ module SmartAnswer
 
       # Q36 going_abroad
       checkbox_question :is_work_or_sick_pay? do
-        uk_benefits_abroad_calculator.periods_of_impairment.each_key do |period|
+        Calculators::UkBenefitsAbroadCalculator::PERIODS_OF_IMPAIRMENT.each_key do |period|
           option period
         end
 
@@ -499,7 +496,7 @@ module SmartAnswer
 
       # Q37 going_abroad
       checkbox_question :is_any_of_the_following_apply? do
-        uk_benefits_abroad_calculator.all_dispute_criteria.each_key do |criterion|
+        Calculators::UkBenefitsAbroadCalculator::DISPUTE_CRITERIA.each_key do |criterion|
           option criterion
         end
 

--- a/lib/smart_answer_flows/uk-benefits-abroad.rb
+++ b/lib/smart_answer_flows/uk-benefits-abroad.rb
@@ -17,38 +17,13 @@ module SmartAnswer
       multiple_choice :going_or_already_abroad? do
         option :going_abroad
         option :already_abroad
-        save_input_as :going_or_already_abroad
 
-        on_response do
+        on_response do |response|
           self.calculator = uk_benefits_abroad_calculator
-        end
+          calculator.going_abroad = (response == "going_abroad")
 
-        calculate :country_question_title do
-          if going_or_already_abroad == "going_abroad"
-            "Which country are you moving to?"
-          else
-            "Which country are you living in?"
-          end
-        end
-
-        calculate :why_abroad_question_title do
-          if going_or_already_abroad == "going_abroad"
-            "Why are you going abroad?"
-          else
-            "Why have you gone abroad?"
-          end
-        end
-
-        calculate :going_abroad do
-          going_or_already_abroad == "going_abroad"
-        end
-
-        calculate :already_abroad do
-          going_or_already_abroad == "already_abroad"
-        end
-
-        calculate :already_abroad_text_two do
-          " or permanently" if already_abroad
+          self.going_abroad = calculator.going_abroad
+          self.already_abroad = calculator.already_abroad
         end
 
         next_node do
@@ -76,7 +51,7 @@ module SmartAnswer
         calculate :how_long_question_titles do
           if benefit == "disability_benefits"
             "How long will you be abroad for?"
-          elsif going_or_already_abroad == "going_abroad"
+          elsif going_abroad
             "How long are you going abroad for?"
           else
             "How long will you be living abroad for?"

--- a/lib/smart_answer_flows/uk-benefits-abroad.rb
+++ b/lib/smart_answer_flows/uk-benefits-abroad.rb
@@ -46,16 +46,9 @@ module SmartAnswer
         option :tax_credits
         option :income_support
 
-        save_input_as :benefit
-
-        calculate :how_long_question_titles do
-          if benefit == "disability_benefits"
-            "How long will you be abroad for?"
-          elsif going_abroad
-            "How long are you going abroad for?"
-          else
-            "How long will you be living abroad for?"
-          end
+        on_response do |response|
+          self.benefit = response
+          calculator.benefit = benefit
         end
 
         next_node do |response|

--- a/lib/smart_answer_flows/uk-benefits-abroad.rb
+++ b/lib/smart_answer_flows/uk-benefits-abroad.rb
@@ -527,7 +527,9 @@ module SmartAnswer
         option :less_than_a_year_other
         option :more_than_a_year
 
-        save_input_as :how_long_abroad_jsa
+        on_response do |response|
+          self.how_long_abroad_jsa = response
+        end
 
         next_node do |response|
           case response

--- a/lib/smart_answer_flows/uk-benefits-abroad/outcomes/bb_going_abroad_eea_outcome.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/outcomes/bb_going_abroad_eea_outcome.erb
@@ -1,5 +1,5 @@
 <% govspeak_for :body do %>
-  You can export bereavement benefits to <%= country_name %> at the same rate as if you were living in the UK.
+  You can export bereavement benefits to <%= calculator.country_name %> at the same rate as if you were living in the UK.
 
   Claim [Bereavement Allowance](/bereavement-allowance#how-to-claim), [Bereavement Payment](/bereavement-payment#how-to-claim) or [Widowed Parent's Allowance](/widowed-parents-allowance#how-to-claim) before you leave the UK.
 

--- a/lib/smart_answer_flows/uk-benefits-abroad/outcomes/bb_going_abroad_other_outcome.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/outcomes/bb_going_abroad_other_outcome.erb
@@ -1,5 +1,5 @@
 <% govspeak_for :body do %>
-  You can export bereavement benefits to <%= country_name %> although you won't get any annual increases after you've moved there.
+  You can export bereavement benefits to <%= calculator.country_name %> although you won't get any annual increases after you've moved there.
 
   Claim [Bereavement Allowance](/bereavement-allowance#how-to-claim), [Bereavement Payment](/bereavement-payment#how-to-claim)
    or [Widowed Parent's Allowance](/widowed-parents-allowance#how-to-claim)

--- a/lib/smart_answer_flows/uk-benefits-abroad/outcomes/bb_going_abroad_ss_outcome.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/outcomes/bb_going_abroad_ss_outcome.erb
@@ -1,5 +1,5 @@
 <% govspeak_for :body do %>
-  You can export bereavement benefits to <%= country_name %> although you won't get any annual increases after you've moved there.
+  You can export bereavement benefits to <%= calculator.country_name %> although you won't get any annual increases after you've moved there.
 
   Claim [Bereavement Allowance](/bereavement-allowance/how-to-claim), [Bereavement Payment](/bereavement-payment#how-to-claim) or [Widowed Parent's Allowance](/widowed-parents-allowance#how-to-claim) before leaving the UK.
 

--- a/lib/smart_answer_flows/uk-benefits-abroad/outcomes/child_benefit_fy_already_abroad_outcome.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/outcomes/child_benefit_fy_already_abroad_outcome.erb
@@ -1,5 +1,5 @@
 <% govspeak_for :body do %>
-  There is a social security agreement between the UK and <%= country_name %>. You may be able to get Child Benefit abroad.
+  There is a social security agreement between the UK and <%= calculator.country_name %>. You may be able to get Child Benefit abroad.
 
   Contact [HMRC](/child-benefit/further-information) to find out how to claim abroad.
 <% end %>

--- a/lib/smart_answer_flows/uk-benefits-abroad/outcomes/child_benefit_fy_going_abroad_outcome.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/outcomes/child_benefit_fy_going_abroad_outcome.erb
@@ -1,10 +1,10 @@
 <% govspeak_for :body do %>
-  There is a social security agreement between the UK and <%= country_name %>. You may be able to get Child Benefit abroad if you (or your spouse if you go with them):
+  There is a social security agreement between the UK and <%= calculator.country_name %>. You may be able to get Child Benefit abroad if you (or your spouse if you go with them):
 
-  - go to work in <%= country_name %>
+  - go to work in <%= calculator.country_name %>
   - continue to pay National Insurance contributions
 
-  The UK and <%= country_name %> can count time you spend living or working in the other country when deciding if you qualify for benefits there.
+  The UK and <%= calculator.country_name %> can count time you spend living or working in the other country when deciding if you qualify for benefits there.
 
   Contact [HMRC](/child-benefit/further-information) to find out how to claim abroad.
 <% end %>

--- a/lib/smart_answer_flows/uk-benefits-abroad/outcomes/child_benefit_jtu_outcome.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/outcomes/child_benefit_jtu_outcome.erb
@@ -1,5 +1,5 @@
 <% govspeak_for :body do %>
-  You can't get Child Benefit in <%= country_name %>. If you're responsible for a child whose parents have died, you may be able to claim UK [Guardian's Allowance](/guardians-allowance) there.
+  You can't get Child Benefit in <%= calculator.country_name %>. If you're responsible for a child whose parents have died, you may be able to claim UK [Guardian's Allowance](/guardians-allowance) there.
 
   Contact [HMRC](/child-benefit/further-information) to check if you're eligible.
 <% end %>

--- a/lib/smart_answer_flows/uk-benefits-abroad/outcomes/child_benefit_ss_outcome.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/outcomes/child_benefit_ss_outcome.erb
@@ -1,7 +1,7 @@
 <% govspeak_for :body do %>
-  There is a social security agreement between the UK and <%= country_name %>. You may be able to get [Child Benefit](/child-benefit/) abroad.
+  There is a social security agreement between the UK and <%= calculator.country_name %>. You may be able to get [Child Benefit](/child-benefit/) abroad.
 
-  Contact [HMRC](/child-benefit/further-information) to find out if you can get Child Benefit in <%= country_name %>.
+  Contact [HMRC](/child-benefit/further-information) to find out if you can get Child Benefit in <%= calculator.country_name %>.
 
   You may also be able to claim [Guardian's Allowance](/guardians-allowance), if you're responsible for a [child whose parents have died](/child-benefit-child-parent-dies/if-one-or-both-parents-die) and you're getting Child Benefit for them.
 <% end %>

--- a/lib/smart_answer_flows/uk-benefits-abroad/outcomes/db_already_abroad_other_outcome.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/outcomes/db_already_abroad_other_outcome.erb
@@ -6,5 +6,5 @@
   * [Disability Living Allowance](/dla-disability-living-allowance-benefit)
   * [Personal Independence Payment](/pip)
 
-  You may be able to get benefits from <%= country_name %> if you've been paying into a local insurance scheme.  Contact the local authorities to find out if you qualify.
+  You may be able to get benefits from <%= calculator.country_name %> if you've been paying into a local insurance scheme.  Contact the local authorities to find out if you qualify.
 <% end %>

--- a/lib/smart_answer_flows/uk-benefits-abroad/outcomes/esa_already_abroad_eea_outcome.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/outcomes/esa_already_abroad_eea_outcome.erb
@@ -3,7 +3,7 @@
 
   Contact the [International Pension Centre](/international-pension-centre) to get ESA.
 
-  You may be able to get benefits from <%= country_name %> if you've been paying into a local social security insurance scheme.  Contact the local authorities to find out more.
+  You may be able to get benefits from <%= calculator.country_name %> if you've been paying into a local social security insurance scheme.  Contact the local authorities to find out more.
 
   *[ESA]: Employment Support Allowance
 <% end %>

--- a/lib/smart_answer_flows/uk-benefits-abroad/outcomes/esa_already_abroad_other_outcome.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/outcomes/esa_already_abroad_other_outcome.erb
@@ -1,7 +1,7 @@
 <% govspeak_for :body do %>
   You can't get ESA.
 
-  You may be able to get benefits from <%= country_name %> if you've paid into a local social security insurance scheme. Contact the local authorities to find out more.
+  You may be able to get benefits from <%= calculator.country_name %> if you've paid into a local social security insurance scheme. Contact the local authorities to find out more.
 
   *[ESA]: Employment Support Allowance
 <% end %>

--- a/lib/smart_answer_flows/uk-benefits-abroad/outcomes/esa_already_abroad_ss_outcome.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/outcomes/esa_already_abroad_ss_outcome.erb
@@ -1,5 +1,5 @@
 <% govspeak_for :body do %>
-  You can’t claim ESA. If you were receiving [Incapacity Benefit](/incapacity-benefit) while living in <%= country_name %>, you may be asked to transition from Incapacity Benefit to ESA (contributory).
+  You can’t claim ESA. If you were receiving [Incapacity Benefit](/incapacity-benefit) while living in <%= calculator.country_name %>, you may be asked to transition from Incapacity Benefit to ESA (contributory).
 
-  You may also be able to get benefits from <%= country_name %> if you’ve paid into a local social security insurance scheme. Contact the local authorities to find out more.
+  You may also be able to get benefits from <%= calculator.country_name %> if you’ve paid into a local social security insurance scheme. Contact the local authorities to find out more.
 <% end %>

--- a/lib/smart_answer_flows/uk-benefits-abroad/outcomes/esa_going_abroad_other_outcome.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/outcomes/esa_going_abroad_other_outcome.erb
@@ -1,7 +1,7 @@
 <% govspeak_for :body do %>
   You can't claim ESA.
 
-  You may be able to get benefits from <%= country_name %> if you've paid into a local social security insurance scheme.
+  You may be able to get benefits from <%= calculator.country_name %> if you've paid into a local social security insurance scheme.
 
   *[ESA]: Employment Support Allowance
 <% end %>

--- a/lib/smart_answer_flows/uk-benefits-abroad/outcomes/iidb_going_abroad_ss_outcome.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/outcomes/iidb_going_abroad_ss_outcome.erb
@@ -1,5 +1,5 @@
 <% govspeak_for :body do %>
-  The UK and <%= country_name %> have a social security agreement. You may be able to carry on getting [Industrial Injuries Disablement Benefit](/industrial-injuries-disablement-benefit).
+  The UK and <%= calculator.country_name %> have a social security agreement. You may be able to carry on getting [Industrial Injuries Disablement Benefit](/industrial-injuries-disablement-benefit).
 
   Tell the office that deals with your benefit that you're planning to move abroad.
 <% end %>

--- a/lib/smart_answer_flows/uk-benefits-abroad/outcomes/jsa_eea_already_abroad_outcome.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/outcomes/jsa_eea_already_abroad_outcome.erb
@@ -1,7 +1,7 @@
 <% govspeak_for :body do %>
-  You can't get JSA while you're abroad. You may qualify for unemployment benefits in <%= country_name %>.
+  You can't get JSA while you're abroad. You may qualify for unemployment benefits in <%= calculator.country_name %>.
 
-  Ask the authorities in <%= country_name %> about any benefits you might be entitled to.
+  Ask the authorities in <%= calculator.country_name %> about any benefits you might be entitled to.
 
   *[JSA]: Jobseeker's Allowance
 <% end %>

--- a/lib/smart_answer_flows/uk-benefits-abroad/outcomes/jsa_not_entitled_outcome.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/outcomes/jsa_not_entitled_outcome.erb
@@ -1,7 +1,7 @@
 <% govspeak_for :body do %>
   You can't get JSA abroad.
 
-  Ask the authorities in <%= country_name %> about any benefits you might be entitled to.
+  Ask the authorities in <%= calculator.country_name %> about any benefits you might be entitled to.
 
   *[JSA]: Jobseeker's Allowance
 <% end %>

--- a/lib/smart_answer_flows/uk-benefits-abroad/outcomes/jsa_social_security_already_abroad_outcome.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/outcomes/jsa_social_security_already_abroad_outcome.erb
@@ -1,7 +1,7 @@
 <% govspeak_for :body do %>
-  You can’t claim JSA from abroad. You may qualify for unemployment benefits in <%= country_name %>.
+  You can’t claim JSA from abroad. You may qualify for unemployment benefits in <%= calculator.country_name %>.
 
-  Ask the authorities in <%= country_name %> about any benefits you might be entitled to.
+  Ask the authorities in <%= calculator.country_name %> about any benefits you might be entitled to.
 
   *[JSA]: Jobseeker's Allowance
 <% end %>

--- a/lib/smart_answer_flows/uk-benefits-abroad/outcomes/jsa_social_security_going_abroad_outcome.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/outcomes/jsa_social_security_going_abroad_outcome.erb
@@ -1,7 +1,7 @@
 <% govspeak_for :body do %>
-  You can't get JSA while you're abroad. Your [UK National Insurance contributions](/national-insurance) may help you qualify for unemployment benefits because of the UK's social security agreements with <%= country_name %>.
+  You can't get JSA while you're abroad. Your [UK National Insurance contributions](/national-insurance) may help you qualify for unemployment benefits because of the UK's social security agreements with <%= calculator.country_name %>.
 
-  Ask the authorities in <%= country_name %> about any benefits you might be entitled to.
+  Ask the authorities in <%= calculator.country_name %> about any benefits you might be entitled to.
 
   *[JSA]: Jobseeker's Allowance
 <% end %>

--- a/lib/smart_answer_flows/uk-benefits-abroad/outcomes/ssp_already_abroad_not_entitled_outcome.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/outcomes/ssp_already_abroad_not_entitled_outcome.erb
@@ -1,5 +1,5 @@
 <% govspeak_for :body do %>
   You can't claim Statutory Sick Pay.
 
-  You may be able to get benefits from <%= country_name %> if you've paid into a social security insurance scheme there.
+  You may be able to get benefits from <%= calculator.country_name %> if you've paid into a social security insurance scheme there.
 <% end %>

--- a/lib/smart_answer_flows/uk-benefits-abroad/outcomes/ssp_going_abroad_not_entitled_outcome.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/outcomes/ssp_going_abroad_not_entitled_outcome.erb
@@ -1,5 +1,5 @@
 <% govspeak_for :body do %>
   You can't get Statutory Sick Pay while you're abroad.
 
-  You may be able to get benefits from <%= country_name %> if you've paid into a social security insurance scheme there.
+  You may be able to get benefits from <%= calculator.country_name %> if you've paid into a social security insurance scheme there.
 <% end %>

--- a/lib/smart_answer_flows/uk-benefits-abroad/questions/db_how_long_abroad.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/questions/db_how_long_abroad.erb
@@ -1,5 +1,5 @@
 <% text_for :title do %>
-  <%= how_long_question_titles %>
+  <%= calculator.how_long_question_titles %>
 <% end %>
 
 <% options(

--- a/lib/smart_answer_flows/uk-benefits-abroad/questions/esa_how_long_abroad.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/questions/esa_how_long_abroad.erb
@@ -1,5 +1,5 @@
 <% text_for :title do %>
-  <%= how_long_question_titles %>
+  <%= calculator.how_long_question_titles %>
 <% end %>
 
 <% options(

--- a/lib/smart_answer_flows/uk-benefits-abroad/questions/esa_how_long_abroad.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/questions/esa_how_long_abroad.erb
@@ -5,5 +5,5 @@
 <% options(
   "esa_under_a_year_medical": "Less than 1 year, to get medical treatment for yourself or your child",
   "esa_under_a_year_other": "Less than 1 year, for a different reason",
-  "esa_more_than_a_year": "More than 1 year#{already_abroad_text_two}"
+  "esa_more_than_a_year": "More than 1 year#{calculator.already_abroad_text_two}"
 ) %>

--- a/lib/smart_answer_flows/uk-benefits-abroad/questions/tax_credits_how_long_abroad.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/questions/tax_credits_how_long_abroad.erb
@@ -1,5 +1,5 @@
 <% text_for :title do %>
-  <%= how_long_question_titles %>
+  <%= calculator.how_long_question_titles %>
 <% end %>
 
 <% options(

--- a/lib/smart_answer_flows/uk-benefits-abroad/questions/which_country.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/questions/which_country.erb
@@ -1,3 +1,3 @@
 <% text_for :title do %>
-  <%= country_question_title %>
+  <%= calculator.country_question_title %>
 <% end %>

--- a/test/integration/smart_answer_flows/uk_benefits_abroad_test.rb
+++ b/test/integration/smart_answer_flows/uk_benefits_abroad_test.rb
@@ -494,7 +494,7 @@ class UKBenefitsAbroadTest < ActiveSupport::TestCase
           end
           should "ask why are you going abroad" do
             assert_current_node :tax_credits_why_going_abroad?
-            assert_state_variable :why_abroad_question_title, "Why are you going abroad?"
+            assert_equal current_state.calculator.why_abroad_question_title, "Why are you going abroad?"
           end
           context "answer holiday" do
             setup do
@@ -542,7 +542,7 @@ class UKBenefitsAbroadTest < ActiveSupport::TestCase
             end
             should "ask you what country you're moving to" do
               assert_current_node :which_country?
-              assert_state_variable :country_question_title, "Which country are you moving to?"
+              assert_equal current_state.calculator.country_question_title, "Which country are you moving to?"
             end
             context "answer EEA country" do
               setup do

--- a/test/integration/smart_answer_flows/uk_benefits_abroad_test.rb
+++ b/test/integration/smart_answer_flows/uk_benefits_abroad_test.rb
@@ -731,7 +731,7 @@ class UKBenefitsAbroadTest < ActiveSupport::TestCase
       end
       should "ask how long you're gong abroad for" do
         assert_current_node :db_how_long_abroad?
-        assert_state_variable :how_long_question_titles, "How long will you be abroad for?"
+        assert_equal current_state.calculator.how_long_question_titles, "How long will you be abroad for?"
       end
       context "answer temporarily" do
         setup do

--- a/test/unit/list_validator_test.rb
+++ b/test/unit/list_validator_test.rb
@@ -34,4 +34,22 @@ class ListValidatorTest < ActiveSupport::TestCase
       assert_not @list_validator.all_valid?(nil)
     end
   end
+
+  context ".call" do
+    setup do
+      @constraint = { a: 1, b: 1 }
+    end
+
+    should "return true if test sample within contraint keys" do
+      assert ListValidator.call(constraint: @constraint, test: [:a])
+    end
+
+    should "return true if test sample within contraint keys and a string" do
+      assert ListValidator.call(constraint: @constraint, test: %w[a])
+    end
+
+    should "return false if test sample not with contraint keys" do
+      assert_not ListValidator.call(constraint: @constraint, test: [:x])
+    end
+  end
 end


### PR DESCRIPTION
:warning: Only merge changes if you are happy for them to go live. :warning: 

Updates uk benefits abroad flow to remove methods `calculate` and `save_input_as`.

Processing has been moved to SmartAnswer::Calculators::UkBenefitsAbroadCalculator.

Also:

- Adds ListValidator.call which carries out required formatting steps
  within class rather than by object passing data in.

[Trello ticket](https://trello.com/c/YsfICJPz/415-update-deprecated-syntax-for-existing-smart-answer-flow)