### PR TITLE
Fix escaped text being sent to Publishing API

### DIFF
--- a/lib/smart_answer/erb_renderer/format_capture_helper.rb
+++ b/lib/smart_answer/erb_renderer/format_capture_helper.rb
@@ -13,7 +13,7 @@ module SmartAnswer
       content = capture_content(&block)
       content = strip_leading_spaces(content)
       content = normalize_blank_lines(content)
-      content_for(name, content.strip)
+      content_for(name, content.strip.html_safe)
     end
 
     def govspeak_for(name, &block)

--- a/test/integration/engine/input_validation_test.rb
+++ b/test/integration/engine/input_validation_test.rb
@@ -47,7 +47,7 @@ class InputValidationTest < EngineIntegrationTest
 
       within "#current-question" do
         assert_page_has_content "What size bonus do you want?"
-        within(".govuk-error-message") { assert_page_has_content "You can&#39;t request a bonus less than your annual salary." }
+        within(".govuk-error-message") { assert_page_has_content "You can't request a bonus less than your annual salary." }
         assert page.has_field?("response", type: "text", with: "3000")
       end
 

--- a/test/unit/format_capture_helper_test.rb
+++ b/test/unit/format_capture_helper_test.rb
@@ -46,9 +46,9 @@ module SmartAnswer
         assert_match @test_obj.content_for(:name), "content"
       end
 
-      should "not be HTML safe" do
+      should "be HTML safe" do
         @test_obj.text_for(:name) { "Text" }
-        assert_not @test_obj.content_for(:name).html_safe?
+        assert @test_obj.content_for(:name).html_safe?
       end
     end
 

--- a/test/unit/graph_presenter_test.rb
+++ b/test/unit/graph_presenter_test.rb
@@ -20,7 +20,7 @@ module SmartAnswer
       expected_labels = {
         q1?: "MultipleChoice\n-\nWhat is the answer to q1?\n\n( ) yes\n( ) no",
         q2?: "MultipleChoice\n-\nWhat is the answer to q2?\n\n( ) a\n( ) b",
-        q_with_interpolation?: "MultipleChoice\n-\nQuestion with &lt;%= inter.pol.ation\n%&gt;?\n\n( ) x\n( ) y",
+        q_with_interpolation?: "MultipleChoice\n-\nQuestion with <%= inter.pol.ation %>?\n\n( ) x\n( ) y",
         done_a: "Outcome\n-\ndone_a",
         done_b: "Outcome\n-\ndone_b",
       }

--- a/test/unit/smart_answer_flows/calculate_statutory_sick_pay_view_test.rb
+++ b/test/unit/smart_answer_flows/calculate_statutory_sick_pay_view_test.rb
@@ -17,12 +17,12 @@ module SmartAnswer
 
       should "have a must_be_within_eight_weeks error message" do
         @state.error = "error_must_be_within_eight_weeks"
-        assert_equal "You need to enter a date within 8 weeks of the current period of sickness or it isn&#39;t a linked period of sickness.", @presenter.error
+        assert_equal "You need to enter a date within 8 weeks of the current period of sickness or it isn't a linked period of sickness.", @presenter.error
       end
 
       should "have a must_be_at_least_1_day_before_first_sick_day error message" do
         @state.error = "error_must_be_at_least_1_day_before_first_sick_day"
-        assert_equal "You need to enter a date at least 1 day before the start of the current period of sickness or it isn&#39;t a separate linked period of sickness.", @presenter.error
+        assert_equal "You need to enter a date at least 1 day before the start of the current period of sickness or it isn't a separate linked period of sickness.", @presenter.error
       end
 
       should "have a start_before_end error message" do


### PR DESCRIPTION
This marks content within a text_for block in a ERB smart answer template as HTML safe (e.g. title, meta description). This prevents characters being escaped, which can be sent to Publishing API and cause the escaped characters to be displayed. For example the use of apostrophes in a title on a start page. The content item contained a title with the escape sequence `&#39;` instead of a `'` and was shown to the users.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.
