### PR TITLE
Update PR template based on retro actions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,7 @@
-:warning: Only merge changes if you are happy for them to go live. :warning: 
+:warning: This application is Continuously Deployed: :warning:
 
-This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.
+- Merged changes are automatically deployed to staging and production.
+
+- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.
+
+- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.


### PR DESCRIPTION
https://trello.com/c/9HyK1pht/174-consolidate-cd-retro-outcomes-into-cards-or-the-draft-rfc

This makes a couple of changes to:

- Explicitly ask developers to read the deployment guidelines.

- Suggest monitoring the progress of a release after merging.

## New template

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.