### PR TITLE
Add FCDO to sponsoring organisation check

### DIFF
--- a/app/models/worldwide_organisation.rb
+++ b/app/models/worldwide_organisation.rb
@@ -23,7 +23,7 @@ class WorldwideOrganisation
   end
 
   def fco_sponsored?
-    @sponsors.any? { |sponsor| sponsor["details"]["acronym"] == "FCO" }
+    @sponsors.any? { |sponsor| sponsor["details"]["acronym"].in?(%w[FCO FCDO]) }
   end
 
   def offices_with_service(service_title)

--- a/test/unit/worldwide_organisation_test.rb
+++ b/test/unit/worldwide_organisation_test.rb
@@ -19,16 +19,18 @@ class WorldwideOrganisationTest < ActiveSupport::TestCase
   end
 
   context "fco_sponsored?" do
-    should "return true for an organisation sponsored by the FCO" do
-      organisation_data = { sponsors: [
-        { details: { acronym: "FCO" } },
-      ] }
-      worldwide_organisation = WorldwideOrganisation.new(organisation_data)
+    should "return true for an organisation sponsored by the FCO or the FCDO" do
+      orgs = %w[FCO FCDO]
 
-      assert_equal true, worldwide_organisation.fco_sponsored?
+      orgs.each do |org|
+        organisation_data = { sponsors: [{ details: { acronym: org } }] }
+        worldwide_organisation = WorldwideOrganisation.new(organisation_data)
+
+        assert_equal true, worldwide_organisation.fco_sponsored?
+      end
     end
 
-    should "return false for an organisation not sponsored by the FCO" do
+    should "return false for an organisation not sponsored by the FCO nor by the FCDO" do
       organisation_data = { sponsors: [] }
       worldwide_organisation = WorldwideOrganisation.new(organisation_data)
 


### PR DESCRIPTION
This is part of the work around the Machinery of Government changes that will see FCO and DFID merge to become a new department.

After noticing that [a run in integration](https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/172527/console) of the rake task introduced in https://github.com/alphagov/whitehall/pull/5777 had a breaking effect on some smart answers, we decided to check for both FCO and FCDO in the `WorldwideOrganisation#fco_sponsored?` method.

After all content has been switched to the new FCDO organisation there will be some cleanup work to do (e.g. remove FCO, rename methods, etc), but for the moment this allows us to go ahead with the sponsoring organisations work.

Trello card: https://trello.com/c/yBvz6SbU/2095-spike-updating-worldwide-organisation-sponsoring-organisations-automatically-to-a-new-org-replace-fco-with-fcdo

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.
