### PR TITLE
Fix typo and change quote type

### DIFF
--- a/lib/smart_answer_flows/coronavirus-find-support/coronavirus_find_support.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/coronavirus_find_support.erb
@@ -1,5 +1,5 @@
 <% text_for :title do %>
-  Find out what you can do if you're struggling bacause of coronavirus (COVID-19)
+  Find out what you can do if you’re struggling because of coronavirus (COVID-19)
 <% end %>
 
 <% govspeak_for :body do %>


### PR DESCRIPTION
Fix typo.  Also, change quote back to the original curly quote as it is being incorrectly rendered as `you&#39;re` - potentially because it is being double-escaped.

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.
