### PR TITLE
Remove secret token initializer

### DIFF
--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -1,7 +1,0 @@
-# Be sure to restart your server when you modify this file.
-
-# Your secret key for verifying the integrity of signed cookies.
-# If you change this key, all old signed cookies will become invalid!
-# Make sure the secret is at least 30 characters and all random,
-# no regular words or you'll be exposed to dictionary attacks.
-SmartAnswers::Application.config.secret_key_base = SecureRandom.hex


### PR DESCRIPTION
When upgrading from pre-Rails 4 the setting of `secret_key_base` was moved from an initializer to secrets [as described in the upgrade docs](https://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#config-secrets-yml). However, both systems are still present in app. Previously this wasn't an issue as session was not being used.

The secret key base is returned at the console with `SmartAnswers::Application.secret_key_base` (documented [here](https://api.rubyonrails.org/classes/Rails/Application.html#method-i-secret_key_base)). So the initializer is setting an unused config parameter.

With the new session based flows now being added, this anomaly needs addressing by removing the initializer.

