### PR TITLE
Add extra event tracking to smart answers (inc find Coronavirus Support)

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -8,8 +8,9 @@
 //= require govuk_publishing_components/components/step-by-step-nav
 //= require helpers
 //= require components/escape-link
+//= require modules/track-responses
 
 window.addEventListener('DOMContentLoaded', function () {
   var error = document.getElementById('current-error');
-  if (error) { error.focus() };
+  if (error) { error.focus() }
 })

--- a/app/assets/javascripts/modules/track-responses.js
+++ b/app/assets/javascripts/modules/track-responses.js
@@ -1,0 +1,93 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (global, GOVUK) {
+  'use strict'
+
+  GOVUK.Modules.TrackResponses = function () {
+    this.start = function (element) {
+      track(element[0])
+    }
+
+    function getQuestionKey(submittedForm) {
+      return submittedForm.getAttribute('data-question-key');
+    }
+
+    function getResponseLabelsForMultipleChoice(submittedForm) {
+      var labels = []
+      var checkedOptions = submittedForm.querySelectorAll('input:checked')
+
+      if (checkedOptions.length) {
+        checkedOptions.forEach(function (checkedOption) {
+          var checkedOptionId = checkedOption.getAttribute('id')
+          var checkedOptionLabel = submittedForm.querySelectorAll('label[for="' + checkedOptionId + '"]')
+          
+          var eventLabel = checkedOptionLabel.length
+            ? checkedOptionLabel[0].innerText.trim()
+            : checkedOption.value
+
+          labels.push(eventLabel)
+        })
+      } else {
+        labels.push("no response")
+      }
+
+      return labels
+    }
+
+    function getResponseLabelsForSelectOption(submittedForm) {
+      var labels = []
+      var selectInputs = submittedForm.querySelectorAll('select')
+
+      if (selectInputs.length) {
+        selectInputs.forEach(function (select) {
+          var value = select.value
+
+          if (value) {
+            var label = select.options[select.selectedIndex].innerHTML
+            var eventLabel = label.length ? label : value
+            labels.push(eventLabel)
+          } else {
+            labels.push("no response")
+          }
+        })
+      }
+
+      return labels
+    }
+
+    function getResponseLabels(submittedForm) {
+      var responseLabels = []
+      var questionType = submittedForm.getAttribute('data-type')
+      
+      switch (questionType) {
+        case 'checkbox_question':
+        case 'multiple_choice_question':
+          responseLabels = getResponseLabelsForMultipleChoice(submittedForm)
+          break
+        
+        case 'country_select_question':
+          responseLabels = getResponseLabelsForSelectOption(submittedForm)
+          break
+        
+        default:
+          break
+      }
+
+      return responseLabels
+    }
+
+    function track (element) {
+      element.addEventListener('submit', function (event) {
+        var submittedForm = event.target
+        var questionKey = getQuestionKey(submittedForm)
+        var responseLabels = getResponseLabels(submittedForm)
+
+        responseLabels.forEach(function(label){
+          var options = { transport: 'beacon', label: label }
+          GOVUK.analytics.trackEvent('question_answer', questionKey, options)
+        })
+      })
+    }
+  }
+})(window, window.GOVUK)

--- a/app/views/smart_answers/_previous_answers.html.erb
+++ b/app/views/smart_answers/_previous_answers.html.erb
@@ -2,7 +2,17 @@
   <table class="govuk-table previous-answers-table">
     <caption class="govuk-table__caption">
       <h2 class="govuk-heading-m">Previous answers</h2>
-      <p class="govuk-body"><%= link_to "Start again", restart_flow_path(@presenter), :class => "govuk-link" %></p>
+      <p class="govuk-body">
+      <%= link_to "Start again", 
+        restart_flow_path(@presenter), 
+        :class => "govuk-link",
+        :data => {
+          module: "track-click",
+          "track-action": "Start again",
+          "track-category": "StartAgain",
+          "track-label": @presenter.current_node.title
+        } %>
+      </p>
     </caption>
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">

--- a/app/views/smart_answers/question.html.erb
+++ b/app/views/smart_answers/question.html.erb
@@ -13,7 +13,13 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render 'smart_answers/debug' %>
-    <%= form_tag current_question_path(@presenter), :method => :get do %>
+    <%= form_tag(current_question_path(@presenter),
+        :method => :get,
+        :data => {
+          module: "track-responses",
+          type: question.partial_template_name,
+          "question-key": question.title
+        }) do %>
       <div class="govuk-!-margin-bottom-6 govuk-!-margin-top-8" id="current-question">
         <div data-debug-template-path="<%= question.relative_erb_template_path %>">
           <% show_body = ['salary_question', 'country_select_question'].include? question.partial_template_name %>

--- a/spec/javascripts/modules/track-responses.spec.js
+++ b/spec/javascripts/modules/track-responses.spec.js
@@ -1,0 +1,252 @@
+/* eslint-env jasmine */
+/* global GOVUK */
+
+describe('Track responses', function () {
+  GOVUK.analytics = GOVUK.analytics || {}
+  GOVUK.analytics.trackEvent = function () {}
+
+  describe('checkbox question', function() {
+    var tracker, form
+
+    var createForm = function() {
+      var element = document.createElement('form');
+      element.setAttribute('onsubmit', 'event.preventDefault()')
+      element.setAttribute('data-module', 'track-responses')
+      element.setAttribute('data-type', 'checkbox_question')
+      element.setAttribute('data-question-key', 'question-key')
+      element.setAttribute('method', 'post')
+
+      var fieldset = document.createElement('fieldset');
+  
+      var checkboxes = [
+        {label: "Construction label", value: "construction"},
+        {label: "Accommodation label", value: "accommodation"},
+        {value: "furniture"}
+      ]
+
+      checkboxes.forEach(function(checkbox, index){
+        var id = 'checkbox-' + index
+        var checkbox_wrapper = document.createElement('div')
+        var input = document.createElement('input')
+        input.type = 'checkbox'
+        input.id = id
+        input.name = 'checkbox_question[]'
+        input.value = checkbox.value
+
+        checkbox_wrapper.appendChild(input)
+
+        if (checkbox.label) {
+          var label = document.createElement('label')
+          label.setAttribute('for', id)
+          label.innerText = checkbox.label
+          checkbox_wrapper.appendChild(label)
+        }
+
+        fieldset.appendChild(checkbox_wrapper)
+      })
+
+      element.appendChild(fieldset)
+
+      var button = document.createElement('button')
+      button.type = 'submit'
+
+      element.appendChild(button)
+
+      return element
+    }
+
+    beforeEach(function () {
+      spyOn(GOVUK.analytics, 'trackEvent')
+
+      form = createForm()
+
+      tracker = new GOVUK.Modules.TrackResponses()
+      tracker.start([form])
+    })
+
+    afterEach(function () {
+      GOVUK.analytics.trackEvent.calls.reset()
+    })
+
+    it('tracks checked checkboxes when clicking submit', function () {
+      form.querySelector('input[value="accommodation"]').click()
+      form.querySelector('input[value="construction"]').click()
+      form.dispatchEvent(new Event('submit'))
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'question_answer', 'question-key', { transport: 'beacon', label: 'Construction label' }
+      )
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'question_answer', 'question-key', { transport: 'beacon', label: 'Accommodation label' }
+      )
+    })
+
+    it('track events sends value of checkbox when no label is set', function () {
+      form.querySelector('input[value="furniture"]').click()
+      form.dispatchEvent(new Event('submit'))
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'question_answer', 'question-key', { transport: 'beacon', label: 'furniture' }
+      )
+    })
+
+    it('track event triggered when no response is made', function () {
+      form.dispatchEvent(new Event('submit'))
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'question_answer', 'question-key', { transport: 'beacon', label: 'no response' }
+      )
+    })
+  })
+
+  describe('radio question', function() {
+    var tracker, form
+
+    var createForm = function() {
+      var element = document.createElement('form');
+      element.setAttribute('onsubmit', 'event.preventDefault()')
+      element.setAttribute('data-module', 'track-responses')
+      element.setAttribute('data-type', 'multiple_choice_question')
+      element.setAttribute('data-question-key', 'question-key')
+      element.setAttribute('method', 'post')
+
+      var fieldset = document.createElement('fieldset');
+
+      var radios = [
+        {label: "Construction label", value: "construction"},
+        {label: "Accommodation label", value: "accommodation"},
+        {label: "Furniture label", value: "furniture"}
+      ]
+
+      radios.forEach(function(radio, index){
+        var id = 'radio-' + index
+        var radio_wrapper = document.createElement('div')
+        var input = document.createElement('input')
+        input.type = 'radio'
+        input.id = id
+        input.name = 'radio_question'
+        input.value = radio.value
+
+        radio_wrapper.appendChild(input)
+
+        if (radio.label) {
+          var label = document.createElement('label')
+          label.setAttribute('for', id)
+          label.innerText = radio.label
+          radio_wrapper.appendChild(label)
+        }
+
+        fieldset.appendChild(radio_wrapper)
+      })
+
+      element.appendChild(fieldset)
+
+      var button = document.createElement('button')
+      button.type = 'submit'
+
+      element.appendChild(button)
+
+      return element
+    }
+
+    beforeEach(function () {
+      spyOn(GOVUK.analytics, 'trackEvent')
+
+      form = createForm()
+
+      tracker = new GOVUK.Modules.TrackResponses()
+      tracker.start([form])
+    })
+
+    afterEach(function () {
+      GOVUK.analytics.trackEvent.calls.reset()
+    })
+
+    it('tracks selected option when clicking submit', function () {
+      form.querySelector('input[value="accommodation"]').click()
+      form.dispatchEvent(new Event('submit'))
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'question_answer', 'question-key', { transport: 'beacon', label: 'Accommodation label' }
+      )
+    })
+
+    it('track event triggered when no response is made', function () {
+      form.dispatchEvent(new Event('submit'))
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'question_answer', 'question-key', { transport: 'beacon', label: 'no response' }
+      )
+    })
+  })
+
+  describe('select question', function() {
+    var tracker, form
+
+    var createForm = function() {
+      var element = document.createElement('form');
+      element.setAttribute('onsubmit', 'event.preventDefault()')
+      element.setAttribute('data-module', 'track-responses')
+      element.setAttribute('data-type', 'country_select_question')
+      element.setAttribute('data-question-key', 'question-key')
+      element.setAttribute('method', 'post')
+
+      var select = document.createElement('select');
+      select.name = 'select_question'
+
+      var selectOptions = [
+        {label: "Select option", value: ""},
+        {label: "Construction label", value: "construction"},
+        {label: "Accommodation label", value: "accommodation"},
+        {label: "Furniture label", value: "furniture"}
+      ]
+
+      selectOptions.forEach(function(opt, index){
+        var option = document.createElement('option')
+        option.value = opt.value
+        option.innerText = opt.label
+
+        select.appendChild(option)
+      })
+
+      element.appendChild(select)
+
+      var button = document.createElement('button')
+      button.type = 'submit'
+
+      element.appendChild(button)
+
+      return element
+    }
+
+    beforeEach(function () {
+      spyOn(GOVUK.analytics, 'trackEvent')
+
+      form = createForm()
+
+      tracker = new GOVUK.Modules.TrackResponses()
+      tracker.start([form])
+    })
+
+    afterEach(function () {
+      GOVUK.analytics.trackEvent.calls.reset()
+    })
+
+    it('tracks selected option when clicking submit', function () {
+      form.querySelector('select[name="select_question"]').value = "accommodation"
+      form.dispatchEvent(new Event('submit'))
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'question_answer', 'question-key', { transport: 'beacon', label: 'Accommodation label' }
+      )
+    })
+
+    it('track event triggered when no response is made', function () {
+      form.dispatchEvent(new Event('submit'))
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'question_answer', 'question-key', { transport: 'beacon', label: 'no response' }
+      )
+    })
+  })
+})


### PR DESCRIPTION
## What

Add extra event tracking to smart answers before Find Coronavirus Support is migrated so we can track how users interact with the tool.

We will need to add:

- Tracking to the question/answer combinations

To add

Pages
eventCategory : question_answer
eventAction: [selection 
eventLabel: [question]

Link to doc here with more details https://docs.google.com/spreadsheets/d/1EhSbmUgrZfkyGLdwsGnRZ_HedxwvuCdWrHAuGPdKjH4/edit?usp=sharing

Some smart answers collect information that could be considered personal. for example: https://www.gov.uk/state-pension-age/y/age which is stripped out in the URL before it reaches Google Analytics. This will also need to apply to the event data. 

## Why

So we know how users are interacting with the tool so we can identify points of failure and report on what users select

https://trello.com/c/QR4lSsFX/477-add-extra-event-tracking-to-smart-answers-inc-find-coronavirus-support
