### PR TITLE
Remove line from pension calculator start page

### DIFF
--- a/lib/smart_answer_flows/state-pension-age/state_pension_age.erb
+++ b/lib/smart_answer_flows/state-pension-age/state_pension_age.erb
@@ -9,8 +9,6 @@
 <% govspeak_for :body do %>
 Your State Pension age is the earliest age you can start receiving your State Pension. It may be different to the age you can get a [workplace or personal pension](/early-retirement-pension/personal-and-workplace-pensions).  
 
-Your State Pension age is worked out based on your gender and date of birth. 
-
 ^[The State Pension age is under review](/government/news/proposed-new-timetable-for-state-pension-age-increases) and may change in the future.^
 
 Use this tool to check: 


### PR DESCRIPTION
Remove: 'Your State Pension age is worked out based on your gender and date of birth.'

Because this is not true for all users.

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.
