### PR TITLE
Add copy to no_visa_needed outcome based on EEA countries

### DIFF
--- a/lib/smart_answer/calculators/uk_visa_calculator.rb
+++ b/lib/smart_answer/calculators/uk_visa_calculator.rb
@@ -73,6 +73,10 @@ module SmartAnswer::Calculators
       @passport_country == "hong-kong"
     end
 
+    def passport_country_is_ireland?
+      @passport_country == "ireland"
+    end
+
     def passport_country_is_latvia?
       @passport_country == "latvia" || @passport_country == "latvia-alien-passport"
     end

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_no_visa_needed.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_no_visa_needed.erb
@@ -4,6 +4,18 @@
 
 <% govspeak_for :body do %>
 
+  <% if calculator.passport_country_in_eea?%>
+    <% if calculator.passport_country_is_ireland? %>
+      This will not change when [new immigration rules](/guidance/new-immigration-system-what-you-need-to-know) come in on 1 January 2021.
+    <% else %>
+      You may need a visa if you're coming to the UK on or after 1 January 2021 to work, live or study. [Find how UK immigration is changing for EU nationals](/guidance/new-immigration-system-what-you-need-to-know).
+
+      From 1 January 2021, you can still visit the UK for up to 6 months without applying for a visa
+
+      If you come to the UK by 31 December 2020, you can [apply to the EU Settlement Scheme by 30 June 2021](/settled-status-eu-citizens-families) to continue to work, live or study in the UK.
+    <% end %>
+  <% end %>
+
   <% if calculator.study_visit? %>
     <% if calculator.passport_country_in_epassport_gate_list? %>
       You must go to a border control officer when you arrive in the UK to get a stamp in your passport. This will allow you to study in the UK.

--- a/test/unit/calculators/uk_visa_calculator_test.rb
+++ b/test/unit/calculators/uk_visa_calculator_test.rb
@@ -377,6 +377,20 @@ module SmartAnswer
         end
       end
 
+      context "#passport_country_is_ireland?" do
+        should 'return true if passport_country is "ireland"' do
+          calculator = UkVisaCalculator.new
+          calculator.passport_country = "ireland"
+          assert calculator.passport_country_is_ireland?
+        end
+
+        should 'return false if passport_country is not "ireland"' do
+          calculator = UkVisaCalculator.new
+          calculator.passport_country = "not-ireland"
+          assert_not calculator.passport_country_is_ireland?
+        end
+      end
+
       context "#passport_country_is_latvia?" do
         should "return true if passport_country is Latvia" do
           calculator = UkVisaCalculator.new


### PR DESCRIPTION
Visitors from EEA countries to the UK may need a visa from January 1 2021. This PR updates the copy on the outcome to alert users of the coming changes.

Ireland is an exception, so an alternative message is displayed.

[trello](https://trello.com/c/bk7V0VKe/2100-3-check-if-you-need-a-visa-smart-answer-change)