### PR TITLE
Fix bug in childcare costs flow

### DIFF
--- a/lib/smart_answer_flows/childcare-costs-for-tax-credits.rb
+++ b/lib/smart_answer_flows/childcare-costs-for-tax-credits.rb
@@ -139,7 +139,7 @@ module SmartAnswer
       # Q9
       money_question :how_much_12_months_2? do
         on_response do |response|
-          calculator.new_weekly_cost = calculator.weekly_cost_from_annual(response)
+          calculator.new_weekly_costs = calculator.weekly_cost_from_annual(response)
         end
 
         next_node do |response|


### PR DESCRIPTION
User are unable to continue past Q9: how much do you expect to pay in total over the next 12 months question. This was due to an incorrectly referenced variable.

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.
