### PR TITLE
Refactor outcome titles to be govspeak headers

### DIFF
--- a/lib/smart_answer_flows/additional-commodity-code/outcomes/commodity_code_result.erb
+++ b/lib/smart_answer_flows/additional-commodity-code/outcomes/commodity_code_result.erb
@@ -1,12 +1,10 @@
-<% text_for :title do %>
-  <% unless calculator.has_commodity_code? %>
-    The product composition you indicated is not possible.
-  <% else %>
-    The Meursing code for a product with this composition is 7<%= calculator.commodity_code %>.
-  <% end %>
-<% end %>
-
 <% govspeak_for :body do %>
+  <% unless calculator.has_commodity_code? %>
+  ## The product composition you indicated is not possible.
+  <% else %>
+  ## The Meursing code for a product with this composition is 7<%= calculator.commodity_code %>.
+  <% end %>
+
   <% if calculator.has_commodity_code? %>
     Use these four digits together with the ten-digit commodity code from [Trade Tariff](/trade-tariff).
   <% end %>

--- a/lib/smart_answer_flows/all-smart-answer-questions/all_smart_answer_questions.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/all_smart_answer_questions.erb
@@ -2,11 +2,9 @@
   Do SEO magic here.
 <% end %>
 
-<% text_for :title do %>
-  All Smart Answer questions
-<% end %>
-
 <% govspeak_for :body do %>
+  ##  All Smart Answer questions
+
   This flow shows all the different question types for Smart Answers.
   You can [peek at the results](/all-smart-answer-questions/y/mithrandir,olorin,tharkun/mordor/2019-01-01/1900-01-01/2020-02-29/0000-12-25/9999999.0/four/yes/WC2B%206NH/500000.0-month/world/0/0.5) and access all the different question types individually via changing the previous answers.
 <% end %>

--- a/lib/smart_answer_flows/all-smart-answer-questions/outcomes/outcome.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/outcomes/outcome.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  Congratulations
-<% end %>
-
 <% govspeak_for :body do %>
+  ## Congratulations
+
   You managed to get through all the questions.
 <% end %>
 

--- a/lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_affected_greater_than_cap.erb
+++ b/lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_affected_greater_than_cap.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  Based on your answers, you'll be affected by the benefit cap as you get <%= format_money(total_benefits_amount) %> in benefits and your benefit cap is <%= format_money(benefit_cap) %>.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## Based on your answers, you'll be affected by the benefit cap as you get <%= format_money(total_benefits_amount) %> in benefits and your benefit cap is <%= format_money(benefit_cap) %>.
+
   Your Housing Benefit will be: <%= format_money(new_housing_benefit) %>.
 
   ##How this is worked out

--- a/lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_affected_greater_than_cap_london.erb
+++ b/lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_affected_greater_than_cap_london.erb
@@ -1,9 +1,6 @@
-<% text_for :title do %>
-  Based on your answers, you’re affected by the Greater London benefit cap.
-
-<% end %>
-
 <% govspeak_for :body do %>
+  ## Based on your answers, you’re affected by the Greater London benefit cap.
+
 
   Your weekly benefits | Greater London benefit cap
   -|-

--- a/lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_affected_greater_than_cap_national.erb
+++ b/lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_affected_greater_than_cap_national.erb
@@ -1,9 +1,6 @@
-<% text_for :title do %>
-  Based on your answers, you’re affected by the outside London benefit cap.
-
-<% end %>
-
 <% govspeak_for :body do %>
+  ## Based on your answers, you’re affected by the outside London benefit cap.
+
 
   Your weekly benefits | Outside London benefit cap
   -|-

--- a/lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_not_affected_exemptions.erb
+++ b/lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_not_affected_exemptions.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  Based on your answers, you’re not affected by the benefit cap.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## Based on your answers, you’re not affected by the benefit cap.
+
   These benefits are exempt from the new benefit cap:
 
 - Working Tax Credit

--- a/lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_not_affected_exemptions_future.erb
+++ b/lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_not_affected_exemptions_future.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  Based on your answers, you’re not affected by the benefit cap.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## Based on your answers, you’re not affected by the benefit cap.
+
   These benefits are exempt from the benefit cap:
 
 - Working Tax Credit

--- a/lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_not_affected_less_than_cap.erb
+++ b/lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_not_affected_less_than_cap.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  Based on your answers, you won’t be affected by the benefit cap. This is because the total amount of benefits you get are less than the benefit cap.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## Based on your answers, you won’t be affected by the benefit cap. This is because the total amount of benefits you get are less than the benefit cap.
+
   ##How this is worked out
 
   The total amount of your benefits are added together:

--- a/lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_not_affected_less_than_cap_london.erb
+++ b/lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_not_affected_less_than_cap_london.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  Based on your answers, you’re not affected by the Greater London benefit cap.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## Based on your answers, you’re not affected by the Greater London benefit cap.
+
   This is because the total amount of benefits you get are the same as or lower than this benefit cap.
 
   ##How this is worked out

--- a/lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_not_affected_less_than_cap_national.erb
+++ b/lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_not_affected_less_than_cap_national.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  Based on your answers, you’re not affected by the outside London benefit cap.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## Based on your answers, you’re not affected by the outside London benefit cap.
+
   This is because the total amount of benefits you get are the same as or lower than this benefit cap.
   
   ##How this is worked out

--- a/lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_not_affected_no_housing_benefit.erb
+++ b/lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_not_affected_no_housing_benefit.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  Based on your answers, you’re not affected by the benefit cap.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## Based on your answers, you’re not affected by the benefit cap.
+
   You might be affected by this cap if you start claiming Housing Benefit.
 
   Contact the Department for Work and Pensions if you need further help:

--- a/lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_not_affected_no_housing_benefit_future.erb
+++ b/lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_not_affected_no_housing_benefit_future.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  Based on your answers, you’re not affected by the benefit cap.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## Based on your answers, you’re not affected by the benefit cap.
+
   You might be affected by this cap if you start claiming Housing Benefit.
 
   Contact the Department for Work and Pensions if you need further help:

--- a/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.erb
@@ -1,8 +1,5 @@
-<% text_for :title do %>
-  Support you may be entitled to
-<% end %>
-
 <% govspeak_for :body do %>
+  ## Support you may be entitled to
 
   $CTA
   ### Deferring VAT

--- a/lib/smart_answer_flows/calculate-agricultural-holiday-entitlement/outcomes/done.erb
+++ b/lib/smart_answer_flows/calculate-agricultural-holiday-entitlement/outcomes/done.erb
@@ -1,3 +1,3 @@
-<% text_for :title do %>
-  Your statutory holiday entitlement is <%= calculator.holiday_entitlement_days %> days.
+<% govspeak_for :body do %>
+  ## Your statutory holiday entitlement is <%= calculator.holiday_entitlement_days %> days.
 <% end %>

--- a/lib/smart_answer_flows/calculate-agricultural-holiday-entitlement/outcomes/done_with_number_formatting.erb
+++ b/lib/smart_answer_flows/calculate-agricultural-holiday-entitlement/outcomes/done_with_number_formatting.erb
@@ -1,3 +1,3 @@
-<% text_for :title do %>
-  Your statutory holiday entitlement is <%= sprintf("%.1f", calculator.holiday_entitlement_days) %> days.
+<% govspeak_for :body do %>
+  ## Your statutory holiday entitlement is <%= sprintf("%.1f", calculator.holiday_entitlement_days) %> days.
 <% end %>

--- a/lib/smart_answer_flows/calculate-employee-redundancy-pay/outcomes/done.erb
+++ b/lib/smart_answer_flows/calculate-employee-redundancy-pay/outcomes/done.erb
@@ -1,9 +1,6 @@
-<% text_for :title do %>
-  Statutory redundancy payment: <%= format_money(statutory_redundancy_pay) %> (<%= format_money(statutory_redundancy_pay_ni) %> in Northern Ireland).
-
-<% end %>
-
 <% govspeak_for :body do %>
+  ## Statutory redundancy payment: <%= format_money(statutory_redundancy_pay) %> (<%= format_money(statutory_redundancy_pay_ni) %> in Northern Ireland).
+
   ##How it’s worked out
 
   Your employee's entitlement is <%= number_of_weeks_entitlement %> weeks.

--- a/lib/smart_answer_flows/calculate-employee-redundancy-pay/outcomes/done_no_statutory.erb
+++ b/lib/smart_answer_flows/calculate-employee-redundancy-pay/outcomes/done_no_statutory.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  Your employee is not entitled to statutory redundancy pay.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## Your employee is not entitled to statutory redundancy pay.
+
   A minimum of 2 years’ continuous service is needed before an employee can get statutory redundancy pay.
 <% end %>
 

--- a/lib/smart_answer_flows/calculate-married-couples-allowance/outcomes/highest_earner_done.erb
+++ b/lib/smart_answer_flows/calculate-married-couples-allowance/outcomes/highest_earner_done.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  The highest earner qualifies for Married Couple's Allowance - they'll get <%= format_money(calculator.calculate_allowance) %> off their tax bill.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## The highest earner qualifies for Married Couple's Allowance - they'll get <%= format_money(calculator.calculate_allowance) %> off their tax bill.
+
   <%= render partial: 'done_body' %>
 <% end %>
 

--- a/lib/smart_answer_flows/calculate-married-couples-allowance/outcomes/husband_done.erb
+++ b/lib/smart_answer_flows/calculate-married-couples-allowance/outcomes/husband_done.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  The husband qualifies for Married Couple's Allowance - he'll get <%= format_money(calculator.calculate_allowance) %> off his tax bill.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## The husband qualifies for Married Couple's Allowance - he'll get <%= format_money(calculator.calculate_allowance) %> off his tax bill.
+
   <%= render partial: 'done_body' %>
 <% end %>
 

--- a/lib/smart_answer_flows/calculate-married-couples-allowance/outcomes/sorry.erb
+++ b/lib/smart_answer_flows/calculate-married-couples-allowance/outcomes/sorry.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  You don't qualify for Married Couple's Allowance.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## You don't qualify for Married Couple's Allowance.
+
   You or your partner had to be born before 6 April 1935 to be [eligible for Married Couple's Allowance](/married-couples-allowance/eligibility).
 
   If you and your partner were born on or after 6 April 1935, you may be able to claim [Marriage Allowance](/marriage-allowance) instead.

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/entitled_to_sick_pay.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/outcomes/entitled_to_sick_pay.erb
@@ -1,5 +1,5 @@
 <% govspeak_for :body do %>
-  ##Statutory Sick Pay (SSP)
+  ## Statutory Sick Pay (SSP)
 
   Your employee is entitled to SSP for <%= calculator.days_paid %> days out of <%= calculator.normal_workdays %> working days taken off sick between <%= format_date(calculator.sick_start_date) %> and <%= format_date(calculator.sick_end_date) %>
 

--- a/lib/smart_answer_flows/calculate-your-redundancy-pay/outcomes/done.erb
+++ b/lib/smart_answer_flows/calculate-your-redundancy-pay/outcomes/done.erb
@@ -1,9 +1,6 @@
-<% text_for :title do %>
-  Based on your answers, your statutory redundancy payment is <%= format_money(statutory_redundancy_pay) %> (<%= format_money(statutory_redundancy_pay_ni) %> in Northern Ireland).
-
-<% end %>
-
 <% govspeak_for :body do %>
+  ## Based on your answers, your statutory redundancy payment is <%= format_money(statutory_redundancy_pay) %> (<%= format_money(statutory_redundancy_pay_ni) %> in Northern Ireland).
+
   ##How it’s worked out
 
   Pay is capped at <%= format_money(rate) %> (<%= format_money(ni_rate) %> in Northern Ireland) per week. Length of service is capped at 20 years.

--- a/lib/smart_answer_flows/calculate-your-redundancy-pay/outcomes/done_no_statutory.erb
+++ b/lib/smart_answer_flows/calculate-your-redundancy-pay/outcomes/done_no_statutory.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  Based on your answers, you’re not entitled to statutory redundancy pay.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## Based on your answers, you’re not entitled to statutory redundancy pay.
+
   You need to have worked for your employer continuously for at least 2 years before you can get statutory redundancy pay.
 <% end %>
 

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_diplomatic_business.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_diplomatic_business.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  Diplomatic Business
-<% end %>
-
 <% govspeak_for :body do %>
+  ## Diplomatic Business
+
   You won’t need a visa to come to the UK for a posting or to transit through the UK if you’re going to or returning from a posting in another country. You can still apply for an [exempt vignette](/exempt-vignette).
 
   Your partner or family members [may need a visa to join you](/government/collections/visa-application-forms-diplomats-and-official-visits).

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_joining_family_m.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_joining_family_m.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  You may need a visa to join a member of your family or partner for a long stay
-<% end %>
-
 <% govspeak_for :body do %>
+  ## You may need a visa to join a member of your family or partner for a long stay
+
   ^You **won’t need a visa** if you’re visiting for a short period (up to 6 months) and you won’t work or study.^
 
   The visa you apply for depends on your family member or partner’s situation.

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_joining_family_nvn.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_joining_family_nvn.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  You’ll need a visa to join your family or partner in the UK for a long stay
-<% end %>
-
 <% govspeak_for :body do %>
+  ## You’ll need a visa to join your family or partner in the UK for a long stay
+
   ^You don’t need a visa if you’re visiting family or a partner for 6 months or less.^
 
   The visa you apply for depends on your family member’s situation.

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_marriage_electronic_visa_waiver.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_marriage_electronic_visa_waiver.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  You’ll need a visa to come to the UK
-<% end %>
-
 <% govspeak_for :body do %>
+  ## You’ll need a visa to come to the UK
+
   Apply for a [Marriage Visitor visa](/marriage-visa) if you and your partner want to get married or enter into a civil partnership in the UK.
 
   If you want to live in the UK permanently, you must apply for a [family of a settled person visa](/join-family-in-uk) if your partner is any of the following:

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_marriage_nvn_ukot.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_marriage_nvn_ukot.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  You’ll need a visa to come to the UK
-<% end %>
-
 <% govspeak_for :body do %>
+  ## You’ll need a visa to come to the UK
+
   Apply for a [Marriage Visitor visa](/marriage-visa) if you and your partner want to get married or enter into a civil partnership in the UK.
 
   If you want to live in the UK permanently, you must apply for a [family of a settled person visa](/join-family-in-uk) if your partner is any of the following:

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_marriage_taiwan.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_marriage_taiwan.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  You’ll need a visa to come to the UK
-<% end %>
-
 <% govspeak_for :body do %>
+  ## You’ll need a visa to come to the UK
+
   Apply for a [Marriage Visitor visa](/marriage-visa) if you and your partner want to get married or enter into a civil partnership in the UK.
 
   If you want to live in the UK permanently, you must apply for a [family of a settled person visa](/join-family-in-uk) if your partner is any of the following:

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_marriage_visa_nat_datv.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_marriage_visa_nat_datv.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  You’ll need a visa to come to the UK
-<% end %>
-
 <% govspeak_for :body do %>
+  ## You’ll need a visa to come to the UK
+
   <%= render partial: 'stateless_or_refugee', locals: {calculator: calculator} %>
 
   <%= render partial: 'estonia_or_latvia', locals: {calculator: calculator} %>

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_medical_n.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_medical_n.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  You won’t need a visa to visit the UK
-<% end %>
-
 <% govspeak_for :body do %>
+  ## You won’t need a visa to visit the UK
+
   You can stay in the UK for up to 6 months without a visa.
 
   However, you should bring the [same documents](/government/publications/visitor-visa-guide-to-supporting-documents) you’d need to apply for a [Standard Visitor visa](/standard-visitor-visa), to show to officers at the UK border.

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_medical_y.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_medical_y.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  You’ll need a visa to visit the UK
-<% end %>
-
 <% govspeak_for :body do %>
+  ## You’ll need a visa to visit the UK
+
   You should apply for a [Standard Visitor visa](/standard-visitor-visa).
 
   <%= render partial: 'stateless_or_refugee', locals: {calculator: calculator} %>

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_no_visa_needed.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_no_visa_needed.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  You do not need a visa to come to the UK
-<% end %>
-
 <% govspeak_for :body do %>
+  ## You do not need a visa to come to the UK
+
 
   <% if calculator.study_visit? %>
     <% if calculator.passport_country_in_epassport_gate_list? %>

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_partner_family_british_citizen_y.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_partner_family_british_citizen_y.erb
@@ -1,7 +1,5 @@
-<% text_for :title do %>
-  You’ll need a visa to join your family or partner in the UK
-<% end %>
-
 <% govspeak_for :body do %>
+  ## You’ll need a visa to join your family or partner in the UK
+
   Apply for a [‘family of a settled person’ visa](/join-family-in-uk).
 <% end %>

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_partner_family_eea_n.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_partner_family_eea_n.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  You’ll need a visa to join your family or partner in the UK
-<% end %>
-
 <% govspeak_for :body do %>
+  ## You’ll need a visa to join your family or partner in the UK
+
   The visa you need depends on your partner or family member’s situation.
 
   ## They’re working or studying in the UK

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_partner_family_eea_y.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_partner_family_eea_y.erb
@@ -1,7 +1,5 @@
-<% text_for :title do %>
-  You’ll need a visa to join your family or partner in the UK
-<% end %>
-
 <% govspeak_for :body do %>
+  ## You’ll need a visa to join your family or partner in the UK
+
   Apply for a [family permit](/family-permit).
 <% end %>

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_school_n.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_school_n.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  You won’t need a visa to come to the UK
-<% end %>
-
 <% govspeak_for :body do %>
+  ## You won’t need a visa to come to the UK
+
   You can stay in the UK for up to 6 months without a visa.
 
   However, you should bring the [same documents](https://www.gov.uk/government/publications/visitor-visa-guide-to-supporting-documents) you'd need to apply for a visa, to show to officers at the UK border. 

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_school_waiver.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_school_waiver.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  You’ll need an electronic visa waiver (EVW) or a visa
-<% end %>
-
 <% govspeak_for :body do %>
+  ## You’ll need an electronic visa waiver (EVW) or a visa
+
   You must either apply for:
 
   + an [EVW](/get-electronic-visa-waiver) to stay for up to 6 months

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_school_y.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_school_y.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  You’ll need a visa to stay with your child
-<% end %>
-
 <% govspeak_for :body do %>
+  ## You’ll need a visa to stay with your child
+
   You can apply for a [parent of a Tier 4 child visa](/parent-of-a-child-at-school-visa) if your child is under 12.
 
   <% if calculator.passport_country_is_estonia? || calculator.passport_country_is_latvia? %>

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_standard_visitor_visa.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_standard_visitor_visa.erb
@@ -1,12 +1,10 @@
-<% text_for :title do %>
-  You’ll need a visa to come to the UK
-<% end %>
-
 <% govspeak_for :body do %>
+  ## You’ll need a visa to come to the UK
+
   Apply for a [Standard Visitor visa](/standard-visitor-visa).
 
   <% if calculator.passport_country_is_china? %>
-    ##You're travelling in a tour group
+    ## You're travelling in a tour group
 
     You can apply for an [‘ADS visa’](/ads-visa) if you’re planning to travel to the UK as part of a tour group for less than 30 days.
   <% end %>

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_study_m.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_study_m.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  You’ll need a visa to study in the UK
-<% end %>
-
 <% govspeak_for :body do %>
+  ## You’ll need a visa to study in the UK
+
   <%= render partial: 'stateless_or_refugee', locals: {calculator: calculator} %>
 
   Apply for a [Short-term study visa](/study-visit-visa) if you are studying for 6 months or less.

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_study_waiver.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_study_waiver.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  You’ll need an electronic visa waiver (EVW) or a visa
-<% end %>
-
 <% govspeak_for :body do %>
+  ## You’ll need an electronic visa waiver (EVW) or a visa
+
   You must either apply for:
 
   + an [EVW](/get-electronic-visa-waiver)

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_study_waiver_taiwan.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_study_waiver_taiwan.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  You won't need a visa if your passport has a personal ID number on the bio data page.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## You won't need a visa if your passport has a personal ID number on the bio data page.
+
   However, you should bring the [same documents](/study-visit-visa/documents-you-must-provide) you'd need to apply for a visa, to show to officers at the UK border.
 
   ^If the bio data page in your passport doesn't include a personal ID number, you must [apply for a short-term study visa](/study-visit-visa).^

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_study_y.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_study_y.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  You’ll need a visa to study in the UK
-<% end %>
-
 <% govspeak_for :body do %>
+  ## You’ll need a visa to study in the UK
+
   The visa you apply for depends on your circumstances.
 
   <%= render partial: 'stateless_or_refugee', locals: {calculator: calculator} %>

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_tourism_visa_partner.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_tourism_visa_partner.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  You’ll need a visa to come to the UK
-<% end %>
-
 <% govspeak_for :body do %>
+  ## You’ll need a visa to come to the UK
+
   The visa you need depends on your partner or family member’s situation.
 
   ## They’re a British citizen

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_datv_exception.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_datv_exception.erb
@@ -1,3 +1,3 @@
-<% text_for :title do %>
-  You won’t need a visa to pass through the UK in transit
+<% govspeak_for :body do %>
+  ## You won’t need a visa to pass through the UK in transit
 <% end %>

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_leaving_airport.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_leaving_airport.erb
@@ -1,18 +1,14 @@
-<% text_for :title do %>
-  <% if calculator.passport_country_in_electronic_visa_waiver_list? %>
-    You’ll need an electronic visa waiver (EVW) or a Visitor in Transit visa
-  <% else %>
-    You’ll need a visa to pass through the UK in transit
-  <% end %>
-<% end %>
-
 <% govspeak_for :body do %>
   <% if calculator.passport_country_in_electronic_visa_waiver_list? %>
+    ## You’ll need an electronic visa waiver (EVW) or a Visitor in Transit visa
+
     You must either apply for:
 
     - an [EVW](/get-electronic-visa-waiver)
     - a [Visitor in Transit visa](/transit-visa)
   <% else %>
+    ## You’ll need a visa to pass through the UK in transit
+
     You should apply for a [Visitor in Transit visa](/transit-visa) if you arrive on a flight and will pass through immigration control before you leave the UK.
   <% end %>
 

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_leaving_airport_datv.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_leaving_airport_datv.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  You’ll need a visa to pass through the UK in transit
-<% end %>
-
 <% govspeak_for :body do %>
+  ## You’ll need a visa to pass through the UK in transit
+
   You should apply for a [Visitor in Transit visa](/transit-visa) if you arrive on a flight and will pass through immigration control before you leave the UK.
 
 ^ You don’t need to apply for a Visitor in Transit visa if you already have a Marriage Visitor or Standard Visitor visa. ^

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_not_leaving_airport.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_not_leaving_airport.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  You’ll need a visa to pass through the UK in transit (unless you’re exempt)
-<% end %>
-
 <% govspeak_for :body do %>
+  ## You’ll need a visa to pass through the UK in transit (unless you’re exempt)
+
   You should apply for a [Direct Airside Transit visa](/transit-visa) if you arrive in the UK on a flight and leave again without passing through immigration control.
 
   ##Exemptions

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_refugee_not_leaving_airport.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_refugee_not_leaving_airport.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  You may need a Direct Airside Transit Visa
-<% end %>
-
 <% govspeak_for :body do %>
+  ## You may need a Direct Airside Transit Visa
+
   You’ll need a [Direct Airside Transit visa](/transit-visa/direct-airside-transit-visa) if you’re a refugee and originally from one of these countries:
 
   * Afghanistan

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_taiwan.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_taiwan.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  You won’t need a visa if your passport has a personal ID number on the bio data page.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## You won’t need a visa if your passport has a personal ID number on the bio data page.
+
   However, you should bring the [same documents](/government/publications/visitor-visa-guide-to-supporting-documents) you’d need to apply for a visa, to show to officers at the UK border.
 
   ^If the bio data page in your passport doesn’t include a personal ID number, you must [apply for a transit visa](/transit-visa).^

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_taiwan_through_border_control.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_taiwan_through_border_control.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  You won't need a visa if your passport has a personal ID number on the bio data page.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## You won't need a visa if your passport has a personal ID number on the bio data page.
+
   However, you should bring the [same documents](/government/publications/visitor-visa-guide-to-supporting-documents) you'd need to apply for a visa, to show to officers at the UK border.
 
   ^ If the bio data page in your passport doesn't include a personal ID number, you should apply for a [Visitor in Transit](/transit-visa) visa.

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_to_the_republic_of_ireland.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_to_the_republic_of_ireland.erb
@@ -1,26 +1,19 @@
-<% text_for :title do %>
-  <% if calculator.passport_country_is_taiwan? %>
-    You won’t need a visa if your passport has a personal ID number on the bio data page.
-  <% elsif calculator.passport_country_in_electronic_visa_waiver_list? %>
-    You’ll need an electronic visa waiver (EVW) or a visitor visa
-  <% else %>
-    You’ll need a visa to pass through the UK (unless you’re exempt)
-  <% end %>
-<% end %>
-
 <% govspeak_for :body do %>
   <% if calculator.passport_country_is_taiwan? %>
+    ## You won’t need a visa if your passport has a personal ID number on the bio data page.
 
     However, you should bring the [same documents](/government/publications/visitor-visa-guide-to-supporting-documents) you’d need to apply for a visa, to show to officers at the UK border.
 
     If your passport doesn’t have a personal ID number on the bio data page you’ll usually need to apply for a UK [standard visitor visa](/standard-visitor-visa).
   <% elsif calculator.passport_country_in_electronic_visa_waiver_list? %>
+    ## You’ll need an electronic visa waiver (EVW) or a visitor visa
 
     You must either apply for:
 
     - an [EVW](/get-electronic-visa-waiver)
     - a [Standard Visitor visa](/standard-visitor-visa)
   <% else %>
+    ## You’ll need a visa to pass through the UK (unless you’re exempt)
 
     You’ll usually need to apply for a UK [standard visitor visa](/standard-visitor-visa).
   <% end %>

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_venezuela.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_transit_venezuela.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  You won’t need a visa if you have an ePassport
-<% end %>
-
 <% govspeak_for :body do %>
+  ## You won’t need a visa if you have an ePassport
+
   However, you should bring the [same documents](/government/publications/visitor-visa-guide-to-supporting-documents) you'd need to apply for a visa, to show to officers at the UK border.
 
   ^ If you don't have an ePassport, you should apply for a [Direct Airside Transit Visa](/transit-visa/direct-airside-transit-visa) unless you're exempt.

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_visit_waiver.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_visit_waiver.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  You’ll need an electronic visa waiver (EVW) or a visitor visa
-<% end %>
-
 <% govspeak_for :body do %>
+  ## You’ll need an electronic visa waiver (EVW) or a visitor visa
+
   You must either apply for:
 
   + an [EVW](/get-electronic-visa-waiver)

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_visit_waiver_taiwan.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_visit_waiver_taiwan.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  You won't need a visa if your passport has a personal ID number on the bio data page.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## You won't need a visa if your passport has a personal ID number on the bio data page.
+
   However, you should bring the [same documents](/government/publications/visitor-visa-guide-to-supporting-documents) you’d need to apply for a visa, to show to officers at the UK border.
 
   ^If the bio data page in your passport doesn’t include a personal ID number, you must [apply for a Standard Visitor visa](/standard-visitor-visa).^

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_work_m.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_work_m.erb
@@ -1,9 +1,6 @@
-<% text_for :title do %>
-  You'll need a visa to work, do business or academic research in the UK
-
-<% end %>
-
 <% govspeak_for :body do %>
+  ## You'll need a visa to work, do business or academic research in the UK
+
   The visa you need to apply for depends on your circumstances.
 
   <%= render partial: 'stateless_or_refugee', locals: {calculator: calculator} %>

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_work_n.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_work_n.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  You don't need a visa for some business and academic visits, but you must get a visa to work in the UK.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## You don't need a visa for some business and academic visits, but you must get a visa to work in the UK.
+
   You may be able to come to the UK without a visa if you:
 
   - are invited as an expert in your profession

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_work_waiver.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_work_waiver.erb
@@ -1,9 +1,6 @@
-<% text_for :title do %>
-  You'll need to apply to do business, academic research or work in the UK
-
-<% end %>
-
 <% govspeak_for :body do %>
+  ## You'll need to apply to do business, academic research or work in the UK
+
   What you need to apply for depends on your circumstances.
 
   ##Business and academic visits

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_work_y.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_work_y.erb
@@ -1,12 +1,10 @@
-<% text_for :title do %>
-  You’ll need a visa to work or do business or academic research in the UK
-<% end %>
-
 <% govspeak_for :body do %>
+  ## You’ll need a visa to work or do business or academic research in the UK
+
   The visa you apply for depends on your circumstances.
 
   <% if calculator.passport_country_is_turkey? %>
-    ###Turkish nationals
+  ## Turkish nationals
 
     You can apply for a [Turkish business person visa](/turkish-business-person) if you want to come and set up a business in the UK.
   <% end %>

--- a/lib/smart_answer_flows/childcare-costs-for-tax-credits/outcomes/call_helpline_detailed.erb
+++ b/lib/smart_answer_flows/childcare-costs-for-tax-credits/outcomes/call_helpline_detailed.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  Call the Tax Credit Helpline to work out your average weekly childcare costs.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## Call the Tax Credit Helpline to work out your average weekly childcare costs.
+
   You’ll need to tell them:
 
   - the start and end date of the childcare

--- a/lib/smart_answer_flows/childcare-costs-for-tax-credits/outcomes/call_helpline_plain.erb
+++ b/lib/smart_answer_flows/childcare-costs-for-tax-credits/outcomes/call_helpline_plain.erb
@@ -1,3 +1,3 @@
-<% text_for :title do %>
-  Contact [HM Revenue and Customs (HMRC)](/government/organisations/hm-revenue-customs/contact/tax-credits-enquiries) for help in working out your costs.
+<% govspeak_for :body do %>
+  ## Contact [HM Revenue and Customs (HMRC)](/government/organisations/hm-revenue-customs/contact/tax-credits-enquiries) for help in working out your costs.
 <% end %>

--- a/lib/smart_answer_flows/childcare-costs-for-tax-credits/outcomes/cost_changed.erb
+++ b/lib/smart_answer_flows/childcare-costs-for-tax-credits/outcomes/cost_changed.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  Your average weekly childcare costs have <%= calculator.title_change_text %> by <%= format_money(calculator.difference_money) %>.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## Your average weekly childcare costs have <%= calculator.title_change_text %> by <%= format_money(calculator.difference_money) %>.
+
   <% if calculator.ten_or_more %>
     <% if calculator.cost_change_4_weeks %>
       Call [HM Revenue and Customs (HMRC)](/government/organisations/hm-revenue-customs/contact/tax-credits-enquiries) if you expect this to last for 4 weeks in a row or more.

--- a/lib/smart_answer_flows/childcare-costs-for-tax-credits/outcomes/no_change.erb
+++ b/lib/smart_answer_flows/childcare-costs-for-tax-credits/outcomes/no_change.erb
@@ -1,7 +1,5 @@
-<% text_for :title do %>
-  There is no change to your tax credits.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## There is no change to your tax credits.
+
   You do not have to report anything to [HM Revenue and Customs (HMRC)](/government/organisations/hm-revenue-customs/contact/tax-credits-enquiries).
 <% end %>

--- a/lib/smart_answer_flows/childcare-costs-for-tax-credits/outcomes/no_longer_paying.erb
+++ b/lib/smart_answer_flows/childcare-costs-for-tax-credits/outcomes/no_longer_paying.erb
@@ -1,7 +1,5 @@
-<% text_for :title do %>
-  You’re no longer paying for childcare.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## You’re no longer paying for childcare.
+
   If you expect this to last for 4 weeks or more, tell [HM Revenue and Customs (HMRC)](/government/organisations/hm-revenue-customs/contact/tax-credits-enquiries).
 <% end %>

--- a/lib/smart_answer_flows/childcare-costs-for-tax-credits/outcomes/round_up_weekly.erb
+++ b/lib/smart_answer_flows/childcare-costs-for-tax-credits/outcomes/round_up_weekly.erb
@@ -1,7 +1,5 @@
-<% text_for :title do %>
-  Round up the amount you pay each week to the nearest pound to get your weekly childcare cost.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## Round up the amount you pay each week to the nearest pound to get your weekly childcare cost.
+
   Use that figure on your claim form.
 <% end %>

--- a/lib/smart_answer_flows/childcare-costs-for-tax-credits/outcomes/weekly_costs_are_x.erb
+++ b/lib/smart_answer_flows/childcare-costs-for-tax-credits/outcomes/weekly_costs_are_x.erb
@@ -1,7 +1,5 @@
-<% text_for :title do %>
-  Your weekly childcare costs are <%= format_money(calculator.weekly_cost) %>.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## Your weekly childcare costs are <%= format_money(calculator.weekly_cost) %>.
+
   Use this figure on your claim form.
 <% end %>

--- a/lib/smart_answer_flows/coronavirus-business-reopening/outcomes/_cleaning.erb
+++ b/lib/smart_answer_flows/coronavirus-business-reopening/outcomes/_cleaning.erb
@@ -72,7 +72,7 @@ Positive pressure systems and extractors can operate as normal.
 
 
 <% if calculator.sector?("homes") %>
-  ### Other people’s homes
+  ## Other people’s homes
 
   If you work in people’s homes you need to minimise the risk of passing infection on to other people.
 
@@ -89,7 +89,7 @@ Positive pressure systems and extractors can operate as normal.
 <% end %>
 
 <% if calculator.sector?("hospitality") %>
-  ### Restaurants, pubs, bars and takeaway services
+  ## Restaurants, pubs, bars and takeaway services
 
   ^ You should follow [government guidance on cleaning food preparation and service areas](/government/publications/covid-19-guidance-for-food-businesses/guidance-for-food-businesses-on-coronavirus-covid-19) at all times.  ^
 
@@ -111,7 +111,7 @@ Positive pressure systems and extractors can operate as normal.
 <% end %>
 
 <% if calculator.sector?("shops") %>
-  ### Shops and branches
+  ## Shops and branches
 
   Once you’re open you should frequently clean objects and surfaces that are touched regularly, such as:
 
@@ -145,7 +145,7 @@ Positive pressure systems and extractors can operate as normal.
 <% end %>
 
 <% if calculator.sector?("vehicles") %>
-  ### Vehicles
+  ## Vehicles
 
   You should:
 

--- a/lib/smart_answer_flows/coronavirus-business-reopening/outcomes/_main.erb
+++ b/lib/smart_answer_flows/coronavirus-business-reopening/outcomes/_main.erb
@@ -93,7 +93,7 @@ You should consider this in your risk assessment.
   - remind customers that face coverings are mandatory in most indoor places including shops and supermarkets, indoor shopping centres, banks, building societies, salons and hair dressers, massage parlours, tattoo and piercing parlours, post offices and where food or drink is purchased at a take-away outlet (some people don’t have to wear a face covering including [for health, age or equality reasons](https://www.gov.uk/guidance/coronavirus-covid-19-safer-travel-guidance-for-passengers#exemptions-face-coverings))
 
   <% if calculator.sector?("fitness") %>
-    ### Sports and fitness facilities
+  ## Sports and fitness facilities
 
     You should follow the above guidelines and:
     
@@ -111,7 +111,7 @@ You should consider this in your risk assessment.
   <% end %>
 
   <% if calculator.sector?("hotels") %>
-    ### Room Service
+  ## Room Service
 
     You should:
 

--- a/lib/smart_answer_flows/coronavirus-business-reopening/outcomes/_social_distancing.erb
+++ b/lib/smart_answer_flows/coronavirus-business-reopening/outcomes/_social_distancing.erb
@@ -75,7 +75,7 @@ You should:
 
 
 <% if calculator.sector?("homes") %>
-  ### Working in other people’s homes
+  ## Working in other people’s homes
 
   To minimise risk from travelling to the home you should:
 
@@ -95,7 +95,7 @@ You should:
 <% end %>
 
 <% if calculator.sector?("hospitality") %>
-  ### Managing service of food and drink
+  ## Managing service of food and drink
 
   You should:
 
@@ -117,7 +117,7 @@ You should:
 <% end %>
 
 <% if calculator.sector?("vehicles") %>
-  ### Using vehicles
+  ## Using vehicles
 
   You should: 
 

--- a/lib/smart_answer_flows/coronavirus-find-support/outcomes/results.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/outcomes/results.erb
@@ -1,16 +1,14 @@
-<% text_for :title do %>
-  <% if calculator.has_results? %>
-    Information based on your answers
-  <% else %>
-    Information based on your answers - no specific information
-  <% end %>
-<% end %>
-
 <% html_for :body do %>
   <div class="govspeak-wrapper">
 <% end %>
 
 <% govspeak_for :body do %>
+  <% if calculator.has_results? %>
+    ## Information based on your answers
+  <% else %>
+    ## Information based on your answers - no specific information
+  <% end %>
+
   <% if calculator.has_results? %>
 
     <%= render("feeling_unsafe", calculator: calculator) if calculator.user_feels_unsafe? %>

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties/outcomes/filed_and_paid_on_time.erb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties/outcomes/filed_and_paid_on_time.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  You don't have to pay a penalty
-<% end %>
-
 <% govspeak_for :body do %>
+  ## You don't have to pay a penalty
+
   You sent your tax return on or before the deadline, so you don’t have to pay a penalty.
 
   You paid your bill on time, so there is no interest or penalty for late payment.

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties/outcomes/late.erb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties/outcomes/late.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  You paid tax or sent your return late
-<% end %>
-
 <% govspeak_for :body do %>
+  ## You paid tax or sent your return late
+
   | Key facts | Your results |
   |-----------|--------------|
   | Your penalty for sending the return late | <%= calculator.late_filing_penalty == 0 ? 'none' : format_money(calculator.late_filing_penalty) %> |

--- a/lib/smart_answer_flows/help-if-you-are-arrested-abroad/outcomes/answer_one_generic.erb
+++ b/lib/smart_answer_flows/help-if-you-are-arrested-abroad/outcomes/answer_one_generic.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  Help for British nationals arrested abroad
-<% end %>
-
 <% govspeak_for :body do %>
+  ## Help for British nationals arrested abroad
+
   $!
   The Foreign & Commonwealth Office (FCO) or the nearest British embassy, high commission or consulate can give advice on local laws and procedures, contact friends and provide a list of lawyers and translators.
   $!
@@ -34,7 +32,7 @@
   - visiting prisoners when needed
 
   <% if has_extra_downloads %>
-    ##Download prisoner packs and other helpful information
+    ## Download prisoner packs and other helpful information
 
     The FCO has produced guides explaining the legal and prison system in different countries for British nationals arrested abroad.
 

--- a/lib/smart_answer_flows/help-if-you-are-arrested-abroad/outcomes/answer_three_british_overseas_territories.erb
+++ b/lib/smart_answer_flows/help-if-you-are-arrested-abroad/outcomes/answer_three_british_overseas_territories.erb
@@ -1,8 +1,5 @@
-<% text_for :title do %>
-  Help for British nationals arrested abroad
-<% end %>
-
 <% govspeak_for :body do %>
+## Help for British nationals arrested abroad
 
 %The Foreign and Commonwealth Office (FCO) does not provide consular assistance in the British Overseas Territories. All visitors, including British nationals visiting or resident in the territory, should look to the local authorities for assistance.%
 

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_1.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_1.erb
@@ -1,5 +1,5 @@
-<% text_for :title do %>
-  The husband, wife or civil partner gets all of the estate.
+<% govspeak_for :body do %>
+  ## The husband, wife or civil partner gets all of the estate.
 <% end %>
 
 <% govspeak_for :next_steps do %>

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_2.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_2.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  The estate is shared equally between the children or their descendants.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## The estate is shared equally between the children or their descendants.
+
   If a son or daughter has already died, their children (the grandchildren of the deceased) inherit in their place.
 <% end %>
 

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_20.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_20.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  The husband, wife or civil partner keeps all the assets (including property), up to £270,000, and all the personal possessions, whatever their value.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## The husband, wife or civil partner keeps all the assets (including property), up to £270,000, and all the personal possessions, whatever their value.
+
   The remainder of the estate will be shared as follows:
 
   * the husband, wife or civil partner gets an absolute interest in half of the remainder

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_23.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_23.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  The estate is shared equally between the half-brothers or half-sisters.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## The estate is shared equally between the half-brothers or half-sisters.
+
   If a half-brother or half-sister has already died, their children (nieces and nephews of the deceased) inherit in their place.
 <% end %>
 

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_24.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_24.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  The estate is shared equally between the half-aunts or half-uncles.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## The estate is shared equally between the half-aunts or half-uncles.
+
   If an aunt or uncle has already died, their children (the cousins of the deceased) inherit in their place.
 <% end %>
 

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_25.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_25.erb
@@ -1,5 +1,5 @@
-<% text_for :title do %>
-  The whole estate goes to the Crown.
+<% govspeak_for :body do %>
+  ## The whole estate goes to the Crown.
 <% end %>
 
 <% govspeak_for :next_steps do %>

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_3.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_3.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  The estate is shared equally between the parents.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## The estate is shared equally between the parents.
+
   They may have to pay Inheritance Tax.
 <% end %>
 

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_4.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_4.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  The estate is shared equally between the brothers or sisters.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## The estate is shared equally between the brothers or sisters.
+
   If a brother or sister has already died, their children (nieces and nephews of the deceased) inherit in their place.
 <% end %>
 

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_40.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_40.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  The husband, wife or civil partner gets the house up to a value of £473,000. They’ll get a lump sum of £473,000 if the house is worth more, and may have to sell off the property.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## The husband, wife or civil partner gets the house up to a value of £473,000. They’ll get a lump sum of £473,000 if the house is worth more, and may have to sell off the property.
+
   They also get:
 
   - furniture and moveable household goods up to the value of £29,000

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_41.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_41.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  The husband, wife or civil partner gets the house up to a value of £473,000. They’ll get a lump sum of £473,000 if the house is worth more, and may have to sell off the property.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## The husband, wife or civil partner gets the house up to a value of £473,000. They’ll get a lump sum of £473,000 if the house is worth more, and may have to sell off the property.
+
   They also get:
 
   - furniture and moveable household goods up to the value of £29,000

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_42.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_42.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  The husband, wife or civil partner gets the house up to a value of £473,000.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## The husband, wife or civil partner gets the house up to a value of £473,000.
+
   They also get:
 
   - furniture and moveable household goods up to the value of £29,000

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_43.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_43.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  The husband, wife or civil partner gets the house up to a value of £473,000. They’ll get a lump sum of £473,000 if the house is worth more, and may have to sell off the property.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## The husband, wife or civil partner gets the house up to a value of £473,000. They’ll get a lump sum of £473,000 if the house is worth more, and may have to sell off the property.
+
   They also get:
 
   - up to £89,000 in cash

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_44.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_44.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  The estate is split in two, half goes to the parents and half to the brothers or sisters.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## The estate is split in two, half goes to the parents and half to the brothers or sisters.
+
   If a brother or sister has already died, their children (nieces and nephews of the deceased) inherit in their place.
 <% end %>
 

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_45.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_45.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  The estate is shared equally between any great aunts or great uncles.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## The estate is shared equally between any great aunts or great uncles.
+
   They may have to pay Inheritance Tax.
 <% end %>
 

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_46.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_46.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  The whole estate goes to the Crown.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## The whole estate goes to the Crown.
+
   However, before this can happen there would need to be proof that there are no surviving relatives in any generation.
 <% end %>
 

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_5.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_5.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  The estate is shared equally between the grandparent(s).
-<% end %>
-
 <% govspeak_for :body do %>
+  ## The estate is shared equally between the grandparent(s).
+
   They may have to pay Inheritance Tax.
 <% end %>
 

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_6.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_6.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  The estate is shared equally between the aunts or uncles.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## The estate is shared equally between the aunts or uncles.
+
   If an aunt or uncle has already died, their children (the cousins of the deceased) inherit in their place.
 <% end %>
 

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_60.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_60.erb
@@ -1,5 +1,5 @@
-<% text_for :title do %>
-  The husband, wife or civil partner gets all of the estate but they must survive the deceased by at least 28 days.
+<% govspeak_for :body do %>
+  ## The husband, wife or civil partner gets all of the estate but they must survive the deceased by at least 28 days.
 <% end %>
 
 <% govspeak_for :next_steps do %>

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_61.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_61.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  The husband, wife or civil partner keeps all the assets (including property), up to £250,000, and all the personal possessions, whatever their value.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## The husband, wife or civil partner keeps all the assets (including property), up to £250,000, and all the personal possessions, whatever their value.
+
   The husband, wife or civil partner must survive the deceased by at least 28 days to inherit.
 
   They also get one third of the rest of the estate.

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_62.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_62.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  The husband, wife or civil partner keeps all the assets (including property), up to £250,000, and all the personal possessions, whatever their value.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## The husband, wife or civil partner keeps all the assets (including property), up to £250,000, and all the personal possessions, whatever their value.
+
   The husband, wife or civil partner must survive the deceased by at least 28 days to inherit.
 
   The remainder of the estate is divided in half between the:

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_63.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_63.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  The husband, wife or civil partner keeps all the assets (including property) up to £450,000, and all the personal possessions, whatever their value.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## The husband, wife or civil partner keeps all the assets (including property) up to £450,000, and all the personal possessions, whatever their value.
+
   The husband, wife or civil partner must survive the deceased by at least 28 days to inherit.
 
   They also get half of the amount left over.

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_64.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_64.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  The husband, wife or civil partner keeps all the assets (including property) up to £450,000, and all the personal possessions, whatever their value.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## The husband, wife or civil partner keeps all the assets (including property) up to £450,000, and all the personal possessions, whatever their value.
+
   The husband, wife or civil partner must survive the deceased by at least 28 days to inherit.
 
   They also get half the amount left over.

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_65.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_65.erb
@@ -1,5 +1,5 @@
-<% text_for :title do %>
-  The husband, wife or civil partner gets all of the estate but they must survive the deceased by at least 28 days.
+<% govspeak_for :body do %>
+  ## The husband, wife or civil partner gets all of the estate but they must survive the deceased by at least 28 days.
 <% end %>
 
 <% govspeak_for :next_steps do %>

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_66.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_66.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  The estate is shared equally between the children.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## The estate is shared equally between the children.
+
   If a son or daughter has already died, their children (the grandchildren of the deceased) inherit in their place.
 
   They may have to pay Inheritance Tax.

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_67.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_67.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  The estate goes to the next of kin - the person is closest in blood relationship to the deceased in the family tree.
-<% end %>
-
 <% govspeak_for :body do %>
+  ## The estate goes to the next of kin - the person is closest in blood relationship to the deceased in the family tree.
+
   If nobody claims the estate, the whole estate goes to the Crown.
 <% end %>
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/china/_title.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/china/_title.erb
@@ -1,7 +1,5 @@
-<% text_for :title do %>
-  <% if calculator.partner_is_same_sex? %>
-    Same-sex marriage in China
-  <% else %>
-    Marriage in China
-  <% end %>
+<% if calculator.partner_is_same_sex? %>
+  Same-sex marriage in China
+<% else %>
+  Marriage in China
 <% end %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/colombia/_title.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/colombia/_title.erb
@@ -1,7 +1,5 @@
-<% text_for :title do %>
-    <% if calculator.partner_is_same_sex? %>
-      Same-sex marriage in Colombia
-    <% else %>
-      Marriage in Colombia
-    <% end %>
+<% if calculator.partner_is_same_sex? %>
+  Same-sex marriage in Colombia
+<% else %>
+  Marriage in Colombia
 <% end %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/croatia/_title.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/croatia/_title.erb
@@ -1,7 +1,5 @@
-<% text_for :title do %>
-  <% if calculator.partner_is_same_sex? %>
-    Civil partnership in Croatia
-  <% else %>
-    Marriage in Croatia
-  <% end %>
+<% if calculator.partner_is_same_sex? %>
+  Civil partnership in Croatia
+<% else %>
+  Marriage in Croatia
 <% end %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/finland/_title.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/finland/_title.erb
@@ -1,3 +1,1 @@
-<% text_for :title do %>
-  Marriage in Finland
-<% end %>
+Marriage in Finland

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/france/_title.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/france/_title.erb
@@ -1,7 +1,5 @@
-<% text_for :title do %>
-  <% if calculator.partner_is_same_sex? %>
-    Marriage and PACS in France
-  <% else %>
-    Marriage and PACS in France
-  <% end %>
+<% if calculator.partner_is_same_sex? %>
+  Marriage and PACS in France
+<% else %>
+  Marriage and PACS in France
 <% end %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/germany/_title.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/germany/_title.erb
@@ -1,11 +1,9 @@
-<% text_for :title do %>
-  <% if calculator.partner_is_same_sex? %>
-    <% if calculator.partner_is_national_of_ceremony_country? %>
-      Same-sex marriage in Germany
-    <% else %>
-      Same-sex marriage in Germany
-    <% end %>
+<% if calculator.partner_is_same_sex? %>
+  <% if calculator.partner_is_national_of_ceremony_country? %>
+    Same-sex marriage in Germany
   <% else %>
-    Marriage in Germany
+    Same-sex marriage in Germany
   <% end %>
+<% else %>
+  Marriage in Germany
 <% end %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/iceland/_title.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/iceland/_title.erb
@@ -1,3 +1,1 @@
-<% text_for :title do %>
-  Marriage and Civil partnership in Iceland
-<% end %>
+Marriage and Civil partnership in Iceland

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/iran/_title.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/iran/_title.erb
@@ -1,7 +1,5 @@
-<% text_for :title do %>
-  <% if calculator.partner_is_same_sex? %>
-    Same-sex marriage and civil partnership in Iran
-  <% else %>
-    Marriage in Iran
-  <% end %>
+<% if calculator.partner_is_same_sex? %>
+  Same-sex marriage and civil partnership in Iran
+<% else %>
+  Marriage in Iran
 <% end %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/_title.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/_title.erb
@@ -1,7 +1,5 @@
-<% text_for :title do %>
-  <% if calculator.partner_is_same_sex? %>
-    Same-sex marriage and civil partnership in Jordan
-  <% else %>
-    Marriage in Jordan
-  <% end %>
+<% if calculator.partner_is_same_sex? %>
+  Same-sex marriage and civil partnership in Jordan
+<% else %>
+  Marriage in Jordan
 <% end %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/latvia/_title.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/latvia/_title.erb
@@ -1,11 +1,9 @@
-<% text_for :title do %>
-  <% if calculator.partner_is_same_sex? %>
-    <% if calculator.partner_is_national_of_ceremony_country? %>
-      Same-sex marriage and civil partnership in Latvia
-    <% else %>
-      Same-sex marriage in Latvia
-    <% end %>
+<% if calculator.partner_is_same_sex? %>
+  <% if calculator.partner_is_national_of_ceremony_country? %>
+    Same-sex marriage and civil partnership in Latvia
   <% else %>
-    Marriage in Latvia
+    Same-sex marriage in Latvia
   <% end %>
+<% else %>
+  Marriage in Latvia
 <% end %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/mozambique/_title.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/mozambique/_title.erb
@@ -1,7 +1,5 @@
-<% text_for :title do %>
-  <% if calculator.partner_is_same_sex? %>
-    Same-sex marriage and civil partnership in Mozambique
-  <% else %>
-    Marriage in Mozambique
-  <% end %>
+<% if calculator.partner_is_same_sex? %>
+  Same-sex marriage and civil partnership in Mozambique
+<% else %>
+  Marriage in Mozambique
 <% end %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/philippines/_title.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/philippines/_title.erb
@@ -1,7 +1,5 @@
-<% text_for :title do %>
-  <% if calculator.partner_is_same_sex? %>
-    Same-sex marriage in the Philippines
-  <% else %>
-    Marriage in the Philippines
-  <% end %>
+<% if calculator.partner_is_same_sex? %>
+  Same-sex marriage in the Philippines
+<% else %>
+  Marriage in the Philippines
 <% end %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/poland/_title.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/poland/_title.erb
@@ -1,7 +1,5 @@
-<% text_for :title do %>
-  <% if calculator.partner_is_same_sex? %>
-    Same-sex marriage and civil partnership in Poland
-  <% else %>
-    Marriage in Poland
-  <% end %>
-<% end %>
+ <% if calculator.partner_is_same_sex? %>
+   Same-sex marriage and civil partnership in Poland
+ <% else %>
+   Marriage in Poland
+ <% end %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/portugal/_title.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/portugal/_title.erb
@@ -1,7 +1,5 @@
-<% text_for :title do %>
-  <% if calculator.partner_is_same_sex? %>
-    Same-sex marriage in Portugal
-  <% else %>
-    Marriage in Portugal
-  <% end %>
+<% if calculator.partner_is_same_sex? %>
+  Same-sex marriage in Portugal
+<% else %>
+  Marriage in Portugal
 <% end %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/romania/_title.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/romania/_title.erb
@@ -1,10 +1,8 @@
-<% text_for :title do %>
-  <% if calculator.partner_is_same_sex? &&
-      calculator.partner_is_national_of_ceremony_country? %>
-    Same-sex marriage and civil partnership in Romania
-  <% elsif calculator.partner_is_same_sex? %>
-    Same-sex marriage in Romania
-  <% else %>
-    Marriage in Romania
-  <% end %>
+<% if calculator.partner_is_same_sex? &&
+    calculator.partner_is_national_of_ceremony_country? %>
+  Same-sex marriage and civil partnership in Romania
+<% elsif calculator.partner_is_same_sex? %>
+  Same-sex marriage in Romania
+<% else %>
+  Marriage in Romania
 <% end %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/thailand/_title.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/thailand/_title.erb
@@ -1,7 +1,5 @@
-<% text_for :title do %>
-  <% if calculator.partner_is_same_sex? %>
-    Same-sex marriage and civil partnership in Thailand
-    <% else %>
-    Marriage in Thailand
-  <% end %>
+<% if calculator.partner_is_same_sex? %>
+  Same-sex marriage and civil partnership in Thailand
+  <% else %>
+  Marriage in Thailand
 <% end %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/turkey/_title.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/turkey/_title.erb
@@ -1,7 +1,5 @@
-<% text_for :title do %>
-  <% if calculator.partner_is_same_sex? %>
-    Same-sex marriage in Turkey
-  <% else %>
-    Marriage in Turkey
-  <% end %>
+<% if calculator.partner_is_same_sex? %>
+  Same-sex marriage in Turkey
+<% else %>
+  Marriage in Turkey
 <% end %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/usa/_title.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/usa/_title.erb
@@ -1,7 +1,5 @@
-<% text_for :title do %>
-  <% if calculator.partner_is_same_sex? %>
-    Same-sex marriage in the USA
-  <% else %>
-    Marriage in the USA
-  <% end %>
+<% if calculator.partner_is_same_sex? %>
+  Same-sex marriage in the USA
+<% else %>
+  Marriage in the USA
 <% end %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/vietnam/_title.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/vietnam/_title.erb
@@ -1,7 +1,5 @@
-<% text_for :title do %>
-  <% if calculator.partner_is_same_sex? %>
-    Same-sex marriage in Vietnam
-  <% else %>
-    Marriage in Vietnam
-  <% end %>
+<% if calculator.partner_is_same_sex? %>
+  Same-sex marriage in Vietnam
+<% else %>
+  Marriage in Vietnam
 <% end %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_marriage_abroad_in_country.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/outcome_marriage_abroad_in_country.erb
@@ -1,7 +1,5 @@
-<% text_for :title do %>
-    <%= render partial: 'countries/'+calculator.ceremony_country+'/title', locals: {calculator: calculator} %>
-<% end %>
-
 <% govspeak_for :body do %>
+  ## <%= render partial: 'countries/'+calculator.ceremony_country+'/title', locals: {calculator: calculator} %>
+
     <%= render partial: 'countries/'+calculator.path_to_outcome.join('/'), locals: {calculator: calculator} %>
 <% end %>

--- a/lib/smart_answer_flows/maternity-paternity-calculator/outcomes/_paternity_entitled_to_leave.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/outcomes/_paternity_entitled_to_leave.erb
@@ -1,9 +1,9 @@
 <% if leave_type == "adoption" %>
-  ##Statutory Adoption Leave
+  ## Statutory Adoption Leave
 
   The employee is entitled to Statutory Adoption Leave.
 <% else %>
-  ##Statutory Paternity Leave
+  ## Statutory Paternity Leave
 
   The employee is entitled to Statutory Paternity Leave.
 <% end %>

--- a/lib/smart_answer_flows/maternity-paternity-calculator/outcomes/adoption_leave_and_pay.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/outcomes/adoption_leave_and_pay.erb
@@ -1,12 +1,12 @@
 <% govspeak_for :body do %>
   <% if calculator.employee_has_contract_adoption == 'no' %>
-    ##Statutory Adoption Leave
+    ## Statutory Adoption Leave
 
     The employee is not entitled to Statutory Adoption Leave because they don’t have an employment contract with you.
 
     Write to them within 28 days of their leave request confirming this.
   <% else %>
-    ##Statutory Adoption Leave
+    ## Statutory Adoption Leave
 
     The employee is entitled to up to 52 weeks Statutory Adoption Leave if they [claim the leave on time](/employers-adoption-pay-leave/notice-period).
 

--- a/lib/smart_answer_flows/maternity-paternity-calculator/outcomes/adoption_not_entitled_to_leave_or_pay.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/outcomes/adoption_not_entitled_to_leave_or_pay.erb
@@ -1,5 +1,5 @@
 <% govspeak_for :body do %>
-  ##Not entitled to Statutory Adoption Leave and Pay
+  ## Not entitled to Statutory Adoption Leave and Pay
 
   <% if adoption_is_from_overseas%>
     The employee is not entitled to Statutory Adoption Leave or Pay because they must have started working for you on <%= format_date(a_leave_employment_threshold) %>.

--- a/lib/smart_answer_flows/maternity-paternity-calculator/outcomes/maternity_leave_and_pay_result.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/outcomes/maternity_leave_and_pay_result.erb
@@ -1,6 +1,6 @@
 <% govspeak_for :body do %>
   <% if has_employment_contract_between_dates == 'yes' || has_employment_contract_now == 'yes' %>
-    ##Statutory Maternity Leave
+    ## Statutory Maternity Leave
 
     The employee is entitled to up to 52 weeks Statutory Maternity Leave.
 
@@ -12,7 +12,7 @@
     |Earliest date leave can start | <%= format_date(leave_earliest_start_date) %> |
 
   <% else %>
-    ##Statutory Maternity Leave
+    ## Statutory Maternity Leave
 
     The employee is not entitled to Statutory Maternity Leave because they do not have an employment contract with you.
 
@@ -22,13 +22,13 @@
 
   <% if not_entitled_to_pay_reason.present? %>
     <% if calculator.earnings_for_pay_period %>
-      ##Statutory Maternity Pay
+      ## Statutory Maternity Pay
 
       The employee is not entitled to Statutory Maternity Pay.
       Their average weekly earnings are <%= format_money(average_weekly_earnings) %> (you can’t round this figure up or down). To qualify:
 
     <% else %>
-      ##Statutory Maternity Pay
+      ## Statutory Maternity Pay
 
       The employee is not entitled to Statutory Maternity Pay. To qualify:
 
@@ -55,7 +55,7 @@
     $D [Download Form SMP1, Non-payment of Statutory Maternity Pay (PDF, 59KB)](http://www.dwp.gov.uk/advisers/claimforms/smp1_print.pdf) $D
 
   <% else %>
-    ##Statutory Maternity Pay
+    ## Statutory Maternity Pay
 
     The employee is entitled to up to 39 weeks Statutory Maternity Pay (SMP) if they [claim SMP in time](/maternity-leave-pay-employees/notice-period "Notice period") and give [proof of the pregnancy](/maternity-leave-pay-employees/eligibility "Proof of pregnancy").
 

--- a/lib/smart_answer_flows/maternity-paternity-calculator/outcomes/paternity_leave_and_pay.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/outcomes/paternity_leave_and_pay.erb
@@ -25,7 +25,7 @@
     <%= render partial: 'paternity_not_entitled_to_pay_outro' %>
   <% else %>
     <% if leave_type == "adoption" %>
-      ##Statutory Adoption Pay (SAP)
+      ## Statutory Adoption Pay (SAP)
 
       The employee is entitled to SAP.
 
@@ -39,7 +39,7 @@
        | **Total SAP: <%= format_money(total_spp) %>**
 
     <% else %>
-      ##Statutory Paternity Pay (SPP)
+      ## Statutory Paternity Pay (SPP)
 
       The employee is entitled to SPP.
 

--- a/lib/smart_answer_flows/maternity-paternity-calculator/outcomes/paternity_not_entitled_to_leave_or_pay.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/outcomes/paternity_not_entitled_to_leave_or_pay.erb
@@ -30,7 +30,7 @@
 
     <%= render partial: 'paternity_not_entitled_to_pay_outro' %>
   <% else %>
-    ##Not entitled to Statutory Paternity Pay or Leave
+    ## Not entitled to Statutory Paternity Pay or Leave
 
     The employee is not entitled to Statutory Paternity Leave or Pay because:
 

--- a/lib/smart_answer_flows/plan-adoption-leave/outcomes/adoption_leave_details.erb
+++ b/lib/smart_answer_flows/plan-adoption-leave/outcomes/adoption_leave_details.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  Your Adoption Leave dates
-<% end %>
-
 <% govspeak_for :body do %>
+  ## Your Adoption Leave dates
+
   You can take up to 52 weeks Statutory Adoption Leave.
 
   The dates below are based on this and the date the child starts to live with you: <%= arrival_date_formatted %>.

--- a/lib/smart_answer_flows/report-a-lost-or-stolen-passport/outcomes/contact_the_embassy.erb
+++ b/lib/smart_answer_flows/report-a-lost-or-stolen-passport/outcomes/contact_the_embassy.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  You must report your lost or stolen passport
-<% end %>
-
 <% govspeak_for :body do %>
+  ## You must report your lost or stolen passport
+
 You can cancel your passport immediately by [reporting it online](https://www.loststolenpassport.service.gov.uk/report/passport-holder).
 
 ###Help cancelling your passport

--- a/lib/smart_answer_flows/simplified-expenses-checker/outcomes/you_can_use_result.erb
+++ b/lib/smart_answer_flows/simplified-expenses-checker/outcomes/you_can_use_result.erb
@@ -1,7 +1,7 @@
 <% govspeak_for :body do %>
   <% if calculator.capital_allowance_claimed? &&
       calculator.neither_new_nor_used_vehicle? %>
-    ##For your vehicle
+    ## For your vehicle
 
     You can’t use simplified expenses for your vehicle because you’ve already claimed capital allowances for it.
 
@@ -11,7 +11,7 @@
 
   <% elsif calculator.simplified_expenses_claimed? &&
       calculator.neither_new_nor_used_vehicle? %>
-    ##For your vehicle
+    ## For your vehicle
 
     You can’t claim capital allowances for your vehicle because you’ve already claimed simplified expenses for it.
 

--- a/lib/smart_answer_flows/state-pension-age/outcomes/bus_pass_result.erb
+++ b/lib/smart_answer_flows/state-pension-age/outcomes/bus_pass_result.erb
@@ -1,9 +1,6 @@
-<% text_for :title do %>
-  Your bus pass age
-
-<% end %>
-
 <% govspeak_for :body do %>
+  ## Your bus pass age
+
   The date you qualify for a bus pass is:
 
   - on <%= format_date(calculator.bus_pass_qualification_date) %>, if you live in England

--- a/lib/smart_answer_flows/state-pension-age/outcomes/has_reached_sp_age.erb
+++ b/lib/smart_answer_flows/state-pension-age/outcomes/has_reached_sp_age.erb
@@ -1,9 +1,6 @@
-<% text_for :title do %>
-  You reached State Pension age on <%= format_date(calculator.state_pension_date) %>.
-
-<% end %>
-
 <% govspeak_for :body do %>
+  ## You reached State Pension age on <%= format_date(calculator.state_pension_date) %>.
+
   Your State Pension age was <%= calculator.state_pension_age %>.
 
   You should have got your pension claim pack before you reached your State Pension age.

--- a/lib/smart_answer_flows/state-pension-age/outcomes/not_yet_reached_sp_age.erb
+++ b/lib/smart_answer_flows/state-pension-age/outcomes/not_yet_reached_sp_age.erb
@@ -1,9 +1,6 @@
-<% text_for :title do %>
-  You’ll reach State Pension age on <%= format_date(calculator.state_pension_date) %>.
-
-<% end %>
-
 <% govspeak_for :body do %>
+  ## You’ll reach State Pension age on <%= format_date(calculator.state_pension_date) %>.
+
   Your State Pension age is <%= calculator.state_pension_age %>.
 
   <% if calculator.rolling_increase_period? %>

--- a/lib/smart_answer_flows/state-pension-through-partner/outcomes/impossibility_due_to_divorce_outcome.erb
+++ b/lib/smart_answer_flows/state-pension-through-partner/outcomes/impossibility_due_to_divorce_outcome.erb
@@ -1,5 +1,5 @@
 <% govspeak_for :body do %>
-  ##You reached State Pension age before 6 April 2016
+  ## You reached State Pension age before 6 April 2016
 
   You may be able to increase your basic State Pension up to <%= format_money(calculator.higher_basic_state_pension_rate) %> a week if:
 

--- a/lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_eu_students.erb
+++ b/lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_eu_students.erb
@@ -8,11 +8,11 @@
   The loan pays for the cost of your course and must be paid back.
 
   <% if course_type == 'eu-full-time' %>
-    ##Living costs
+    ## Living costs
 
     Most EU full-time students don't qualify for help with living costs (known as 'maintenance').
   <% else %>
-    ##Living costs
+    ## Living costs
 
     EU part-time students don't qualify for help with living costs (known as 'maintenance').
   <% end %>

--- a/lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_uk_full_time_dental_medical_students.erb
+++ b/lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_uk_full_time_dental_medical_students.erb
@@ -1,6 +1,6 @@
 <% govspeak_for :body do %>
   <%= render partial: 'disclaimer' %>
-    ##If you’re studying to become a doctor or dentist
+    ## If you’re studying to become a doctor or dentist
 
     The amount you get will change during your course.
 

--- a/lib/smart_answer_flows/vat-payment-deadlines/outcomes/result_bacs_direct_credit.erb
+++ b/lib/smart_answer_flows/vat-payment-deadlines/outcomes/result_bacs_direct_credit.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  Paying by Bacs Direct Credit
-<% end %>
-
 <% govspeak_for :body do %>
+  ## Paying by Bacs Direct Credit
+
   The last date you can pay is <%= last_payment_date %>.
 
   The money must have cleared by <%= funds_received_by %>.

--- a/lib/smart_answer_flows/vat-payment-deadlines/outcomes/result_bank_giro.erb
+++ b/lib/smart_answer_flows/vat-payment-deadlines/outcomes/result_bank_giro.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  Paying by Bank Giro
-<% end %>
-
 <% govspeak_for :body do %>
+  ## Paying by Bank Giro
+
   The last date you can pay is <%= last_payment_date %>.
 
   The money must have cleared by <%= funds_received_by %>.

--- a/lib/smart_answer_flows/vat-payment-deadlines/outcomes/result_chaps.erb
+++ b/lib/smart_answer_flows/vat-payment-deadlines/outcomes/result_chaps.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  Paying by CHAPS
-<% end %>
-
 <% govspeak_for :body do %>
+  ## Paying by CHAPS
+
   The last date you can pay is <%= last_payment_date %>.
 
   HMRC must receive the money by <%= funds_received_by %>.

--- a/lib/smart_answer_flows/vat-payment-deadlines/outcomes/result_cheque.erb
+++ b/lib/smart_answer_flows/vat-payment-deadlines/outcomes/result_cheque.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  Paying by cheque
-<% end %>
-
 <% govspeak_for :body do %>
+  ## Paying by cheque
+
   You can only pay by cheque if you’re exempt from submitting online VAT returns. If you need to pay by cheque for any other reason, pay by Bank Giro.
 
   The last day you can post your cheque is <%= last_posting_date %>.

--- a/lib/smart_answer_flows/vat-payment-deadlines/outcomes/result_direct_debit.erb
+++ b/lib/smart_answer_flows/vat-payment-deadlines/outcomes/result_direct_debit.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  Paying by direct debit
-<% end %>
-
 <% govspeak_for :body do %>
+  ## Paying by direct debit
+
   The last date you can set up a direct debit is <%= last_dd_setup_date %>.
 
   The date the money will be taken from your account is <%= funds_taken %>.

--- a/lib/smart_answer_flows/vat-payment-deadlines/outcomes/result_online_debit_credit_card.erb
+++ b/lib/smart_answer_flows/vat-payment-deadlines/outcomes/result_online_debit_credit_card.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  Paying by online debit or credit card
-<% end %>
-
 <% govspeak_for :body do %>
+  ## Paying by online debit or credit card
+
   The last date you can pay is <%= last_payment_date %>.
 
   The money must have cleared by <%= funds_received_by %>.

--- a/lib/smart_answer_flows/vat-payment-deadlines/outcomes/result_online_telephone_banking.erb
+++ b/lib/smart_answer_flows/vat-payment-deadlines/outcomes/result_online_telephone_banking.erb
@@ -1,8 +1,6 @@
-<% text_for :title do %>
-  Paying online or by telephone banking
-<% end %>
-
 <% govspeak_for :body do %>
+  ## Paying online or by telephone banking
+
   The last date you can pay is <%= last_payment_date %>.
 
   You need your VAT registration number as the payment reference.


### PR DESCRIPTION
This removes the usage of `text_for :title` from the outcome templates as future work would like to repurpose it to specify the outcome page's h1 title (currently the flow name). The current titles are moved to the body section and rendered as h2 in govspeak, which shouldn't have user facing changes.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.
