### PR TITLE
Session controller and forms: add validation and error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ tmp/
 coverage
 
 .byebug_history
+
+yarn.lock

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,6 +8,7 @@ $govuk-use-legacy-palette: false;
 @import "govuk_publishing_components/components/contextual-sidebar";
 @import "govuk_publishing_components/components/date-input";
 @import "govuk_publishing_components/components/error-message";
+@import "govuk_publishing_components/components/error-summary";
 @import "govuk_publishing_components/components/feedback";
 @import "govuk_publishing_components/components/fieldset";
 @import "govuk_publishing_components/components/govspeak";

--- a/app/controllers/session_answers_controller.rb
+++ b/app/controllers/session_answers_controller.rb
@@ -10,8 +10,11 @@ class SessionAnswersController < ApplicationController
   end
 
   def update
-    form.save
-    redirect_to session_flow_path(flow_name, flow.next_node)
+    if form.save
+      redirect_to session_flow_path(flow_name, flow.next_node)
+    else
+      render :show
+    end
   end
 
 private

--- a/app/forms/coronavirus_find_support/able_to_go_out_form.rb
+++ b/app/forms/coronavirus_find_support/able_to_go_out_form.rb
@@ -1,6 +1,6 @@
 module CoronavirusFindSupport
   class AbleToGoOutForm < Form
-    answer_flow :session_answers
+    answer_flow :coronavirus_find_support
     answer_node :able_to_go_out
   end
 end

--- a/app/forms/coronavirus_find_support/afford_food_form.rb
+++ b/app/forms/coronavirus_find_support/afford_food_form.rb
@@ -1,7 +1,8 @@
 module CoronavirusFindSupport
   class AffordFoodForm < Form
-    answer_flow :coronavirus_find_support
-    answer_node :afford_food
+    attr_accessor :afford_food
+
+    validates :afford_food, presence: { message: "Select yes if you’re finding it hard to afford food" }
 
     def options
       {

--- a/app/forms/coronavirus_find_support/afford_food_form.rb
+++ b/app/forms/coronavirus_find_support/afford_food_form.rb
@@ -1,6 +1,6 @@
 module CoronavirusFindSupport
   class AffordFoodForm < Form
-    answer_flow :session_answers
+    answer_flow :coronavirus_find_support
     answer_node :afford_food
 
     def options

--- a/app/forms/coronavirus_find_support/afford_rent_mortgage_bills_form.rb
+++ b/app/forms/coronavirus_find_support/afford_rent_mortgage_bills_form.rb
@@ -1,6 +1,6 @@
 module CoronavirusFindSupport
   class AffordRentMortgageBillsForm < Form
-    answer_flow :session_answers
+    answer_flow :coronavirus_find_support
     answer_node :afford_rent_mortgage_bills
 
     def options

--- a/app/forms/coronavirus_find_support/afford_rent_mortgage_bills_form.rb
+++ b/app/forms/coronavirus_find_support/afford_rent_mortgage_bills_form.rb
@@ -1,7 +1,9 @@
 module CoronavirusFindSupport
   class AffordRentMortgageBillsForm < Form
-    answer_flow :coronavirus_find_support
-    answer_node :afford_rent_mortgage_bills
+    attr_accessor :afford_rent_mortgage_bills
+
+    validates :afford_rent_mortgage_bills,
+              presence: { message: "Select yes if you’re finding it hard to pay your rent, mortgage or bills" }
 
     def options
       {

--- a/app/forms/coronavirus_find_support/feel_safe_form.rb
+++ b/app/forms/coronavirus_find_support/feel_safe_form.rb
@@ -1,7 +1,9 @@
 module CoronavirusFindSupport
   class FeelSafeForm < Form
-    answer_flow :coronavirus_find_support
-    answer_node :feel_safe
+    attr_accessor :feel_safe
+
+    validates :feel_safe,
+              presence: { message: "Select if you feel safe where you live or if you’re worried about someone else" }
 
     def options
       {

--- a/app/forms/coronavirus_find_support/feel_safe_form.rb
+++ b/app/forms/coronavirus_find_support/feel_safe_form.rb
@@ -1,6 +1,6 @@
 module CoronavirusFindSupport
   class FeelSafeForm < Form
-    answer_flow :session_answers
+    answer_flow :coronavirus_find_support
     answer_node :feel_safe
 
     def options

--- a/app/forms/coronavirus_find_support/get_food_form.rb
+++ b/app/forms/coronavirus_find_support/get_food_form.rb
@@ -1,7 +1,8 @@
 module CoronavirusFindSupport
   class GetFoodForm < Form
-    answer_flow :coronavirus_find_support
-    answer_node :get_food
+    attr_accessor :get_food
+
+    validates :get_food, presence: { message: "Select yes if you’re able to get food" }
 
     def options
       {

--- a/app/forms/coronavirus_find_support/get_food_form.rb
+++ b/app/forms/coronavirus_find_support/get_food_form.rb
@@ -1,6 +1,6 @@
 module CoronavirusFindSupport
   class GetFoodForm < Form
-    answer_flow :session_answers
+    answer_flow :coronavirus_find_support
     answer_node :get_food
 
     def options

--- a/app/forms/coronavirus_find_support/need_help_with_form.rb
+++ b/app/forms/coronavirus_find_support/need_help_with_form.rb
@@ -1,7 +1,13 @@
 module CoronavirusFindSupport
   class NeedHelpWithForm < Form
-    answer_flow :session_answers
+    answer_flow :coronavirus_find_support
     answer_node :need_help_with
+
+    attr_accessor :need_help_with
+
+    validates :need_help_with,
+              presence: { message: "Select what you need to find help with, or ‘Not sure’" },
+              valid_options: true
 
     def options
       {

--- a/app/forms/coronavirus_find_support/need_help_with_form.rb
+++ b/app/forms/coronavirus_find_support/need_help_with_form.rb
@@ -1,8 +1,5 @@
 module CoronavirusFindSupport
   class NeedHelpWithForm < Form
-    answer_flow :coronavirus_find_support
-    answer_node :need_help_with
-
     attr_accessor :need_help_with
 
     validates :need_help_with,

--- a/app/forms/form.rb
+++ b/app/forms/form.rb
@@ -24,6 +24,24 @@ class Form
   def initialize(params, session)
     @params = params
     @session = session
+    assign_attributes_from_params
+  end
+
+  # if an attribute is assigned in a child class
+  # for example:
+  #
+  #   `attr_accessor :foo`
+  #
+  # and params contains a value with matching key
+  #
+  #   params = { foo: :bar }
+  #
+  # Then that value will be assigned to the attribute
+  #
+  #   f = MyForm.new(params, {})
+  #   f.foo => :bar
+  def assign_attributes_from_params
+    self.attributes = params.select { |k, _| self.class.attribute_method?(k) }
   end
 
   def checkbox_options
@@ -43,7 +61,19 @@ class Form
   end
 
   def save
-    session[:flow_name] ||= {}
-    session[:flow_name][:node_name] = params[:node_name]
+    prepare_session
+    update_session if valid?
+  end
+
+  def prepare_session
+    session[flow_name] ||= {}
+  end
+
+  def update_session
+    session[flow_name][node_name] = data_to_be_stored_in_session
+  end
+
+  def data_to_be_stored_in_session
+    params[node_name]
   end
 end

--- a/app/helpers/session_answers_helper.rb
+++ b/app/helpers/session_answers_helper.rb
@@ -5,10 +5,32 @@ module SessionAnswersHelper
     end
   end
 
+  def form_for_node
+    form_with path: session_flow_path(flow_name, node_name), method: :put, local: true do
+      yield
+    end
+  end
+
+  def govuk_radio_for_node(form)
+    render(
+      "govuk_publishing_components/components/radio",
+      heading: tag.h1(content_for(:title), class: "govuk-fieldset__heading"),
+      heading_size: "xl",
+      name: "#{form.node_name}[]",
+      items: form.radio_options,
+      error_message: error_summary(form, form.node_name),
+      id: form.node_name,
+    )
+  end
+
   def error_summary(form, attribute)
     messages = form.errors[attribute]
     return if messages.empty?
 
     messages.to_sentence
+  end
+
+  def continue_button
+    render "govuk_publishing_components/components/button", text: "Continue"
   end
 end

--- a/app/helpers/session_answers_helper.rb
+++ b/app/helpers/session_answers_helper.rb
@@ -1,0 +1,14 @@
+module SessionAnswersHelper
+  def items_for_error_summary(form)
+    form.errors.each_with_object([]) do |(attr, message), array|
+      array << { text: message, href: "##{attr}" }
+    end
+  end
+
+  def error_summary(form, attribute)
+    messages = form.errors[attribute]
+    return if messages.empty?
+
+    messages.to_sentence
+  end
+end

--- a/app/validators/valid_options_validator.rb
+++ b/app/validators/valid_options_validator.rb
@@ -1,0 +1,28 @@
+# Adds the option :valid_options for ActiveModel validates method
+#
+# Usage within an ActiveModel:
+#   validates :foo, valid_options: true
+#
+# With this set, for the form to be valid `form.foo` must return:
+#  - an array containing only keys from `form.options`
+#
+# To add a custom message:
+#   validates :foo, valid_options: { message: "My custom message" }
+#
+class ValidOptionsValidator < ActiveModel::EachValidator
+  def validate_each(form, attribute, value)
+    return if value.blank?
+
+    mismatch = mismatching(value, form.options.keys)
+
+    unless mismatch.empty?
+      form.errors[attribute] << (options[:message] || "Please select one of the options provided")
+    end
+  end
+
+  def mismatching(content, options)
+    return [content] unless content.is_a?(Array)
+
+    content.map(&:to_sym) - options.map(&:to_sym)
+  end
+end

--- a/app/views/application/_error_summary.erb
+++ b/app/views/application/_error_summary.erb
@@ -1,0 +1,5 @@
+<%= render "govuk_publishing_components/components/error_summary", {
+  id: "error-summary",
+  title: "There is a problem",
+  items: items_for_error_summary(form)
+} %>

--- a/app/views/session_answers/coronavirus_find_support/_afford_food.html.erb
+++ b/app/views/session_answers/coronavirus_find_support/_afford_food.html.erb
@@ -2,15 +2,7 @@
   Are you finding it hard to afford food?
 <% end %>
 
-<%= form_with path: session_flow_path(flow_name, node_name), method: :put, local: true do |form| %>
-  <%= render "govuk_publishing_components/components/radio", {
-    heading: content_tag(:h1, content_for(:title), class: "govuk-fieldset__heading"),
-    heading_size: "xl",
-    name: "#{node_name}[]",
-    items: @form.radio_options
-  } %>
-
-  <%= render "govuk_publishing_components/components/button", {
-    text: "Continue"
-  } %>
+<%= form_for_node do %>
+  <%= govuk_radio_for_node(@form) %>
+  <%= continue_button %>
 <% end %>

--- a/app/views/session_answers/coronavirus_find_support/_afford_rent_mortgage_bills.html.erb
+++ b/app/views/session_answers/coronavirus_find_support/_afford_rent_mortgage_bills.html.erb
@@ -2,15 +2,7 @@
   Are you finding it hard to afford rent, your mortgage or bills?
 <% end %>
 
-<%= form_with path: session_flow_path(flow_name, node_name), method: :put, local: true do |form| %>
-  <%= render "govuk_publishing_components/components/radio", {
-    heading: content_tag(:h1, content_for(:title), class: "govuk-fieldset__heading"),
-    heading_size: "xl",
-    name: "#{node_name}[]",
-    items: @form.radio_options
-  } %>
-
-  <%= render "govuk_publishing_components/components/button", {
-    text: "Continue"
-  } %>
+<%= form_for_node do %>
+  <%= govuk_radio_for_node(@form) %>
+  <%= continue_button %>
 <% end %>

--- a/app/views/session_answers/coronavirus_find_support/_feel_safe.html.erb
+++ b/app/views/session_answers/coronavirus_find_support/_feel_safe.html.erb
@@ -2,15 +2,7 @@
   Do you feel safe where you live?
 <% end %>
 
-<%= form_with path: session_flow_path(flow_name, node_name), method: :put, local: true do |form| %>
-  <%= render "govuk_publishing_components/components/radio", {
-    heading: content_tag(:h1, content_for(:title), class: "govuk-fieldset__heading"),
-    heading_size: "xl",
-    name: "#{node_name}[]",
-    items: @form.radio_options
-  } %>
-
-  <%= render "govuk_publishing_components/components/button", {
-    text: "Continue"
-  } %>
+<%= form_for_node do %>
+  <%= govuk_radio_for_node(@form) %>
+  <%= continue_button %>
 <% end %>

--- a/app/views/session_answers/coronavirus_find_support/_get_food.html.erb
+++ b/app/views/session_answers/coronavirus_find_support/_get_food.html.erb
@@ -2,15 +2,7 @@
   Are you able to get food?
 <% end %>
 
-<%= form_with path: session_flow_path(flow_name, node_name), method: :put, local: true do |form| %>
-  <%= render "govuk_publishing_components/components/radio", {
-    heading: content_tag(:h1, content_for(:title), class: "govuk-fieldset__heading"),
-    heading_size: "xl",
-    name: "#{node_name}[]",
-    items: @form.radio_options
-  } %>
-
-  <%= render "govuk_publishing_components/components/button", {
-    text: "Continue"
-  } %>
+<%= form_for_node do %>
+  <%= govuk_radio_for_node(@form) %>
+  <%= continue_button %>
 <% end %>

--- a/app/views/session_answers/coronavirus_find_support/_need_help_with.html.erb
+++ b/app/views/session_answers/coronavirus_find_support/_need_help_with.html.erb
@@ -2,7 +2,7 @@
   What do you need help with because of coronavirus?
 <% end %>
 
-<%= form_with path: session_flow_path(flow_name, node_name), method: :put, local: true do |form| %>
+<%= form_for_node do %>
   <%= render "govuk_publishing_components/components/checkboxes", {
     heading: content_tag(:h1, content_for(:title), class: "govuk-fieldset__heading"),
     heading_size: "xl",
@@ -12,7 +12,5 @@
     id: node_name
   } %>
 
-  <%= render "govuk_publishing_components/components/button", {
-    text: "Continue"
-  } %>
+  <%= continue_button %>
 <% end %>

--- a/app/views/session_answers/coronavirus_find_support/_need_help_with.html.erb
+++ b/app/views/session_answers/coronavirus_find_support/_need_help_with.html.erb
@@ -7,7 +7,9 @@
     heading: content_tag(:h1, content_for(:title), class: "govuk-fieldset__heading"),
     heading_size: "xl",
     name: "#{node_name}[]",
-    items: @form.checkbox_options
+    items: @form.checkbox_options,
+    error: error_summary(@form, node_name),
+    id: node_name
   } %>
 
   <%= render "govuk_publishing_components/components/button", {

--- a/app/views/session_answers/show.html.erb
+++ b/app/views/session_answers/show.html.erb
@@ -4,6 +4,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
+    <%= render('error_summary', form: @form) if @form.errors.present? %>
     <%= render "session_answers/#{flow_name}/#{node_name}" %>
   </div>
 </div>

--- a/test/controllers/session_answers_controller_test.rb
+++ b/test/controllers/session_answers_controller_test.rb
@@ -29,6 +29,20 @@ class SessionAnswersControllerTest < ActionDispatch::IntegrationTest
     #    end
   end
 
+  def params
+    @params ||= { need_help_with: %w[paying_bills] }
+  end
+
   context "PUT /:flow_name/:node_name" do
+    should "redirect to next node" do
+      put session_flow_path(flow_name, node_name), params: params
+      assert_redirected_to session_flow_path(flow_name, :feel_safe)
+    end
+
+    should "render page on error" do
+      @params = {}
+      put session_flow_path(flow_name, node_name), params: params
+      assert_response :success
+    end
   end
 end

--- a/test/controllers/session_answers_controller_test.rb
+++ b/test/controllers/session_answers_controller_test.rb
@@ -34,15 +34,31 @@ class SessionAnswersControllerTest < ActionDispatch::IntegrationTest
   end
 
   context "PUT /:flow_name/:node_name" do
-    should "redirect to next node" do
+    setup do
       put session_flow_path(flow_name, node_name), params: params
-      assert_redirected_to session_flow_path(flow_name, :feel_safe)
     end
 
-    should "render page on error" do
+    should "redirect to next node" do
+      assert_redirected_to session_flow_path(flow_name, :feel_safe)
+    end
+  end
+
+  context "PUT /:flow_name/:node_name on error" do
+    setup do
       @params = {}
       put session_flow_path(flow_name, node_name), params: params
+    end
+
+    should "re-render page" do
       assert_response :success
+    end
+
+    should "display an error on element" do
+      assert_match(/govuk-error-message/, response.body)
+    end
+
+    should "display an error summary" do
+      assert_match(/govuk-error-summary/, response.body)
     end
   end
 end

--- a/test/unit/forms/coronavirus_find_support/afford_food_test.rb
+++ b/test/unit/forms/coronavirus_find_support/afford_food_test.rb
@@ -1,0 +1,52 @@
+require "test_helper"
+
+module CoronavirusFindSupport
+  class AffordFoodTest < ActiveSupport::TestCase
+    def session
+      @session ||= {}
+    end
+
+    def input
+      @input ||= "Yes"
+    end
+
+    def params
+      @params ||= { afford_food: input, flow_name: :coronavirus_find_support, node_name: :afford_food }
+    end
+
+    def form
+      @form ||= AffordFoodForm.new(ActionController::Parameters.new(params), session)
+    end
+
+    context "#save" do
+      should "return true if successful" do
+        assert form.save
+      end
+
+      should "save input to session" do
+        form.save
+        assert_equal input, session.dig(form.flow_name, form.node_name)
+      end
+    end
+
+    context "#save no entry" do
+      setup do
+        @params = {}
+      end
+
+      should "not return true" do
+        assert_not form.save
+      end
+
+      should "not save input to session" do
+        form.save
+        assert_nil session.dig(form.flow_name, form.node_name)
+      end
+
+      should "populate errors" do
+        form.save
+        assert_equal "Select yes if you’re finding it hard to afford food", form.errors[:afford_food].join
+      end
+    end
+  end
+end

--- a/test/unit/forms/coronavirus_find_support/afford_rent_mortgage_bills_form_test.rb
+++ b/test/unit/forms/coronavirus_find_support/afford_rent_mortgage_bills_form_test.rb
@@ -1,0 +1,59 @@
+require "test_helper"
+
+module CoronavirusFindSupport
+  class AffordRentMortgageBillsFormTest < ActiveSupport::TestCase
+    def session
+      @session ||= {}
+    end
+
+    def input
+      @input ||= "Yes"
+    end
+
+    def params
+      @params ||= {
+        afford_rent_mortgage_bills: input,
+        flow_name: :coronavirus_find_support,
+        node_name: :afford_rent_mortgage_bills,
+      }
+    end
+
+    def form
+      @form ||= AffordRentMortgageBillsForm.new(ActionController::Parameters.new(params), session)
+    end
+
+    context "#save" do
+      should "return true if successful" do
+        assert form.save
+      end
+
+      should "save input to session" do
+        form.save
+        assert_equal input, session.dig(form.flow_name, form.node_name)
+      end
+    end
+
+    context "#save no entry" do
+      setup do
+        @params = {}
+      end
+
+      should "not return true" do
+        assert_not form.save
+      end
+
+      should "not save input to session" do
+        form.save
+        assert_nil session.dig(form.flow_name, form.node_name)
+      end
+
+      should "populate errors" do
+        form.save
+        assert_equal(
+          "Select yes if you’re finding it hard to pay your rent, mortgage or bills",
+          form.errors[:afford_rent_mortgage_bills].join,
+        )
+      end
+    end
+  end
+end

--- a/test/unit/forms/coronavirus_find_support/feel_safe_form_test.rb
+++ b/test/unit/forms/coronavirus_find_support/feel_safe_form_test.rb
@@ -1,0 +1,55 @@
+require "test_helper"
+
+module CoronavirusFindSupport
+  class FeelSafeFormTest < ActiveSupport::TestCase
+    def session
+      @session ||= {}
+    end
+
+    def input
+      @input ||= "Yes"
+    end
+
+    def params
+      @params ||= { feel_safe: input, flow_name: :coronavirus_find_support, node_name: :feel_safe }
+    end
+
+    def form
+      @form ||= FeelSafeForm.new(ActionController::Parameters.new(params), session)
+    end
+
+    context "#save" do
+      should "return true if successful" do
+        assert form.save
+      end
+
+      should "save input to session" do
+        form.save
+        assert_equal input, session.dig(form.flow_name, form.node_name)
+      end
+    end
+
+    context "#save no entry" do
+      setup do
+        @params = {}
+      end
+
+      should "not return true" do
+        assert_not form.save
+      end
+
+      should "not save input to session" do
+        form.save
+        assert_nil session.dig(form.flow_name, form.node_name)
+      end
+
+      should "populate errors" do
+        form.save
+        assert_equal(
+          "Select if you feel safe where you live or if you’re worried about someone else",
+          form.errors[:feel_safe].join,
+        )
+      end
+    end
+  end
+end

--- a/test/unit/forms/coronavirus_find_support/get_food_form_test.rb
+++ b/test/unit/forms/coronavirus_find_support/get_food_form_test.rb
@@ -1,0 +1,52 @@
+require "test_helper"
+
+module CoronavirusFindSupport
+  class GetFoodFormTest < ActiveSupport::TestCase
+    def session
+      @session ||= {}
+    end
+
+    def input
+      @input ||= "Yes"
+    end
+
+    def params
+      @params ||= { get_food: input, flow_name: :coronavirus_find_support, node_name: :get_food }
+    end
+
+    def form
+      @form ||= GetFoodForm.new(ActionController::Parameters.new(params), session)
+    end
+
+    context "#save" do
+      should "return true if successful" do
+        assert form.save
+      end
+
+      should "save input to session" do
+        form.save
+        assert_equal input, session.dig(form.flow_name, form.node_name)
+      end
+    end
+
+    context "#save no entry" do
+      setup do
+        @params = {}
+      end
+
+      should "not return true" do
+        assert_not form.save
+      end
+
+      should "not save input to session" do
+        form.save
+        assert_nil session.dig(form.flow_name, form.node_name)
+      end
+
+      should "populate errors" do
+        form.save
+        assert_equal "Select yes if you’re able to get food", form.errors[:get_food].join
+      end
+    end
+  end
+end

--- a/test/unit/forms/coronavirus_find_support/need_help_with_form_test.rb
+++ b/test/unit/forms/coronavirus_find_support/need_help_with_form_test.rb
@@ -11,11 +11,11 @@ module CoronavirusFindSupport
     end
 
     def params
-      @params ||= { need_help_with: input }
+      @params ||= { need_help_with: input, flow_name: :coronavirus_find_support, node_name: :need_help_with }
     end
 
     def form
-      @form ||= NeedHelpWithForm.new(params, session)
+      @form ||= NeedHelpWithForm.new(ActionController::Parameters.new(params), session)
     end
 
     context "#save" do

--- a/test/unit/forms/coronavirus_find_support/need_help_with_form_test.rb
+++ b/test/unit/forms/coronavirus_find_support/need_help_with_form_test.rb
@@ -1,0 +1,97 @@
+require "test_helper"
+
+module CoronavirusFindSupport
+  class NeedHelpWithFormTest < ActiveSupport::TestCase
+    def session
+      @session ||= {}
+    end
+
+    def input
+      @input ||= %w[feeling_unsafe]
+    end
+
+    def params
+      @params ||= { need_help_with: input }
+    end
+
+    def form
+      @form ||= NeedHelpWithForm.new(params, session)
+    end
+
+    context "#save" do
+      should "return true if successful" do
+        assert form.save
+      end
+
+      should "save input to session" do
+        form.save
+        assert_equal input, session.dig(form.flow_name, form.node_name)
+      end
+
+      should "not populate errors" do
+        form.save
+        assert form.errors.empty?
+      end
+    end
+
+    context "#save with multiple options selected" do
+      setup do
+        @input = %w[feeling_unsafe paying_bills getting_food]
+      end
+
+      should "return true if successful" do
+        assert form.save
+      end
+
+      should "save input to session" do
+        form.save
+        assert_equal input, session.dig(form.flow_name, form.node_name)
+      end
+
+      should "not populate errors" do
+        form.save
+        assert form.errors.empty?
+      end
+    end
+
+    context "#save with incorrect key" do
+      setup do
+        @params = { unknown: input }
+      end
+
+      should "not return true" do
+        assert_not form.save
+      end
+
+      should "not save input to session" do
+        form.save
+        assert_nil session.dig(form.flow_name, form.node_name)
+      end
+
+      should "populate errors" do
+        form.save
+        assert_equal "Select what you need to find help with, or ‘Not sure’", form.errors[:need_help_with].join
+      end
+    end
+
+    context "#save with unknown option" do
+      setup do
+        @input = %w[unknown]
+      end
+
+      should "not return true" do
+        assert_not form.save
+      end
+
+      should "not save input to session" do
+        form.save
+        assert_nil session.dig(form.flow_name, form.node_name)
+      end
+
+      should "populate errors" do
+        form.save
+        assert form.errors.present?
+      end
+    end
+  end
+end

--- a/test/unit/forms/form_test.rb
+++ b/test/unit/forms/form_test.rb
@@ -1,0 +1,51 @@
+require "test_helper"
+
+class FormTest < ActiveSupport::TestCase
+  class TempForm < Form
+    answer_flow :flow
+    answer_node :node
+  end
+
+  def params
+    @params ||= {}
+  end
+
+  def session
+    @session ||= {}
+  end
+
+  def form_class
+    @form_class ||= TempForm
+  end
+
+  def form
+    @form ||= form_class.new(ActionController::Parameters.new(params), session)
+  end
+
+  should "raise error when options not defined" do
+    assert_raise(Form::NotImplementedError) { form.options }
+  end
+
+  should "get flow name from class if defined" do
+    assert_equal TempForm.flow_name, form.flow_name
+  end
+
+  should "get node name from class if defined" do
+    assert_equal TempForm.node_name, form.node_name
+  end
+
+  context "when flow and node not defined at class" do
+    setup do
+      @form_class = Class.new(Form)
+      @params = { flow_name: :some_flow, node_name: :some_node }
+    end
+
+    should "get flow name from params" do
+      assert_equal params[:flow_name], form.flow_name
+    end
+
+    should "get node name from params" do
+      assert_equal params[:node_name], form.node_name
+    end
+  end
+end


### PR DESCRIPTION
_Note - this will merge into session_answers_

- Add tests of form submission and error handling to the session answers controller test
- Add form tests for all the active existing forms
- Add a session answers helper to wrap commonly used form functionality
- Add yarn.lock to gitignore
- Add error summary partial
- Update session answers controller to only redirect to next node on successful save
- Update forms to use validation
- Update node partials to use form helpers (thereby enabling error handling in each)

[Trello Ticket 433](https://trello.com/c/Z0oehuaw/433-session-controller-add-validation-and-error-handling)