### PR TITLE
Remove deprecated methods from MinimumWageCalculatorE…

### DIFF
--- a/lib/smart_answer_flows/minimum-wage-calculator-employers.rb
+++ b/lib/smart_answer_flows/minimum-wage-calculator-employers.rb
@@ -14,15 +14,11 @@ module SmartAnswer
         option "current_payment"
         option "past_payment"
 
-        calculate :calculator do |response|
-          if response == "past_payment"
-            Calculators::MinimumWageCalculator.new(date: Date.parse("2019-04-01"))
-          else
-            Calculators::MinimumWageCalculator.new
-          end
+        on_response do |response|
+          self.calculator = Calculators::MinimumWageCalculator.new
+          calculator.date = Date.parse("2019-04-01") if response == "past_payment"
+          self.accommodation_charge = nil
         end
-
-        calculate :accommodation_charge
 
         next_node do |response|
           case response
@@ -36,10 +32,6 @@ module SmartAnswer
 
       # Q3
       value_question :how_old_are_you?, parse: Integer do
-        precalculate :age_title do
-          "How old are you?"
-        end
-
         validate do |response|
           calculator.valid_age?(response)
         end

--- a/test/integration/smart_answer_flows/flow_test_helper.rb
+++ b/test/integration/smart_answer_flows/flow_test_helper.rb
@@ -47,6 +47,16 @@ module FlowTestHelper
     end
   end
 
+  # To be used with test class inheriting from ActionDispatch::IntegrationTest
+  def assert_page_renders
+    silence_warnings do # Without this get a Mocha deprecation warning that I was unable to find the source of.
+      ContentItemRetriever.stubs(:fetch).returns({})
+      path = "/#{@flow.name}/y/#{@responses.join('/')}"
+      get path
+      assert_equal response.code, "200"
+    end
+  end
+
   def assert_current_node_is_error(message = nil)
     assert current_state.error, "Expected #{current_state.current_node} to be in error state"
     assert_equal message, current_state.error if message

--- a/test/integration/smart_answer_flows/minimum_wage_calculator_employers_test.rb
+++ b/test/integration/smart_answer_flows/minimum_wage_calculator_employers_test.rb
@@ -3,18 +3,50 @@ require_relative "flow_test_helper"
 
 require "smart_answer_flows/minimum-wage-calculator-employers"
 
-class MinimumWageCalculatorEmployersTest < ActiveSupport::TestCase
+class MinimumWageCalculatorEmployersTest < ActionDispatch::IntegrationTest
+  # This tests the parts of the flow defined within MinimumWageCalculatorEmployersFlow
+  # Much of the user journey is through a shared flow Shared::MinimumWageFlow
+  # Which is tested via AmIGettingMinimumWageTest
   include FlowTestHelper
 
   setup do
     setup_for_testing_flow SmartAnswer::MinimumWageCalculatorEmployersFlow
   end
 
-  # Q1
-  should "ask 'what would you like to check?'" do
+  should "complete flow for current payment under school age" do
     assert_current_node :what_would_you_like_to_check?
+    assert_page_renders
+    add_response "current_payment"
+    assert_current_node :are_you_an_apprentice? # in shared flow
+    assert_page_renders
+    add_response "not_an_apprentice" # Choice that will return flow from shared
+    assert_current_node :how_old_are_you?
+    assert_page_renders
+    add_response "15"
+    assert_current_node :under_school_leaving_age # outcome
+    assert_page_renders
   end
 
-  # This is the employer version of the shared minimum wage calculator.
-  # The full flow is tested in the employee version.
+  should "complete flow for current payment over school age" do
+    assert_current_node :what_would_you_like_to_check?
+    add_response "current_payment"
+    assert_current_node :are_you_an_apprentice? # in shared flow
+    assert_page_renders
+    add_response "not_an_apprentice" # Choice that will return flow from shared
+    assert_current_node :how_old_are_you?
+    assert_page_renders
+    add_response "22"
+    assert_current_node :how_often_do_you_get_paid?
+    assert_page_renders
+    # current node and rest of flow in shared flow
+  end
+
+  should "complete flow for past payment under school age" do
+    assert_current_node :what_would_you_like_to_check?
+    add_response "past_payment"
+    assert_current_node :were_you_an_apprentice?
+    assert_page_renders
+    # current node and rest of flow in shared flow
+    # No options return from shared flow
+  end
 end


### PR DESCRIPTION
Replace use of calculate and precalculate from MinimumWageCalculatorEmployersFlow

age_title not used so remove precalculation without replacing functionality

Use `assert_page_renders` to check view render without error.

[Trello Ticket](https://trello.com/c/Mq3mxlvW/439-remove-deprecated-methods-from-minimum-wage-calculator-employers-flow)
Part of [Epic](https://trello.com/c/YsfICJPz/415-epic-update-deprecated-syntax-for-existing-smart-answer-flow)

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.
