### PR TITLE
Fix wrongly displayed apostrophe

### DIFF
--- a/lib/smart_answer_flows/calculate-employee-redundancy-pay/calculate_employee_redundancy_pay.erb
+++ b/lib/smart_answer_flows/calculate-employee-redundancy-pay/calculate_employee_redundancy_pay.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% text_for :meta_description do %>
-  Employer calculator - calculate your employee's statutory redundancy payment
+  Employer calculator - calculate your employee’s statutory redundancy payment
 <% end %>
 
 <% govspeak_for :body do %>


### PR DESCRIPTION
Similar to https://github.com/alphagov/smart-answers/pull/4769 

I realised that there was another single quote in the header page that was causing some funny behaviour. 

<img width="294" alt="Screenshot 2020-08-13 at 11 23 05" src="https://user-images.githubusercontent.com/24547207/90123836-59666f00-dd57-11ea-8bd2-a332a8a76596.png">

