### PR TITLE
Add option to hide captions on questions

### DIFF
--- a/app/presenters/question_presenter.rb
+++ b/app/presenters/question_presenter.rb
@@ -34,6 +34,7 @@ class QuestionPresenter < NodePresenter
   end
 
   def caption
+    return nil if @renderer.hide_caption
     return @renderer.content_for(:caption) if @renderer.content_for(:caption).present?
 
     @flow_presenter.title

--- a/app/views/smart_answers/inputs/_caption.html.erb
+++ b/app/views/smart_answers/inputs/_caption.html.erb
@@ -1,1 +1,3 @@
-<span class="govuk-caption-l"><%= question.caption %></span>
+<% if question.caption.present? %>
+  <span class="govuk-caption-l"><%= question.caption %></span>
+<% end %>

--- a/app/views/smart_answers/inputs/_caption.html.erb
+++ b/app/views/smart_answers/inputs/_caption.html.erb
@@ -1,0 +1,1 @@
+<span class="govuk-caption-l"><%= question.caption %></span>

--- a/app/views/smart_answers/inputs/_country_select_question.html.erb
+++ b/app/views/smart_answers/inputs/_country_select_question.html.erb
@@ -1,4 +1,4 @@
-<span class="govuk-caption-l"><%= question.caption %></span>
+<%= render "smart_answers/inputs/caption", { question: question } %>
 <%= render "govuk_publishing_components/components/select", {
   id: "response",
   label: question.title,

--- a/app/views/smart_answers/inputs/_country_select_question.html.erb
+++ b/app/views/smart_answers/inputs/_country_select_question.html.erb
@@ -1,4 +1,4 @@
-<%= render "smart_answers/inputs/caption", { question: question } %>
+<%= render "smart_answers/inputs/caption", question: question %>
 <%= render "govuk_publishing_components/components/select", {
   id: "response",
   label: question.title,

--- a/app/views/smart_answers/inputs/_date_question.html.erb
+++ b/app/views/smart_answers/inputs/_date_question.html.erb
@@ -32,7 +32,7 @@
   } %>
 <% end %>
 
-<%= render "smart_answers/inputs/caption", { question: question } %>
+<%= render "smart_answers/inputs/caption", question: question %>
 <%= render "govuk_publishing_components/components/fieldset", {
   legend_text: question.title,
   heading_level: 1,

--- a/app/views/smart_answers/inputs/_date_question.html.erb
+++ b/app/views/smart_answers/inputs/_date_question.html.erb
@@ -32,7 +32,7 @@
   } %>
 <% end %>
 
-<span class="govuk-caption-l"><%= question.caption %></span>
+<%= render "smart_answers/inputs/caption", { question: question } %>
 <%= render "govuk_publishing_components/components/fieldset", {
   legend_text: question.title,
   heading_level: 1,

--- a/app/views/smart_answers/inputs/_money_question.html.erb
+++ b/app/views/smart_answers/inputs/_money_question.html.erb
@@ -1,4 +1,4 @@
-<span class="govuk-caption-l"><%= question.caption %></span>
+<%= render "smart_answers/inputs/caption", { question: question } %>
 <%= render "govuk_publishing_components/components/input", {
   label: {
     text: question.title,

--- a/app/views/smart_answers/inputs/_money_question.html.erb
+++ b/app/views/smart_answers/inputs/_money_question.html.erb
@@ -1,4 +1,4 @@
-<%= render "smart_answers/inputs/caption", { question: question } %>
+<%= render "smart_answers/inputs/caption", question: question %>
 <%= render "govuk_publishing_components/components/input", {
   label: {
     text: question.title,

--- a/app/views/smart_answers/inputs/_postcode_question.html.erb
+++ b/app/views/smart_answers/inputs/_postcode_question.html.erb
@@ -1,4 +1,4 @@
-<span class="govuk-caption-l"><%= question.caption %></span>
+<%= render "smart_answers/inputs/caption", { question: question } %>
 <%= render "govuk_publishing_components/components/input", {
   label: {
     text: question.title,

--- a/app/views/smart_answers/inputs/_postcode_question.html.erb
+++ b/app/views/smart_answers/inputs/_postcode_question.html.erb
@@ -1,4 +1,4 @@
-<%= render "smart_answers/inputs/caption", { question: question } %>
+<%= render "smart_answers/inputs/caption", question: question %>
 <%= render "govuk_publishing_components/components/input", {
   label: {
     text: question.title,

--- a/app/views/smart_answers/inputs/_salary_question.html.erb
+++ b/app/views/smart_answers/inputs/_salary_question.html.erb
@@ -1,4 +1,4 @@
-<span class="govuk-caption-l"><%= question.caption %></span>
+<%= render "smart_answers/inputs/caption", { question: question } %>
 <%= render "govuk_publishing_components/components/input", {
   label: {
     text: question.title,

--- a/app/views/smart_answers/inputs/_salary_question.html.erb
+++ b/app/views/smart_answers/inputs/_salary_question.html.erb
@@ -1,4 +1,4 @@
-<%= render "smart_answers/inputs/caption", { question: question } %>
+<%= render "smart_answers/inputs/caption", question: question %>
 <%= render "govuk_publishing_components/components/input", {
   label: {
     text: question.title,

--- a/app/views/smart_answers/inputs/_value_question.html.erb
+++ b/app/views/smart_answers/inputs/_value_question.html.erb
@@ -1,4 +1,4 @@
-<span class="govuk-caption-l"><%= question.caption %></span>
+<%= render "smart_answers/inputs/caption", { question: question } %>
 <%= render "govuk_publishing_components/components/input", {
   label: {
     text: question.title,

--- a/app/views/smart_answers/inputs/_value_question.html.erb
+++ b/app/views/smart_answers/inputs/_value_question.html.erb
@@ -1,4 +1,4 @@
-<%= render "smart_answers/inputs/caption", { question: question } %>
+<%= render "smart_answers/inputs/caption", question: question %>
 <%= render "govuk_publishing_components/components/input", {
   label: {
     text: question.title,

--- a/doc/smart-answers/erb-templates/question-templates.md
+++ b/doc/smart-answers/erb-templates/question-templates.md
@@ -134,3 +134,13 @@ Example with label text and hint text:
   "red-grapes": "Red grapes"
 ) %>
 ```
+
+## Hiding the caption
+
+If you need hide the caption text above the question text. This can be set using the following method:
+
+```erb
+<% hide_caption true %>
+```
+
+By default the caption is shown (`hide_caption false`).

--- a/lib/smart_answer/erb_renderer.rb
+++ b/lib/smart_answer/erb_renderer.rb
@@ -16,6 +16,8 @@ module SmartAnswer
       @view.extend(ErbRenderer::FormatCaptureHelper)
     end
 
+    delegate :hide_caption, to: :rendered_view
+
     def option(key)
       rendered_view
       @view.options.fetch(key)

--- a/lib/smart_answer/erb_renderer/question_options_helper.rb
+++ b/lib/smart_answer/erb_renderer/question_options_helper.rb
@@ -3,5 +3,9 @@ module SmartAnswer
     def options(new_options = nil)
       @options = new_options || @options || {}
     end
+
+    def hide_caption(hide_caption = false)
+      @hide_caption = hide_caption || @hide_caption
+    end
   end
 end

--- a/lib/smart_answer_flows/coronavirus-find-support/questions/need_help_with.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/questions/need_help_with.erb
@@ -1,3 +1,5 @@
+<% hide_caption true %>
+
 <% text_for :title do %>
   What do you need help with because of coronavirus?
 <% end %>

--- a/test/unit/checkbox_question_presenter_test.rb
+++ b/test/unit/checkbox_question_presenter_test.rb
@@ -33,6 +33,7 @@ module SmartAnswer
     end
 
     test "#caption returns the given caption when a caption is given" do
+      @renderer.stubs(:hide_caption).returns(false)
       @renderer.stubs(:content_for).with(:caption).returns("caption-text")
 
       assert_equal "caption-text", @presenter.caption

--- a/test/unit/erb_renderer_test.rb
+++ b/test/unit/erb_renderer_test.rb
@@ -71,6 +71,36 @@ module SmartAnswer
       end
     end
 
+    test "#hide_caption returns true if set as true in the view" do
+      erb_template = "<% hide_caption true %>"
+
+      with_erb_template_file("template-name", erb_template) do |erb_template_directory|
+        renderer = ErbRenderer.new(template_directory: erb_template_directory, template_name: "template-name")
+
+        assert renderer.hide_caption
+      end
+    end
+
+    test "#hide_caption returns false if set as false in the view" do
+      erb_template = "<% hide_caption false %>"
+
+      with_erb_template_file("template-name", erb_template) do |erb_template_directory|
+        renderer = ErbRenderer.new(template_directory: erb_template_directory, template_name: "template-name")
+
+        assert_not renderer.hide_caption
+      end
+    end
+
+    test "#hide_caption returns false if not set in the view" do
+      erb_template = ""
+
+      with_erb_template_file("template-name", erb_template) do |erb_template_directory|
+        renderer = ErbRenderer.new(template_directory: erb_template_directory, template_name: "template-name")
+
+        assert_not renderer.hide_caption
+      end
+    end
+
     test "#option returns then option for specified key" do
       erb_template = "<% options(option_one: 'option-one-text', option_two: { label: 'option-two-text', hint_text: 'option-two-hint-text'}) %>"
 

--- a/test/unit/money_question_presenter_test.rb
+++ b/test/unit/money_question_presenter_test.rb
@@ -4,7 +4,9 @@ module SmartAnswer
   class MoneyQuestionPresenterTest < ActiveSupport::TestCase
     setup do
       @question = Question::Base.new(nil, :question_name?)
+
       @renderer = stub("renderer")
+
       @presenter = MoneyQuestionPresenter.new(@question, nil, nil, renderer: @renderer)
     end
 
@@ -25,6 +27,7 @@ module SmartAnswer
     end
 
     test "#caption returns the given caption when a caption is given" do
+      @renderer.stubs(:hide_caption).returns(false)
       @renderer.stubs(:content_for).with(:caption).returns("caption-text")
 
       assert_equal "caption-text", @presenter.caption

--- a/test/unit/multiple_choice_question_presenter_test.rb
+++ b/test/unit/multiple_choice_question_presenter_test.rb
@@ -28,6 +28,7 @@ module SmartAnswer
     end
 
     test "#caption returns the given caption when a caption is given" do
+      @renderer.stubs(:hide_caption).returns(false)
       @renderer.stubs(:content_for).with(:caption).returns("caption-text")
 
       assert_equal "caption-text", @presenter.caption

--- a/test/unit/question_presenter_test.rb
+++ b/test/unit/question_presenter_test.rb
@@ -4,7 +4,9 @@ module SmartAnswer
   class QuestionPresenterTest < ActiveSupport::TestCase
     setup do
       @question = Question::Base.new(nil, :question_name?)
+
       @renderer = stub("renderer")
+
       @presenter = QuestionPresenter.new(@question, nil, nil, renderer: @renderer)
     end
 
@@ -59,6 +61,7 @@ module SmartAnswer
     end
 
     test "#caption returns single line of content rendered for caption block" do
+      @renderer.stubs(:hide_caption).returns(false)
       @renderer.stubs(:content_for).with(:caption).returns("caption-text")
 
       assert_equal "caption-text", @presenter.caption
@@ -116,12 +119,14 @@ module SmartAnswer
     end
 
     test "#caption returns the given caption when a caption is given" do
+      @renderer.stubs(:hide_caption).returns(false)
       @renderer.stubs(:content_for).with(:caption).returns("caption-text")
 
       assert_equal "caption-text", @presenter.caption
     end
 
     test "#caption returns the caption when both a title and a caption are given" do
+      @renderer.stubs(:hide_caption).returns(false)
       @renderer.stubs(:content_for).with(:title).returns("title-text")
       @renderer.stubs(:content_for).with(:caption).returns("caption-text")
 

--- a/test/unit/value_question_presenter_test.rb
+++ b/test/unit/value_question_presenter_test.rb
@@ -4,7 +4,9 @@ module SmartAnswer
   class ValueQuestionPresenterTest < ActiveSupport::TestCase
     setup do
       @question = Question::Base.new(nil, :question_name?)
+
       @renderer = stub("renderer")
+
       @presenter = ValueQuestionPresenter.new(@question, nil, nil, renderer: @renderer)
     end
 
@@ -25,6 +27,7 @@ module SmartAnswer
     end
 
     test "#caption returns the given caption when a caption is given" do
+      @renderer.stubs(:hide_caption).returns(false)
       @renderer.stubs(:content_for).with(:caption).returns("caption-text")
 
       assert_equal "caption-text", @presenter.caption


### PR DESCRIPTION
This adds the following option that can be specified in question templates to hide the caption text above a question.

```erb
<% hide_caption true %>
```

The default behaviour is the caption is always shown, which is the existing behaviour.

To achieve this, I refactored the caption HTML fragment into a separate partial to make it easier to modify.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.
