### PR TITLE
Add option to use title as outcome page heading

### DIFF
--- a/app/presenters/outcome_presenter.rb
+++ b/app/presenters/outcome_presenter.rb
@@ -19,6 +19,14 @@ class OutcomePresenter < NodePresenter
     @renderer.content_for(:title)
   end
 
+  def heading_title
+    title_as_heading? ? title : @flow_presenter.title
+  end
+
+  def title_as_heading?
+    @renderer.use_title_as_h1
+  end
+
   def body
     @renderer.content_for(:body)
   end

--- a/app/views/smart_answers/result.html.erb
+++ b/app/views/smart_answers/result.html.erb
@@ -10,7 +10,7 @@
   <div id="result-info" class="govuk-grid-column-two-thirds outcome">
     <%= render 'smart_answers/debug' %>
     <%= render "govuk_publishing_components/components/title", {
-      title: @presenter.title
+      title: outcome.heading_title
     } %>
 
     <div class="govuk-!-margin-bottom-6 result-body" data-debug-template-path="<%= outcome.relative_erb_template_path %>">
@@ -18,7 +18,7 @@
         <%= render "govuk_publishing_components/components/heading", {
           text: outcome.title,
           margin_bottom: 6
-        } %>
+        } unless outcome.title_as_heading? %>
       <% end %>
 
       <%= outcome.body %>

--- a/doc/smart-answers/erb-templates/outcome-templates.md
+++ b/doc/smart-answers/erb-templates/outcome-templates.md
@@ -32,6 +32,16 @@ Used to generate the main content. Expected to be govspeak or HTML. Example:
 <% end %>
 ```
 
+### `:use_title_as_h1`
+
+When `true`, specifies that you want to use the given `title` as the outcome page
+`<h1>` heading instead of the default `<h2>` heading.  The flow title is no longer
+shown.
+
+```erb
+<% use_title_as_h1 true %>
+```
+
 ### `next_steps`
 
 Used to generate the "next steps" content (at the top of the right-hand sidebar). Expected to be govspeak or HTML. Example:

--- a/lib/smart_answer/erb_renderer.rb
+++ b/lib/smart_answer/erb_renderer.rb
@@ -17,6 +17,7 @@ module SmartAnswer
     end
 
     delegate :hide_caption, to: :rendered_view
+    delegate :use_title_as_h1, to: :rendered_view
 
     def option(key)
       rendered_view

--- a/lib/smart_answer/erb_renderer/question_options_helper.rb
+++ b/lib/smart_answer/erb_renderer/question_options_helper.rb
@@ -7,5 +7,9 @@ module SmartAnswer
     def hide_caption(hide_caption = false)
       @hide_caption = hide_caption || @hide_caption
     end
+
+    def use_title_as_h1(use_title_as_h1 = false)
+      @use_title_as_h1 = use_title_as_h1 || @use_title_as_h1
+    end
   end
 end

--- a/lib/smart_answer_flows/all-smart-answer-questions/outcomes/outcome.erb
+++ b/lib/smart_answer_flows/all-smart-answer-questions/outcomes/outcome.erb
@@ -1,3 +1,5 @@
+<% use_title_as_h1 true %>
+
 <% text_for :title do %>
   Congratulations
 <% end %>

--- a/test/unit/erb_renderer_test.rb
+++ b/test/unit/erb_renderer_test.rb
@@ -71,6 +71,36 @@ module SmartAnswer
       end
     end
 
+    test "#use_title_as_h1 returns true if it is set to true" do
+      erb_template = "<% use_title_as_h1 true %>"
+
+      with_erb_template_file("template-name", erb_template) do |erb_template_directory|
+        renderer = ErbRenderer.new(template_directory: erb_template_directory, template_name: "template-name")
+
+        assert renderer.use_title_as_h1
+      end
+    end
+
+    test "#use_title_as_h1 returns false if it is set to false" do
+      erb_template = "<% use_title_as_h1 false %>"
+
+      with_erb_template_file("template-name", erb_template) do |erb_template_directory|
+        renderer = ErbRenderer.new(template_directory: erb_template_directory, template_name: "template-name")
+
+        assert_not renderer.use_title_as_h1
+      end
+    end
+
+    test "#use_title_as_h1 returns false if it is not set" do
+      erb_template = ""
+
+      with_erb_template_file("template-name", erb_template) do |erb_template_directory|
+        renderer = ErbRenderer.new(template_directory: erb_template_directory, template_name: "template-name")
+
+        assert_not renderer.use_title_as_h1
+      end
+    end
+
     test "#hide_caption returns true if set as true in the view" do
       erb_template = "<% hide_caption true %>"
 

--- a/test/unit/outcome_presenter_test.rb
+++ b/test/unit/outcome_presenter_test.rb
@@ -51,6 +51,28 @@ module SmartAnswer
       assert_equal "title-text", @presenter.title
     end
 
+    test "#heading_title when title_as_heading is false returns the flow title" do
+      flow = stub("flow_presenter")
+      outcome = OutcomePresenter.new(stub("outcome"), flow, nil, renderer: stub("renderer"))
+
+      flow.stubs(:title).returns("flow-title")
+      outcome.stubs(:title).returns("outcome-title")
+      outcome.stubs(:title_as_heading?).returns(false)
+
+      assert_equal outcome.heading_title, flow.title
+    end
+
+    test "#heading_title when title_as_heading is true returns the outcome title" do
+      flow = stub("flow_presenter")
+      outcome = OutcomePresenter.new(stub("outcome"), flow, nil, renderer: stub("renderer"))
+
+      flow.stubs(:title).returns("flow-title")
+      outcome.stubs(:title).returns("outcome-title")
+      outcome.stubs(:title_as_heading?).returns(true)
+
+      assert_equal outcome.heading_title, outcome.title
+    end
+
     test "#body returns content rendered for body block" do
       @renderer.stubs(:content_for).with(:body).returns("body-html")
 


### PR DESCRIPTION
- Add support to use the page title instead of flow name as the
  outcome page heading (`h1`)
- Add tests
- Add documentation
- Update AllSmartAnswers flow outcome page to use title as heading

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.

[Trello](https://trello.com/c/DXCVrn1z/446-results-page-layout-and-styling)
