### PR TITLE
Fix destroy session

### DIFF
--- a/app/controllers/session_answers_controller.rb
+++ b/app/controllers/session_answers_controller.rb
@@ -17,7 +17,7 @@ class SessionAnswersController < ApplicationController
   end
 
   def destroy
-    session.delete(:responses)
+    session_store.clear
 
     if params[:ext_r] == "true"
       redirect_to "https://bbc.co.uk/news"

--- a/app/services/session_store.rb
+++ b/app/services/session_store.rb
@@ -14,4 +14,8 @@ class SessionStore
   def add_response(response)
     hash[current_node] = response
   end
+
+  def clear
+    session.delete(flow_name)
+  end
 end

--- a/test/unit/services/session_store_test.rb
+++ b/test/unit/services/session_store_test.rb
@@ -43,4 +43,19 @@ class SessionStoreTest < ActiveSupport::TestCase
       assert_equal [:a, node_name, :c], session[flow_name].keys
     end
   end
+
+  context "#clear" do
+    should "remove entries from session" do
+      session_store.add_response(response)
+      session_store.clear
+      assert_equal({}, session)
+    end
+
+    should "not change other data in session" do
+      other_data = { foo: :bar }
+      session.merge! other_data
+      session_store.clear
+      assert_equal other_data, session
+    end
+  end
 end


### PR DESCRIPTION
- Add method to `SessionStore` to remove data for flow from session
- Use new method in session controller destroy action
- Use mock expectations of session store to test session storage in
  controller test
- Test details of session store deletion in session store unit test

[Trello card](https://trello.com/c/VTW7MQrX/491-fix-destroy-session-route-to-clear-the-session-data)
