### PR TITLE
Fix apostrophe’s from being wrongly displayed.

### DIFF
--- a/lib/smart_answer_flows/help-if-you-are-arrested-abroad/help_if_you_are_arrested_abroad.erb
+++ b/lib/smart_answer_flows/help-if-you-are-arrested-abroad/help_if_you_are_arrested_abroad.erb
@@ -1,5 +1,5 @@
 <% text_for :title do %>
-  Help if you're arrested abroad
+  Help if you’re arrested abroad
 <% end %>
 
 <% text_for :meta_description do %>

--- a/lib/smart_answer_flows/uk-benefits-abroad/uk_benefits_abroad.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/uk_benefits_abroad.erb
@@ -1,9 +1,9 @@
 <% text_for :title do %>
-  UK benefits if you're going or living abroad
+  UK benefits if you’re going or living abroad
 <% end %>
 
 <% text_for :meta_description do %>
-  Find out what benefits you might be able to receive while you're abroad and how to export them from the UK or claim them while abroad
+  Find out what benefits you might be able to receive while you’re abroad and how to export them from the UK or claim them while abroad
 <% end %>
 
 <% govspeak_for :body do %>


### PR DESCRIPTION
There were a few apostrophe’s that were wrongly input so they displayed as &#39; rather than ’. This Fixes them in titles and descriptions.