### PR TITLE
Refactor of FormFinder.call so a little easier to debug

### DIFF
--- a/app/forms/form_finder.rb
+++ b/app/forms/form_finder.rb
@@ -11,6 +11,7 @@ class FormFinder
   }.freeze
 
   def self.call(flow_name, node_name, params, session)
-    (FORMS.dig flow_name.to_sym, node_name.to_sym).new(params, session)
+    flow_class = FORMS.dig(flow_name.to_sym, node_name.to_sym)
+    flow_class.new(params, session)
   end
 end


### PR DESCRIPTION
_merges into `session_answers`_

Very small tweak. Splits FormFinder.call over two lines to make it easier to debug difference between class not being found, and it not initializing successfully.

[trello ticket](https://trello.com/c/ZhdviMRc/435-session-controller-refactor-formfinder-to-make-it-easier-to-debug)