### PR TITLE
Change pretext for workplace exception to body text

### DIFF
--- a/lib/smart_answer_flows/coronavirus-employee-risk-assessment/questions/is_your_workplace_an_exception.erb
+++ b/lib/smart_answer_flows/coronavirus-employee-risk-assessment/questions/is_your_workplace_an_exception.erb
@@ -2,7 +2,7 @@
   workplace = calculator.where_do_you_work
 %>
 
-<% govspeak_for :pretext do %>
+<% text_for :body do %>
   <% case workplace %>
   <% when "auction_house" %>
     Your workplace should be closed unless you work at a livestock auction house. 


### PR DESCRIPTION
Updates to the styling of the question caused pretext to display as body text before the page heading. This move the text to the question description.

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.
