### PR TITLE
Remove self assessment scheme from business support flow

### DIFF
--- a/lib/smart_answer/calculators/business_coronavirus_support_finder_calculator.rb
+++ b/lib/smart_answer/calculators/business_coronavirus_support_finder_calculator.rb
@@ -7,15 +7,11 @@ module SmartAnswer::Calculators
                   :self_employed,
                   :non_domestic_property,
                   :sectors,
-                  :rate_relief_march_2020,
-                  :self_assessment_july_2020
+                  :rate_relief_march_2020
 
     RULES = {
       job_retention_scheme: lambda { |calculator|
         calculator.paye_scheme == "yes"
-      },
-      self_assessment_payments: lambda { |calculator|
-        calculator.self_assessment_july_2020 == "yes"
       },
       statutory_sick_rebate: lambda { |calculator|
         calculator.business_size == "0_to_249" &&

--- a/lib/smart_answer_flows/business-coronavirus-support-finder.rb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder.rb
@@ -90,7 +90,7 @@ module SmartAnswer
           if calculator.non_domestic_property != "none"
             question :sectors?
           else
-            question :self_assessment_july_2020?
+            outcome :results
           end
         end
       end
@@ -115,19 +115,6 @@ module SmartAnswer
 
         on_response do |response|
           calculator.rate_relief_march_2020 = response
-        end
-
-        next_node do
-          question :self_assessment_july_2020?
-        end
-      end
-
-      multiple_choice :self_assessment_july_2020? do
-        option :yes
-        option :no
-
-        on_response do |response|
-          calculator.self_assessment_july_2020 = response
         end
 
         next_node do

--- a/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.erb
@@ -12,22 +12,6 @@
   [Check if you are eligible to defer your VAT payment](/guidance/deferral-of-vat-payments-due-to-coronavirus-covid-19)
   $CTA
 
-  <% if calculator.show?(:self_assessment_payments) %>
-    $CTA
-    ### Deferring Self Assessment payments on account
-
-    If you are due to pay a Self Assessment payment on account by 31 July 2020, you can defer payment up until January 2021. You will not be charged any interest or penalties during the deferral period.
-
-    You do not need to be self-employed to be eligible for the deferment.
-
-    The deferment is optional. If you are still able to pay your second payment on 31 July, you should do so.
-
-    This is an automatic offer. You do not need to apply for the deferral, or tell HMRC. If you normally pay by Direct Debit you should contact your bank to cancel your Direct Debit as soon as you can. You do not need to contact HMRC before doing this.
-
-    [Check if you are eligible to defer your Self Assessment payment on account](/guidance/defer-your-self-assessment-payment-on-account-due-to-coronavirus-covid-19)
-    $CTA
-  <% end %>
-
   <% if calculator.show?(:statutory_sick_rebate) %>
     $CTA
     ### Statutory Sick Pay rebate

--- a/test/integration/smart_answer_flows/business_coronavirus_support_finder_test.rb
+++ b/test/integration/smart_answer_flows/business_coronavirus_support_finder_test.rb
@@ -28,8 +28,6 @@ class BusinessCoronavirusSupportFinderFlowTest < ActiveSupport::TestCase
       add_response "retail_hospitality_or_leisure"
       assert_current_node :rate_relief_march_2020?
       add_response "yes"
-      assert_current_node :self_assessment_july_2020?
-      add_response "yes"
       assert_current_node :results
     end
   end
@@ -48,8 +46,6 @@ class BusinessCoronavirusSupportFinderFlowTest < ActiveSupport::TestCase
       add_response "no"
       assert_current_node :non_domestic_property?
       add_response "none"
-      assert_current_node :self_assessment_july_2020?
-      add_response "no"
       assert_current_node :results
     end
   end

--- a/test/unit/calculators/business_coronavirus_support_calculator_test.rb
+++ b/test/unit/calculators/business_coronavirus_support_calculator_test.rb
@@ -19,18 +19,6 @@ module SmartAnswer::Calculators
         end
       end
 
-      context "self_assessment_payments" do
-        should "return true when criteria met" do
-          @calculator.self_assessment_july_2020 = "yes"
-          assert @calculator.show?(:self_assessment_payments)
-        end
-
-        should "return false when criteria not met" do
-          @calculator.self_assessment_july_2020 = "no"
-          assert_not @calculator.show?(:self_assessment_payments)
-        end
-      end
-
       context "statutory_sick_rebate" do
         setup do
           @calculator.business_size = "0_to_249"


### PR DESCRIPTION
No longer needed as after 31 July 2020 when the scheme ended.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.
