### PR TITLE
Update styling of the index page

### DIFF
--- a/app/assets/stylesheets/smart_answers.scss
+++ b/app/assets/stylesheets/smart_answers.scss
@@ -54,6 +54,11 @@ $is-ie: false !default;
   }
 }
 
+.smart-answers-list .govuk-table {
+  font-size: 15px;
+}
+
+
 //Heroku alert
 .heroku-alert {
     margin: 0 15px 15px 15px;

--- a/app/helpers/index_helper.rb
+++ b/app/helpers/index_helper.rb
@@ -1,0 +1,18 @@
+module IndexHelper
+  def title_and_url(flow_name, title)
+    tag.p(title) + link_to("/#{flow_name}", smart_answer_path(flow_name))
+  end
+
+  def live_link(flow_name, status)
+    if status == :draft
+      "https://draft-origin.publishing.service.gov.uk/#{flow_name}"
+    else
+      "https://www.gov.uk/#{flow_name}"
+    end
+  end
+
+  def code_links(flow_name)
+    tag.p(link_to("Definition", "https://www.github.com/alphagov/smart-answers/blob/master/lib/smart_answer_flows/#{flow_name}.rb")) +
+      tag.p(link_to("Templates", "https://www.github.com/alphagov/smart-answers/blob/master/lib/smart_answer_flows/#{flow_name}"))
+  end
+end

--- a/app/views/smart_answers/index.html.erb
+++ b/app/views/smart_answers/index.html.erb
@@ -1,14 +1,35 @@
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1>Smart Answers</h1>
+  <div class="govuk-grid-column-full">
+    <%= render "govuk_publishing_components/components/title", {
+      title: "Smart Answers"
+    } %>
 
-    <ul>
-      <% @flows.each do |flow| %>
-        <li>
-          <%= link_to flow.name, smart_answer_path(flow.name) %>
-          (<%= link_to 'visualise', visualise_path(flow.name) %>)
-        </li>
-      <% end %>
-    </ul>
+    <div class="smart-answers-list">
+      <%= render "govuk_publishing_components/components/table", {
+        head: [
+          { text: "Title" },
+          { text: "Status" },
+          { text: "Questions" },
+          { text: "Outcomes" },
+          { text: "Links" },
+          { text: "" },
+        ],
+        rows: @flows.map { |flow|
+          presenter = FlowPresenter.new({}, flow)
+          [
+            { text: title_and_url(flow.name, presenter.start_node.title) },
+            { text: link_to(flow.status.capitalize, live_link(flow.name, flow.status)) },
+            { text: flow.questions.count },
+            { text: flow.outcomes.count },
+            { text: code_links(flow.name) },
+            { text: link_to('Visualise', visualise_path(flow.name)) },
+          ] 
+        }
+      } %>
+    </div>
+
   </div>
 </div>
+
+<style>
+</style>


### PR DESCRIPTION
Change formatting of the page to use a table to be able to show addition information including title, flow definition link, question count and outcome count.

![image](https://user-images.githubusercontent.com/11051676/92242231-663e3480-eeb7-11ea-8d95-723b43b816b5.png)

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.
