### PR TITLE
Fix issue rendering uk benefits abroad flow

### DIFF
--- a/lib/smart_answer_flows/uk-benefits-abroad/questions/tax_credits_why_going_abroad.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/questions/tax_credits_why_going_abroad.erb
@@ -1,5 +1,5 @@
 <% text_for :title do %>
-  <%= why_abroad_question_title %>
+  <%= calculator.why_abroad_question_title %>
 <% end %>
 
 <% options(


### PR DESCRIPTION
Adds missing reference to calculator for the why_abroad_question_title.

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.
