### PR TITLE
Correcting content errors

### DIFF
--- a/lib/smart_answer_flows/calculate-employee-redundancy-pay/calculate_employee_redundancy_pay.erb
+++ b/lib/smart_answer_flows/calculate-employee-redundancy-pay/calculate_employee_redundancy_pay.erb
@@ -7,8 +7,6 @@
 <% end %>
 
 <% govspeak_for :body do %>
-  Calculate an employee’s statutory redundancy pay.
-
   Redundancy payments are based on age, weekly pay and number of years in the job.
 
   Your employee's weekly pay is the average they earned per week over the 12 weeks before the day they got their redundancy notice.


### PR DESCRIPTION
Removed first line that duplicated content title. Replaced apostrophe in title as appearing as HTML encoding.

https://trello.com/c/cOUB6MkQ/1828-error-on-calculate-statutory-redundancy-calculator

:warning: Only merge changes if you are happy for them to go live. :warning: 

This application is now [continuously deployed](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request). Merged changes are automatically deployed to staging and production.
