### PR TITLE
Add /s/ segment to session based routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
         format: false
   end
 
-  get "/:id/destroy_session", to: "session_answers#destroy", as: :destroy_session_flow
-  get "/:id/:node_name", to: "session_answers#show", as: :session_flow
-  get "/:id/:node_name/next", to: "session_answers#update", as: :update_session_flow
+  get "/:id/s/destroy_session", to: "session_answers#destroy", as: :destroy_session_flow
+  get "/:id/s/:node_name", to: "session_answers#show", as: :session_flow
+  get "/:id/s/:node_name/next", to: "session_answers#update", as: :update_session_flow
 end

--- a/test/unit/flow_presenter_test.rb
+++ b/test/unit/flow_presenter_test.rb
@@ -194,7 +194,7 @@ class FlowPresenterTest < ActiveSupport::TestCase
     should "return path to first page in session flow using sessions" do
       @flow.use_session(true)
       flow_presenter = FlowPresenter.new({}, @flow)
-      assert_equal "/flow-name/first_question_key", flow_presenter.start_page_link
+      assert_equal "/flow-name/s/first_question_key", flow_presenter.start_page_link
     end
   end
 end


### PR DESCRIPTION
We need to add an extra segment to routes for session based smart answers. Currently the routes are:
Start page: /flow-name
Node pages: /flow-name/node-name

We need:
Start page: /flow-name
Node pages: /flow-name/s/node-name


[trello ticket](https://trello.com/c/Z6P5tR0j/488-add-extra-segment-to-session-based-routes)