### PR TITLE
Remove Ruby version from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source "https://rubygems.org"
 
-ruby File.read(".ruby-version").chomp
-
 gem "rails", "6.0.3.2"
 
 gem "railties"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -405,8 +405,5 @@ DEPENDENCIES
   uk_postcode
   webmock
 
-RUBY VERSION
-   ruby 2.6.6
-
 BUNDLED WITH
    1.17.3


### PR DESCRIPTION
Since there is an automated process for updating Ruby versions in govuk apps, I changed the version locally and verified that no updates to the code were necessary. The tests should pass for both old and new Ruby versions without deprecation warnings.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.
