### PR TITLE
Fix start again link to clear session data

### DIFF
--- a/app/helpers/current_question_helper.rb
+++ b/app/helpers/current_question_helper.rb
@@ -19,10 +19,11 @@ module CurrentQuestionHelper
   end
 
   def restart_flow_path(presenter)
-    flow_name = params[:id]
-    flow_name.gsub!(/_/, "-") if presenter.use_session?
-
-    smart_answer_path(flow_name)
+    if presenter.use_session?
+      destroy_session_flow_path(presenter.name)
+    else
+      smart_answer_path(presenter.name)
+    end
   end
 
   def prefill_value_is?(value)

--- a/test/helpers/current_question_helper_test.rb
+++ b/test/helpers/current_question_helper_test.rb
@@ -17,8 +17,7 @@ class CurrentQuestionHelperTest < ActionView::TestCase
     end
 
     should "return root smart answer path for session answer" do
-      @params = { id: "coronavirus_find_support" }
-      assert_equal smart_answer_path(flow_name), restart_flow_path(session_presenter)
+      assert_equal destroy_session_flow_path(flow_name), restart_flow_path(session_presenter)
     end
   end
 


### PR DESCRIPTION
For session based flows the start again link didn't clear previous responses. This caused an issue where users would be shown results page immediately again. Now user's sessions are clear and they return to the start of the flow.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.
