### PR TITLE
Update Flow#resolve_state to work with change previous answer

### DIFF
--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -153,14 +153,19 @@ module SmartAnswer
 
     def resolve_state(responses, requested_node)
       state = start_state
-
       until state.nil?
-        return state if state.error
-        return state if state.current_node.to_s == requested_node && !responses.key?(state.current_node.to_s)
-        return state if node(state.current_node).outcome?
+        node_name = state.current_node.to_s
 
-        response = responses[state.current_node.to_s]
-        state = transistion_state(state, response)
+        return state unless responses.key?(node_name)
+
+        response = responses[node_name]
+        new_state = transistion_state(state, response)
+
+        return new_state if new_state.error
+        return state if node_name == requested_node
+        return new_state if node(new_state.current_node).outcome?
+
+        state = new_state
       end
     end
 


### PR DESCRIPTION
- Update loop to look ahead to see if next state would error
- Return state if it matches requested node and no error detected
- Return next state if it errors
- Return next state if it is an outcome

[Trello Card](https://trello.com/c/UMehDuhS/490-fix-changing-a-previous-answer)