### PR TITLE
Add feedback links for each section in find support flow

### DIFF
--- a/app/assets/stylesheets/smart_answers.scss
+++ b/app/assets/stylesheets/smart_answers.scss
@@ -51,6 +51,9 @@ $is-ie: false !default;
       margin-bottom: govuk-spacing(8);
     }
 
+    .app-c-callout-title {
+      @extend %govuk-heading-s;
+    }
   }
 }
 

--- a/lib/smart_answer_flows/coronavirus-find-support/outcomes/_being_unemployed.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/outcomes/_being_unemployed.erb
@@ -149,3 +149,11 @@
 <% if calculator.needs_help_in?("scotland") %>
   [Find help with benefits (mygov.scot)](https://www.mygov.scot/benefits-support/)
 <% end %>
+
+$CTA
+  <h3 class="app-c-callout-title">Was this information on being made redundant or unemployed, or not having any work helpful?</h3>
+
+  [Give feedback on this service](/done/find-coronavirus-support)
+$CTA
+
+---

--- a/lib/smart_answer_flows/coronavirus-find-support/outcomes/_feeling_unsafe.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/outcomes/_feeling_unsafe.erb
@@ -56,4 +56,10 @@ Find additional helplines [if you’re a victim of domestic abuse or feel at ris
   [Get advice for children (Children’s Commissioner for Wales)](https://www.childcomwales.org.uk/coronavirus/)
 <% end %>
 
+$CTA
+  <h3 class="app-c-callout-title">Was this information on what to do if you’re feeling unsafe or worried about someone else helpful?</h3>
+
+  [Give feedback on this service](/done/find-coronavirus-support)
+$CTA
+
 ---

--- a/lib/smart_answer_flows/coronavirus-find-support/outcomes/_getting_food.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/outcomes/_getting_food.erb
@@ -67,4 +67,10 @@ You might be able to phone or email your local shops to get a food delivery, or 
   [Get more information on accessing food and other essential supplies](https://gov.wales/getting-food-and-essential-supplies-during-coronavirus-pandemic)
 <% end %>
 
+$CTA
+  <h3 class="app-c-callout-title">Was this information on getting food helpful?</h3>
+
+  [Give feedback on this service](/done/find-coronavirus-support)
+$CTA
+
 ---

--- a/lib/smart_answer_flows/coronavirus-find-support/outcomes/_going_to_work.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/outcomes/_going_to_work.erb
@@ -68,4 +68,10 @@
 
 [Find out about getting statutory sick pay if you’re self-isolating (Acas)](https://www.acas.org.uk/coronavirus/self-isolation-and-sick-pay)
 
+$CTA
+  <h3 class="app-c-callout-title">Was this information on going in to work helpful?</h3>
+
+  [Give feedback on this service](/done/find-coronavirus-support)
+$CTA
+
 ---

--- a/lib/smart_answer_flows/coronavirus-find-support/outcomes/_mental_health.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/outcomes/_mental_health.erb
@@ -32,4 +32,10 @@
 
 [Supporting children’s mental health during coronavirus (Young Minds)](https://youngminds.org.uk/find-help/for-parents/supporting-your-child-during-the-coronavirus-pandemic/)
 
+$CTA
+  <h3 class="app-c-callout-title">Was this information on mental health and wellbeing helpful?</h3>
+
+  [Give feedback on this service](/done/find-coronavirus-support)
+$CTA
+
 ---

--- a/lib/smart_answer_flows/coronavirus-find-support/outcomes/_paying_bills.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/outcomes/_paying_bills.erb
@@ -50,4 +50,10 @@
   [Find out about your rights if you have a social landlord (mygov.scot)](https://www.mygov.scot/social-rental-rights/)
 <% end %>
 
+$CTA
+  <h3 class="app-c-callout-title">Was this information on paying your bills, rent, or mortgage helpful?</h3>
+
+  [Give feedback on this service](/done/find-coronavirus-support)
+$CTA
+
 ---

--- a/lib/smart_answer_flows/coronavirus-find-support/outcomes/_somewhere_to_live.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/outcomes/_somewhere_to_live.erb
@@ -92,4 +92,10 @@
   [Get coronavirus housing advice (Shelter Scotland)](https://scotland.shelter.org.uk/get_advice/scottish_housing_advice_coronavirus_COVID_19)
 <% end %>
 
+$CTA
+  <h3 class="app-c-callout-title">Was this information on having somewhere to live helpful?</h3>
+
+  [Give feedback on this service](/done/find-coronavirus-support)
+$CTA
+
 ---

--- a/lib/smart_answer_flows/coronavirus-find-support/outcomes/results.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/outcomes/results.erb
@@ -53,13 +53,13 @@
 
       [Get advice from Citizens Advice](https://www.citizensadvice.org.uk/wales/health/coronavirus-what-it-means-for-you/)
     <% end %>
+
+    $CTA
+      <h3 class="app-c-callout-title">What were you looking for support with?</h3>
+
+      [Give feedback on this service](/done/find-coronavirus-support)
+    $CTA
   <% end %>
-
-  $CTA
-    ### Help us improve
-
-    [Give feedback on this service](/done/find-coronavirus-support)
-  $CTA
 <% end %>
 
 <% html_for :body do %>


### PR DESCRIPTION
This adds feedback link boxes to each section on the results page. It also moves the general link at the end of results page to the no results page. This adds custom scss for app-c-callout-title to style the smaller h3 heading, as govuk-heading-s is doesn't have precedence over the existing scss selectors.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.
