### PR TITLE
Fix node names in url string

### DIFF
--- a/app/controllers/session_answers_controller.rb
+++ b/app/controllers/session_answers_controller.rb
@@ -2,7 +2,7 @@ class SessionAnswersController < ApplicationController
   before_action :set_cache_headers
 
   def start
-    redirect_to session_flow_path(id: params[:id], node_name: next_node_name)
+    redirect_to session_flow_path(id: params[:id], node_slug: next_node_slug)
   end
 
   def show
@@ -13,7 +13,7 @@ class SessionAnswersController < ApplicationController
 
   def update
     add_new_response_to_session
-    redirect_to session_flow_path(id: params[:id], node_name: next_node_name)
+    redirect_to session_flow_path(id: params[:id], node_slug: next_node_slug)
   end
 
   def destroy
@@ -52,9 +52,13 @@ private
   def session_store
     @session_store ||= SessionStore.new(
       flow_name: name,
-      current_node: params[:node_name],
+      current_node: node_name,
       session: session,
     )
+  end
+
+  def node_name
+    @node_name ||= params[:node_slug].underscore if params[:node_slug].present?
   end
 
   def flow_registry
@@ -66,15 +70,15 @@ private
   end
 
   def page_type
-    return :landing if params[:node_name].blank?
+    return :landing if node_name.blank?
     return :result if presenter.finished?
 
     :question
   end
   helper_method :page_type
 
-  def next_node_name
-    presenter.current_state.current_node.to_s
+  def next_node_slug
+    presenter.current_state.current_node.to_s.dasherize
   end
 
   def debug?

--- a/app/helpers/current_question_helper.rb
+++ b/app/helpers/current_question_helper.rb
@@ -15,7 +15,7 @@ module CurrentQuestionHelper
 
   def session_answers_question_path(presenter)
     node_name = presenter.current_state.current_node.to_s
-    update_session_flow_path(id: params[:id], node_name: node_name)
+    update_session_flow_path(id: params[:id], node_slug: node_name.dasherize)
   end
 
   def restart_flow_path(presenter)

--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -94,7 +94,7 @@ class FlowPresenter
 
   def change_collapsed_question_link(question_number, question)
     if use_session?
-      session_flow_path(params[:id], node_name: question.node_name)
+      session_flow_path(params[:id], node_slug: question.node_slug)
     else
       smart_answer_path(
         id: @params[:id],

--- a/app/presenters/node_presenter.rb
+++ b/app/presenters/node_presenter.rb
@@ -10,4 +10,8 @@ class NodePresenter
   def node_name
     @node.name
   end
+
+  def node_slug
+    node_name.to_s.dasherize
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,6 @@ Rails.application.routes.draw do
 
   get "/:id/s/destroy_session", to: "session_answers#destroy", as: :destroy_session_flow
   get "/:id/s", to: "session_answers#start", as: :start_session_flow
-  get "/:id/s/:node_name", to: "session_answers#show", as: :session_flow
-  get "/:id/s/:node_name/next", to: "session_answers#update", as: :update_session_flow
+  get "/:id/s/:node_slug", to: "session_answers#show", as: :session_flow
+  get "/:id/s/:node_slug/next", to: "session_answers#update", as: :update_session_flow
 end

--- a/lib/smart_answer/calculators/coronavirus_find_support_calculator.rb
+++ b/lib/smart_answer/calculators/coronavirus_find_support_calculator.rb
@@ -66,31 +66,31 @@ module SmartAnswer::Calculators
 
     def next_question(current_node)
       nodes = %i[
-        need_help_with?
-        feel_safe?
-        afford_rent_mortgage_bills?
-        get_food?
-        have_you_been_made_unemployed?
-        are_you_off_work_ill?
-        have_you_been_evicted?
+        need_help_with
+        feel_safe
+        afford_rent_mortgage_bills
+        get_food
+        have_you_been_made_unemployed
+        are_you_off_work_ill
+        have_you_been_evicted
       ]
 
       if nodes.slice(0..0).include?(current_node) && needs_help_with?("feeling_unsafe")
-        :feel_safe?
+        :feel_safe
       elsif nodes.slice(0..1).include?(current_node) && needs_help_with?("paying_bills")
-        :afford_rent_mortgage_bills?
+        :afford_rent_mortgage_bills
       elsif nodes.slice(0..2).include?(current_node) && needs_help_with?("getting_food")
-        :afford_food?
+        :afford_food
       elsif nodes.slice(0..3).include?(current_node) && needs_help_with?("being_unemployed")
-        :self_employed?
+        :self_employed
       elsif nodes.slice(0..4).include?(current_node) && needs_help_with?("going_to_work")
-        :worried_about_work?
+        :worried_about_work
       elsif nodes.slice(0..5).include?(current_node) && needs_help_with?("somewhere_to_live")
-        :have_somewhere_to_live?
+        :have_somewhere_to_live
       elsif nodes.slice(0..6).include?(current_node) && needs_help_with?("mental_health")
-        :mental_health_worries?
+        :mental_health_worries
       else
-        :nation?
+        :nation
       end
     end
   end

--- a/lib/smart_answer_flows/coronavirus-find-support.rb
+++ b/lib/smart_answer_flows/coronavirus-find-support.rb
@@ -12,7 +12,7 @@ module SmartAnswer
       # ======================================================================
       # What do you need help with because of coronavirus?
       # ======================================================================
-      checkbox_question :need_help_with? do
+      checkbox_question :need_help_with do
         option :feeling_unsafe
         option :paying_bills
         option :getting_food
@@ -28,14 +28,14 @@ module SmartAnswer
         end
 
         next_node do
-          question calculator.next_question(:need_help_with?)
+          question calculator.next_question(:need_help_with)
         end
       end
 
       # ======================================================================
       # Do you feel safe where you live?
       # ======================================================================
-      multiple_choice :feel_safe? do
+      multiple_choice :feel_safe do
         option :yes
         option :yes_but_i_am_concerned_about_others
         option :no
@@ -46,14 +46,14 @@ module SmartAnswer
         end
 
         next_node do
-          question calculator.next_question(:feel_safe?)
+          question calculator.next_question(:feel_safe)
         end
       end
 
       # ======================================================================
       # Are you finding it hard to afford rent, your mortgage or bills?
       # ======================================================================
-      multiple_choice :afford_rent_mortgage_bills? do
+      multiple_choice :afford_rent_mortgage_bills do
         option :yes
         option :no
         option :not_sure
@@ -63,14 +63,14 @@ module SmartAnswer
         end
 
         next_node do
-          question calculator.next_question(:afford_rent_mortgage_bills?)
+          question calculator.next_question(:afford_rent_mortgage_bills)
         end
       end
 
       # ======================================================================
       # Are you finding it hard to afford food?
       # ======================================================================
-      multiple_choice :afford_food? do
+      multiple_choice :afford_food do
         option :yes
         option :no
         option :not_sure
@@ -80,14 +80,14 @@ module SmartAnswer
         end
 
         next_node do
-          question :get_food?
+          question :get_food
         end
       end
 
       # ======================================================================
       # Are your able to get food?
       # ======================================================================
-      multiple_choice :get_food? do
+      multiple_choice :get_food do
         option :yes
         option :no
         option :not_sure
@@ -97,14 +97,14 @@ module SmartAnswer
         end
 
         next_node do
-          question calculator.next_question(:get_food?)
+          question calculator.next_question(:get_food)
         end
       end
 
       # ======================================================================
       # Are you self-employed or a sole trader?
       # ======================================================================
-      multiple_choice :self_employed? do
+      multiple_choice :self_employed do
         option :yes
         option :no
         option :not_sure
@@ -115,9 +115,9 @@ module SmartAnswer
 
         next_node do
           if calculator.self_employed == "yes"
-            question calculator.next_question(:have_you_been_made_unemployed?)
+            question calculator.next_question(:have_you_been_made_unemployed)
           else
-            question :have_you_been_made_unemployed?
+            question :have_you_been_made_unemployed
           end
         end
       end
@@ -125,7 +125,7 @@ module SmartAnswer
       # ======================================================================
       # Have you been told to stop working?
       # ======================================================================
-      multiple_choice :have_you_been_made_unemployed? do
+      multiple_choice :have_you_been_made_unemployed do
         option :yes_i_have_been_made_unemployed
         option :yes_i_have_been_put_on_furlough
         option :no
@@ -136,14 +136,14 @@ module SmartAnswer
         end
 
         next_node do
-          question calculator.next_question(:have_you_been_made_unemployed?)
+          question calculator.next_question(:have_you_been_made_unemployed)
         end
       end
 
       # ======================================================================
       # Are you worried about going in to work?
       # ======================================================================
-      multiple_choice :worried_about_work? do
+      multiple_choice :worried_about_work do
         option :yes
         option :no
         option :not_sure
@@ -153,14 +153,14 @@ module SmartAnswer
         end
 
         next_node do
-          question :are_you_off_work_ill?
+          question :are_you_off_work_ill
         end
       end
 
       # ======================================================================
       # Are you off work because you're ill or self-isolating?
       # ======================================================================
-      multiple_choice :are_you_off_work_ill? do
+      multiple_choice :are_you_off_work_ill do
         option :yes
         option :no
 
@@ -169,14 +169,14 @@ module SmartAnswer
         end
 
         next_node do
-          question calculator.next_question(:are_you_off_work_ill?)
+          question calculator.next_question(:are_you_off_work_ill)
         end
       end
 
       # ======================================================================
       # Do you have somewhere to live?
       # ======================================================================
-      multiple_choice :have_somewhere_to_live? do
+      multiple_choice :have_somewhere_to_live do
         option :yes
         option :yes_but_i_might_lose_it
         option :no
@@ -187,14 +187,14 @@ module SmartAnswer
         end
 
         next_node do
-          question :have_you_been_evicted?
+          question :have_you_been_evicted
         end
       end
 
       # ======================================================================
       # Have you been evicted?
       # ======================================================================
-      multiple_choice :have_you_been_evicted? do
+      multiple_choice :have_you_been_evicted do
         option :yes
         option :yes_i_might_be_soon
         option :no
@@ -205,14 +205,14 @@ module SmartAnswer
         end
 
         next_node do
-          question calculator.next_question(:have_you_been_evicted?)
+          question calculator.next_question(:have_you_been_evicted)
         end
       end
 
       # ======================================================================
       # Are you worries about your mental health or someone else's mental health?
       # ======================================================================
-      multiple_choice :mental_health_worries? do
+      multiple_choice :mental_health_worries do
         option :yes
         option :no
         option :not_sure
@@ -222,14 +222,14 @@ module SmartAnswer
         end
 
         next_node do
-          question :nation?
+          question :nation
         end
       end
 
       # ======================================================================
       # Where do you live?
       # ======================================================================
-      multiple_choice :nation? do
+      multiple_choice :nation do
         option :england
         option :scotland
         option :wales

--- a/test/controllers/session_answers_controller_test.rb
+++ b/test/controllers/session_answers_controller_test.rb
@@ -6,7 +6,7 @@ class SessionAnswersControllerTest < ActionDispatch::IntegrationTest
   end
 
   def nodes
-    %i[need_help_with? afford_food?]
+    %i[need_help_with afford_food]
   end
 
   # Session is not directly accessible in controller tests

--- a/test/controllers/session_answers_controller_test.rb
+++ b/test/controllers/session_answers_controller_test.rb
@@ -6,7 +6,7 @@ class SessionAnswersControllerTest < ActionDispatch::IntegrationTest
   end
 
   def nodes
-    %i[need_help_with afford_food]
+    %i[need-help-with afford-food]
   end
 
   # Session is not directly accessible in controller tests
@@ -26,13 +26,13 @@ class SessionAnswersControllerTest < ActionDispatch::IntegrationTest
     end
 
     should "redirect to show first node" do
-      assert_redirected_to(session_flow_path(id: flow_name, node_name: nodes[0]))
+      assert_redirected_to(session_flow_path(id: flow_name, node_slug: nodes[0]))
     end
   end
 
-  context "GET /:id/s/:node_name" do
+  context "GET /:id/s/:node_slug" do
     setup do
-      get session_flow_path(id: flow_name, node_name: nodes[0])
+      get session_flow_path(id: flow_name, node_slug: nodes[0])
     end
 
     should "be successful" do
@@ -60,25 +60,25 @@ class SessionAnswersControllerTest < ActionDispatch::IntegrationTest
     { "response" => %w[getting_food], "next" => "1" }
   end
 
-  context "GET /:id/s/:node_name/next" do
+  context "GET /:id/s/:node_slug/next" do
     should "redirect to next node" do
-      get update_session_flow_path(id: flow_name, node_name: nodes[0]), params: params
-      assert_redirected_to(session_flow_path(id: flow_name, node_name: nodes[1]))
+      get update_session_flow_path(id: flow_name, node_slug: nodes[0]), params: params
+      assert_redirected_to(session_flow_path(id: flow_name, node_slug: nodes[1]))
     end
 
     should "updates session" do
       session_store.expects(:add_response).with(params["response"])
-      get update_session_flow_path(id: flow_name, node_name: nodes[0]), params: params
+      get update_session_flow_path(id: flow_name, node_slug: nodes[0]), params: params
     end
   end
 
-  context "GET /:id/s/:node_name/next with error submission" do
+  context "GET /:id/s/:node_slug/next with error submission" do
     setup do
-      get update_session_flow_path(id: flow_name, node_name: nodes[0]), params: { "response" => [], "next" => "1" }
+      get update_session_flow_path(id: flow_name, node_slug: nodes[0]), params: { "response" => [], "next" => "1" }
     end
 
     should "redirect back to show" do
-      assert_redirected_to(session_flow_path(id: flow_name, node_name: nodes[0]))
+      assert_redirected_to(session_flow_path(id: flow_name, node_slug: nodes[0]))
     end
 
     should "display error" do
@@ -89,7 +89,7 @@ class SessionAnswersControllerTest < ActionDispatch::IntegrationTest
 
   context "GET /:id/s/destroy_session" do
     setup do
-      get update_session_flow_path(id: flow_name, node_name: nodes[0]), params: params
+      get update_session_flow_path(id: flow_name, node_slug: nodes[0]), params: params
     end
 
     should "redirect to external sitewhen the ext_r option is present and true" do

--- a/test/helpers/current_question_helper_test.rb
+++ b/test/helpers/current_question_helper_test.rb
@@ -7,7 +7,7 @@ class CurrentQuestionHelperTest < ActionView::TestCase
     end
 
     should "return link to session answer when flow uses sessions" do
-      assert_equal update_session_flow_path(flow_name, node_name), current_question_path(session_presenter)
+      assert_equal update_session_flow_path(flow_name, node_name.dasherize), current_question_path(session_presenter)
     end
   end
 

--- a/test/integration/smart_answer_flows/coronavirus_find_support_test.rb
+++ b/test/integration/smart_answer_flows/coronavirus_find_support_test.rb
@@ -12,103 +12,103 @@ class CoronavirusFindSupportFlowTest < ActiveSupport::TestCase
 
   context "specific outcomes" do
     should "show no specific information results for the minimal flow" do
-      assert_current_node :need_help_with?
+      assert_current_node :need_help_with
       add_response "none"
-      assert_current_node :nation?
+      assert_current_node :nation
       add_response "england"
       assert_current_node :results
     end
 
     should "show results for a user that can get food and is self-employed" do
-      assert_current_node :need_help_with?
+      assert_current_node :need_help_with
       add_response "being_unemployed,feeling_unsafe,getting_food,going_to_work,mental_health,paying_bills,somewhere_to_live"
-      assert_current_node :feel_safe?
+      assert_current_node :feel_safe
       add_response "no"
-      assert_current_node :afford_rent_mortgage_bills?
+      assert_current_node :afford_rent_mortgage_bills
       add_response "no"
-      assert_current_node :afford_food?
+      assert_current_node :afford_food
       add_response "no"
 
-      assert_current_node :get_food?
+      assert_current_node :get_food
       add_response "yes"
-      assert_current_node :self_employed?
+      assert_current_node :self_employed
       add_response "yes"
 
-      assert_current_node :worried_about_work?
+      assert_current_node :worried_about_work
       add_response "yes"
-      assert_current_node :are_you_off_work_ill?
+      assert_current_node :are_you_off_work_ill
       add_response "yes"
-      assert_current_node :have_somewhere_to_live?
+      assert_current_node :have_somewhere_to_live
       add_response "no"
-      assert_current_node :have_you_been_evicted?
+      assert_current_node :have_you_been_evicted
       add_response "yes"
-      assert_current_node :mental_health_worries?
+      assert_current_node :mental_health_worries
       add_response "yes"
-      assert_current_node :nation?
+      assert_current_node :nation
       add_response "england"
       assert_current_node :results
     end
 
     should "show results for a user that cannot get food, is not self-employed, and has been made unemployed" do
-      assert_current_node :need_help_with?
+      assert_current_node :need_help_with
       add_response "being_unemployed,feeling_unsafe,getting_food,going_to_work,mental_health,paying_bills,somewhere_to_live"
-      assert_current_node :feel_safe?
+      assert_current_node :feel_safe
       add_response "no"
-      assert_current_node :afford_rent_mortgage_bills?
+      assert_current_node :afford_rent_mortgage_bills
       add_response "no"
-      assert_current_node :afford_food?
+      assert_current_node :afford_food
       add_response "no"
 
-      assert_current_node :get_food?
+      assert_current_node :get_food
       add_response "no"
-      assert_current_node :self_employed?
+      assert_current_node :self_employed
       add_response "no"
-      assert_current_node :have_you_been_made_unemployed?
+      assert_current_node :have_you_been_made_unemployed
       add_response "yes_i_have_been_made_unemployed"
 
-      assert_current_node :worried_about_work?
+      assert_current_node :worried_about_work
       add_response "yes"
-      assert_current_node :are_you_off_work_ill?
+      assert_current_node :are_you_off_work_ill
       add_response "no"
-      assert_current_node :have_somewhere_to_live?
+      assert_current_node :have_somewhere_to_live
       add_response "no"
-      assert_current_node :have_you_been_evicted?
+      assert_current_node :have_you_been_evicted
       add_response "yes"
-      assert_current_node :mental_health_worries?
+      assert_current_node :mental_health_worries
       add_response "yes"
-      assert_current_node :nation?
+      assert_current_node :nation
       add_response "england"
       assert_current_node :results
     end
 
     should "show results for a user that can get food, is not self-employed, and has not been made unemployed" do
-      assert_current_node :need_help_with?
+      assert_current_node :need_help_with
       add_response "being_unemployed,feeling_unsafe,getting_food,going_to_work,mental_health,paying_bills,somewhere_to_live"
-      assert_current_node :feel_safe?
+      assert_current_node :feel_safe
       add_response "no"
-      assert_current_node :afford_rent_mortgage_bills?
+      assert_current_node :afford_rent_mortgage_bills
       add_response "no"
-      assert_current_node :afford_food?
-      add_response "no"
-
-      assert_current_node :get_food?
-      add_response "yes"
-      assert_current_node :self_employed?
-      add_response "no"
-      assert_current_node :have_you_been_made_unemployed?
+      assert_current_node :afford_food
       add_response "no"
 
-      assert_current_node :worried_about_work?
+      assert_current_node :get_food
       add_response "yes"
-      assert_current_node :are_you_off_work_ill?
+      assert_current_node :self_employed
       add_response "no"
-      assert_current_node :have_somewhere_to_live?
+      assert_current_node :have_you_been_made_unemployed
       add_response "no"
-      assert_current_node :have_you_been_evicted?
+      assert_current_node :worried_about_work
       add_response "yes"
-      assert_current_node :mental_health_worries?
+      assert_current_node :are_you_off_work_ill
+      add_response "no"
+      assert_current_node :have_somewhere_to_live
+      add_response "no"
+      assert_current_node :have_you_been_evicted
       add_response "yes"
-      assert_current_node :nation?
+      assert_current_node :mental_health_worries
+      add_response "yes"
+
+      assert_current_node :nation
       add_response "england"
       assert_current_node :results
     end

--- a/test/unit/calculators/coronavirus_find_support_calculator_test.rb
+++ b/test/unit/calculators/coronavirus_find_support_calculator_test.rb
@@ -10,189 +10,189 @@ module SmartAnswer::Calculators
       context "user is on the need_help_with? node" do
         should "return feel_safe? when paying_bills has been chosen" do
           @calculator.need_help_with = "feeling_unsafe"
-          assert_equal @calculator.next_question(:need_help_with?), :feel_safe?
+          assert_equal @calculator.next_question(:need_help_with), :feel_safe
         end
 
         should "return afford_rent_mortgage_bills? when paying_bills has been chosen" do
           @calculator.need_help_with = "paying_bills"
-          assert_equal @calculator.next_question(:need_help_with?), :afford_rent_mortgage_bills?
+          assert_equal @calculator.next_question(:need_help_with), :afford_rent_mortgage_bills
         end
 
         should "return self_employed? when getting_food has been chosen" do
           @calculator.need_help_with = "getting_food"
-          assert_equal @calculator.next_question(:need_help_with?), :afford_food?
+          assert_equal @calculator.next_question(:need_help_with), :afford_food
         end
 
         should "return self_employed? when being_unemployed has been chosen" do
           @calculator.need_help_with = "being_unemployed"
-          assert_equal @calculator.next_question(:need_help_with?), :self_employed?
+          assert_equal @calculator.next_question(:need_help_with), :self_employed
         end
 
         should "return worried_about_work? when going_to_work has been chosen" do
           @calculator.need_help_with = "going_to_work"
-          assert_equal @calculator.next_question(:need_help_with?), :worried_about_work?
+          assert_equal @calculator.next_question(:need_help_with), :worried_about_work
         end
 
         should "return have_somewhere_to_live? when somewhere_to_live has been chosen" do
           @calculator.need_help_with = "somewhere_to_live"
-          assert_equal @calculator.next_question(:need_help_with?), :have_somewhere_to_live?
+          assert_equal @calculator.next_question(:need_help_with), :have_somewhere_to_live
         end
 
         should "return mental_health_worries? when mental_health has been chosen" do
           @calculator.need_help_with = "mental_health"
-          assert_equal @calculator.next_question(:need_help_with?), :mental_health_worries?
+          assert_equal @calculator.next_question(:need_help_with), :mental_health_worries
         end
 
         should "return nation? when there are no other selected options" do
           @calculator.need_help_with = ""
-          assert_equal @calculator.next_question(:need_help_with?), :nation?
+          assert_equal @calculator.next_question(:need_help_with), :nation
         end
       end
 
       context "user is on the feel_safe? node" do
         should "return afford_rent_mortgage_bills? when paying_bills has been chosen" do
           @calculator.need_help_with = "paying_bills"
-          assert_equal @calculator.next_question(:feel_safe?), :afford_rent_mortgage_bills?
+          assert_equal @calculator.next_question(:feel_safe), :afford_rent_mortgage_bills
         end
 
         should "return self_employed? when getting_food has been chosen" do
           @calculator.need_help_with = "getting_food"
-          assert_equal @calculator.next_question(:feel_safe?), :afford_food?
+          assert_equal @calculator.next_question(:feel_safe), :afford_food
         end
 
         should "return self_employed? when being_unemployed has been chosen" do
           @calculator.need_help_with = "being_unemployed"
-          assert_equal @calculator.next_question(:feel_safe?), :self_employed?
+          assert_equal @calculator.next_question(:feel_safe), :self_employed
         end
 
         should "return worried_about_work? when going_to_work has been chosen" do
           @calculator.need_help_with = "going_to_work"
-          assert_equal @calculator.next_question(:feel_safe?), :worried_about_work?
+          assert_equal @calculator.next_question(:feel_safe), :worried_about_work
         end
 
         should "return have_somewhere_to_live? when somewhere_to_live has been chosen" do
           @calculator.need_help_with = "somewhere_to_live"
-          assert_equal @calculator.next_question(:feel_safe?), :have_somewhere_to_live?
+          assert_equal @calculator.next_question(:feel_safe), :have_somewhere_to_live
         end
 
         should "return mental_health_worries? when mental_health has been chosen" do
           @calculator.need_help_with = "mental_health"
-          assert_equal @calculator.next_question(:feel_safe?), :mental_health_worries?
+          assert_equal @calculator.next_question(:feel_safe), :mental_health_worries
         end
 
         should "return nation? when there are no other selected options" do
           @calculator.need_help_with = ""
-          assert_equal @calculator.next_question(:feel_safe?), :nation?
+          assert_equal @calculator.next_question(:feel_safe), :nation
         end
       end
 
       context "user is on the afford_rent_mortgage_bills? node" do
         should "return self_employed? when getting_food has been chosen" do
           @calculator.need_help_with = "getting_food"
-          assert_equal @calculator.next_question(:afford_rent_mortgage_bills?), :afford_food?
+          assert_equal @calculator.next_question(:afford_rent_mortgage_bills), :afford_food
         end
 
         should "return self_employed? when being_unemployed has been chosen" do
           @calculator.need_help_with = "being_unemployed"
-          assert_equal @calculator.next_question(:afford_rent_mortgage_bills?), :self_employed?
+          assert_equal @calculator.next_question(:afford_rent_mortgage_bills), :self_employed
         end
 
         should "return worried_about_work? when going_to_work has been chosen" do
           @calculator.need_help_with = "going_to_work"
-          assert_equal @calculator.next_question(:afford_rent_mortgage_bills?), :worried_about_work?
+          assert_equal @calculator.next_question(:afford_rent_mortgage_bills), :worried_about_work
         end
 
         should "return have_somewhere_to_live? when somewhere_to_live has been chosen" do
           @calculator.need_help_with = "somewhere_to_live"
-          assert_equal @calculator.next_question(:afford_rent_mortgage_bills?), :have_somewhere_to_live?
+          assert_equal @calculator.next_question(:afford_rent_mortgage_bills), :have_somewhere_to_live
         end
 
         should "return mental_health_worries? when mental_health has been chosen" do
           @calculator.need_help_with = "mental_health"
-          assert_equal @calculator.next_question(:afford_rent_mortgage_bills?), :mental_health_worries?
+          assert_equal @calculator.next_question(:afford_rent_mortgage_bills), :mental_health_worries
         end
 
         should "return nation? when there are no other selected options" do
           @calculator.need_help_with = ""
-          assert_equal @calculator.next_question(:afford_rent_mortgage_bills?), :nation?
+          assert_equal @calculator.next_question(:afford_rent_mortgage_bills), :nation
         end
       end
 
       context "user is on the get_food? node" do
         should "return self_employed? when being_unemployed has been chosen" do
           @calculator.need_help_with = "being_unemployed"
-          assert_equal @calculator.next_question(:get_food?), :self_employed?
+          assert_equal @calculator.next_question(:get_food), :self_employed
         end
 
         should "return worried_about_work? when going_to_work has been chosen" do
           @calculator.need_help_with = "going_to_work"
-          assert_equal @calculator.next_question(:get_food?), :worried_about_work?
+          assert_equal @calculator.next_question(:get_food), :worried_about_work
         end
 
         should "return have_somewhere_to_live? when somewhere_to_live has been chosen" do
           @calculator.need_help_with = "somewhere_to_live"
-          assert_equal @calculator.next_question(:get_food?), :have_somewhere_to_live?
+          assert_equal @calculator.next_question(:get_food), :have_somewhere_to_live
         end
 
         should "return mental_health_worries? when mental_health has been chosen" do
           @calculator.need_help_with = "mental_health"
-          assert_equal @calculator.next_question(:get_food?), :mental_health_worries?
+          assert_equal @calculator.next_question(:get_food), :mental_health_worries
         end
 
         should "return nation? when there are no other selected options" do
           @calculator.need_help_with = ""
-          assert_equal @calculator.next_question(:get_food?), :nation?
+          assert_equal @calculator.next_question(:get_food), :nation
         end
       end
 
       context "user is on the have_you_been_made_unemployed? node" do
         should "return worried_about_work? when going_to_work has been chosen" do
           @calculator.need_help_with = "going_to_work"
-          assert_equal @calculator.next_question(:have_you_been_made_unemployed?), :worried_about_work?
+          assert_equal @calculator.next_question(:have_you_been_made_unemployed), :worried_about_work
         end
 
         should "return have_somewhere_to_live? when somewhere_to_live has been chosen" do
           @calculator.need_help_with = "somewhere_to_live"
-          assert_equal @calculator.next_question(:have_you_been_made_unemployed?), :have_somewhere_to_live?
+          assert_equal @calculator.next_question(:have_you_been_made_unemployed), :have_somewhere_to_live
         end
 
         should "return mental_health_worries? when mental_health has been chosen" do
           @calculator.need_help_with = "mental_health"
-          assert_equal @calculator.next_question(:have_you_been_made_unemployed?), :mental_health_worries?
+          assert_equal @calculator.next_question(:have_you_been_made_unemployed), :mental_health_worries
         end
 
         should "return nation? when there are no other selected options" do
           @calculator.need_help_with = ""
-          assert_equal @calculator.next_question(:have_you_been_made_unemployed?), :nation?
+          assert_equal @calculator.next_question(:have_you_been_made_unemployed), :nation
         end
       end
 
       context "user is on the are_you_off_work_ill? node" do
         should "return have_somewhere_to_live? when somewhere_to_live has been chosen" do
           @calculator.need_help_with = "somewhere_to_live"
-          assert_equal @calculator.next_question(:are_you_off_work_ill?), :have_somewhere_to_live?
+          assert_equal @calculator.next_question(:are_you_off_work_ill), :have_somewhere_to_live
         end
 
         should "return mental_health_worries? when mental_health has been chosen" do
           @calculator.need_help_with = "mental_health"
-          assert_equal @calculator.next_question(:are_you_off_work_ill?), :mental_health_worries?
+          assert_equal @calculator.next_question(:are_you_off_work_ill), :mental_health_worries
         end
 
         should "return nation? when there are no other selected options" do
           @calculator.need_help_with = ""
-          assert_equal @calculator.next_question(:are_you_off_work_ill?), :nation?
+          assert_equal @calculator.next_question(:are_you_off_work_ill), :nation
         end
       end
 
       context "user is on the have_you_been_evicted? node" do
         should "return mental_health_worries? when mental_health has been chosen" do
           @calculator.need_help_with = "mental_health"
-          assert_equal @calculator.next_question(:have_you_been_evicted?), :mental_health_worries?
+          assert_equal @calculator.next_question(:have_you_been_evicted), :mental_health_worries
         end
 
         should "return nation? when there are no other selected options" do
           @calculator.need_help_with = ""
-          assert_equal @calculator.next_question(:have_you_been_evicted?), :nation?
+          assert_equal @calculator.next_question(:have_you_been_evicted), :nation
         end
       end
     end

--- a/test/unit/flow_presenter_test.rb
+++ b/test/unit/flow_presenter_test.rb
@@ -123,9 +123,9 @@ class FlowPresenterTest < ActiveSupport::TestCase
       flow = flow_registry.find(name)
       params = { id: name }
       flow_presenter = FlowPresenter.new(params, flow)
-      question = OpenStruct.new(node_name: "foo")
+      question = OpenStruct.new(node_slug: "foo")
       assert_equal(
-        flow_presenter.session_flow_path(name, question.node_name),
+        flow_presenter.session_flow_path(name, question.node_slug),
         flow_presenter.change_collapsed_question_link(1, question),
       )
     end

--- a/test/unit/node_presenter_test.rb
+++ b/test/unit/node_presenter_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class NodePresenterTest < ActiveSupport::TestCase
+  def node
+    OpenStruct.new(name: :foo_bar)
+  end
+
+  def node_presenter
+    @node_presenter ||= NodePresenter.new(node, nil)
+  end
+
+  context "#node_name" do
+    should "return node name" do
+      assert_equal :foo_bar, node_presenter.node_name
+    end
+  end
+
+  context "#node_slug" do
+    should "return version of node name for url path" do
+      assert_equal "foo-bar", node_presenter.node_slug
+    end
+  end
+end


### PR DESCRIPTION
What
Node names in the URL currently render with question marks and underscores instead of dashes. The question marks get HTML escaped which add unreadable text the URL. For GOV.UK we prefer to use dashes vs underscores.

e.g.

/flow-name/s/node_name%3F should be /flow-name/s/node-name

How

- Removed `?` from node names in flow definitions
- Use a dasherized version of node name in urls. With `node_path` used to identify the version of node name used in url paths.

[trello ticket](https://trello.com/c/3A0bLXHz/496-fix-node-names-in-url-string)