### PR TITLE
Add new `/flow-name/s` route with redirect to flow start

### DIFF
--- a/app/controllers/session_answers_controller.rb
+++ b/app/controllers/session_answers_controller.rb
@@ -1,6 +1,10 @@
 class SessionAnswersController < ApplicationController
   before_action :set_cache_headers
 
+  def start
+    redirect_to session_flow_path(id: params[:id], node_name: next_node_name)
+  end
+
   def show
     @title = presenter.title
     @content_item = ContentItemRetriever.fetch(name) if presenter.finished?

--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -138,7 +138,7 @@ class FlowPresenter
 
   def start_page_link
     if use_session?
-      session_flow_path(name, node_name: questions.first.name)
+      start_session_flow_path(name)
     else
       smart_answer_path(name, started: "y")
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
   end
 
   get "/:id/s/destroy_session", to: "session_answers#destroy", as: :destroy_session_flow
+  get "/:id/s", to: "session_answers#start", as: :start_session_flow
   get "/:id/s/:node_name", to: "session_answers#show", as: :session_flow
   get "/:id/s/:node_name/next", to: "session_answers#update", as: :update_session_flow
 end

--- a/test/controllers/session_answers_controller_test.rb
+++ b/test/controllers/session_answers_controller_test.rb
@@ -9,7 +9,17 @@ class SessionAnswersControllerTest < ActionDispatch::IntegrationTest
     %i[need_help_with? afford_food?]
   end
 
-  context "GET /:id/:node_name" do
+  context "GET /:id/s" do
+    setup do
+      get start_session_flow_path(flow_name)
+    end
+
+    should "redirect to show first node" do
+      assert_redirected_to(session_flow_path(id: flow_name, node_name: nodes[0]))
+    end
+  end
+
+  context "GET /:id/s/:node_name" do
     setup do
       get session_flow_path(id: flow_name, node_name: nodes[0])
     end
@@ -39,7 +49,7 @@ class SessionAnswersControllerTest < ActionDispatch::IntegrationTest
     { "response" => %w[getting_food], "next" => "1" }
   end
 
-  context "GET /:id/:node_name/next" do
+  context "GET /:id/s/:node_name/next" do
     setup do
       get update_session_flow_path(id: flow_name, node_name: nodes[0]), params: params
     end
@@ -49,7 +59,7 @@ class SessionAnswersControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  context "GET /:id/:node_name/next with error submission" do
+  context "GET /:id/s/:node_name/next with error submission" do
     setup do
       get update_session_flow_path(id: flow_name, node_name: nodes[0]), params: { "response" => [], "next" => "1" }
     end
@@ -64,7 +74,7 @@ class SessionAnswersControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  context "GET /:id/destroy_session" do
+  context "GET /:id/s/destroy_session" do
     setup do
       get update_session_flow_path(id: flow_name, node_name: nodes[0]), params: params
     end

--- a/test/unit/flow_presenter_test.rb
+++ b/test/unit/flow_presenter_test.rb
@@ -194,7 +194,7 @@ class FlowPresenterTest < ActiveSupport::TestCase
     should "return path to first page in session flow using sessions" do
       @flow.use_session(true)
       flow_presenter = FlowPresenter.new({}, @flow)
-      assert_equal "/flow-name/s/first_question_key", flow_presenter.start_page_link
+      assert_equal "/flow-name/s", flow_presenter.start_page_link
     end
   end
 end


### PR DESCRIPTION
## What

We need to add a redirect for the route `/flow-name/s` to the start of the flow (i.e first question).

## Why
To prevent user's experience errors when navigating to `/flow-name/s`. It can also be used as the start page link and prevent errors being served between the app being deployed and the content item being updated if the first question changes in a flow is change.

[trello](https://trello.com/c/21zTfVTa/489-add-new-flow-name-s-route-with-redirect-to-flow-start)