### PR TITLE
Change the 'nation' question type

### DIFF
--- a/lib/smart_answer/calculators/coronavirus_find_support_calculator.rb
+++ b/lib/smart_answer/calculators/coronavirus_find_support_calculator.rb
@@ -14,12 +14,6 @@ module SmartAnswer::Calculators
                   :have_you_been_made_unemployed,
                   :mental_health_worries
 
-    def valid_nation?
-      return false if nation.blank?
-
-      nation != "none"
-    end
-
     def has_results?
       return false if need_help_with.blank?
 

--- a/lib/smart_answer_flows/coronavirus-find-support.rb
+++ b/lib/smart_answer_flows/coronavirus-find-support.rb
@@ -229,7 +229,7 @@ module SmartAnswer
       # ======================================================================
       # Where do you live?
       # ======================================================================
-      checkbox_question :nation? do
+      multiple_choice :nation? do
         option :england
         option :scotland
         option :wales
@@ -237,10 +237,6 @@ module SmartAnswer
 
         on_response do |response|
           calculator.nation = response
-        end
-
-        validate do
-          calculator.valid_nation?
         end
 
         next_node do

--- a/test/integration/smart_answer_flows/coronavirus_find_support_test.rb
+++ b/test/integration/smart_answer_flows/coronavirus_find_support_test.rb
@@ -45,7 +45,7 @@ class CoronavirusFindSupportFlowTest < ActiveSupport::TestCase
       assert_current_node :mental_health_worries?
       add_response "yes"
       assert_current_node :nation?
-      add_response "england,scotland,wales,northern_ireland"
+      add_response "england"
       assert_current_node :results
     end
 
@@ -77,7 +77,7 @@ class CoronavirusFindSupportFlowTest < ActiveSupport::TestCase
       assert_current_node :mental_health_worries?
       add_response "yes"
       assert_current_node :nation?
-      add_response "england,scotland,wales,northern_ireland"
+      add_response "england"
       assert_current_node :results
     end
 
@@ -109,7 +109,7 @@ class CoronavirusFindSupportFlowTest < ActiveSupport::TestCase
       assert_current_node :mental_health_worries?
       add_response "yes"
       assert_current_node :nation?
-      add_response "england,scotland,wales,northern_ireland"
+      add_response "england"
       assert_current_node :results
     end
   end


### PR DESCRIPTION
## What

This change updates the `nation` question in the `Coronavirus Find Support` flow to be a radio (multiple choice) question type, from a checkbox question type.

## Why

To bring the question in-line with the current tool and existing content.

## Changes

* Change the `nation` question type.
* Remove the `valid_nation?` validation method from the `Coronavirus Find Support` Calculator. This validation is no longer required as the question is now a simple distinct value and no longer a list with a default 'none' option.
* Update appropriate tests.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.

[Trello](https://trello.com/c/zt5ecaCP/500-change-nation-question-to-multiple-choice-radio-type)