### PR TITLE
Update session store so that it works if page is returned to

### DIFF
--- a/app/helpers/current_question_helper.rb
+++ b/app/helpers/current_question_helper.rb
@@ -15,8 +15,15 @@ module CurrentQuestionHelper
 
   def session_answers_question_path(presenter)
     node_name = presenter.current_state.current_node.to_s
-    node_name.delete_suffix!("?")
     update_session_flow_path(id: params[:id], node_name: node_name)
+  end
+
+  def start_of_flow_path(presenter)
+    if presenter.use_session?
+      session_flow_path(presenter.name, node_name: presenter.questions.first.name)
+    else
+      smart_answer_path(presenter.name, started: "y")
+    end
   end
 
   def restart_flow_path(presenter)

--- a/app/presenters/node_presenter.rb
+++ b/app/presenters/node_presenter.rb
@@ -6,4 +6,8 @@ class NodePresenter
     @flow_presenter = flow_presenter
     @state = state || SmartAnswer::State.new(nil)
   end
+
+  def node_name
+    @node.name
+  end
 end

--- a/app/services/session_store.rb
+++ b/app/services/session_store.rb
@@ -1,0 +1,17 @@
+class SessionStore
+  attr_reader :flow_name, :current_node, :session
+
+  def initialize(flow_name:, current_node:, session:)
+    @flow_name = flow_name
+    @current_node = current_node
+    @session = session
+  end
+
+  def hash
+    session[flow_name] ||= {}
+  end
+
+  def add_response(response)
+    hash[current_node] = response
+  end
+end

--- a/app/views/smart_answers/_debug.html.erb
+++ b/app/views/smart_answers/_debug.html.erb
@@ -5,6 +5,11 @@
       <% @presenter.current_state.to_hash.each do |k, v| %>
         <%= "#{k}: #{v.to_s}"%>
       <% end %>
+
+      Session store:
+      <% @session_store.hash.each do |k, v| %>
+        <%= "#{k}: #{v.inspect}"%>
+      <% end if @session_store %>
     </pre>
   </article>
 <% end %>

--- a/app/views/smart_answers/_previous_answers.html.erb
+++ b/app/views/smart_answers/_previous_answers.html.erb
@@ -14,11 +14,11 @@
     <tbody class="govuk-table__body">
       <% @presenter.collapsed_questions.each_with_index do |question, number_questions_so_far| %>
         <%= render(
-            'previous_answer',
+            'smart_answers/previous_answer',
             question: question,
             accepted_response: @presenter.accepted_responses[number_questions_so_far],
-            question_link: @presenter.change_collapsed_question_link(number_questions_so_far + 1),
-          ) unless @presenter.use_session?
+            question_link: @presenter.change_collapsed_question_link(number_questions_so_far + 1, question),
+          )
         %>
       <% end %>
     </tbody>

--- a/app/views/smart_answers/landing.html.erb
+++ b/app/views/smart_answers/landing.html.erb
@@ -18,7 +18,7 @@
 
         <%= render "govuk_publishing_components/components/button", {
           text: start_node.start_button_text,
-          href: smart_answer_path(@name.to_s, started: "y"),
+          href: start_of_flow_path(@presenter),
           rel: "nofollow",
           start: true,
           margin_bottom: true,

--- a/test/controllers/session_answers_controller_test.rb
+++ b/test/controllers/session_answers_controller_test.rb
@@ -6,7 +6,7 @@ class SessionAnswersControllerTest < ActionDispatch::IntegrationTest
   end
 
   def nodes
-    %i[need_help_with afford_food]
+    %i[need_help_with? afford_food?]
   end
 
   context "GET /:id/:node_name" do
@@ -42,11 +42,12 @@ class SessionAnswersControllerTest < ActionDispatch::IntegrationTest
       get update_session_flow_path(id: flow_name, node_name: nodes[0]), params: { "response" => [], "next" => "1" }
     end
 
-    should "render error successfully" do
-      assert_response :success
+    should "redirect back to show" do
+      assert_redirected_to(session_flow_path(id: flow_name, node_name: nodes[0]))
     end
 
     should "display error" do
+      follow_redirect!
       assert_match(/govuk-error-message/, response.body)
     end
   end

--- a/test/helpers/current_question_helper_test.rb
+++ b/test/helpers/current_question_helper_test.rb
@@ -22,6 +22,16 @@ class CurrentQuestionHelperTest < ActionView::TestCase
     end
   end
 
+  context "#start_of_flow_path" do
+    should "return path to first page in smart flow" do
+      assert_equal smart_answer_path(flow_name, started: "y"), start_of_flow_path(presenter)
+    end
+
+    should "return path to first page in session flow when session answer" do
+      assert_equal session_flow_path(flow_name, node_name: first_question.name), start_of_flow_path(session_presenter)
+    end
+  end
+
   def flow_name
     "coronavirus-find-support"
   end
@@ -39,6 +49,7 @@ class CurrentQuestionHelperTest < ActionView::TestCase
   def presenter
     @presenter ||= OpenStruct.new(
       accepted_responses: [],
+      name: flow_name,
     )
   end
 
@@ -46,12 +57,20 @@ class CurrentQuestionHelperTest < ActionView::TestCase
     @session_presenter ||= OpenStruct.new(
       "use_session?" => true,
       current_state: current_state,
+      questions: [first_question],
+      name: flow_name,
     )
   end
 
   def current_state
     @current_state ||= OpenStruct.new(
       current_node: node_name,
+    )
+  end
+
+  def first_question
+    @first_question ||= OpenStruct.new(
+      name: "first",
     )
   end
 end

--- a/test/unit/services/session_store_test.rb
+++ b/test/unit/services/session_store_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+
+class SessionStoreTest < ActiveSupport::TestCase
+  def flow_name
+    @flow_name ||= :flow_name
+  end
+
+  def node_name
+    @node_name ||= :node_name
+  end
+
+  def response
+    @response ||= SecureRandom.uuid
+  end
+
+  def responses
+    @responses ||= {}
+  end
+
+  def session
+    @session ||= { flow_name => responses }
+  end
+
+  def session_store
+    @session_store ||= SessionStore.new(flow_name: flow_name, current_node: node_name, session: session)
+  end
+
+  context "#add_response" do
+    should "adds response to empty store" do
+      session_store.add_response(response)
+      assert_equal response, session.dig(flow_name, node_name)
+    end
+
+    should "replace existing entry" do
+      @responses = { a: "a", node_name => "b", c: "c" }
+      session_store.add_response(response)
+      assert_equal response, session.dig(flow_name, node_name)
+    end
+
+    should "not alter order of responses" do
+      @responses = { a: "a", node_name => "b", c: "c" }
+      session_store.add_response(response)
+      assert_equal [:a, node_name, :c], session[flow_name].keys
+    end
+  end
+end


### PR DESCRIPTION
This iteration of the session store system works for all happy paths that I can find. It will both complete a journey, and allow a user to return to an earlier part of the flow and alter an input.

The main outstanding issue is that error handling is not working. In that, if you submit a form without entering anything the page is shown again, but without an error message.

- Adds handling of data in the form of a hash (params) rather than an array, within the `Flow`.
- Adds testing of the hash handling of `Flow`
- Uses a `SessionStore` to manage data storage with session. The initial benefit is that it simplifies namespacing the session data (so that data entry from one flow won't overwrite that from another)
- Adds `SessionStore` tests
- Updates landing page and return to flow links to work with session store.

[Trello ticket](https://trello.com/c/NUE5PJkG/469-update-session-store-so-that-it-works-if-page-is-returned-to)