### PR TITLE
Fix issue for weekly costs result page show error

### DIFF
--- a/lib/smart_answer_flows/childcare-costs-for-tax-credits/outcomes/weekly_costs_are_x.erb
+++ b/lib/smart_answer_flows/childcare-costs-for-tax-credits/outcomes/weekly_costs_are_x.erb
@@ -1,5 +1,5 @@
 <% text_for :title do %>
-  Your weekly childcare costs are <%= format_money(weekly_cost) %>.
+  Your weekly childcare costs are <%= format_money(calculator.weekly_cost) %>.
 <% end %>
 
 <% govspeak_for :body do %>


### PR DESCRIPTION
This is due an missing reference to the calculator from previous work deprecating old flow syntax.

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.
