### PR TITLE
Coronavirus Find Support Results Page Style Changes

### DIFF
--- a/lib/smart_answer_flows/coronavirus-find-support/outcomes/_being_unemployed.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/outcomes/_being_unemployed.erb
@@ -126,3 +126,4 @@
   [Get advice on benefits (Advice NI)](https://www.adviceni.net/)
 <% end %>
 
+---

--- a/lib/smart_answer_flows/coronavirus-find-support/outcomes/_feeling_unsafe.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/outcomes/_feeling_unsafe.erb
@@ -59,3 +59,5 @@ Find additional helplines [if you’re a victim of domestic abuse or feel at ris
 <% if calculator.needs_help_in?("wales") %>
   [Get advice for children (Children’s Commissioner for Wales)](https://www.childcomwales.org.uk/coronavirus/)
 <% end %>
+
+---

--- a/lib/smart_answer_flows/coronavirus-find-support/outcomes/_getting_food.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/outcomes/_getting_food.erb
@@ -65,3 +65,5 @@ You might be able to phone or email your local shops to get a food delivery, or 
 <% if calculator.needs_help_in?("wales") %>
   [Get more information on accessing food and other essential supplies](https://gov.wales/getting-food-and-essential-supplies-during-coronavirus-pandemic)
 <% end %>
+
+---

--- a/lib/smart_answer_flows/coronavirus-find-support/outcomes/_going_to_work.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/outcomes/_going_to_work.erb
@@ -29,3 +29,5 @@
 <% if calculator.needs_help_in?("wales") %>
   [What to do if you’ve been told to go back in to work and you’re worried (Citizens Advice)](https://www.citizensadvice.org.uk/wales/work/coronavirus-if-youre-worried-about-working/)
 <% end %>
+
+---

--- a/lib/smart_answer_flows/coronavirus-find-support/outcomes/_mental_health.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/outcomes/_mental_health.erb
@@ -29,3 +29,5 @@
 <% if calculator.needs_help_in?("wales") %>
   [Additional information about taking care of your mental health (Public Health Wales)](https://phw.nhs.wales/topics/latest-information-on-novel-coronavirus-covid-19/staying-well-at-home/how-are-you-feeling/)
 <% end %>
+
+---

--- a/lib/smart_answer_flows/coronavirus-find-support/outcomes/_paying_bills.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/outcomes/_paying_bills.erb
@@ -43,3 +43,5 @@
 <% if calculator.needs_help_in?("wales") %>
   [What to do if you’re finding it hard to pay rent (Welsh Government)](https://gov.wales/coronavirus-covid-19-guidance-for-tenants-in-the-private-rented-sector-html)
 <% end %>
+
+---

--- a/lib/smart_answer_flows/coronavirus-find-support/outcomes/_somewhere_to_live.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/outcomes/_somewhere_to_live.erb
@@ -81,3 +81,5 @@
 <% if calculator.needs_help_in?("wales") %>
   [Get information on evictions (Welsh Government)](https://gov.wales/coronavirus-covid-19-guidance-for-tenants-in-the-private-rented-sector-html)
 <% end %>
+
+---

--- a/lib/smart_answer_flows/coronavirus-find-support/outcomes/results.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/outcomes/results.erb
@@ -6,6 +6,10 @@
   <% end %>
 <% end %>
 
+<% html_for :body do %>
+  <div class="govspeak-wrapper">
+<% end %>
+
 <% govspeak_for :body do %>
   <% if calculator.has_results? %>
 
@@ -52,4 +56,8 @@
 
     [Give feedback on this service](https://www.gov.uk/done/find-coronavirus-support)
   $CTA
+<% end %>
+
+<% html_for :body do %>
+  </div>
 <% end %>


### PR DESCRIPTION
Update styles on the Coronavirus Find Support flow results page.

- Ensure headings are correct size and style
- Add an `HR` tag to visually separate question groups

**Please note**:

Using dev tools (or other) - you will not be able to validate the styles as `govuk-heading-l`, `govuk-heading-m` and `govuk-heading-s`.  Here's why...

`govspeak` changes the size of all headings within a `<% govspeak_for ... do %>` block, so in order to achieve the correct size and style the following is required to wrap the body `govspeak` text...

```
<% html_for :body do %>
  <div class="govspeak-wrapper">
<% end %>

<% govspeak_for :body do %>
  ...
<% end %>

<% html_for :body do %>
  </div>
<% end %>
```

This applies the styles that are `@extended` in `stylesheets/smart_answers.scss` which puts the heading size back to the correct ones required by the `govuk-heading-x` styles, like this...

```
.govspeak-wrapper {
  h2 { @extend %govuk-heading-l; }
  h3 { @extend %govuk-heading-m; }
  ...
}
```

The upshot, is that dev tools shows `<h2>...</h2>` and **not** `<h2  class='govuk-heading-l'>...</h2>` for example.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.

[Trello](https://trello.com/c/DXCVrn1z/446-results-page-layout-and-styling)
