### PR TITLE
Fix apostrophes from being escaped in start pages

### DIFF
--- a/lib/smart_answer_flows/calculate-married-couples-allowance/calculate_married_couples_allowance.erb
+++ b/lib/smart_answer_flows/calculate-married-couples-allowance/calculate_married_couples_allowance.erb
@@ -1,5 +1,5 @@
 <% text_for :title do %>
-  Calculate your Married Couple's Allowance
+  Calculate your Married Couple’s Allowance
 
 <% end %>
 

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/calculate_statutory_sick_pay.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/calculate_statutory_sick_pay.erb
@@ -1,5 +1,5 @@
 <% text_for :title do %>
-  Calculate your employee's statutory sick pay
+  Calculate your employee’s statutory sick pay
 <% end %>
 
 <% text_for :meta_description do %>


### PR DESCRIPTION
There's currently a bug where standard apostrophes in the title on start pages are being escaped and displayed as &#39;. This is a quick fix to use typographic apostrophes that aren't escaped. Future work will aim to prevent character from being escaped.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.
