### PR TITLE
Adds an assertion that causes the current page to be rendered

### DIFF
--- a/test/integration/smart_answer_flows/flow_test_helper.rb
+++ b/test/integration/smart_answer_flows/flow_test_helper.rb
@@ -37,6 +37,15 @@ module FlowTestHelper
     end
   end
 
+  def assert_page_renders
+    silence_warnings do # Without this get a Mocha deprecation warning that I was unable to find the source of.
+      ContentItemRetriever.stubs(:fetch).returns({})
+      path = "/#{@flow.name}/y/#{@responses.join('/')}"
+      get path
+      assert_equal response.code, "200"
+    end
+  end
+
   def assert_current_node(node_name, opts = {})
     assert_equal node_name, current_state.current_node
     assert @flow.node_exists?(node_name), "Node #{node_name} does not exist."

--- a/test/integration/smart_answer_flows/uk_benefits_abroad_test.rb
+++ b/test/integration/smart_answer_flows/uk_benefits_abroad_test.rb
@@ -3,12 +3,17 @@ require_relative "flow_test_helper"
 
 require "smart_answer_flows/uk-benefits-abroad"
 
-class UKBenefitsAbroadTest < ActiveSupport::TestCase
+class UKBenefitsAbroadTest < ActionDispatch::IntegrationTest
   include FlowTestHelper
 
   setup do
     setup_for_testing_flow SmartAnswer::UkBenefitsAbroadFlow
     stub_world_locations %w[albania austria canada jamaica kosovo]
+  end
+
+  def assert_current_node(node_name, opts = {})
+    super
+    assert_page_renders
   end
 
   # Q1


### PR DESCRIPTION
If there is an error on the page the render this will detect the error.

Prior to this, tests were not detecting page errors.

Includes an example of use in the UK Benefits Abroad flow.

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.

[Trello Ticket](https://trello.com/c/Z0oehuaw/433-session-controller-add-validation-and-error-handling)