### PR TITLE
Fix routes published for smart answer content item

### DIFF
--- a/app/presenters/flow_content_item.rb
+++ b/app/presenters/flow_content_item.rb
@@ -19,7 +19,7 @@ class FlowContentItem
       rendering_app: "smartanswers",
       locale: "en",
       public_updated_at: Time.zone.now.iso8601,
-      routes: [{ type: "prefix", path: "/#{flow_presenter.name}/" }],
+      routes: [{ type: "prefix", path: flow_presenter.start_page_link }],
     }
   end
 

--- a/test/unit/flow_content_item_test.rb
+++ b/test/unit/flow_content_item_test.rb
@@ -115,7 +115,7 @@ module SmartAnswer
       presenter = stub_flow_registration_presenter
       content_item = FlowContentItem.new(presenter)
 
-      expected_route = { type: "prefix", path: "/flow-name/" }
+      expected_route = { type: "prefix", path: "/flow-name/y" }
       assert content_item.payload[:routes].include?(expected_route)
     end
   end


### PR DESCRIPTION
We aren't able to publish smart answer content items because the Publishing API doesn't accept routes "above" the base path. This reverts the route to be `/flow-name/y` for non-session based smart answers. However, we still will be unable to publish session based smart answers.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.
