### PR TITLE
Allow custom text for question captions

### DIFF
--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -60,7 +60,7 @@ class FlowPresenter
                       else
                         NodePresenter
                       end
-    @node_presenters[node.name] ||= presenter_class.new(node, current_state, {}, params)
+    @node_presenters[node.name] ||= presenter_class.new(node, self, current_state, {}, params)
   end
 
   def current_question_number

--- a/app/presenters/node_presenter.rb
+++ b/app/presenters/node_presenter.rb
@@ -1,8 +1,9 @@
 class NodePresenter
   delegate :outcome?, to: :@node
 
-  def initialize(node, state = nil, _options = {}, _params = {})
+  def initialize(node, flow_presenter, state = nil, _options = {}, _params = {})
     @node = node
+    @flow_presenter = flow_presenter
     @state = state || SmartAnswer::State.new(nil)
   end
 end

--- a/app/presenters/outcome_presenter.rb
+++ b/app/presenters/outcome_presenter.rb
@@ -1,6 +1,6 @@
 class OutcomePresenter < NodePresenter
-  def initialize(node, state = nil, options = {}, params = {})
-    super(node, state)
+  def initialize(node, flow_presenter, state = nil, options = {}, params = {})
+    super(node, flow_presenter, state)
     @params = params
     helpers = options[:helpers] || []
     @renderer = options[:renderer] || SmartAnswer::ErbRenderer.new(

--- a/app/presenters/question_presenter.rb
+++ b/app/presenters/question_presenter.rb
@@ -1,8 +1,8 @@
 class QuestionPresenter < NodePresenter
   attr_reader :params
 
-  def initialize(node, state = nil, options = {}, params = {})
-    super(node, state)
+  def initialize(node, flow_presenter, state = nil, options = {}, params = {})
+    super(node, flow_presenter, state)
     @params = params
     @renderer = options[:renderer]
     helpers = options[:helpers] || []
@@ -31,6 +31,12 @@ class QuestionPresenter < NodePresenter
 
   def hint
     @renderer.content_for(:hint)
+  end
+
+  def caption
+    return @renderer.content_for(:caption) if @renderer.content_for(:caption).present?
+
+    @flow_presenter.title
   end
 
   def label

--- a/app/views/smart_answers/inputs/_checkbox_question.html.erb
+++ b/app/views/smart_answers/inputs/_checkbox_question.html.erb
@@ -2,7 +2,7 @@
   name: "response[]",
   heading: question.title,
   heading_size: "l",
-  heading_caption: @presenter.title,
+  heading_caption: question.caption,
   is_page_heading: true,
   description: question.body,
   id: "response",

--- a/app/views/smart_answers/inputs/_country_select_question.html.erb
+++ b/app/views/smart_answers/inputs/_country_select_question.html.erb
@@ -1,4 +1,4 @@
-<span class="govuk-caption-l"><%= @presenter.title %></span>
+<span class="govuk-caption-l"><%= question.caption %></span>
 <%= render "govuk_publishing_components/components/select", {
   id: "response",
   label: question.title,

--- a/app/views/smart_answers/inputs/_date_question.html.erb
+++ b/app/views/smart_answers/inputs/_date_question.html.erb
@@ -32,7 +32,7 @@
   } %>
 <% end %>
 
-<span class="govuk-caption-l"><%= @presenter.title %></span>
+<span class="govuk-caption-l"><%= question.caption %></span>
 <%= render "govuk_publishing_components/components/fieldset", {
   legend_text: question.title,
   heading_level: 1,

--- a/app/views/smart_answers/inputs/_money_question.html.erb
+++ b/app/views/smart_answers/inputs/_money_question.html.erb
@@ -1,4 +1,4 @@
-<span class="govuk-caption-l"><%= @presenter.title %></span>
+<span class="govuk-caption-l"><%= question.caption %></span>
 <%= render "govuk_publishing_components/components/input", {
   label: {
     text: question.title,

--- a/app/views/smart_answers/inputs/_multiple_choice_question.html.erb
+++ b/app/views/smart_answers/inputs/_multiple_choice_question.html.erb
@@ -2,7 +2,7 @@
   name: "response",
   heading: question.title,
   heading_size: "l",
-  heading_caption: @presenter.title,
+  heading_caption: question.caption,
   is_page_heading: true,
   hint: question.hint,
   id_prefix: "response",

--- a/app/views/smart_answers/inputs/_postcode_question.html.erb
+++ b/app/views/smart_answers/inputs/_postcode_question.html.erb
@@ -1,4 +1,4 @@
-<span class="govuk-caption-l"><%= @presenter.title %></span>
+<span class="govuk-caption-l"><%= question.caption %></span>
 <%= render "govuk_publishing_components/components/input", {
   label: {
     text: question.title,

--- a/app/views/smart_answers/inputs/_salary_question.html.erb
+++ b/app/views/smart_answers/inputs/_salary_question.html.erb
@@ -1,4 +1,4 @@
-<span class="govuk-caption-l"><%= @presenter.title %></span>
+<span class="govuk-caption-l"><%= question.caption %></span>
 <%= render "govuk_publishing_components/components/input", {
   label: {
     text: question.title,

--- a/app/views/smart_answers/inputs/_value_question.html.erb
+++ b/app/views/smart_answers/inputs/_value_question.html.erb
@@ -1,4 +1,4 @@
-<span class="govuk-caption-l"><%= @presenter.title %></span>
+<span class="govuk-caption-l"><%= question.caption %></span>
 <%= render "govuk_publishing_components/components/input", {
   label: {
     text: question.title,

--- a/doc/smart-answers/erb-templates/question-templates.md
+++ b/doc/smart-answers/erb-templates/question-templates.md
@@ -26,6 +26,18 @@ Used as a "hint" paragraph and can only be text. Example:
 <% end %>
 ```
 
+### `:caption`
+
+Used as a "caption" paragraph and can only be text. Example:
+
+```erb
+<% text_for :caption do %>
+  This is a caption
+<% end %>
+```
+
+If `:caption` is not supplied the `:title` (i.e. the flow name) from the `start_node` is used.
+
 ### `:label`
 
 Used as a label (preceding the input control) for value questions. Can only be text. Example:

--- a/lib/graph_presenter.rb
+++ b/lib/graph_presenter.rb
@@ -85,7 +85,7 @@ private
   end
 
   def node_title(node)
-    presenter = QuestionPresenter.new(node, {}, helpers: [MethodMissingHelper])
+    presenter = QuestionPresenter.new(node, nil, {}, helpers: [MethodMissingHelper])
     presenter.title
   end
 

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/how_much_money.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/how_much_money.erb
@@ -2,6 +2,10 @@
   Money question: How much does the world cost?
 <% end %>
 
+<% text_for :caption do %>
+  This is a caption
+<% end %>
+
 <% govspeak_for :body do %>
   Body can contain further explanations.
 <% end %>

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/how_much_salary.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/how_much_salary.erb
@@ -2,6 +2,10 @@
   Salary question: What would you like your salary to be?
 <% end %>
 
+<% text_for :caption do %>
+  This is a caption
+<% end %>
+
 <% govspeak_for :body do %>
   Body can contain further explanations.
 

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_boolean_choice.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_boolean_choice.erb
@@ -2,6 +2,10 @@
   Multiple choice (yes/no): Would you like to see the other questions?
 <% end %>
 
+<% text_for :caption do %>
+  This is a caption
+<% end %>
+
 <% govspeak_for :body do %>
   Body can contain further explanations.
 

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_checkboxes.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_checkboxes.erb
@@ -2,6 +2,10 @@
   Checkbox question: What are other names for Gandalf?
 <% end %>
 
+<% text_for :caption do %>
+  This is a caption
+<% end %>
+
 <% govspeak_for :body do %>
   Body can contain further explanations.
 

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_choice.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_choice.erb
@@ -2,6 +2,10 @@
   Multiple choice: Which of these numbers is not a prime number?
 <% end %>
 
+<% text_for :caption do %>
+  This is a caption
+<% end %>
+
 <% govspeak_for :body do %>
   Body can contain further explanations.
 

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_country.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_country.erb
@@ -2,6 +2,10 @@
   Country select: Where are you now?
 <% end %>
 
+<% text_for :caption do %>
+  This is a caption
+<% end %>
+
 <% govspeak_for :body do %>
   Body can contain further explanations.
 

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_date.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_date.erb
@@ -2,6 +2,10 @@
   Date question: What date is tomorrow?
 <% end %>
 
+<% text_for :caption do %>
+  This is a caption
+<% end %>
+
 <% govspeak_for :body do %>
   Body can contain further explanations.
 

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_date_of_birth.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_date_of_birth.erb
@@ -2,6 +2,10 @@
   Date question: What is your date of birth?
 <% end %>
 
+<% text_for :caption do %>
+  This is a caption
+<% end %>
+
 <% govspeak_for :body do %>
   Body can contain further explanations.
 

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_float.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_float.erb
@@ -2,6 +2,10 @@
   Value/float question: What is 1/2?
 <% end %>
 
+<% text_for :caption do %>
+  This is a caption
+<% end %>
+
 <% govspeak_for :body do %>
   Body can contain further explanations.
 <% end %>

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_integer.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_integer.erb
@@ -2,6 +2,10 @@
   Value/integer question: How many software engineers does it take to change a light bulb?
 <% end %>
 
+<% text_for :caption do %>
+  This is a caption
+<% end %>
+
 <% govspeak_for :body do %>
   Body can contain further explanations.
 <% end %>

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_postcode.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_postcode.erb
@@ -2,6 +2,10 @@
   Postcode question: Where is Aviation House?
 <% end %>
 
+<% text_for :caption do %>
+  This is a caption
+<% end %>
+
 <% govspeak_for :body do %>
   Body can contain further explanations.
 <% end %>

--- a/lib/smart_answer_flows/all-smart-answer-questions/questions/which_value.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/questions/which_value.erb
@@ -2,6 +2,10 @@
   Value question: "Hello ..."?
 <% end %>
 
+<% text_for :caption do %>
+  This is a caption
+<% end %>
+
 <% govspeak_for :body do %>
   Body can contain further explanations.
 <% end %>

--- a/test/integration/smart_answer_flows/flow_test_helper.rb
+++ b/test/integration/smart_answer_flows/flow_test_helper.rb
@@ -25,14 +25,14 @@ module FlowTestHelper
 
   def current_question
     @current_question ||= begin
-      presenter = QuestionPresenter.new(@flow.node(current_state.current_node), current_state)
+      presenter = QuestionPresenter.new(@flow.node(current_state.current_node), nil, current_state)
       presenter.title
     end
   end
 
   def outcome_body
     @outcome_body ||= begin
-      presenter = OutcomePresenter.new(@flow.node(current_state.current_node), current_state)
+      presenter = OutcomePresenter.new(@flow.node(current_state.current_node), nil, current_state)
       Nokogiri::HTML::DocumentFragment.parse(presenter.body)
     end
   end

--- a/test/unit/checkbox_question_presenter_test.rb
+++ b/test/unit/checkbox_question_presenter_test.rb
@@ -14,7 +14,7 @@ module SmartAnswer
       @renderer.stubs(:option).with(:option2).returns({ label: "Option 2", hint_text: "Hint 2" })
       @renderer.stubs(:option).with(:option3).returns({ label: "Option 3" })
 
-      @presenter = CheckboxQuestionPresenter.new(@question, nil, renderer: @renderer)
+      @presenter = CheckboxQuestionPresenter.new(@question, nil, nil, renderer: @renderer)
     end
 
     test "#response_labels returns option labels for responses" do
@@ -30,6 +30,12 @@ module SmartAnswer
       assert_equal(["Option 1", "Option 2", "Option 3"], @presenter.checkboxes.map { |c| c[:label] })
       assert_equal([nil, "Hint 2", nil], @presenter.checkboxes.map { |c| c[:hint] })
       assert_equal([nil, nil, nil], @presenter.checkboxes.map { |c| c[:checked] })
+    end
+
+    test "#caption returns the given caption when a caption is given" do
+      @renderer.stubs(:content_for).with(:caption).returns("caption-text")
+
+      assert_equal "caption-text", @presenter.caption
     end
   end
 end

--- a/test/unit/money_question_presenter_test.rb
+++ b/test/unit/money_question_presenter_test.rb
@@ -5,7 +5,7 @@ module SmartAnswer
     setup do
       @question = Question::Base.new(nil, :question_name?)
       @renderer = stub("renderer")
-      @presenter = MoneyQuestionPresenter.new(@question, nil, renderer: @renderer)
+      @presenter = MoneyQuestionPresenter.new(@question, nil, nil, renderer: @renderer)
     end
 
     test "#hint_text returns single line of content rendered for hint block" do
@@ -22,6 +22,12 @@ module SmartAnswer
       @renderer.stubs(:content_for).with(:suffix_label).returns("suffix")
 
       assert_equal "body, hint-text, suffix", @presenter.hint_text
+    end
+
+    test "#caption returns the given caption when a caption is given" do
+      @renderer.stubs(:content_for).with(:caption).returns("caption-text")
+
+      assert_equal "caption-text", @presenter.caption
     end
   end
 end

--- a/test/unit/multiple_choice_question_presenter_test.rb
+++ b/test/unit/multiple_choice_question_presenter_test.rb
@@ -14,7 +14,7 @@ module SmartAnswer
       @renderer.stubs(:option).with(:option2).returns("Option 2")
       @renderer.stubs(:option).with(:option3).returns("Option 3")
 
-      @presenter = MultipleChoiceQuestionPresenter.new(@question, nil, renderer: @renderer)
+      @presenter = MultipleChoiceQuestionPresenter.new(@question, nil, nil, renderer: @renderer)
     end
 
     test "#response_label returns option label" do
@@ -25,6 +25,12 @@ module SmartAnswer
       assert_equal(%w[option1 option2 option3], @presenter.radio_buttons.map { |c| c[:value] })
       assert_equal(["Option 1", "Option 2", "Option 3"], @presenter.radio_buttons.map { |c| c[:text] })
       assert_equal([nil, nil, nil], @presenter.radio_buttons.map { |c| c[:checked] })
+    end
+
+    test "#caption returns the given caption when a caption is given" do
+      @renderer.stubs(:content_for).with(:caption).returns("caption-text")
+
+      assert_equal "caption-text", @presenter.caption
     end
   end
 end

--- a/test/unit/outcome_presenter_test.rb
+++ b/test/unit/outcome_presenter_test.rb
@@ -5,7 +5,7 @@ module SmartAnswer
     setup do
       outcome = Outcome.new(nil, :outcome_name)
       @renderer = stub("renderer")
-      @presenter = OutcomePresenter.new(outcome, nil, renderer: @renderer)
+      @presenter = OutcomePresenter.new(outcome, nil, nil, renderer: @renderer)
     end
 
     test "renderer is constructed using template name and directory obtained from outcome node" do
@@ -19,7 +19,7 @@ module SmartAnswer
         ),
       )
 
-      OutcomePresenter.new(outcome)
+      OutcomePresenter.new(outcome, nil)
     end
 
     test "renderer is constructed with default helper modules" do
@@ -32,7 +32,7 @@ module SmartAnswer
         SmartAnswer::MarriageAbroadHelper,
       ]))
 
-      OutcomePresenter.new(outcome)
+      OutcomePresenter.new(outcome, nil)
     end
 
     test "renderer is constructed with supplied helper modules" do
@@ -42,7 +42,7 @@ module SmartAnswer
 
       SmartAnswer::ErbRenderer.expects(:new).with(has_entry(helpers: includes(helper)))
 
-      OutcomePresenter.new(outcome, nil, helpers: [helper])
+      OutcomePresenter.new(outcome, nil, nil, helpers: [helper])
     end
 
     test "#title returns single line of content rendered for title block" do

--- a/test/unit/question_presenter_test.rb
+++ b/test/unit/question_presenter_test.rb
@@ -5,7 +5,7 @@ module SmartAnswer
     setup do
       @question = Question::Base.new(nil, :question_name?)
       @renderer = stub("renderer")
-      @presenter = QuestionPresenter.new(@question, nil, renderer: @renderer)
+      @presenter = QuestionPresenter.new(@question, nil, nil, renderer: @renderer)
     end
 
     test "renderer is constructed using template name and directory obtained from question node" do
@@ -19,7 +19,7 @@ module SmartAnswer
         ),
       )
 
-      QuestionPresenter.new(question)
+      QuestionPresenter.new(question, nil)
     end
 
     test "#title returns single line of content rendered for title block" do
@@ -58,16 +58,22 @@ module SmartAnswer
       assert_equal "post-body-html", @presenter.post_body
     end
 
+    test "#caption returns single line of content rendered for caption block" do
+      @renderer.stubs(:content_for).with(:caption).returns("caption-text")
+
+      assert_equal "caption-text", @presenter.caption
+    end
+
     test "#error returns nil if there is no error" do
       state = stub("state", error: nil)
-      presenter = QuestionPresenter.new(@question, state, renderer: @renderer)
+      presenter = QuestionPresenter.new(@question, nil, state, renderer: @renderer)
 
       assert_nil presenter.error
     end
 
     test "#error returns error message for specific key if it exists" do
       state = stub("state", error: "error_key")
-      presenter = QuestionPresenter.new(@question, state, renderer: @renderer)
+      presenter = QuestionPresenter.new(@question, nil, state, renderer: @renderer)
       presenter.stubs(:error_message_for).with("error_key").returns("error-message-text")
 
       assert_equal "error-message-text", presenter.error
@@ -75,7 +81,7 @@ module SmartAnswer
 
     test "#error returns error message for fallback key if specific key does not exist" do
       state = stub("state", error: "error_key")
-      presenter = QuestionPresenter.new(@question, state, renderer: @renderer)
+      presenter = QuestionPresenter.new(@question, nil, state, renderer: @renderer)
       presenter.stubs(:error_message_for).with("error_key").returns(nil)
       presenter.stubs(:error_message_for).with("error_message").returns("fallback-error-message-text")
 
@@ -84,7 +90,7 @@ module SmartAnswer
 
     test "#error returns default error message for fallback key does not exist" do
       state = stub("state", error: "error_key")
-      presenter = QuestionPresenter.new(@question, state, renderer: @renderer)
+      presenter = QuestionPresenter.new(@question, nil, state, renderer: @renderer)
       presenter.stubs(:error_message_for).with("error_key").returns(nil)
       presenter.stubs(:error_message_for).with("error_message").returns(nil)
 
@@ -107,6 +113,19 @@ module SmartAnswer
       @renderer.stubs(:relative_erb_template_path).returns("relative-erb-template-path")
 
       assert_equal "relative-erb-template-path", @presenter.relative_erb_template_path
+    end
+
+    test "#caption returns the given caption when a caption is given" do
+      @renderer.stubs(:content_for).with(:caption).returns("caption-text")
+
+      assert_equal "caption-text", @presenter.caption
+    end
+
+    test "#caption returns the caption when both a title and a caption are given" do
+      @renderer.stubs(:content_for).with(:title).returns("title-text")
+      @renderer.stubs(:content_for).with(:caption).returns("caption-text")
+
+      assert_equal "caption-text", @presenter.caption
     end
   end
 end

--- a/test/unit/question_with_options_presenter_test.rb
+++ b/test/unit/question_with_options_presenter_test.rb
@@ -11,7 +11,7 @@ module SmartAnswer
 
       renderer.stubs(:option).with(:option_one).returns("option-one-text")
       renderer.stubs(:option).with(:option_two).returns({ label: "option-two-text", hint_text: "option-two-hint" })
-      @presenter = QuestionWithOptionsPresenter.new(question, nil, renderer: renderer)
+      @presenter = QuestionWithOptionsPresenter.new(question, nil, nil, renderer: renderer)
     end
 
     test "#all_options returns options with labels and values" do

--- a/test/unit/smart_answer_flows/calculate_statutory_sick_pay_view_test.rb
+++ b/test/unit/smart_answer_flows/calculate_statutory_sick_pay_view_test.rb
@@ -12,7 +12,7 @@ module SmartAnswer
       setup do
         question = @flow.node(:linked_sickness_end_date?)
         @state = SmartAnswer::State.new(question)
-        @presenter = QuestionPresenter.new(question, @state)
+        @presenter = QuestionPresenter.new(question, nil, @state)
       end
 
       should "have a must_be_within_eight_weeks error message" do

--- a/test/unit/smart_answer_flows/part_year_profit_tax_credits_view_test.rb
+++ b/test/unit/smart_answer_flows/part_year_profit_tax_credits_view_test.rb
@@ -12,7 +12,7 @@ module SmartAnswer
       setup do
         question = @flow.node(:when_did_your_tax_credits_award_end?)
         @state = SmartAnswer::State.new(question)
-        @presenter = QuestionPresenter.new(question, @state)
+        @presenter = QuestionPresenter.new(question, nil, @state)
       end
 
       should "have a default error message" do
@@ -25,7 +25,7 @@ module SmartAnswer
       setup do
         question = @flow.node(:what_date_do_your_accounts_go_up_to?)
         @state = SmartAnswer::State.new(question)
-        @presenter = QuestionPresenter.new(question, @state)
+        @presenter = QuestionPresenter.new(question, nil, @state)
       end
 
       should "have a default error message" do
@@ -38,7 +38,7 @@ module SmartAnswer
       setup do
         question = @flow.node(:have_you_stopped_trading?)
         @state = SmartAnswer::State.new(question)
-        @presenter = MultipleChoiceQuestionPresenter.new(question, @state)
+        @presenter = MultipleChoiceQuestionPresenter.new(question, nil, @state)
       end
 
       should "have options with labels" do
@@ -56,7 +56,7 @@ module SmartAnswer
         question = @flow.node(:do_your_accounts_cover_a_12_month_period?)
         @state = SmartAnswer::State.new(question)
         @state.accounting_year_ends_on = Date.parse("2016-04-05")
-        @presenter = MultipleChoiceQuestionPresenter.new(question, @state)
+        @presenter = MultipleChoiceQuestionPresenter.new(question, nil, @state)
       end
 
       should "display title with interpolated basis_period_ends_on" do
@@ -80,7 +80,7 @@ module SmartAnswer
         @state = SmartAnswer::State.new(question)
         @state.basis_period_begins_on = Date.parse("2015-04-06")
         @state.basis_period_ends_on = Date.parse("2016-04-05")
-        @presenter = QuestionPresenter.new(question, @state)
+        @presenter = QuestionPresenter.new(question, nil, @state)
       end
 
       should "display title with interpolated basis_period_begins_on and basis_period_ends_on" do
@@ -99,7 +99,7 @@ module SmartAnswer
         question = @flow.node(:did_you_start_trading_before_the_relevant_accounting_year?)
         @state = SmartAnswer::State.new(question)
         @state.accounting_year_begins_on = Date.parse("2015-04-06")
-        @presenter = MultipleChoiceQuestionPresenter.new(question, @state)
+        @presenter = MultipleChoiceQuestionPresenter.new(question, nil, @state)
       end
 
       should "have options with labels" do
@@ -123,7 +123,7 @@ module SmartAnswer
         @state = SmartAnswer::State.new(question)
         @state.tax_year_begins_on = Date.parse("2015-04-06")
         @state.tax_year_ends_on = Date.parse("2016-04-05")
-        @presenter = QuestionPresenter.new(question, @state)
+        @presenter = QuestionPresenter.new(question, nil, @state)
       end
 
       should "display hint with interpolated tax_year_begins_on and tax_year_ends_on" do
@@ -148,7 +148,7 @@ module SmartAnswer
         question = @flow.node(:when_did_you_start_trading?)
         @state = SmartAnswer::State.new(question)
         @state.award_period_ends_on = Date.parse("2015-08-01")
-        @presenter = QuestionPresenter.new(question, @state)
+        @presenter = QuestionPresenter.new(question, nil, @state)
       end
 
       should "display hint with interpolated award_period_ends_on" do
@@ -180,7 +180,7 @@ module SmartAnswer
 
       context "common output" do
         setup do
-          presenter = OutcomePresenter.new(@outcome, @state)
+          presenter = OutcomePresenter.new(@outcome, nil, @state)
           @body = presenter.body
         end
 
@@ -200,7 +200,7 @@ module SmartAnswer
       context "and the stopped_trading_on date is not set" do
         setup do
           @calculator.stubs(stopped_trading_on: nil)
-          presenter = OutcomePresenter.new(@outcome, @state)
+          presenter = OutcomePresenter.new(@outcome, nil, @state)
           @body = presenter.body
         end
 
@@ -212,7 +212,7 @@ module SmartAnswer
       context "and the stopped_trading_on date is set" do
         setup do
           @calculator.stubs(stopped_trading_on: Date.parse("2016-04-05"))
-          presenter = OutcomePresenter.new(@outcome, @state)
+          presenter = OutcomePresenter.new(@outcome, nil, @state)
           @body = presenter.body
         end
 

--- a/test/unit/value_question_presenter_test.rb
+++ b/test/unit/value_question_presenter_test.rb
@@ -5,7 +5,7 @@ module SmartAnswer
     setup do
       @question = Question::Base.new(nil, :question_name?)
       @renderer = stub("renderer")
-      @presenter = ValueQuestionPresenter.new(@question, nil, renderer: @renderer)
+      @presenter = ValueQuestionPresenter.new(@question, nil, nil, renderer: @renderer)
     end
 
     test "#hint_text returns single line of content rendered for hint block" do
@@ -22,6 +22,12 @@ module SmartAnswer
       @renderer.stubs(:content_for).with(:suffix_label).returns("suffix")
 
       assert_equal "body, hint-text, suffix", @presenter.hint_text
+    end
+
+    test "#caption returns the given caption when a caption is given" do
+      @renderer.stubs(:content_for).with(:caption).returns("caption-text")
+
+      assert_equal "caption-text", @presenter.caption
     end
   end
 end


### PR DESCRIPTION
- Add support for custom `caption` text on questions
- Default `caption` text to existing `start_node` `title` text if no `caption` is supplied
- Add tests
- Add documentation
- Update AllSmartAnswers flow to show `caption`s

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.

[Trello](https://trello.com/c/90fLabok/452-allow-custom-text-for-question-captions)