### PR TITLE
434 session controller move view text to translation files

### DIFF
--- a/app/forms/coronavirus_find_support/afford_food_form.rb
+++ b/app/forms/coronavirus_find_support/afford_food_form.rb
@@ -1,15 +1,12 @@
 module CoronavirusFindSupport
   class AffordFoodForm < Form
-    attr_accessor :afford_food
+    answer_flow :coronavirus_find_support
+    answer_node :afford_food
 
-    validates :afford_food, presence: { message: "Select yes if you’re finding it hard to afford food" }
+    validates :afford_food, presence: { message: t("errors.blank") }
 
     def options
-      {
-        yes: "Yes",
-        no: "No",
-        not_sure: "Not sure",
-      }
+      %i[yes no not_sure]
     end
   end
 end

--- a/app/forms/coronavirus_find_support/afford_rent_mortgage_bills_form.rb
+++ b/app/forms/coronavirus_find_support/afford_rent_mortgage_bills_form.rb
@@ -1,16 +1,12 @@
 module CoronavirusFindSupport
   class AffordRentMortgageBillsForm < Form
-    attr_accessor :afford_rent_mortgage_bills
+    answer_flow :coronavirus_find_support
+    answer_node :afford_rent_mortgage_bills
 
-    validates :afford_rent_mortgage_bills,
-              presence: { message: "Select yes if you’re finding it hard to pay your rent, mortgage or bills" }
+    validates :afford_rent_mortgage_bills, presence: { message: t("errors.blank") }
 
     def options
-      {
-        yes: "Yes",
-        no: "No",
-        not_sure: "Not sure",
-      }
+      %i[yes no not_sure]
     end
   end
 end

--- a/app/forms/coronavirus_find_support/feel_safe_form.rb
+++ b/app/forms/coronavirus_find_support/feel_safe_form.rb
@@ -1,17 +1,17 @@
 module CoronavirusFindSupport
   class FeelSafeForm < Form
-    attr_accessor :feel_safe
+    answer_flow :coronavirus_find_support
+    answer_node :feel_safe
 
-    validates :feel_safe,
-              presence: { message: "Select if you feel safe where you live or if you’re worried about someone else" }
+    validates :feel_safe, presence: { message: t("errors.blank") }
 
     def options
-      {
-        yes: "Yes",
-        yes_but_i_am_concerned_about_others: "Yes, but I’m worried about the safety of another adult or a child",
-        no: "No",
-        not_sure: "Not sure",
-      }
+      %i[
+        yes
+        yes_but_i_am_concerned_about_others
+        no
+        not_sure
+      ]
     end
   end
 end

--- a/app/forms/coronavirus_find_support/get_food_form.rb
+++ b/app/forms/coronavirus_find_support/get_food_form.rb
@@ -1,15 +1,12 @@
 module CoronavirusFindSupport
   class GetFoodForm < Form
-    attr_accessor :get_food
+    answer_flow :coronavirus_find_support
+    answer_node :get_food
 
-    validates :get_food, presence: { message: "Select yes if you’re able to get food" }
+    validates :get_food, presence: { message: t("errors.blank") }
 
     def options
-      {
-        yes: "Yes",
-        no: "No",
-        not_sure: "Not sure",
-      }
+      %i[yes no not_sure]
     end
   end
 end

--- a/app/forms/coronavirus_find_support/need_help_with_form.rb
+++ b/app/forms/coronavirus_find_support/need_help_with_form.rb
@@ -1,32 +1,23 @@
 module CoronavirusFindSupport
   class NeedHelpWithForm < Form
-    attr_accessor :need_help_with
-
-    def self.i18n_scope
-      [:session_answers, :coronavirus_find_support, :need_help_with]
-    end
-
-    def self.t(translation_name)
-      I18n.t(translation_name, scope:i18n_scope)
-    end
-
-    delegate :my_scope, :t, to: :class
+    answer_flow :coronavirus_find_support
+    answer_node :need_help_with
 
     validates :need_help_with,
               presence: { message: t("errors.blank") },
-              valid_options: true
+              valid_options: { message: t("errors.valid_options") }
 
     def options
-      [
-        :feeling_unsafe,
-        :paying_bills,
-        :getting_food,
-        :being_unemployed,
-        :going_to_work,
-        :somewhere_to_live,
-        :mental_health,
-        :not_sure,
-      ].each_with_object({}) { |option, hash| hash[option] = t("options.#{option}") }
+      %i[
+        feeling_unsafe
+        paying_bills
+        getting_food
+        being_unemployed
+        going_to_work
+        somewhere_to_live
+        mental_health
+        not_sure
+      ]
     end
   end
 end

--- a/app/forms/coronavirus_find_support/need_help_with_form.rb
+++ b/app/forms/coronavirus_find_support/need_help_with_form.rb
@@ -2,21 +2,31 @@ module CoronavirusFindSupport
   class NeedHelpWithForm < Form
     attr_accessor :need_help_with
 
+    def self.i18n_scope
+      [:session_answers, :coronavirus_find_support, :need_help_with]
+    end
+
+    def self.t(translation_name)
+      I18n.t(translation_name, scope:i18n_scope)
+    end
+
+    delegate :my_scope, :t, to: :class
+
     validates :need_help_with,
-              presence: { message: "Select what you need to find help with, or ‘Not sure’" },
+              presence: { message: t("errors.blank") },
               valid_options: true
 
     def options
-      {
-        feeling_unsafe: "Feeling unsafe where you live, or being worried about someone else",
-        paying_bills: "Paying bills",
-        getting_food: "Getting food",
-        being_unemployed: "Being unemployed or not having any work",
-        going_to_work: "Going in to work",
-        somewhere_to_live: "Having somewhere to live",
-        mental_health: "Mental health and wellbeing",
-        not_sure: "I'm not sure",
-      }
+      [
+        :feeling_unsafe,
+        :paying_bills,
+        :getting_food,
+        :being_unemployed,
+        :going_to_work,
+        :somewhere_to_live,
+        :mental_health,
+        :not_sure,
+      ].each_with_object({}) { |option, hash| hash[option] = t("options.#{option}") }
     end
   end
 end

--- a/app/forms/form.rb
+++ b/app/forms/form.rb
@@ -16,8 +16,19 @@ class Form
 
     def answer_node(node_name)
       @node_name = node_name
+      attr_accessor node_name
+    end
+
+    def i18n_scope
+      [:session_answers, flow_name, node_name]
+    end
+
+    def t(translation_name)
+      I18n.t(translation_name, scope: i18n_scope)
     end
   end
+
+  delegate :t, to: :class
 
   def initialize(params, session)
     @params = params
@@ -58,16 +69,20 @@ class Form
     @node_name ||= self.class.node_name || params[:node_name]
   end
 
-  def checkbox_options
-    options.each_with_object([]) do |(key, value), array|
-      array << { label: value, value: key.to_s }
+  def options_for(type)
+    options.map do |option|
+      text = t("options.#{option}")
+      text_key = type == :radio ? :text : :label
+      { text_key => text, value: option }
     end
   end
 
+  def checkbox_options
+    options_for :checkbox
+  end
+
   def radio_options
-    options.each_with_object([]) do |(key, value), array|
-      array << { text: value, value: key.to_s }
-    end
+    options_for :radio
   end
 
   def options

--- a/app/validators/valid_options_validator.rb
+++ b/app/validators/valid_options_validator.rb
@@ -13,10 +13,10 @@ class ValidOptionsValidator < ActiveModel::EachValidator
   def validate_each(form, attribute, value)
     return if value.blank?
 
-    mismatch = mismatching(value, form.options.keys)
+    mismatch = mismatching(value, form.options)
 
     unless mismatch.empty?
-      form.errors[attribute] << (options[:message] || "Please select one of the options provided")
+      form.errors[attribute] << (options[:message] || I18n.t(".activemodel.errors.validators.valid_options.message"))
     end
   end
 

--- a/app/views/session_answers/coronavirus_find_support/_able_to_go_out.html.erb
+++ b/app/views/session_answers/coronavirus_find_support/_able_to_go_out.html.erb
@@ -1,3 +1,3 @@
 <% content_for :title do %>
-  Are you able to leave your home for food, medicine, or health reasons?
+  <%= t('.title') %>
 <% end %>

--- a/app/views/session_answers/coronavirus_find_support/_afford_food.html.erb
+++ b/app/views/session_answers/coronavirus_find_support/_afford_food.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title do %>
-  Are you finding it hard to afford food?
+  <%= t('.title') %>
 <% end %>
 
 <%= form_for_node do %>

--- a/app/views/session_answers/coronavirus_find_support/_afford_rent_mortgage_bills.html.erb
+++ b/app/views/session_answers/coronavirus_find_support/_afford_rent_mortgage_bills.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title do %>
-  Are you finding it hard to afford rent, your mortgage or bills?
+  <%= t('.title') %>
 <% end %>
 
 <%= form_for_node do %>

--- a/app/views/session_answers/coronavirus_find_support/_feel_safe.html.erb
+++ b/app/views/session_answers/coronavirus_find_support/_feel_safe.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title do %>
-  Do you feel safe where you live?
+  <%= t('.title') %>
 <% end %>
 
 <%= form_for_node do %>

--- a/app/views/session_answers/coronavirus_find_support/_get_food.html.erb
+++ b/app/views/session_answers/coronavirus_find_support/_get_food.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title do %>
-  Are you able to get food?
+  <%= t('.title') %>
 <% end %>
 
 <%= form_for_node do %>

--- a/app/views/session_answers/coronavirus_find_support/_need_help_with.html.erb
+++ b/app/views/session_answers/coronavirus_find_support/_need_help_with.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title do %>
-  What do you need help with because of coronavirus?
+  <%= t('.title') %>
 <% end %>
 
 <%= form_for_node do %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,6 +36,7 @@ module SmartAnswers
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     config.i18n.enforce_available_locales = false
     config.i18n.default_locale = :"en-GB"
+    config.i18n.load_path += Dir[Rails.root.join("config/locales/**/*.yml")]
 
     # Configure the default encoding used in templates for Ruby 1.9.
     config.encoding = "utf-8"

--- a/config/locales/activemodel.yml
+++ b/config/locales/activemodel.yml
@@ -1,0 +1,7 @@
+---
+en-GB:
+  activemodel:
+    errors:
+      validators:
+        valid_options:
+          message: Option does not match one of the definded options

--- a/config/locales/session_answers/coronavirus_find_support.yml
+++ b/config/locales/session_answers/coronavirus_find_support.yml
@@ -1,0 +1,17 @@
+---
+en-GB:
+  session_answers:
+    coronavirus_find_support:
+      need_help_with:
+        title: What do you need help with because of coronavirus?
+        options:
+          feeling_unsafe: Feeling unsafe where you live, or being worried about someone else
+          paying_bills: Paying bills
+          getting_food: Getting food
+          being_unemployed: Being unemployed or not having any work
+          going_to_work: Going in to work
+          somewhere_to_live: Having somewhere to live
+          mental_health: Mental health and wellbeing
+          not_sure: "I'm not sure"
+        errors:
+          blank: "Select what you need to find help with, or ‘Not sure’"

--- a/config/locales/session_answers/coronavirus_find_support.yml
+++ b/config/locales/session_answers/coronavirus_find_support.yml
@@ -9,33 +9,33 @@ en-GB:
         errors:
           blank: "Select yes if you’re finding it hard to afford food"
         options:
-          yes: Yes
-          no: No
+          "yes": "Yes"
+          "no": "No"
           not_sure: Not sure
       afford_rent_mortgage_bills:
         title: Are you finding it hard to afford rent, your mortgage or bills?
         errors:
           blank: "Select yes if you’re finding it hard to pay your rent, mortgage or bills"
         options:
-          yes: Yes
-          no: No
+          "yes": "Yes"
+          "no": "No"
           not_sure: Not sure
       feel_safe:
         title: Do you feel safe where you live?
         errors:
           blank: "Select if you feel safe where you live or if you’re worried about someone else"
         options:
-          yes: Yes
+          "yes": "Yes"
           yes_but_i_am_concerned_about_others: "Yes, but I’m worried about the safety of another adult or a child"
-          no: No
+          "no": "No"
           not_sure: Not sure
       get_food:
         title: Are you able to get food?
         errors:
           blank: "Select yes if you’re able to get food"
         options:
-          yes: Yes
-          no: No
+          "yes": "Yes"
+          "no": "No"
           not_sure: Not sure
       need_help_with:
         title: What do you need help with because of coronavirus?

--- a/config/locales/session_answers/coronavirus_find_support.yml
+++ b/config/locales/session_answers/coronavirus_find_support.yml
@@ -2,8 +2,46 @@
 en-GB:
   session_answers:
     coronavirus_find_support:
+      able_to_go_out:
+        title: Are you able to leave your home for food, medicine, or health reasons?
+      afford_food:
+        title: Are you finding it hard to afford food?
+        errors:
+          blank: "Select yes if you’re finding it hard to afford food"
+        options:
+          yes: Yes
+          no: No
+          not_sure: Not sure
+      afford_rent_mortgage_bills:
+        title: Are you finding it hard to afford rent, your mortgage or bills?
+        errors:
+          blank: "Select yes if you’re finding it hard to pay your rent, mortgage or bills"
+        options:
+          yes: Yes
+          no: No
+          not_sure: Not sure
+      feel_safe:
+        title: Do you feel safe where you live?
+        errors:
+          blank: "Select if you feel safe where you live or if you’re worried about someone else"
+        options:
+          yes: Yes
+          yes_but_i_am_concerned_about_others: "Yes, but I’m worried about the safety of another adult or a child"
+          no: No
+          not_sure: Not sure
+      get_food:
+        title: Are you able to get food?
+        errors:
+          blank: "Select yes if you’re able to get food"
+        options:
+          yes: Yes
+          no: No
+          not_sure: Not sure
       need_help_with:
         title: What do you need help with because of coronavirus?
+        errors:
+          blank: "Select what you need to find help with, or ‘Not sure’"
+          valid_options: Please select one of the options provided
         options:
           feeling_unsafe: Feeling unsafe where you live, or being worried about someone else
           paying_bills: Paying bills
@@ -13,5 +51,3 @@ en-GB:
           somewhere_to_live: Having somewhere to live
           mental_health: Mental health and wellbeing
           not_sure: "I'm not sure"
-        errors:
-          blank: "Select what you need to find help with, or ‘Not sure’"

--- a/test/unit/forms/coronavirus_find_support/need_help_with_form_test.rb
+++ b/test/unit/forms/coronavirus_find_support/need_help_with_form_test.rb
@@ -90,7 +90,7 @@ module CoronavirusFindSupport
 
       should "populate errors" do
         form.save
-        assert form.errors.present?
+        assert_equal "Please select one of the options provided", form.errors[:need_help_with].join
       end
     end
   end


### PR DESCRIPTION
_Note: merges into `session_answers`_

Use translation to define text used in forms and views

- Modify i18n load paths so each flow can have its own translation file
- Create coronavirus find support flow translation file
- Move form texts to translation file
- Move view text (title) to translation file
- Change form.options to an array
- Add translation (t) class and instance methods to forms
- Add default locale for ActiveModel errors - use for default validator error

[trello ticket](https://trello.com/c/5Sg8FoLR/434-session-controller-move-view-text-to-translation-files)