### PR TITLE
Set cookie key used by session as 'smart_answer_session'

### DIFF
--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -1,2 +1,7 @@
-# We don't use sessions in this application, but Rails needs a secret key base anyway.
+# Be sure to restart your server when you modify this file.
+
+# Your secret key for verifying the integrity of signed cookies.
+# If you change this key, all old signed cookies will become invalid!
+# Make sure the secret is at least 30 characters and all random,
+# no regular words or you'll be exposed to dictionary attacks.
 SmartAnswers::Application.config.secret_key_base = SecureRandom.hex

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, expire_after: 4.hours
+Rails.application.config.session_store :cookie_store, expire_after: 4.hours, key: :smart_answer_session


### PR DESCRIPTION
Reinstated default secret token comment as session is now used in app

[Trello Ticket](https://trello.com/c/J5zsdZ72/485-update-cookie-key)