### PR TITLE
Remove redundant route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,11 +11,6 @@ Rails.application.routes.draw do
 
     get "/:id(/:started(/*responses))",
         to: "smart_answers#show",
-        as: :formatted_smart_answer,
-        format: false
-
-    get "/:id(/:started(/*responses))",
-        to: "smart_answers#show",
         as: :smart_answer,
         format: false
   end


### PR DESCRIPTION
The "formatted_smart_answer" route isn't used and is exactly the same the "smart_answer" route.

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.
