### PR TITLE
Add captions to the find support flow

### DIFF
--- a/lib/smart_answer_flows/coronavirus-find-support/questions/afford_food.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/questions/afford_food.erb
@@ -1,4 +1,4 @@
-<% text_for :hint do %>
+<% text_for :caption do %>
   Getting food
 <% end %>
 

--- a/lib/smart_answer_flows/coronavirus-find-support/questions/afford_rent_mortgage_bills.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/questions/afford_rent_mortgage_bills.erb
@@ -1,4 +1,4 @@
-<% text_for :hint do %>
+<% text_for :caption do %>
   Paying bills
 <% end %>
 

--- a/lib/smart_answer_flows/coronavirus-find-support/questions/are_you_off_work_ill.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/questions/are_you_off_work_ill.erb
@@ -1,4 +1,4 @@
-<% text_for :hint do %>
+<% text_for :caption do %>
   Being made redundant or unemployed, or not having any work
 <% end %>
 

--- a/lib/smart_answer_flows/coronavirus-find-support/questions/feel_safe.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/questions/feel_safe.erb
@@ -1,4 +1,4 @@
-<% text_for :hint do %>
+<% text_for :caption do %>
   Feeling unsafe
 <% end %>
 

--- a/lib/smart_answer_flows/coronavirus-find-support/questions/get_food.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/questions/get_food.erb
@@ -1,4 +1,4 @@
-<% text_for :hint do %>
+<% text_for :caption do %>
   Getting food
 <% end %>
 

--- a/lib/smart_answer_flows/coronavirus-find-support/questions/going_in_to_work.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/questions/going_in_to_work.erb
@@ -1,4 +1,4 @@
-<% text_for :hint do %>
+<% text_for :caption do %>
   Going in to work
 <% end %>
 

--- a/lib/smart_answer_flows/coronavirus-find-support/questions/have_somewhere_to_live.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/questions/have_somewhere_to_live.erb
@@ -1,4 +1,4 @@
-<% text_for :hint do %>
+<% text_for :caption do %>
   Having somewhere to live
 <% end %>
 

--- a/lib/smart_answer_flows/coronavirus-find-support/questions/have_you_been_evicted.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/questions/have_you_been_evicted.erb
@@ -1,4 +1,4 @@
-<% text_for :hint do %>
+<% text_for :caption do %>
   Having somewhere to live
 <% end %>
 

--- a/lib/smart_answer_flows/coronavirus-find-support/questions/have_you_been_made_unemployed.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/questions/have_you_been_made_unemployed.erb
@@ -1,4 +1,4 @@
-<% text_for :hint do %>
+<% text_for :caption do %>
   Being made redundant or unemployed, or not having any work
 <% end %>
 

--- a/lib/smart_answer_flows/coronavirus-find-support/questions/mental_health_worries.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/questions/mental_health_worries.erb
@@ -1,4 +1,4 @@
-<% text_for :hint do %>
+<% text_for :caption do %>
   Mental health and wellbeing
 <% end %>
 

--- a/lib/smart_answer_flows/coronavirus-find-support/questions/self_employed.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/questions/self_employed.erb
@@ -1,4 +1,4 @@
-<% text_for :hint do %>
+<% text_for :caption do %>
   Being made redundant or unemployed, or not having any work
 <% end %>
 

--- a/lib/smart_answer_flows/coronavirus-find-support/questions/worried_about_work.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/questions/worried_about_work.erb
@@ -1,4 +1,4 @@
-<% text_for :hint do %>
+<% text_for :caption do %>
   Going in to work
 <% end %>
 


### PR DESCRIPTION
Add question group names where appropriate - as `caption` blocks - to the find support smart answer flow.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.

[Trello](https://trello.com/c/LBnGF4hq/453-add-sections-to-question-caption-for-coronavirus-find-support)
