### PR TITLE
Change nation question type

### DIFF
--- a/lib/smart_answer/calculators/coronavirus_find_support_calculator.rb
+++ b/lib/smart_answer/calculators/coronavirus_find_support_calculator.rb
@@ -27,9 +27,7 @@ module SmartAnswer::Calculators
     end
 
     def needs_help_in?(given_nation)
-      return false if nation.blank?
-
-      nation.split(",").include? given_nation
+      nation == given_nation
     end
 
     def user_feels_unsafe?

--- a/test/unit/calculators/coronavirus_find_support_calculator_test.rb
+++ b/test/unit/calculators/coronavirus_find_support_calculator_test.rb
@@ -238,12 +238,12 @@ module SmartAnswer::Calculators
 
     context "#needs_help_in?" do
       should "return true if the given nation has been chosen" do
-        @calculator.nation = "one,two,three,four"
+        @calculator.nation = "one"
         assert_equal @calculator.needs_help_in?("one"), true
       end
 
       should "return false if the given nation has not been chosen" do
-        @calculator.nation = "one,two,three,four"
+        @calculator.nation = "one"
         assert_equal @calculator.needs_help_in?("five"), false
       end
 


### PR DESCRIPTION
This change updates the `needs_help_in?(nation)` method.

As the `nation` question response is no longer a list, but a single distinct value we only need to test for equality.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.

[Trello](https://trello.com/c/zt5ecaCP/500-change-nation-question-to-multiple-choice-radio-type)
