### PR TITLE
Change button text

### DIFF
--- a/lib/smart_answer_flows/coronavirus-find-support.rb
+++ b/lib/smart_answer_flows/coronavirus-find-support.rb
@@ -5,6 +5,7 @@ module SmartAnswer
       start_page_content_id "6a6ab3c9-4612-4764-8f2f-2c534c3c6b19"
       flow_content_id "31d81949-aa15-48cf-a7f1-f0d0a670e8db"
       status :draft
+      button_text "Continue"
 
       # ======================================================================
       # What do you need help with because of coronavirus?


### PR DESCRIPTION
Change Next Step button text on Covonavirus Find Support to Continue.

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.

[Trello](https://trello.com/c/kIaKsza7/422-rename-next-step-button-continue-for-find-support-flow)
