### PR TITLE
Fix an apostrophe that wasn't displaying properly

### DIFF
--- a/lib/smart_answer_flows/calculate-employee-redundancy-pay/calculate_employee_redundancy_pay.erb
+++ b/lib/smart_answer_flows/calculate-employee-redundancy-pay/calculate_employee_redundancy_pay.erb
@@ -1,5 +1,5 @@
 <% text_for :title do %>
-  Calculate your employee's statutory redundancy pay
+  Calculate your employee’s statutory redundancy pay
 <% end %>
 
 <% text_for :meta_description do %>


### PR DESCRIPTION
The "Calculate your employee's redundancy pay" page title wasn't displaying properly because of a single quote. This changes it so that it won't be displayed as `&#39;`

<img width="644" alt="Screenshot 2020-08-13 at 10 35 45" src="https://user-images.githubusercontent.com/24547207/90122590-6da96c80-dd55-11ea-8d8c-ffa167d18270.png">
