### PR TITLE
Make page titles unique

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,19 @@
+<%
+    answer_title = yield :title
+    question_title = yield :question_title
+    outcome_title = yield :outcome_title
+    if question_title.present?
+      title = "#{question_title} - #{answer_title}"
+    elsif outcome_title.present?
+      title = "#{outcome_title} - #{answer_title}"
+    else
+      title = answer_title
+    end
+%>
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= yield :title %> - GOV.UK</title>
+    <title><%= title %> - GOV.UK</title>
     <%= stylesheet_link_tag "application", :media => "all" %>
     <%= stylesheet_link_tag "print.css", media: "print" %>
     <%= javascript_include_tag "test-dependencies" if Rails.env.test? %>

--- a/app/views/smart_answers/question.html.erb
+++ b/app/views/smart_answers/question.html.erb
@@ -1,13 +1,12 @@
+<% question = @presenter.current_node %>
+<% content_for :question_title do %><% if question.error.present? %>Error - <% end %><%= question.title %><% end %>
 <% content_for :head do %>
   <meta name="robots" content="noindex">
 <% end %>
 
-<% question = @presenter.current_node %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render 'debug' %>
-
     <%= form_tag calculate_current_question_path(@presenter), :method => :get do %>
       <div class="govuk-!-margin-bottom-6 govuk-!-margin-top-8" id="current-question">
         <div data-debug-template-path="<%= question.relative_erb_template_path %>">

--- a/app/views/smart_answers/result.html.erb
+++ b/app/views/smart_answers/result.html.erb
@@ -1,3 +1,7 @@
+<% outcome = @presenter.current_node %>
+<% content_for :outcome_title do %>
+  <% if outcome.title.present? %><%= outcome.title %><% else %>Outcome<% end %>
+<% end %>
 <% content_for :head do %>
   <meta name="robots" content="noindex">
 <% end %>
@@ -8,8 +12,6 @@
     <%= render "govuk_publishing_components/components/title", {
       title: @presenter.title
     } %>
-
-    <% outcome = @presenter.current_node %>
 
     <div class="govuk-!-margin-bottom-6 result-body" data-debug-template-path="<%= outcome.relative_erb_template_path %>">
       <% if outcome.title.present? %>
@@ -28,7 +30,6 @@
           text: "Next steps",
           margin_bottom: 6
         } %>
-
         <%= outcome.next_steps %>
       </div>
     <% end %>

--- a/test/fixtures/smart_answer_flows/smart-answers-controller-sample/outcomes/you_have_a_savoury_tooth.erb
+++ b/test/fixtures/smart_answer_flows/smart-answers-controller-sample/outcomes/you_have_a_savoury_tooth.erb
@@ -1,0 +1,7 @@
+<% govspeak_for :body do %>
+  savoury-tooth-outcome-govspeak-body
+<% end %>
+
+<% govspeak_for :next_steps do %>
+  savoury-tooth-outcome-govspeak-next-steps
+<% end %>

--- a/test/functional/smart_answers_controller_date_question_test.rb
+++ b/test/functional/smart_answers_controller_date_question_test.rb
@@ -53,6 +53,7 @@ class SmartAnswersControllerDateQuestionTest < ActionController::TestCase
         should "show an error message" do
           submit_response(day: "", month: "", year: "")
           assert_select ".govuk-error-message"
+          assert_contains css_select("title").first.content, /Error/
         end
       end
 

--- a/test/functional/smart_answers_controller_multiple_choice_test.rb
+++ b/test/functional/smart_answers_controller_multiple_choice_test.rb
@@ -30,6 +30,7 @@ class SmartAnswersControllerMultipleChoiceQuestionTest < ActionController::TestC
       should "show an error message" do
         submit_response(nil)
         assert_select ".govuk-error-message"
+        assert_contains css_select("title").first.content, /Error/
       end
     end
   end

--- a/test/functional/smart_answers_controller_salary_question_test.rb
+++ b/test/functional/smart_answers_controller_salary_question_test.rb
@@ -36,6 +36,7 @@ class SmartAnswersControllerSalaryQuestionTest < ActionController::TestCase
         should "show a validation error if invalid amount" do
           assert_select ".govuk-label", /Salary question with error message/
           assert_select ".govuk-error-message", /salary-question-error-message/
+          assert_contains css_select("title").first.content, /Error/
         end
       end
 

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -116,6 +116,8 @@ class SmartAnswersControllerTest < ActionController::TestCase
 
     should "display first question after starting" do
       get :show, params: { id: "smart-answers-controller-sample", started: "y" }
+      assert_contains css_select("title").first.content, /Do you like chocolate?/
+      assert_contains css_select("title").first.content, /Smart answers controller sample/
       assert_select ".govuk-fieldset__legend", /Do you like chocolate\?/
       assert_select "input[name=response][value=yes]"
       assert_select "input[name=response][value=no]"
@@ -123,6 +125,15 @@ class SmartAnswersControllerTest < ActionController::TestCase
 
     should "show outcome when smart answer is complete so that 'smartanswerOutcome' JS event is fired" do
       get :show, params: { id: "smart-answers-controller-sample", started: "y", responses: "yes" }
+      assert_contains css_select("title").first.content, /sweet-tooth-outcome-title/
+      assert_contains css_select("title").first.content, /Smart answers controller sample/
+      assert_select ".outcome"
+    end
+
+    should "show default outcome title when none is supplied" do
+      get :show, params: { id: "smart-answers-controller-sample", started: "y", responses: %w[no no] }
+      assert_contains css_select("title").first.content, /Outcome/
+      assert_contains css_select("title").first.content, /Smart answers controller sample/
       assert_select ".outcome"
     end
 


### PR DESCRIPTION
https://trello.com/c/SPXc1Bak/267-update-smart-answers-to-have-unique-page-titles

This updates question pages to have the question in the title and
the outcome page to specify the results in the title. Previously
all titles were that of the smart answer meaning multiple pages
shared a title which is a WCAG fail.

The pattern for this matches changes being made in Simple Smart Answers here: https://github.com/alphagov/frontend/pull/2438

Tests have been updated to check the title, they are checking for substrings because the whitespace on the full title is a little erratic, although it renders out fine in the browser title.

Note that this refers to the HTML title tag, not the page headings. This can be seen on the browser tab, or in the source as indicated in these screenshots:

### Results page:

![Screenshot 2020-08-13 at 09 25 32](https://user-images.githubusercontent.com/31649453/90111728-f66cdc00-dd46-11ea-8695-4969c4d3fb7d.png)
Path: /additional-commodity-code/y/0/0/0/60

### Question page:

![Screenshot 2020-08-13 at 09 22 22](https://user-images.githubusercontent.com/31649453/90111409-86f6ec80-dd46-11ea-8446-c47621a8cecf.png)
Path: /additional-commodity-code/y/0/0/0


### Error page:

![Screenshot 2020-08-13 at 09 20 09](https://user-images.githubusercontent.com/31649453/90111250-45664180-dd46-11ea-9e0d-a1abecf012e6.png)
Path: /additional-commodity-code/y?next=1

=====
:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.
