### PR TITLE
Fix no-results text & sub-section display issues on the results page of the Coronavirus Find Support flow

### DIFF
--- a/lib/smart_answer/calculators/coronavirus_find_support_calculator.rb
+++ b/lib/smart_answer/calculators/coronavirus_find_support_calculator.rb
@@ -14,52 +14,72 @@ module SmartAnswer::Calculators
                   :have_you_been_made_unemployed,
                   :mental_health_worries
 
-    def has_results?
-      return false if need_help_with.blank?
+    GROUPS = {
+      feeling_unsafe: [:feel_safe],
+      paying_bills: [:afford_rent_mortgage_bills],
+      getting_food: %i[afford_food get_food],
+      being_unemployed: %i[have_you_been_made_unemployed self_employed],
+      going_in_to_work: %i[worried_about_work are_you_off_work_ill],
+      somewhere_to_live: %i[have_somewhere_to_live have_you_been_evicted],
+      mental_health: [:mental_health_worries],
+    }.freeze
 
-      need_help_with != "none"
+    SECTIONS = {
+      feel_safe: lambda { |calculator|
+        calculator.needs_help_with?("feeling_unsafe") && calculator.feel_safe != "yes"
+      },
+      afford_rent_mortgage_bills: lambda { |calculator|
+        calculator.needs_help_with?("paying_bills") && calculator.afford_rent_mortgage_bills != "no"
+      },
+      afford_food: lambda { |calculator|
+        calculator.needs_help_with?("getting_food") && calculator.afford_food != "no"
+      },
+      get_food: lambda { |calculator|
+        calculator.needs_help_with?("getting_food") && calculator.get_food != "yes"
+      },
+      have_you_been_made_unemployed: lambda { |calculator|
+        calculator.needs_help_with?("being_unemployed") && calculator.have_you_been_made_unemployed != "no"
+      },
+      self_employed: lambda { |calculator|
+        calculator.needs_help_with?("being_unemployed") && calculator.self_employed != "yes"
+      },
+      worried_about_work: lambda { |calculator|
+        calculator.needs_help_with?("going_in_to_work") && calculator.worried_about_work != "no"
+      },
+      are_you_off_work_ill: lambda { |calculator|
+        calculator.needs_help_with?("going_in_to_work") && calculator.are_you_off_work_ill == "yes"
+      },
+      have_somewhere_to_live: lambda { |calculator|
+        calculator.needs_help_with?("somewhere_to_live") && calculator.have_somewhere_to_live != "yes"
+      },
+      have_you_been_evicted: lambda { |calculator|
+        calculator.needs_help_with?("somewhere_to_live") && calculator.have_you_been_evicted != "no"
+      },
+      mental_health_worries: lambda { |calculator|
+        calculator.needs_help_with?("mental_health") && calculator.mental_health_worries != "no"
+      },
+    }.freeze
+
+    def show_group?(name)
+      GROUPS[name].map { |section| show_section?(section) }.any?
+    end
+
+    def show_section?(name)
+      SECTIONS[name].call(self)
+    end
+
+    def has_results?
+      GROUPS.keys.map { |group| show_group?(group) }.any?
     end
 
     def needs_help_with?(given_help_item)
-      return false unless has_results?
+      return false if need_help_with.blank?
 
       need_help_with.split(",").include? given_help_item
     end
 
     def needs_help_in?(given_nation)
       nation == given_nation
-    end
-
-    def user_feels_unsafe?
-      needs_help_with?("feeling_unsafe") && feel_safe != "yes"
-    end
-
-    def user_cannot_pay_their_bills?
-      needs_help_with?("paying_bills") && afford_rent_mortgage_bills != "no"
-    end
-
-    def user_cannot_get_food?
-      needs_help_with?("getting_food") && (afford_food != "no" && get_food != "yes")
-    end
-
-    def user_is_worried_about_going_to_work?
-      needs_help_with?("going_to_work") && worried_about_work != "no"
-    end
-
-    def user_is_unemployed?
-      needs_help_with?("being_unemployed") && (
-        (self_employed != "yes" && have_you_been_made_unemployed != "no") || are_you_off_work_ill == "yes"
-      )
-    end
-
-    def user_needs_somewhere_to_live?
-      needs_help_with?("somewhere_to_live") && (
-        have_somewhere_to_live != "yes" || have_you_been_evicted != "no"
-      )
-    end
-
-    def user_has_mental_health_worries?
-      needs_help_with?("mental_health") && mental_health_worries != "no"
     end
 
     def next_question(current_node)

--- a/lib/smart_answer_flows/coronavirus-find-support/outcomes/_being_unemployed.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/outcomes/_being_unemployed.erb
@@ -1,153 +1,157 @@
 ## Being made redundant or unemployed, or not having any work
 
-### If you’ve been made redundant or unemployed, or put on temporary leave (on furlough)
+<% if calculator.show_section?(:have_you_been_made_unemployed) %>
+  ### If you’ve been made redundant or unemployed, or put on temporary leave (on furlough)
 
-[What to do if you’ve lost your job](https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-you-were-employed-and-have-lost-your-job)
+  [What to do if you’ve lost your job](https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-you-were-employed-and-have-lost-your-job)
 
-[What to do if you’ve been furloughed](https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-youre-employed-and-cannot-work)
+  [What to do if you’ve been furloughed](https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-youre-employed-and-cannot-work)
 
-[Check if you can get Universal Credit](https://www.gov.uk/how-to-claim-universal-credit)
+  [Check if you can get Universal Credit](https://www.gov.uk/how-to-claim-universal-credit)
 
-[Your rights if you’ve been made redundant, including information on how much redundancy pay you can get and your notice period](https://www.gov.uk/redundancy-your-rights)
+  [Your rights if you’ve been made redundant, including information on how much redundancy pay you can get and your notice period](https://www.gov.uk/redundancy-your-rights)
 
-[Your rights if you think you might have been discriminated against at work](https://www.gov.uk/discrimination-your-rights/discrimination-at-work)
+  [Your rights if you think you might have been discriminated against at work](https://www.gov.uk/discrimination-your-rights/discrimination-at-work)
 
-[Find out what rights you have if you're pregnant](https://www.gov.uk/working-when-pregnant-your-rights)
+  [Find out what rights you have if you're pregnant](https://www.gov.uk/working-when-pregnant-your-rights)
 
-[What to do if your employer has ended your employment but you have not been made redundant](https://www.gov.uk/dismissal)
+  [What to do if your employer has ended your employment but you have not been made redundant](https://www.gov.uk/dismissal)
 
-<% if calculator.needs_help_in?("northern_ireland") %>
-  [Find out about the financial support and benefits you might be able to get (NI direct)](https://www.nidirect.gov.uk/articles/coronavirus-covid-19-and-benefits)
+  <% if calculator.needs_help_in?("northern_ireland") %>
+    [Find out about the financial support and benefits you might be able to get (NI direct)](https://www.nidirect.gov.uk/articles/coronavirus-covid-19-and-benefits)
+  <% end %>
+
+  <% if calculator.needs_help_in?("wales") %>
+    [Check if you’re eligible for the Discretionary Assistance Fund (Welsh Government)](https://gov.wales/discretionary-assistance-fund-daf)
+  <% end %>
+
+  <% if calculator.needs_help_in?("scotland") %>
+    [Find help with benefits (mygov.scot)](https://www.mygov.scot/benefits-support/)
+  <% end %>
+
+  <% unless calculator.needs_help_in?("northern_ireland") %>
+    [Search and apply for jobs](https://www.gov.uk/find-a-job)
+  <% end %>
+
+  [Find out if you can get help in your local area](https://www.gov.uk/coronavirus-local-help)
+
+  #### Support and advice
+
+  <% if calculator.needs_help_in?("england") %>
+    [Check if your redundancy is fair (Citizens Advice)](https://www.citizensadvice.org.uk/work/leaving-a-job/redundancy/check-if-your-redundancy-is-fair/)
+  <% end %>
+
+  <% if calculator.needs_help_in?("wales") %>
+    [Check if your redundancy is fair (Citizens Advice)](https://www.citizensadvice.org.uk/wales/work/leaving-a-job/redundancy/check-if-your-redundancy-is-fair/)
+  <% end %>
+
+  <% if calculator.needs_help_in?("scotland") %>
+    [Check if your redundancy is fair (Citizens Advice Scotland)](https://www.citizensadvice.org.uk/scotland/work/leaving-a-job/redundancy/check-if-your-redundancy-is-fair/)
+  <% end %>
+
+  <% if calculator.needs_help_in?("england") %>
+    [What to do if you do not think you’re getting your maternity rights (Citizens Advice)](https://www.citizensadvice.org.uk/work/rights-at-work/parental-rights/if-you-dont-get-your-maternity-rights/)
+  <% end %>
+
+  <% if calculator.needs_help_in?("wales") %>
+    [What to do if you do not think you’re getting your maternity rights (Citizens Advice)](https://www.citizensadvice.org.uk/wales/work/rights-at-work/parental-rights/if-you-dont-get-your-maternity-rights/)
+  <% end %>
+
+  <% if calculator.needs_help_in?("scotland") %>
+    [What to do if you do not think you’re getting your maternity rights (Citizens Advice Scotland)](https://www.citizensadvice.org.uk/scotland/work/rights-at-work/parental-rights/if-you-dont-get-your-maternity-rights/)
+  <% end %>
+
+  <% if calculator.needs_help_in?("england") %>
+    [Advice if you’ve been furloughed (Citizens Advice)](https://www.citizensadvice.org.uk/work/coronavirus-being-furloughed-if-you-cant-work/)
+  <% end %>
+
+  <% if calculator.needs_help_in?("scotland") %>
+    [Advice if you’ve been furloughed (Citizens Advice Scotland)](https://www.citizensadvice.org.uk/scotland/work/coronavirus-being-furloughed-if-you-cant-work/)
+  <% end %>
+
+  <% if calculator.needs_help_in?("wales") %>
+    [Advice if you’ve been furloughed (Citizens Advice)](https://www.citizensadvice.org.uk/wales/work/coronavirus-being-furloughed-if-you-cant-work/)
+  <% end %>
+
+  <% if calculator.needs_help_in?("england") %>
+    [Get advice on applying for Universal Credit (Citizens Advice)](https://www.citizensadvice.org.uk/benefits/universal-credit/)
+  <% end %>
+
+  <% if calculator.needs_help_in?("scotland") %>
+    [Get advice on applying for Universal Credit (Citizens Advice Scotland)](https://www.citizensadvice.org.uk/scotland/benefits/universal-credit/)
+  <% end %>
+
+  <% if calculator.needs_help_in?("wales") %>
+    [Get advice on applying for Universal Credit (Citizens Advice)](https://www.citizensadvice.org.uk/wales/benefits/universal-credit/)
+  <% end %>
+
+  <% if calculator.needs_help_in?("northern_ireland") %>
+    [Get help from Citizens Advice](https://www.citizensadvice.org.uk/about-us/northern-ireland/)
+
+    [Get advice on benefits (Advice NI)](https://www.adviceni.net/)
+  <% end %>
+
+  <% if calculator.needs_help_in?("wales") %>
+    [Contact Working Wales if you’ve been made redundant](https://workingwales.gov.wales/)
+  <% end %>
+
+  <% if calculator.needs_help_in?("scotland") %>
+    [Get help if you’ve been made redundant (mygov.scot)](https://www.mygov.scot/help-redundancy/)
+  <% end %>
 <% end %>
 
-<% if calculator.needs_help_in?("wales") %>
-  [Check if you’re eligible for the Discretionary Assistance Fund (Welsh Government)](https://gov.wales/discretionary-assistance-fund-daf)
-<% end %>
+<% if calculator.show_section?(:self_employed) %>
+  ### If you’re self employed, a freelancer, or a sole trader
 
-<% if calculator.needs_help_in?("scotland") %>
-  [Find help with benefits (mygov.scot)](https://www.mygov.scot/benefits-support/)
-<% end %>
+  [What to do if you’re self-employed, a freelancer, or a sole trader and you’re getting less or no work](https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-youre-self-employed-and-getting-less-work-or-no-work)
 
-<% unless calculator.needs_help_in?("northern_ireland") %>
-  [Search and apply for jobs](https://www.gov.uk/find-a-job)
-<% end %>
+  [Find financial support for your business](https://www.gov.uk/business-coronavirus-support-finder)
 
-[Find out if you can get help in your local area](https://www.gov.uk/coronavirus-local-help)
+  <% if calculator.needs_help_in?("northern_ireland") %>
+    [Find out about the financial support and benefits you might be able to get (NI direct)](https://www.nidirect.gov.uk/articles/coronavirus-covid-19-and-benefits)
+  <% end %>
 
-#### Support and advice
+  <% if calculator.needs_help_in?("northern_ireland") %>
+    [Get help with your business rates and find out about coronavirus loans (nibusinessinfo)](https://www.nibusinessinfo.co.uk/content/coronavirus-support-and-advice-self-employed)
+  <% end %>
 
-<% if calculator.needs_help_in?("england") %>
-  [Check if your redundancy is fair (Citizens Advice)](https://www.citizensadvice.org.uk/work/leaving-a-job/redundancy/check-if-your-redundancy-is-fair/)
-<% end %>
+  <% if calculator.needs_help_in?("wales") %>
+    [Check if you’re eligible for the Discretionary Assistance Fund (Welsh Government)](https://gov.wales/discretionary-assistance-fund-daf)
+  <% end %>
 
-<% if calculator.needs_help_in?("wales") %>
-  [Check if your redundancy is fair (Citizens Advice)](https://www.citizensadvice.org.uk/wales/work/leaving-a-job/redundancy/check-if-your-redundancy-is-fair/)
-<% end %>
+  <% if calculator.needs_help_in?("scotland") %>
+    [Find financial support for your business (Scottish Government)](https://findbusinesssupport.gov.scot/coronavirus-advice)
+  <% end %>
 
-<% if calculator.needs_help_in?("scotland") %>
-  [Check if your redundancy is fair (Citizens Advice Scotland)](https://www.citizensadvice.org.uk/scotland/work/leaving-a-job/redundancy/check-if-your-redundancy-is-fair/)
-<% end %>
+  [Find out if you can get help in your local area](https://www.gov.uk/coronavirus-local-help)
 
-<% if calculator.needs_help_in?("england") %>
-  [What to do if you do not think you’re getting your maternity rights (Citizens Advice)](https://www.citizensadvice.org.uk/work/rights-at-work/parental-rights/if-you-dont-get-your-maternity-rights/)
-<% end %>
+  #### Support and advice
 
-<% if calculator.needs_help_in?("wales") %>
-  [What to do if you do not think you’re getting your maternity rights (Citizens Advice)](https://www.citizensadvice.org.uk/wales/work/rights-at-work/parental-rights/if-you-dont-get-your-maternity-rights/)
-<% end %>
+  [What you can do if you’re self employed or a sole trader (Money Advice Service)](https://www.moneyadviceservice.org.uk/en/articles/coronavirus-if-youre-self-employed)
 
-<% if calculator.needs_help_in?("scotland") %>
-  [What to do if you do not think you’re getting your maternity rights (Citizens Advice Scotland)](https://www.citizensadvice.org.uk/scotland/work/rights-at-work/parental-rights/if-you-dont-get-your-maternity-rights/)
-<% end %>
+  <% if calculator.needs_help_in?("england") %>
+    [Get advice on applying for Universal Credit (Citizens Advice)](https://www.citizensadvice.org.uk/benefits/universal-credit/)
+  <% end %>
 
-<% if calculator.needs_help_in?("england") %>
-  [Advice if you’ve been furloughed (Citizens Advice)](https://www.citizensadvice.org.uk/work/coronavirus-being-furloughed-if-you-cant-work/)
-<% end %>
+  <% if calculator.needs_help_in?("scotland") %>
+    [Get advice on applying for Universal Credit (Citizens Advice Scotland)](https://www.citizensadvice.org.uk/scotland/benefits/universal-credit/)
+  <% end %>
 
-<% if calculator.needs_help_in?("scotland") %>
-  [Advice if you’ve been furloughed (Citizens Advice Scotland)](https://www.citizensadvice.org.uk/scotland/work/coronavirus-being-furloughed-if-you-cant-work/)
-<% end %>
+  <% if calculator.needs_help_in?("wales") %>
+    [Get advice on applying for Universal Credit (Citizens Advice)](https://www.citizensadvice.org.uk/wales/benefits/universal-credit/)
+  <% end %>
 
-<% if calculator.needs_help_in?("wales") %>
-  [Advice if you’ve been furloughed (Citizens Advice)](https://www.citizensadvice.org.uk/wales/work/coronavirus-being-furloughed-if-you-cant-work/)
-<% end %>
+  <% if calculator.needs_help_in?("northern_ireland") %>
+    [Get help from Citizens Advice](https://www.citizensadvice.org.uk/about-us/northern-ireland/)
+  <% end %>
 
-<% if calculator.needs_help_in?("england") %>
-  [Get advice on applying for Universal Credit (Citizens Advice)](https://www.citizensadvice.org.uk/benefits/universal-credit/)
-<% end %>
+  <% if calculator.needs_help_in?("northern_ireland") %>
+    [Get advice on benefits (Advice NI)](https://www.adviceni.net/)
+  <% end %>
 
-<% if calculator.needs_help_in?("scotland") %>
-  [Get advice on applying for Universal Credit (Citizens Advice Scotland)](https://www.citizensadvice.org.uk/scotland/benefits/universal-credit/)
-<% end %>
-
-<% if calculator.needs_help_in?("wales") %>
-  [Get advice on applying for Universal Credit (Citizens Advice)](https://www.citizensadvice.org.uk/wales/benefits/universal-credit/)
-<% end %>
-
-<% if calculator.needs_help_in?("northern_ireland") %>
-  [Get help from Citizens Advice](https://www.citizensadvice.org.uk/about-us/northern-ireland/)
-
-  [Get advice on benefits (Advice NI)](https://www.adviceni.net/)
-<% end %>
-
-<% if calculator.needs_help_in?("wales") %>
-  [Contact Working Wales if you’ve been made redundant](https://workingwales.gov.wales/)
-<% end %>
-
-<% if calculator.needs_help_in?("scotland") %>
-  [Get help if you’ve been made redundant (mygov.scot)](https://www.mygov.scot/help-redundancy/)
-<% end %>
-
-### If you’re self employed, a freelancer, or a sole trader
-
-[What to do if you’re self-employed, a freelancer, or a sole trader and you’re getting less or no work](https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-youre-self-employed-and-getting-less-work-or-no-work)
-
-[Find financial support for your business](https://www.gov.uk/business-coronavirus-support-finder)
-
-<% if calculator.needs_help_in?("northern_ireland") %>
-  [Find out about the financial support and benefits you might be able to get (NI direct)](https://www.nidirect.gov.uk/articles/coronavirus-covid-19-and-benefits)
-<% end %>
-
-<% if calculator.needs_help_in?("northern_ireland") %>
-  [Get help with your business rates and find out about coronavirus loans (nibusinessinfo)](https://www.nibusinessinfo.co.uk/content/coronavirus-support-and-advice-self-employed)
-<% end %>
-
-<% if calculator.needs_help_in?("wales") %>
-  [Check if you’re eligible for the Discretionary Assistance Fund (Welsh Government)](https://gov.wales/discretionary-assistance-fund-daf)
-<% end %>
-
-<% if calculator.needs_help_in?("scotland") %>
-  [Find financial support for your business (Scottish Government)](https://findbusinesssupport.gov.scot/coronavirus-advice)
-<% end %>
-
-[Find out if you can get help in your local area](https://www.gov.uk/coronavirus-local-help)
-
-#### Support and advice
-
-[What you can do if you’re self employed or a sole trader (Money Advice Service)](https://www.moneyadviceservice.org.uk/en/articles/coronavirus-if-youre-self-employed)
-
-<% if calculator.needs_help_in?("england") %>
-  [Get advice on applying for Universal Credit (Citizens Advice)](https://www.citizensadvice.org.uk/benefits/universal-credit/)
-<% end %>
-
-<% if calculator.needs_help_in?("scotland") %>
-  [Get advice on applying for Universal Credit (Citizens Advice Scotland)](https://www.citizensadvice.org.uk/scotland/benefits/universal-credit/)
-<% end %>
-
-<% if calculator.needs_help_in?("wales") %>
-  [Get advice on applying for Universal Credit (Citizens Advice)](https://www.citizensadvice.org.uk/wales/benefits/universal-credit/)
-<% end %>
-
-<% if calculator.needs_help_in?("northern_ireland") %>
-  [Get help from Citizens Advice](https://www.citizensadvice.org.uk/about-us/northern-ireland/)
-<% end %>
-
-<% if calculator.needs_help_in?("northern_ireland") %>
-  [Get advice on benefits (Advice NI)](https://www.adviceni.net/)
-<% end %>
-
-<% if calculator.needs_help_in?("scotland") %>
-  [Find help with benefits (mygov.scot)](https://www.mygov.scot/benefits-support/)
+  <% if calculator.needs_help_in?("scotland") %>
+    [Find help with benefits (mygov.scot)](https://www.mygov.scot/benefits-support/)
+  <% end %>
 <% end %>
 
 $CTA

--- a/lib/smart_answer_flows/coronavirus-find-support/outcomes/_feeling_unsafe.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/outcomes/_feeling_unsafe.erb
@@ -1,63 +1,65 @@
 ## Feeling unsafe
 
-### If you do not feel safe where you live or you’re worried about someone else
+<% if calculator.show_section?(:feel_safe) %>
+  ### If you do not feel safe where you live or you’re worried about someone else
 
-If you’re in immediate danger call 999 and ask for the Police.
+  If you’re in immediate danger call 999 and ask for the Police.
 
-If you’re in danger and unable to talk on the phone, call 999, then press 55 when prompted.
+  If you’re in danger and unable to talk on the phone, call 999, then press 55 when prompted.
 
-Call the National Domestic Abuse Helpline on [0808 2000 247](tel:0808 2000 247), you can get advice in different languages. You can also [get help online](https://www.nationaldahelpline.org.uk/Chat-to-us-online).
+  Call the National Domestic Abuse Helpline on [0808 2000 247](tel:0808 2000 247), you can get advice in different languages. You can also [get help online](https://www.nationaldahelpline.org.uk/Chat-to-us-online).
 
-If you’re a child or young person call Childline on [0800 1111](tel:0800 1111) or [get help online](https://www.childline.org.uk).
+  If you’re a child or young person call Childline on [0800 1111](tel:0800 1111) or [get help online](https://www.childline.org.uk).
 
-<% if calculator.needs_help_in?("northern_ireland") %>
-  [Get help from Nexus NI](https://nexusni.org/domestic-and-sexual-abuse-24-hour-helpline/)
-<% end %>
+  <% if calculator.needs_help_in?("northern_ireland") %>
+    [Get help from Nexus NI](https://nexusni.org/domestic-and-sexual-abuse-24-hour-helpline/)
+  <% end %>
 
-<% if calculator.needs_help_in?("wales") %>
-  [Get help from Live Fear Free](https://gov.wales/live-fear-free)
-<% end %>
+  <% if calculator.needs_help_in?("wales") %>
+    [Get help from Live Fear Free](https://gov.wales/live-fear-free)
+  <% end %>
 
-<% if calculator.needs_help_in?("scotland") %>
-  [Get help from Women’s Aid Scotland](https://womensaid.scot/)
+  <% if calculator.needs_help_in?("scotland") %>
+    [Get help from Women’s Aid Scotland](https://womensaid.scot/)
 
-  [Get help from Scotland’s forced marriage and domestic abuse helpline](https://sdafmh.org.uk/)
-<% end %>
+    [Get help from Scotland’s forced marriage and domestic abuse helpline](https://sdafmh.org.uk/)
+  <% end %>
 
-[Contact NSPCC if you’re concerned about a child.](https://www.nspcc.org.uk/keeping-children-safe/our-services/nspcc-helpline/)
+  [Contact NSPCC if you’re concerned about a child.](https://www.nspcc.org.uk/keeping-children-safe/our-services/nspcc-helpline/)
 
-Call Hourglass, if you're an older person or worried about an older person on [0808 808 8141](tel:0808 808 8141), or [find out what support they offer](https://wearehourglass.org/).
+  Call Hourglass, if you're an older person or worried about an older person on [0808 808 8141](tel:0808 808 8141), or [find out what support they offer](https://wearehourglass.org/).
 
-<% if calculator.needs_help_in?("wales") %>
-  [Find helplines if you’re an older person (Older People’s Commissioner for Wales)](https://www.olderpeoplewales.com/en/coronavirus.aspx)
+  <% if calculator.needs_help_in?("wales") %>
+    [Find helplines if you’re an older person (Older People’s Commissioner for Wales)](https://www.olderpeoplewales.com/en/coronavirus.aspx)
 
-  [Find victim support helplines (this page is in Welsh)](https://www.victimsupport.org.uk/help-and-support/get-help/support-near-you/wales)
-<% end %>
+    [Find victim support helplines (this page is in Welsh)](https://www.victimsupport.org.uk/help-and-support/get-help/support-near-you/wales)
+  <% end %>
 
-Call Galop, the LGBT+ helpline on [0800 999 5428](tel:0800 999 5428), or [find out what support they offer](http://www.galop.org.uk/how-we-can-help/).
+  Call Galop, the LGBT+ helpline on [0800 999 5428](tel:0800 999 5428), or [find out what support they offer](http://www.galop.org.uk/how-we-can-help/).
 
-Call Men’s Advice Line on [0808 8010327](tel:0808 8010327) or [get help online](https://mensadviceline.org.uk/).
+  Call Men’s Advice Line on [0808 8010327](tel:0808 8010327) or [get help online](https://mensadviceline.org.uk/).
 
-Call Southall Black Sisters for help for black and minority women, including if you’ve got No Recourse to Public Funds on [0208 571 9595](tel:0208 571 9595). You can get advice in different languages. You can also [find out what support they offer](https://southallblacksisters.org.uk).
+  Call Southall Black Sisters for help for black and minority women, including if you’ve got No Recourse to Public Funds on [0208 571 9595](tel:0208 571 9595). You can get advice in different languages. You can also [find out what support they offer](https://southallblacksisters.org.uk).
 
-Call [Karma Nirvana](https://karmanirvana.org.uk/help/) for help with honour-based abuse and forced marriage on [0800 5999 247](tel:0800 5999 247).
+  Call [Karma Nirvana](https://karmanirvana.org.uk/help/) for help with honour-based abuse and forced marriage on [0800 5999 247](tel:0800 5999 247).
 
-[Get specialist support for Deaf people from Signhealth](https://signhealth.org.uk/with-deaf-people/domestic-abuse/domestic-abuse-service).
+  [Get specialist support for Deaf people from Signhealth](https://signhealth.org.uk/with-deaf-people/domestic-abuse/domestic-abuse-service).
 
-<% if calculator.needs_help_in?("wales") or calculator.needs_help_in?("england") %>
-  [Get help from Rape Crisis](https://rapecrisis.org.uk/get-help)
-<% end %>
+  <% if calculator.needs_help_in?("wales") or calculator.needs_help_in?("england") %>
+    [Get help from Rape Crisis](https://rapecrisis.org.uk/get-help)
+  <% end %>
 
-#### Support and advice
+  #### Support and advice
 
-[Get safety advice for survivors from Women’s Aid](https://www.womensaid.org.uk/covid-19-coronavirus-safety-and-support-resources/). You can get advice in different languages including British Sign Language.
+  [Get safety advice for survivors from Women’s Aid](https://www.womensaid.org.uk/covid-19-coronavirus-safety-and-support-resources/). You can get advice in different languages including British Sign Language.
 
-[Find specialist helplines for black and minority women (Imkaan)](https://www.imkaan.org.uk/get-help).
+  [Find specialist helplines for black and minority women (Imkaan)](https://www.imkaan.org.uk/get-help).
 
-Find additional helplines [if you’re a victim of domestic abuse or feel at risk of abuse](https://www.gov.uk/guidance/domestic-abuse-how-to-get-help" class="govuk-link), or if you are a [victim or witness of a crime](https://www.gov.uk/guidance/coronavirus-covid-19-victim-and-witness-services).
+  Find additional helplines [if you’re a victim of domestic abuse or feel at risk of abuse](https://www.gov.uk/guidance/domestic-abuse-how-to-get-help" class="govuk-link), or if you are a [victim or witness of a crime](https://www.gov.uk/guidance/coronavirus-covid-19-victim-and-witness-services).
 
-<% if calculator.needs_help_in?("wales") %>
-  [Get advice for children (Children’s Commissioner for Wales)](https://www.childcomwales.org.uk/coronavirus/)
+  <% if calculator.needs_help_in?("wales") %>
+    [Get advice for children (Children’s Commissioner for Wales)](https://www.childcomwales.org.uk/coronavirus/)
+  <% end %>
 <% end %>
 
 $CTA

--- a/lib/smart_answer_flows/coronavirus-find-support/outcomes/_getting_food.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/outcomes/_getting_food.erb
@@ -1,70 +1,73 @@
 ## Getting food
 
-### If you’re finding it hard to afford food
+<% if calculator.show_section?(:afford_food) %>
+  ### If you’re finding it hard to afford food
 
-[Find out if you’re eligible for Universal Credit](https://www.gov.uk/universal-credit/eligibility)
+  [Find out if you’re eligible for Universal Credit](https://www.gov.uk/universal-credit/eligibility)
 
-<% if calculator.needs_help_in?("wales") %>
-  [Find out if you can get help from a foodbank (Citizens Advice)](https://www.citizensadvice.org.uk/wales/benefits/help-if-on-a-low-income/using-a-food-bank/)
+  <% if calculator.needs_help_in?("wales") %>
+    [Find out if you can get help from a foodbank (Citizens Advice)](https://www.citizensadvice.org.uk/wales/benefits/help-if-on-a-low-income/using-a-food-bank/)
+  <% end %>
+
+  <% if calculator.needs_help_in?("england") %>
+    [Find out if you can get help from a foodbank (Citizens Advice)](https://www.citizensadvice.org.uk/benefits/help-if-on-a-low-income/using-a-food-bank/)
+  <% end %>
+
+  <% if calculator.needs_help_in?("northern_ireland") %>
+    [Find out about the financial support and benefits you might be able to get (NI direct)](https://www.nidirect.gov.uk/articles/coronavirus-covid-19-and-benefits)
+  <% end %>
+
+  [If you need food urgently and have no other support, find out if you can get help from your council](https://www.gov.uk/coronavirus-local-help)
+
+  [If you have a child, find out if they can get free school meals](https://www.gov.uk/apply-free-school-meals)
+
+  <% unless calculator.needs_help_in?("scotland") %>
+    [Find out if you can apply for Healthy Start vouchers if you’re 10 or more weeks pregnant or have a child under 4](https://www.healthystart.nhs.uk/healthy-start-vouchers/do-i-qualify/)
+  <% end %>
+
+  <% if calculator.needs_help_in?("scotland") %>
+    [Find out if you’re eligible for the Scottish Welfare Fund (mygov.scot)](https://www.mygov.scot/scottish-welfare-fund/)
+
+    [Find out if you can get a grant if you’re a parent or looking after a child (mygov.scot)](https://www.mygov.scot/best-start-grant-best-start-foods/)
+  <% end %>
+
+  <% if calculator.needs_help_in?("wales") %>
+    [Check if you’re eligible for the Discretionary Assistance Fund (Welsh Government)](https://gov.wales/discretionary-assistance-fund-daf)
+  <% end %>
+
+  <% if calculator.needs_help_in?("northern_ireland") %>
+    Call the coronavirus Community Helpline for Northern Ireland on [0808 802 0020](tel:+448088020020), email [covid19@adviceni.net](mailto:covid19@adviceni.net) or text ‘ACTION’ to 81025
+  <% end %>
 <% end %>
 
-<% if calculator.needs_help_in?("england") %>
-  [Find out if you can get help from a foodbank (Citizens Advice)](https://www.citizensadvice.org.uk/benefits/help-if-on-a-low-income/using-a-food-bank/)
-<% end %>
+<% if calculator.show_section?(:get_food) %>
+  ### If you’re unable to get food
 
-<% if calculator.needs_help_in?("northern_ireland") %>
-  [Find out about the financial support and benefits you might be able to get (NI direct)](https://www.nidirect.gov.uk/articles/coronavirus-covid-19-and-benefits)
-<% end %>
+  <% if calculator.needs_help_in?("scotland") %>
+    [Find out if you can get help from the Scottish Government](https://www.gov.scot/publications/coronavirus-covid-19-help-for-vulnerable-people)
+  <% end %>
 
-[If you need food urgently and have no other support, find out if you can get help from your council](https://www.gov.uk/coronavirus-local-help)
+  You might be able to phone or email your local shops to get a food delivery, or get food online.
 
-[If you have a child, find out if they can get free school meals](https://www.gov.uk/apply-free-school-meals)
+  [Find out if you can get help from a volunteer through the NHS Volunteer Responders programme](https://volunteering.royalvoluntaryservice.org.uk/nhs-volunteer-responders-portal/isolating)
 
-<% unless calculator.needs_help_in?("scotland") %>
-  [Find out if you can apply for Healthy Start vouchers if you’re 10 or more weeks pregnant or have a child under 4](https://www.healthystart.nhs.uk/healthy-start-vouchers/do-i-qualify/)
-<% end %>
+  <% if calculator.needs_help_in?("england") %>
+    [Find out how you can pay for your shopping safely if someone else is shopping for you](https://www.gov.uk/guidance/coronavirus-covid-19-accessing-food-and-essential-supplies)
+  <% end %>
 
-<% if calculator.needs_help_in?("scotland") %>
-  [Find out if you’re eligible for the Scottish Welfare Fund (mygov.scot)](https://www.mygov.scot/scottish-welfare-fund/)
+  <% if calculator.needs_help_in?("wales") %>
+    [Find out how you can pay for your shopping safely if someone else is shopping for you](https://gov.wales/getting-food-and-essential-supplies-during-coronavirus-pandemic)
+  <% end %>
 
-  [Find out if you can get a grant if you’re a parent or looking after a child (mygov.scot)](https://www.mygov.scot/best-start-grant-best-start-foods/)
-<% end %>
+  [If you need urgent help contact your local council](https://www.gov.uk/coronavirus-local-help)
 
+  <% if calculator.needs_help_in?("england") %>
+    [Get more information on accessing food and other essential supplies](https://www.gov.uk/guidance/coronavirus-covid-19-accessing-food-and-essential-supplies)
+  <% end %>
 
-<% if calculator.needs_help_in?("wales") %>
-  [Check if you’re eligible for the Discretionary Assistance Fund (Welsh Government)](https://gov.wales/discretionary-assistance-fund-daf)
-<% end %>
-
-<% if calculator.needs_help_in?("northern_ireland") %>
-  Call the coronavirus Community Helpline for Northern Ireland on [0808 802 0020](tel:+448088020020), email [covid19@adviceni.net](mailto:covid19@adviceni.net) or text ‘ACTION’ to 81025
-<% end %>
-
-### If you’re unable to get food
-
-<% if calculator.needs_help_in?("scotland") %>
-  [Find out if you can get help from the Scottish Government](https://www.gov.scot/publications/coronavirus-covid-19-help-for-vulnerable-people)
-<% end %>
-
-You might be able to phone or email your local shops to get a food delivery, or get food online.
-
-[Find out if you can get help from a volunteer through the NHS Volunteer Responders programme](https://volunteering.royalvoluntaryservice.org.uk/nhs-volunteer-responders-portal/isolating)
-
-<% if calculator.needs_help_in?("england") %>
-  [Find out how you can pay for your shopping safely if someone else is shopping for you](https://www.gov.uk/guidance/coronavirus-covid-19-accessing-food-and-essential-supplies)
-<% end %>
-
-<% if calculator.needs_help_in?("wales") %>
-  [Find out how you can pay for your shopping safely if someone else is shopping for you](https://gov.wales/getting-food-and-essential-supplies-during-coronavirus-pandemic)
-<% end %>
-
-[If you need urgent help contact your local council](https://www.gov.uk/coronavirus-local-help)
-
-<% if calculator.needs_help_in?("england") %>
-  [Get more information on accessing food and other essential supplies](https://www.gov.uk/guidance/coronavirus-covid-19-accessing-food-and-essential-supplies)
-<% end %>
-
-<% if calculator.needs_help_in?("wales") %>
-  [Get more information on accessing food and other essential supplies](https://gov.wales/getting-food-and-essential-supplies-during-coronavirus-pandemic)
+  <% if calculator.needs_help_in?("wales") %>
+    [Get more information on accessing food and other essential supplies](https://gov.wales/getting-food-and-essential-supplies-during-coronavirus-pandemic)
+  <% end %>
 <% end %>
 
 $CTA

--- a/lib/smart_answer_flows/coronavirus-find-support/outcomes/_going_to_work.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/outcomes/_going_to_work.erb
@@ -1,72 +1,76 @@
 ## Being worried about working, or off work because you’re self-isolating
 
-### If you’re worried about going in to work
+<% if calculator.show_section?(:worried_about_work) %>
+  ### If you’re worried about going in to work
 
-<% if calculator.needs_help_in?("england") %>
-  [Check if you should go back in to work](https://www.gov.uk/check-how-to-return-to-work-safely)
+  <% if calculator.needs_help_in?("england") %>
+    [Check if you should go back in to work](https://www.gov.uk/check-how-to-return-to-work-safely)
+  <% end %>
+
+  <% if calculator.needs_help_in?("england") %>
+    [What to do if you’ve been told to go back in to work and you’re worried (Citizens Advice)](https://www.citizensadvice.org.uk/work/coronavirus-if-youre-worried-about-working/)
+  <% end %>
+
+  <% if calculator.needs_help_in?("scotland") %>
+    [What to do if you’ve been told to go back in to work and you’re worried (Citizens Advice Scotland)](https://www.citizensadvice.org.uk/scotland/work/coronavirus-if-youre-worried-about-working/)
+  <% end %>
+
+  <% if calculator.needs_help_in?("wales") %>
+    [What to do if you’ve been told to go back in to work and you’re worried (Citizens Advice)](https://www.citizensadvice.org.uk/wales/work/coronavirus-if-youre-worried-about-working/)
+  <% end %>
+
+  <% if calculator.needs_help_in?("northern_ireland") %>
+    [Get help from Citizens Advice](https://www.citizensadvice.org.uk/about-us/northern-ireland/)
+  <% end %>
+
+  [You might have a right to request flexible working, for example working from home - find out how you can make a request (Acas)](https://www.acas.org.uk/making-a-flexible-working-request)
+
+  [Find out if you can take time off for your family and dependents, and what to do if you have problems taking time off](https://www.gov.uk/time-off-for-dependants)
+
+  [Check what help you can get with childcare costs](https://www.gov.uk/childcare-calculator?step-by-step-nav=f237ec8e-e82c-4ffa-8fba-2a88a739783b)
+
+  [Find out if you can take unpaid parental leave](https://www.gov.uk/parental-leave)
+
+  [What to do if you’re shielding because you’ve been told by a doctor you’re clinically extremely vulnerable, but you’ve been told to go back to work](https://www.gov.uk/government/publications/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19#work-and-employment-for-those-who-are-shielding)
+
+  [Your rights if you're pregnant](https://www.gov.uk/working-when-pregnant-your-rights)
+
+  #### Support and advice
+
+  <% if calculator.needs_help_in?("england") %>
+    [What to do if you’re not getting your maternity rights (Citizens Advice)](https://www.citizensadvice.org.uk/work/rights-at-work/parental-rights/if-you-dont-get-your-maternity-rights/)
+  <% end %>
+
+  <% if calculator.needs_help_in?("wales") %>
+    [What to do if you’re not getting your maternity rights (Citizens Advice)](https://www.citizensadvice.org.uk/wales/work/rights-at-work/parental-rights/if-you-dont-get-your-maternity-rights/)
+  <% end %>
+
+  <% if calculator.needs_help_in?("scotland") %>
+    [What to do if you’re not getting your maternity rights (Citizens Advice Scotland)](https://www.citizensadvice.org.uk/scotland/work/rights-at-work/parental-rights/if-you-dont-get-your-maternity-rights/)
+  <% end %>
+
+  [Advice on returning to work after being off (Acas)](https://www.acas.org.uk/absence-from-work/returning-to-work-after-absence)
+
+  [Your rights if you think you might have been discriminated against at work](https://www.gov.uk/discrimination-your-rights/discrimination-at-work)
 <% end %>
 
-<% if calculator.needs_help_in?("england") %>
-  [What to do if you’ve been told to go back in to work and you’re worried (Citizens Advice)](https://www.citizensadvice.org.uk/work/coronavirus-if-youre-worried-about-working/)
+<% if calculator.show_section?(:are_you_off_work_ill) %>
+  ### If you’re off work because you’re ill or self isolating
+
+  [What to do if you’re employed but cannot work, for example if you’re ill](https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-youre-employed-and-cannot-work)
+
+  [Your employment rights if you’re self-isolating after returning to the UK](https://www.gov.uk/guidance/self-isolating-after-returning-to-the-uk-your-employment-rights)
+
+  <% if calculator.needs_help_in?("wales") %>
+    [Check if you’re eligible for the Discretionary Assistance Fund (Welsh Government)](https://gov.wales/discretionary-assistance-fund-daf)
+  <% end %>
+
+  #### Support and advice
+
+  [Find out about the help you can get if you’re self-employed or work in the gig economy (Money Advice Service)](https://www.moneyadviceservice.org.uk/en/articles/coronavirus-what-it-means-for-you)
+
+  [Find out about getting statutory sick pay if you’re self-isolating (Acas)](https://www.acas.org.uk/coronavirus/self-isolation-and-sick-pay)
 <% end %>
-
-<% if calculator.needs_help_in?("scotland") %>
-  [What to do if you’ve been told to go back in to work and you’re worried (Citizens Advice Scotland)](https://www.citizensadvice.org.uk/scotland/work/coronavirus-if-youre-worried-about-working/)
-<% end %>
-
-<% if calculator.needs_help_in?("wales") %>
-  [What to do if you’ve been told to go back in to work and you’re worried (Citizens Advice)](https://www.citizensadvice.org.uk/wales/work/coronavirus-if-youre-worried-about-working/)
-<% end %>
-
-<% if calculator.needs_help_in?("northern_ireland") %>
-  [Get help from Citizens Advice](https://www.citizensadvice.org.uk/about-us/northern-ireland/)
-<% end %>
-
-[You might have a right to request flexible working, for example working from home - find out how you can make a request (Acas)](https://www.acas.org.uk/making-a-flexible-working-request)
-
-[Find out if you can take time off for your family and dependents, and what to do if you have problems taking time off](https://www.gov.uk/time-off-for-dependants)
-
-[Check what help you can get with childcare costs](https://www.gov.uk/childcare-calculator?step-by-step-nav=f237ec8e-e82c-4ffa-8fba-2a88a739783b)
-
-[Find out if you can take unpaid parental leave](https://www.gov.uk/parental-leave)
-
-[What to do if you’re shielding because you’ve been told by a doctor you’re clinically extremely vulnerable, but you’ve been told to go back to work](https://www.gov.uk/government/publications/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19#work-and-employment-for-those-who-are-shielding)
-
-[Your rights if you're pregnant](https://www.gov.uk/working-when-pregnant-your-rights)
-
-#### Support and advice
-
-<% if calculator.needs_help_in?("england") %>
-  [What to do if you’re not getting your maternity rights (Citizens Advice)](https://www.citizensadvice.org.uk/work/rights-at-work/parental-rights/if-you-dont-get-your-maternity-rights/)
-<% end %>
-
-<% if calculator.needs_help_in?("wales") %>
-  [What to do if you’re not getting your maternity rights (Citizens Advice)](https://www.citizensadvice.org.uk/wales/work/rights-at-work/parental-rights/if-you-dont-get-your-maternity-rights/)
-<% end %>
-
-<% if calculator.needs_help_in?("scotland") %>
-  [What to do if you’re not getting your maternity rights (Citizens Advice Scotland)](https://www.citizensadvice.org.uk/scotland/work/rights-at-work/parental-rights/if-you-dont-get-your-maternity-rights/)
-<% end %>
-
-[Advice on returning to work after being off (Acas)](https://www.acas.org.uk/absence-from-work/returning-to-work-after-absence)
-
-[Your rights if you think you might have been discriminated against at work](https://www.gov.uk/discrimination-your-rights/discrimination-at-work)
-
-### If you’re off work because you’re ill or self isolating
-
-[What to do if you’re employed but cannot work, for example if you’re ill](https://www.gov.uk/guidance/coronavirus-covid-19-what-to-do-if-youre-employed-and-cannot-work)
-
-[Your employment rights if you’re self-isolating after returning to the UK](https://www.gov.uk/guidance/self-isolating-after-returning-to-the-uk-your-employment-rights)
-
-<% if calculator.needs_help_in?("wales") %>
-  [Check if you’re eligible for the Discretionary Assistance Fund (Welsh Government)](https://gov.wales/discretionary-assistance-fund-daf)
-<% end %>
-
-#### Support and advice
-
-[Find out about the help you can get if you’re self-employed or work in the gig economy (Money Advice Service)](https://www.moneyadviceservice.org.uk/en/articles/coronavirus-what-it-means-for-you)
-
-[Find out about getting statutory sick pay if you’re self-isolating (Acas)](https://www.acas.org.uk/coronavirus/self-isolation-and-sick-pay)
 
 $CTA
   <h3 class="app-c-callout-title">Was this information on going in to work helpful?</h3>

--- a/lib/smart_answer_flows/coronavirus-find-support/outcomes/_mental_health.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/outcomes/_mental_health.erb
@@ -1,36 +1,38 @@
 ## Mental health and wellbeing
 
-### If you’re worried about your mental health or someone else’s mental health
+<% if calculator.show_section?(:mental_health_worries) %>
+  ### If you’re worried about your mental health or someone else’s mental health
 
-[Getting urgent help for mental health issues (NHS)](https://www.nhs.uk/using-the-nhs/nhs-services/mental-health-services/dealing-with-a-mental-health-crisis-or-emergency/)
+  [Getting urgent help for mental health issues (NHS)](https://www.nhs.uk/using-the-nhs/nhs-services/mental-health-services/dealing-with-a-mental-health-crisis-or-emergency/)
 
-[Coronavirus and wellbeing (NHS)](https://www.nhs.uk/oneyou/every-mind-matters)
+  [Coronavirus and wellbeing (NHS)](https://www.nhs.uk/oneyou/every-mind-matters)
 
-[Coping with mental health problems during coronavirus (Mind)](https://www.mind.org.uk/information-support/coronavirus/coping-with-mental-health-problems-during-coronavirus/)
+  [Coping with mental health problems during coronavirus (Mind)](https://www.mind.org.uk/information-support/coronavirus/coping-with-mental-health-problems-during-coronavirus/)
 
-[Managing feelings about lockdown easing (Mind)](https://www.mind.org.uk/information-support/coronavirus/managing-feelings-about-lockdown-easing/)
+  [Managing feelings about lockdown easing (Mind)](https://www.mind.org.uk/information-support/coronavirus/managing-feelings-about-lockdown-easing/)
 
-[Help for mental health problems if you're LGBT (NHS)](https://www.nhs.uk/conditions/stress-anxiety-depression/mental-health-issues-if-you-are-gay-lesbian-or-bisexual)
+  [Help for mental health problems if you're LGBT (NHS)](https://www.nhs.uk/conditions/stress-anxiety-depression/mental-health-issues-if-you-are-gay-lesbian-or-bisexual)
 
-[Getting help with your mental health if you’re a young person (Young Minds)](https://youngminds.org.uk/find-help/looking-after-yourself/coronavirus-and-mental-health/)
+  [Getting help with your mental health if you’re a young person (Young Minds)](https://youngminds.org.uk/find-help/looking-after-yourself/coronavirus-and-mental-health/)
 
-[Register for phone calls from a volunteer if you’re shielding, isolating, a carer, or having less contact with other people (NHS Volunteer Responders)](https://nhsvolunteerresponders.org.uk/services)
+  [Register for phone calls from a volunteer if you’re shielding, isolating, a carer, or having less contact with other people (NHS Volunteer Responders)](https://nhsvolunteerresponders.org.uk/services)
 
-[Get advice from Age UK if you’re an older person, their carer, their family or friend](https://www.ageuk.org.uk/services/age-uk-advice-line/)
+  [Get advice from Age UK if you’re an older person, their carer, their family or friend](https://www.ageuk.org.uk/services/age-uk-advice-line/)
 
-<% if calculator.needs_help_in?("northern_ireland") %>
-  [Additional information about taking care of your mental health (NI direct)](https://www.nidirect.gov.uk/articles/coronavirus-covid-19-taking-care-your-mental-health-and-wellbeing)
+  <% if calculator.needs_help_in?("northern_ireland") %>
+    [Additional information about taking care of your mental health (NI direct)](https://www.nidirect.gov.uk/articles/coronavirus-covid-19-taking-care-your-mental-health-and-wellbeing)
+  <% end %>
+
+  <% if calculator.needs_help_in?("wales") %>
+    [Additional information about taking care of your mental health (Public Health Wales)](https://phw.nhs.wales/topics/latest-information-on-novel-coronavirus-covid-19/staying-well-at-home/how-are-you-feeling/)
+  <% end %>
+
+  <% if calculator.needs_help_in?("scotland") %>
+    [Additional information about coronavirus and your mental wellbeing from the Scottish Association for Mental Health](https://www.samh.org.uk/about-mental-health/self-help-and-wellbeing/coronavirus-and-your-mental-wellbeing)
+  <% end %>
+
+  [Supporting children’s mental health during coronavirus (Young Minds)](https://youngminds.org.uk/find-help/for-parents/supporting-your-child-during-the-coronavirus-pandemic/)
 <% end %>
-
-<% if calculator.needs_help_in?("wales") %>
-  [Additional information about taking care of your mental health (Public Health Wales)](https://phw.nhs.wales/topics/latest-information-on-novel-coronavirus-covid-19/staying-well-at-home/how-are-you-feeling/)
-<% end %>
-
-<% if calculator.needs_help_in?("scotland") %>
-  [Additional information about coronavirus and your mental wellbeing from the Scottish Association for Mental Health](https://www.samh.org.uk/about-mental-health/self-help-and-wellbeing/coronavirus-and-your-mental-wellbeing)
-<% end %>
-
-[Supporting children’s mental health during coronavirus (Young Minds)](https://youngminds.org.uk/find-help/for-parents/supporting-your-child-during-the-coronavirus-pandemic/)
 
 $CTA
   <h3 class="app-c-callout-title">Was this information on mental health and wellbeing helpful?</h3>

--- a/lib/smart_answer_flows/coronavirus-find-support/outcomes/_paying_bills.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/outcomes/_paying_bills.erb
@@ -1,53 +1,55 @@
 ## Paying your rent, mortgage, or bills
 
-### If you’re finding it hard to pay your rent, mortgage or bills
+<% if calculator.show_section?(:afford_rent_mortgage_bills) %>
+  ### If you’re finding it hard to pay your rent, mortgage or bills
 
-<% if calculator.needs_help_in?("england") %>
-  [What to do if you cannot pay your rent or mortgage (Shelter)](https://england.shelter.org.uk/housing_advice/coronavirus)
-<% end %>
+  <% if calculator.needs_help_in?("england") %>
+    [What to do if you cannot pay your rent or mortgage (Shelter)](https://england.shelter.org.uk/housing_advice/coronavirus)
+  <% end %>
 
-<% if calculator.needs_help_in?("scotland") %>
-  [What to do if you cannot pay your rent or mortgage (Shelter Scotland)](https://scotland.shelter.org.uk/get_advice/scottish_housing_advice_coronavirus_COVID_19)
-<% end %>
+  <% if calculator.needs_help_in?("scotland") %>
+    [What to do if you cannot pay your rent or mortgage (Shelter Scotland)](https://scotland.shelter.org.uk/get_advice/scottish_housing_advice_coronavirus_COVID_19)
+  <% end %>
 
-<% if calculator.needs_help_in?("wales") %>
-  [What to do if you cannot pay your rent or mortgage (Shelter Cymru)](https://sheltercymru.org.uk/get-advice/coronavirus/)
-<% end %>
+  <% if calculator.needs_help_in?("wales") %>
+    [What to do if you cannot pay your rent or mortgage (Shelter Cymru)](https://sheltercymru.org.uk/get-advice/coronavirus/)
+  <% end %>
 
-<% if calculator.needs_help_in?("england") %>
-  [What to do if you cannot pay your bills or mortgage, including if you cannot go out to pay them (Citizens Advice)](https://www.citizensadvice.org.uk/debt-and-money/if-you-cant-pay-your-bills-because-of-coronavirus/)
-<% end %>
+  <% if calculator.needs_help_in?("england") %>
+    [What to do if you cannot pay your bills or mortgage, including if you cannot go out to pay them (Citizens Advice)](https://www.citizensadvice.org.uk/debt-and-money/if-you-cant-pay-your-bills-because-of-coronavirus/)
+  <% end %>
 
-<% if calculator.needs_help_in?("scotland") %>
-  [What to do if you cannot pay your bills or mortgage, including if you cannot go out to pay them (Citizens Advice Scotland)](https://www.citizensadvice.org.uk/scotland/debt-and-money/if-you-cant-pay-your-bills-because-of-coronavirus/)
-<% end %>
+  <% if calculator.needs_help_in?("scotland") %>
+    [What to do if you cannot pay your bills or mortgage, including if you cannot go out to pay them (Citizens Advice Scotland)](https://www.citizensadvice.org.uk/scotland/debt-and-money/if-you-cant-pay-your-bills-because-of-coronavirus/)
+  <% end %>
 
-<% if calculator.needs_help_in?("wales") %>
-  [What to do if you cannot pay your bills or mortgage, including if you cannot go out to pay them (Citizens Advice)](https://www.citizensadvice.org.uk/wales/debt-and-money/if-you-cant-pay-your-bills-because-of-coronavirus/)
-<% end %>
+  <% if calculator.needs_help_in?("wales") %>
+    [What to do if you cannot pay your bills or mortgage, including if you cannot go out to pay them (Citizens Advice)](https://www.citizensadvice.org.uk/wales/debt-and-money/if-you-cant-pay-your-bills-because-of-coronavirus/)
+  <% end %>
 
-<% if calculator.needs_help_in?("northern_ireland") %>
-  [Get help from Citizens Advice](https://www.citizensadvice.org.uk/about-us/northern-ireland/)
+  <% if calculator.needs_help_in?("northern_ireland") %>
+    [Get help from Citizens Advice](https://www.citizensadvice.org.uk/about-us/northern-ireland/)
 
-  [Get help from the housing and debt helpline for Northern Ireland (Housing Rights)](https://www.housingrights.org.uk/)
-<% end %>
+    [Get help from the housing and debt helpline for Northern Ireland (Housing Rights)](https://www.housingrights.org.uk/)
+  <% end %>
 
-[Find out if you can get help paying for childcare](https://www.gov.uk/get-childcare)
+  [Find out if you can get help paying for childcare](https://www.gov.uk/get-childcare)
 
-[Find out if you can get help in your local area](https://www.gov.uk/coronavirus-local-help)
+  [Find out if you can get help in your local area](https://www.gov.uk/coronavirus-local-help)
 
-#### Support and advice
+  #### Support and advice
 
-[Your rights if you’re finding it hard to pay rent](https://www.gov.uk/government/publications/covid-19-and-renting-guidance-for-landlords-tenants-and-local-authorities)
+  [Your rights if you’re finding it hard to pay rent](https://www.gov.uk/government/publications/covid-19-and-renting-guidance-for-landlords-tenants-and-local-authorities)
 
-<% if calculator.needs_help_in?("wales") %>
-  [What to do if you’re finding it hard to pay rent (Welsh Government)](https://gov.wales/coronavirus-covid-19-guidance-for-tenants-in-the-private-rented-sector-html)
-<% end %>
+  <% if calculator.needs_help_in?("wales") %>
+    [What to do if you’re finding it hard to pay rent (Welsh Government)](https://gov.wales/coronavirus-covid-19-guidance-for-tenants-in-the-private-rented-sector-html)
+  <% end %>
 
-<% if calculator.needs_help_in?("scotland") %>
-  [Find out about your rights if you have a private landlord (mygov.scot)](https://www.mygov.scot/private-rental-rights/)
+  <% if calculator.needs_help_in?("scotland") %>
+    [Find out about your rights if you have a private landlord (mygov.scot)](https://www.mygov.scot/private-rental-rights/)
 
-  [Find out about your rights if you have a social landlord (mygov.scot)](https://www.mygov.scot/social-rental-rights/)
+    [Find out about your rights if you have a social landlord (mygov.scot)](https://www.mygov.scot/social-rental-rights/)
+  <% end %>
 <% end %>
 
 $CTA

--- a/lib/smart_answer_flows/coronavirus-find-support/outcomes/_somewhere_to_live.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/outcomes/_somewhere_to_live.erb
@@ -1,93 +1,97 @@
 ## Having somewhere to live
 
-### If you do not have somewhere to live or might become homeless
+<% if calculator.show_section?(:have_somewhere_to_live) %>
+  ### If you do not have somewhere to live or might become homeless
 
-<% if calculator.needs_help_in?("england") %>
-  [Get help if you’re homeless, including advice for EU nationals, refugees and asylum seekers, and disabled people (Shelter)](https://england.shelter.org.uk/housing_advice/homelessness)
+  <% if calculator.needs_help_in?("england") %>
+    [Get help if you’re homeless, including advice for EU nationals, refugees and asylum seekers, and disabled people (Shelter)](https://england.shelter.org.uk/housing_advice/homelessness)
+  <% end %>
+
+  <% if calculator.needs_help_in?("wales") %>
+    [Get help if you’re homeless, including advice for refugees and asylum seekers and EU nationals (Shelter Cymru)](https://sheltercymru.org.uk/get-advice/homelessness/)
+  <% end %>
+
+  <% if calculator.needs_help_in?("northern_ireland") %>
+    Call the Northern Ireland Housing Executive on [03448 920 908](tel:+443448920908)
+  <% end %>
+
+  <% if calculator.needs_help_in?("scotland") %>
+    [Get help if you’re homeless (mygov.scot)](https://www.mygov.scot/homelessness/)
+  <% end %>
+
+  [Find out if you can get help in your local area](https://www.gov.uk/coronavirus-local-help)
+
+  [Get specialist advice for LGBT+ people (Stonewall Housing)](https://stonewallhousing.org/services/advice/)
+
+  [Get help if you’re aged 16 to 25 (Centrepoint)](https://centrepoint.org.uk/youth-homelessness/get-help-now/)
+
+  <% if calculator.needs_help_in?("northern_ireland") %>
+    [Get help from Housing Rights housing and debt helpline](https://www.housingadviceni.org/homeless/coronavirus)
+  <% end %>
+
+  <% if calculator.needs_help_in?("scotland") %>
+    [Get help if you’re homeless from Shelter Scotland](https://scotland.shelter.org.uk/get_advice/advice_topics/homelessness)
+  <% end %>
 <% end %>
 
-<% if calculator.needs_help_in?("wales") %>
-  [Get help if you’re homeless, including advice for refugees and asylum seekers and EU nationals (Shelter Cymru)](https://sheltercymru.org.uk/get-advice/homelessness/)
-<% end %>
+<% if calculator.show_section?(:have_you_been_evicted) %>
+  ### If you’ve been evicted or might be soon
 
-<% if calculator.needs_help_in?("northern_ireland") %>
-  Call the Northern Ireland Housing Executive on [03448 920 908](tel:+443448920908)
-<% end %>
+  <% if calculator.needs_help_in?("england") %>
+    [Get coronavirus housing advice (Shelter)](https://england.shelter.org.uk/housing_advice/coronavirus)
+  <% end %>
 
-<% if calculator.needs_help_in?("scotland") %>
-  [Get help if you’re homeless (mygov.scot)](https://www.mygov.scot/homelessness/)
-<% end %>
+  <% if calculator.needs_help_in?("northern_ireland") %>
+    Call the Northern Ireland Housing Executive on [03448 920 908](tel:+443448920908)
+  <% end %>
 
-[Find out if you can get help in your local area](https://www.gov.uk/coronavirus-local-help)
+  <% if calculator.needs_help_in?("scotland") %>
+    [Find out how to get help if you’re being evicted (mygov.scot)](https://www.mygov.scot/private-tenant-eviction/getting-help/)
+  <% end %>
 
-[Get specialist advice for LGBT+ people (Stonewall Housing)](https://stonewallhousing.org/services/advice/)
+  <% if calculator.needs_help_in?("wales") %>
+    [Get coronavirus housing advice for Wales (Shelter Cymru)](https://sheltercymru.org.uk/get-advice/coronavirus/)
+  <% end %>
 
-[Get help if you’re aged 16 to 25 (Centrepoint)](https://centrepoint.org.uk/youth-homelessness/get-help-now/)
+  <% if calculator.needs_help_in?("england") %>
+    [Get advice and find out about your rights if you’re a Gypsy or Traveller and you’re being evicted (Shelter)](https://england.shelter.org.uk/housing_advice/eviction/gypsies_and_travellers_facing_eviction_from_a_site)
+  <% end %>
 
-<% if calculator.needs_help_in?("northern_ireland") %>
-  [Get help from Housing Rights housing and debt helpline](https://www.housingadviceni.org/homeless/coronavirus)
-<% end %>
+  <% if calculator.needs_help_in?("scotland") %>
+    [Get advice and find out about your rights if you’re a Gypsy or Traveller and you’re being evicted (Shelter Scotland)](https://scotland.shelter.org.uk/get_advice/advice_topics/eviction/eviction_of_gypsiestravellers)
+  <% end %>
 
-<% if calculator.needs_help_in?("scotland") %>
-  [Get help if you’re homeless from Shelter Scotland](https://scotland.shelter.org.uk/get_advice/advice_topics/homelessness)
-<% end %>
+  [Find out if you can get help in your local area](https://www.gov.uk/coronavirus-local-help)
 
-### If you’ve been evicted or might be soon
+  #### Support and advice
 
-<% if calculator.needs_help_in?("england") %>
-  [Get coronavirus housing advice (Shelter)](https://england.shelter.org.uk/housing_advice/coronavirus)
-<% end %>
+  <% if calculator.needs_help_in?("england") %>
+    [Find information about your rights as a tenant](https://www.gov.uk/government/publications/covid-19-and-renting-guidance-for-landlords-tenants-and-local-authorities)
+  <% end %>
 
-<% if calculator.needs_help_in?("northern_ireland") %>
-  Call the Northern Ireland Housing Executive on [03448 920 908](tel:+443448920908)
-<% end %>
+  <% if calculator.needs_help_in?("wales") %>
+    [Get information on evictions (Welsh Government)](https://gov.wales/coronavirus-covid-19-guidance-for-tenants-in-the-private-rented-sector-html)
+  <% end %>
 
-<% if calculator.needs_help_in?("scotland") %>
-  [Find out how to get help if you’re being evicted (mygov.scot)](https://www.mygov.scot/private-tenant-eviction/getting-help/)
-<% end %>
+  <% if calculator.needs_help_in?("scotland") %>
+    [Find out about your rights if you have a private landlord (mygov.scot)](https://www.mygov.scot/private-rental-rights/)
+  <% end %>
 
-<% if calculator.needs_help_in?("wales") %>
-  [Get coronavirus housing advice for Wales (Shelter Cymru)](https://sheltercymru.org.uk/get-advice/coronavirus/)
-<% end %>
+  <% if calculator.needs_help_in?("scotland") %>
+    [Find out about your rights if you have a social landlord (mygov.scot)](https://www.mygov.scot/social-rental-rights/)
+  <% end %>
 
-<% if calculator.needs_help_in?("england") %>
-  [Get advice and find out about your rights if you’re a Gypsy or Traveller and you’re being evicted (Shelter)](https://england.shelter.org.uk/housing_advice/eviction/gypsies_and_travellers_facing_eviction_from_a_site)
-<% end %>
+  <% if calculator.needs_help_in?("northern_ireland") %>
+    [Find advice from the Housing Executive](https://www.nihe.gov.uk/My-Housing-Executive/Advice-for-Housing-Executive-Tenants/Covid-19-(Coronavirus))
+  <% end %>
 
-<% if calculator.needs_help_in?("scotland") %>
-  [Get advice and find out about your rights if you’re a Gypsy or Traveller and you’re being evicted (Shelter Scotland)](https://scotland.shelter.org.uk/get_advice/advice_topics/eviction/eviction_of_gypsiestravellers)
-<% end %>
+  <% if calculator.needs_help_in?("northern_ireland") %>
+    [Get advice from Housing Rights](https://www.housingadviceni.org/coronavirus)
+  <% end %>
 
-[Find out if you can get help in your local area](https://www.gov.uk/coronavirus-local-help)
-
-#### Support and advice
-
-<% if calculator.needs_help_in?("england") %>
-  [Find information about your rights as a tenant](https://www.gov.uk/government/publications/covid-19-and-renting-guidance-for-landlords-tenants-and-local-authorities)
-<% end %>
-
-<% if calculator.needs_help_in?("wales") %>
-  [Get information on evictions (Welsh Government)](https://gov.wales/coronavirus-covid-19-guidance-for-tenants-in-the-private-rented-sector-html)
-<% end %>
-
-<% if calculator.needs_help_in?("scotland") %>
-  [Find out about your rights if you have a private landlord (mygov.scot)](https://www.mygov.scot/private-rental-rights/)
-<% end %>
-
-<% if calculator.needs_help_in?("scotland") %>
-  [Find out about your rights if you have a social landlord (mygov.scot)](https://www.mygov.scot/social-rental-rights/)
-<% end %>
-
-<% if calculator.needs_help_in?("northern_ireland") %>
-  [Find advice from the Housing Executive](https://www.nihe.gov.uk/My-Housing-Executive/Advice-for-Housing-Executive-Tenants/Covid-19-(Coronavirus))
-<% end %>
-
-<% if calculator.needs_help_in?("northern_ireland") %>
-  [Get advice from Housing Rights](https://www.housingadviceni.org/coronavirus)
-<% end %>
-
-<% if calculator.needs_help_in?("scotland") %>
-  [Get coronavirus housing advice (Shelter Scotland)](https://scotland.shelter.org.uk/get_advice/scottish_housing_advice_coronavirus_COVID_19)
+  <% if calculator.needs_help_in?("scotland") %>
+    [Get coronavirus housing advice (Shelter Scotland)](https://scotland.shelter.org.uk/get_advice/scottish_housing_advice_coronavirus_COVID_19)
+  <% end %>
 <% end %>
 
 $CTA

--- a/lib/smart_answer_flows/coronavirus-find-support/outcomes/results.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/outcomes/results.erb
@@ -11,13 +11,13 @@
 <% govspeak_for :body do %>
   <% if calculator.has_results? %>
 
-    <%= render("feeling_unsafe", calculator: calculator) if calculator.user_feels_unsafe? %>
-    <%= render("paying_bills", calculator: calculator) if calculator.user_cannot_pay_their_bills? %>
-    <%= render("getting_food", calculator: calculator) if calculator.user_cannot_get_food? %>
-    <%= render("being_unemployed", calculator: calculator) if calculator.user_is_unemployed? %>
-    <%= render("going_to_work", calculator: calculator) if calculator.user_is_worried_about_going_to_work? %>
-    <%= render("somewhere_to_live", calculator: calculator) if calculator.user_needs_somewhere_to_live? %>
-    <%= render("mental_health", calculator: calculator) if calculator.user_has_mental_health_worries? %>
+    <%= render("feeling_unsafe", calculator: calculator) if calculator.show_group?(:feeling_unsafe) %>
+    <%= render("paying_bills", calculator: calculator) if calculator.show_group?(:paying_bills) %>
+    <%= render("getting_food", calculator: calculator) if calculator.show_group?(:getting_food) %>
+    <%= render("being_unemployed", calculator: calculator) if calculator.show_group?(:being_unemployed) %>
+    <%= render("going_to_work", calculator: calculator) if calculator.show_group?(:going_in_to_work) %>
+    <%= render("somewhere_to_live", calculator: calculator) if calculator.show_group?(:somewhere_to_live) %>
+    <%= render("mental_health", calculator: calculator) if calculator.show_group?(:mental_health) %>
 
   <% else %>
     Based on your answers, there’s no specific information for you in this service at the moment. It will be updated regularly.

--- a/test/integration/smart_answer_flows/coronavirus_find_support_test.rb
+++ b/test/integration/smart_answer_flows/coronavirus_find_support_test.rb
@@ -112,5 +112,33 @@ class CoronavirusFindSupportFlowTest < ActiveSupport::TestCase
       add_response "england"
       assert_current_node :results
     end
+
+    should "not be possible to reach the results page without the no-results text being shown" do
+      assert_current_node :need_help_with
+      add_response "feeling_unsafe"
+      assert_current_node :feel_safe
+      add_response "yes"
+      assert_current_node :nation
+      add_response "england"
+      assert_current_node :results
+
+      assert_match(/Based on your answers, there’s no specific information for you in this service at the moment. It will be updated regularly./, outcome_body)
+    end
+
+    should "show only the appropriate sub-sections that are required based on the users given responses" do
+      assert_current_node :need_help_with
+      add_response "getting_food"
+      assert_current_node :afford_food
+      add_response "yes"
+      assert_current_node :get_food
+      add_response "yes"
+      assert_current_node :nation
+      add_response "england"
+      assert_current_node :results
+
+      assert_match(/Getting food/, outcome_body)
+      assert_match(/If you’re finding it hard to afford food/, outcome_body)
+      assert_no_match(/If you’re unable to get food/, outcome_body)
+    end
   end
 end

--- a/test/unit/calculators/coronavirus_find_support_calculator_test.rb
+++ b/test/unit/calculators/coronavirus_find_support_calculator_test.rb
@@ -6,6 +6,378 @@ module SmartAnswer::Calculators
       @calculator = CoronavirusFindSupportCalculator.new
     end
 
+    context "#show_group?" do
+      context "feel_safe" do
+        should "return true when criteria is met" do
+          @calculator.need_help_with = "feeling_unsafe"
+          @calculator.feel_safe = "no"
+
+          assert @calculator.show_group?(:feeling_unsafe)
+        end
+
+        should "return false when criteria is not met" do
+          @calculator.need_help_with = "feeling_unsafe"
+          @calculator.feel_safe = "yes"
+
+          assert_not @calculator.show_group?(:feeling_unsafe)
+        end
+      end
+
+      context "paying_bills" do
+        should "return true when criteria is met" do
+          @calculator.need_help_with = "paying_bills"
+          @calculator.afford_rent_mortgage_bills = "yes"
+
+          assert @calculator.show_group?(:paying_bills)
+        end
+
+        should "return false when criteria is not met" do
+          @calculator.need_help_with = "paying_bills"
+          @calculator.afford_rent_mortgage_bills = "no"
+
+          assert_not @calculator.show_group?(:paying_bills)
+        end
+      end
+
+      context "getting_food" do
+        should "return true when criteria is met" do
+          @calculator.need_help_with = "getting_food"
+          @calculator.afford_food = "yes"
+          @calculator.get_food = "no"
+
+          assert @calculator.show_group?(:getting_food)
+        end
+
+        should "return false when criteria is not met" do
+          @calculator.need_help_with = "getting_food"
+          @calculator.afford_food = "no"
+          @calculator.get_food = "yes"
+
+          assert_not @calculator.show_group?(:getting_food)
+        end
+      end
+
+      context "being_unemployed" do
+        should "return true when criteria is met" do
+          @calculator.need_help_with = "being_unemployed"
+          @calculator.have_you_been_made_unemployed = "yes"
+          @calculator.self_employed = "no"
+
+          assert @calculator.show_group?(:being_unemployed)
+        end
+
+        should "return false when criteria is not met" do
+          @calculator.need_help_with = "being_unemployed"
+          @calculator.have_you_been_made_unemployed = "no"
+          @calculator.self_employed = "yes"
+
+          assert_not @calculator.show_group?(:being_unemployed)
+        end
+      end
+
+      context "going_in_to_work" do
+        should "return true when criteria is met" do
+          @calculator.need_help_with = "going_in_to_work"
+          @calculator.worried_about_work = "yes"
+          @calculator.are_you_off_work_ill = "yes"
+
+          assert @calculator.show_group?(:going_in_to_work)
+        end
+
+        should "return false when criteria is not met" do
+          @calculator.need_help_with = "going_in_to_work"
+          @calculator.worried_about_work = "no"
+          @calculator.are_you_off_work_ill = "no"
+
+          assert_not @calculator.show_group?(:going_in_to_work)
+        end
+      end
+
+      context "somewhere_to_live" do
+        should "return true when criteria is met" do
+          @calculator.need_help_with = "somewhere_to_live"
+          @calculator.have_somewhere_to_live = "no"
+          @calculator.have_you_been_evicted = "yes"
+
+          assert @calculator.show_group?(:somewhere_to_live)
+        end
+
+        should "return false when criteria is not met" do
+          @calculator.need_help_with = "somewhere_to_live"
+          @calculator.have_somewhere_to_live = "yes"
+          @calculator.have_you_been_evicted = "no"
+
+          assert_not @calculator.show_group?(:somewhere_to_live)
+        end
+      end
+
+      context "mental_health" do
+        should "return true when criteria is met" do
+          @calculator.need_help_with = "mental_health"
+          @calculator.mental_health_worries = "yes"
+
+          assert @calculator.show_group?(:mental_health)
+        end
+
+        should "return false when criteria is not met" do
+          @calculator.need_help_with = "mental_health"
+          @calculator.mental_health_worries = "no"
+
+          assert_not @calculator.show_group?(:mental_health)
+        end
+      end
+    end
+
+    context "#show_section?" do
+      context "feel_safe" do
+        should "return true when criteria is met" do
+          @calculator.need_help_with = "feeling_unsafe"
+          @calculator.feel_safe = "no"
+
+          assert @calculator.show_section?(:feel_safe)
+        end
+
+        should "return false when criteria is not met" do
+          @calculator.need_help_with = "feeling_unsafe"
+          @calculator.feel_safe = "yes"
+
+          assert_not @calculator.show_section?(:feel_safe)
+        end
+      end
+
+      context "afford_rent_mortgage_bills" do
+        should "return true when criteria is met" do
+          @calculator.need_help_with = "paying_bills"
+          @calculator.afford_rent_mortgage_bills = "yes"
+
+          assert @calculator.show_section?(:afford_rent_mortgage_bills)
+        end
+
+        should "return false when criteria is not met" do
+          @calculator.need_help_with = "paying_bills"
+          @calculator.afford_rent_mortgage_bills = "no"
+
+          assert_not @calculator.show_section?(:afford_rent_mortgage_bills)
+        end
+      end
+
+      context "afford_food" do
+        should "return true when criteria is met" do
+          @calculator.need_help_with = "getting_food"
+          @calculator.afford_food = "yes"
+
+          assert @calculator.show_section?(:afford_food)
+        end
+
+        should "return false when criteria is not met" do
+          @calculator.need_help_with = "getting_food"
+          @calculator.afford_food = "no"
+
+          assert_not @calculator.show_section?(:afford_food)
+        end
+      end
+
+      context "get_food" do
+        should "return true when criteria is met" do
+          @calculator.need_help_with = "getting_food"
+          @calculator.get_food = "no"
+
+          assert @calculator.show_section?(:get_food)
+        end
+
+        should "return false when criteria is not met" do
+          @calculator.need_help_with = "getting_food"
+          @calculator.get_food = "yes"
+
+          assert_not @calculator.show_section?(:get_food)
+        end
+      end
+
+      context "have_you_been_made_unemployed" do
+        should "return true when criteria is met" do
+          @calculator.need_help_with = "being_unemployed"
+          @calculator.have_you_been_made_unemployed = "yes"
+
+          assert @calculator.show_section?(:have_you_been_made_unemployed)
+        end
+
+        should "return false when criteria is not met" do
+          @calculator.need_help_with = "being_unemployed"
+          @calculator.have_you_been_made_unemployed = "no"
+
+          assert_not @calculator.show_section?(:have_you_been_made_unemployed)
+        end
+      end
+
+      context "self_employed" do
+        should "return true when criteria is met" do
+          @calculator.need_help_with = "being_unemployed"
+          @calculator.self_employed = "no"
+
+          assert @calculator.show_section?(:self_employed)
+        end
+
+        should "return false when criteria is not met" do
+          @calculator.need_help_with = "being_unemployed"
+          @calculator.self_employed = "yes"
+
+          assert_not @calculator.show_section?(:self_employed)
+        end
+      end
+
+      context "worried_about_work" do
+        should "return true when criteria is met" do
+          @calculator.need_help_with = "going_in_to_work"
+          @calculator.worried_about_work = "yes"
+
+          assert @calculator.show_section?(:worried_about_work)
+        end
+
+        should "return false when criteria is not met" do
+          @calculator.need_help_with = "going_in_to_work"
+          @calculator.worried_about_work = "no"
+
+          assert_not @calculator.show_section?(:worried_about_work)
+        end
+      end
+
+      context "are_you_off_work_ill" do
+        should "return true when criteria is met" do
+          @calculator.need_help_with = "going_in_to_work"
+          @calculator.are_you_off_work_ill = "yes"
+
+          assert @calculator.show_section?(:are_you_off_work_ill)
+        end
+
+        should "return false when criteria is not met" do
+          @calculator.need_help_with = "going_in_to_work"
+          @calculator.are_you_off_work_ill = "no"
+
+          assert_not @calculator.show_section?(:are_you_off_work_ill)
+        end
+      end
+
+      context "have_somewhere_to_live" do
+        should "return true when criteria is met" do
+          @calculator.need_help_with = "somewhere_to_live"
+          @calculator.have_somewhere_to_live = "no"
+
+          assert @calculator.show_section?(:have_somewhere_to_live)
+        end
+
+        should "return false when criteria is not met" do
+          @calculator.need_help_with = "somewhere_to_live"
+          @calculator.have_somewhere_to_live = "yes"
+
+          assert_not @calculator.show_section?(:have_somewhere_to_live)
+        end
+      end
+
+      context "have_you_been_evicted" do
+        should "return true when criteria is met" do
+          @calculator.need_help_with = "somewhere_to_live"
+          @calculator.have_you_been_evicted = "yes"
+
+          assert @calculator.show_section?(:have_you_been_evicted)
+        end
+
+        should "return false when criteria is not met" do
+          @calculator.need_help_with = "somewhere_to_live"
+          @calculator.have_you_been_evicted = "no"
+
+          assert_not @calculator.show_section?(:have_you_been_evicted)
+        end
+      end
+
+      context "mental_health_worries" do
+        should "return true when criteria is met" do
+          @calculator.need_help_with = "mental_health"
+          @calculator.mental_health_worries = "yes"
+
+          assert @calculator.show_section?(:mental_health_worries)
+        end
+
+        should "return false when criteria is not met" do
+          @calculator.need_help_with = "mental_health"
+          @calculator.mental_health_worries = "no"
+
+          assert_not @calculator.show_section?(:mental_health_worries)
+        end
+      end
+    end
+
+    context "#has_results?" do
+      should "return true when criteria is met" do
+        @calculator.need_help_with = "feeling_unsafe,paying_bills,mental_health"
+        @calculator.feel_safe = "no"
+        @calculator.afford_rent_mortgage_bills = "yes"
+        @calculator.mental_health_worries = "no"
+
+        assert_equal @calculator.has_results?, true
+      end
+
+      should "return false when criteria is not met" do
+        @calculator.need_help_with = "feeling_unsafe,going_to_work,mental_health"
+        @calculator.feel_safe = "yes"
+        @calculator.worried_about_work = "no"
+        @calculator.mental_health_worries = "no"
+
+        assert_equal @calculator.has_results?, false
+      end
+
+      should "return false the user does not need_help_with aything" do
+        @calculator.need_help_with = ""
+        assert_equal @calculator.has_results?, false
+
+        @calculator.need_help_with = nil
+        assert_equal @calculator.has_results?, false
+      end
+    end
+
+    context "#needs_help_with?" do
+      should "return true if the given help item has been chosen" do
+        @calculator.need_help_with = "one,two,three,four"
+        assert_equal @calculator.needs_help_with?("one"), true
+      end
+
+      should "return false if the given help item has not been chosen" do
+        @calculator.need_help_with = "one,two,three,four"
+        assert_equal @calculator.needs_help_with?("five"), false
+      end
+
+      should "return false if need_help_with is an empty string" do
+        @calculator.need_help_with = ""
+        assert_equal @calculator.needs_help_with?("one"), false
+      end
+
+      should "return false if need_help_with is nil" do
+        @calculator.need_help_with = nil
+        assert_equal @calculator.needs_help_with?("one"), false
+      end
+    end
+
+    context "#needs_help_in?" do
+      should "return true if the given nation has been chosen" do
+        @calculator.nation = "one"
+        assert_equal @calculator.needs_help_in?("one"), true
+      end
+
+      should "return false if the given nation has not been chosen" do
+        @calculator.nation = "one"
+        assert_equal @calculator.needs_help_in?("five"), false
+      end
+
+      should "return false if nation is an empty string" do
+        @calculator.nation = ""
+        assert_equal @calculator.needs_help_in?("one"), false
+      end
+
+      should "return false if nation is nil" do
+        @calculator.nation = nil
+        assert_equal @calculator.needs_help_in?("one"), false
+      end
+    end
+
     context "#next_question" do
       context "user is on the need_help_with? node" do
         should "return feel_safe? when paying_bills has been chosen" do
@@ -193,531 +565,6 @@ module SmartAnswer::Calculators
         should "return nation? when there are no other selected options" do
           @calculator.need_help_with = ""
           assert_equal @calculator.next_question(:have_you_been_evicted), :nation
-        end
-      end
-    end
-
-    context "#needs_help_with?" do
-      should "return true if the given help item has been chosen" do
-        @calculator.need_help_with = "one,two,three,four"
-        assert_equal @calculator.needs_help_with?("one"), true
-      end
-
-      should "return false if the given help item has not been chosen" do
-        @calculator.need_help_with = "one,two,three,four"
-        assert_equal @calculator.needs_help_with?("five"), false
-      end
-
-      should "return false if need_help_with is an empty string" do
-        @calculator.need_help_with = ""
-        assert_equal @calculator.needs_help_with?("one"), false
-      end
-
-      should "return false if need_help_with is nil" do
-        @calculator.need_help_with = nil
-        assert_equal @calculator.needs_help_with?("one"), false
-      end
-    end
-
-    context "#has_results?" do
-      should "return true if at least one help item has been chosen" do
-        @calculator.need_help_with = "one"
-        assert_equal @calculator.has_results?, true
-      end
-
-      should "return false if need_help_with is an empty string" do
-        @calculator.need_help_with = ""
-        assert_equal @calculator.has_results?, false
-      end
-
-      should "return false if need_help_with is nil" do
-        @calculator.need_help_with = nil
-        assert_equal @calculator.has_results?, false
-      end
-    end
-
-    context "#needs_help_in?" do
-      should "return true if the given nation has been chosen" do
-        @calculator.nation = "one"
-        assert_equal @calculator.needs_help_in?("one"), true
-      end
-
-      should "return false if the given nation has not been chosen" do
-        @calculator.nation = "one"
-        assert_equal @calculator.needs_help_in?("five"), false
-      end
-
-      should "return false if nation is an empty string" do
-        @calculator.nation = ""
-        assert_equal @calculator.needs_help_in?("one"), false
-      end
-
-      should "return false if nation is nil" do
-        @calculator.nation = nil
-        assert_equal @calculator.needs_help_in?("one"), false
-      end
-    end
-
-    context "#user_feels_unsafe?" do
-      context "user has selected feeling_unsafe" do
-        setup do
-          @calculator.need_help_with = "feeling_unsafe"
-        end
-
-        should "return false if the user feels safe" do
-          @calculator.feel_safe = "yes"
-          assert_equal @calculator.user_feels_unsafe?, false
-        end
-
-        should "return true if the user feels safe but not completely" do
-          @calculator.feel_safe = "yes_but"
-          assert_equal @calculator.user_feels_unsafe?, true
-        end
-
-        should "return true if the user does not feel safe" do
-          @calculator.feel_safe = "no"
-          assert_equal @calculator.user_feels_unsafe?, true
-        end
-
-        should "return true if the user is unsure about feeling safe" do
-          @calculator.feel_safe = "not_sure"
-          assert_equal @calculator.user_feels_unsafe?, true
-        end
-      end
-
-      context "user has not selected feeling_unsafe" do
-        should "return false" do
-          @calculator.need_help_with = ""
-          @calculator.feel_safe = "no"
-          assert_equal @calculator.user_feels_unsafe?, false
-        end
-      end
-    end
-
-    context "#user_cannot_pay_their_bills?" do
-      context "user has selected paying_bills" do
-        setup do
-          @calculator.need_help_with = "paying_bills"
-        end
-
-        should "return true if the user is finding it hard to pay their bills" do
-          @calculator.afford_rent_mortgage_bills = "yes"
-          assert_equal @calculator.user_cannot_pay_their_bills?, true
-        end
-
-        should "return false if the user is not finding it hard to pay their bills" do
-          @calculator.afford_rent_mortgage_bills = "no"
-          assert_equal @calculator.user_cannot_pay_their_bills?, false
-        end
-
-        should "return true if the user is unsure if they are finding it hard to pay their bills" do
-          @calculator.afford_rent_mortgage_bills = "not_sure"
-          assert_equal @calculator.user_cannot_pay_their_bills?, true
-        end
-      end
-
-      context "user has not selected paying_bills" do
-        should "return false" do
-          @calculator.need_help_with = ""
-          @calculator.afford_rent_mortgage_bills = "yes"
-          assert_equal @calculator.user_cannot_pay_their_bills?, false
-        end
-      end
-    end
-
-    context "#user_cannot_get_food?" do
-      context "user has selected getting_food" do
-        setup do
-          @calculator.need_help_with = "getting_food"
-        end
-
-        context "user is finding it hard to afford food" do
-          setup do
-            @calculator.afford_food = "yes"
-          end
-
-          should "return false if the user can get food" do
-            @calculator.get_food = "yes"
-            assert_equal @calculator.user_cannot_get_food?, false
-          end
-
-          should "return true if the user cannot get food" do
-            @calculator.get_food = "no"
-            assert_equal @calculator.user_cannot_get_food?, true
-          end
-
-          should "return true if the user is unsure if they can get food" do
-            @calculator.get_food = "not_sure"
-            assert_equal @calculator.user_cannot_get_food?, true
-          end
-        end
-
-        context "user is unsure if they are finding it hard afford food" do
-          setup do
-            @calculator.afford_food = "not_sure"
-          end
-
-          should "return false if the user can get food" do
-            @calculator.get_food = "yes"
-            assert_equal @calculator.user_cannot_get_food?, false
-          end
-
-          should "return true if the user cannot get food" do
-            @calculator.get_food = "no"
-            assert_equal @calculator.user_cannot_get_food?, true
-          end
-
-          should "return true if the user is unsure if they can get food" do
-            @calculator.get_food = "not_sure"
-            assert_equal @calculator.user_cannot_get_food?, true
-          end
-        end
-
-        context "user is not finding it hard to afford food" do
-          setup do
-            @calculator.afford_food = "no"
-          end
-
-          should "return false if the user can get food" do
-            @calculator.get_food = "yes"
-            assert_equal @calculator.user_cannot_get_food?, false
-          end
-
-          should "return false if the user cannot get food" do
-            @calculator.get_food = "no"
-            assert_equal @calculator.user_cannot_get_food?, false
-          end
-
-          should "return false if the user is unsure if they can get food" do
-            @calculator.get_food = "not_sure"
-            assert_equal @calculator.user_cannot_get_food?, false
-          end
-        end
-      end
-
-      context "user has not selected getting_food" do
-        should "return false" do
-          @calculator.need_help_with = ""
-          @calculator.afford_food = "yes"
-          @calculator.get_food = "no"
-          assert_equal @calculator.user_cannot_get_food?, false
-        end
-      end
-    end
-
-    context "#user_is_worried_about_going_to_work?" do
-      context "user has selected going_to_work" do
-        setup do
-          @calculator.need_help_with = "going_to_work"
-        end
-
-        should "return true if the user is worried about work" do
-          @calculator.worried_about_work = "yes"
-          assert_equal @calculator.user_is_worried_about_going_to_work?, true
-        end
-
-        should "return false if the user is not worried about work" do
-          @calculator.worried_about_work = "no"
-          assert_equal @calculator.user_is_worried_about_going_to_work?, false
-        end
-
-        should "return true if the user is unsure about being worried about work" do
-          @calculator.worried_about_work = "not_sure"
-          assert_equal @calculator.user_is_worried_about_going_to_work?, true
-        end
-      end
-
-      context "user has not selected going_to_work" do
-        should "return false" do
-          @calculator.need_help_with = ""
-          @calculator.worried_about_work = "yes"
-          assert_equal @calculator.user_is_worried_about_going_to_work?, false
-        end
-      end
-    end
-
-    context "#user_is_unemployed?" do
-      context "user has selected being_unemployed" do
-        setup do
-          @calculator.need_help_with = "being_unemployed"
-        end
-
-        context "user is not ill" do
-          setup do
-            @calculator.are_you_off_work_ill = "no"
-          end
-
-          context "user is not self-employed" do
-            setup do
-              @calculator.self_employed = "no"
-            end
-
-            should "return true if the user has been made unemployed" do
-              @calculator.have_you_been_made_unemployed = "yes_1"
-              assert_equal @calculator.user_is_unemployed?, true
-            end
-
-            should "return true if the user is going to be made unemployed" do
-              @calculator.have_you_been_made_unemployed = "yes_2"
-              assert_equal @calculator.user_is_unemployed?, true
-            end
-
-            should "return true if the user is unsure if they are going to be made unemployed" do
-              @calculator.have_you_been_made_unemployed = "not_sure"
-              assert_equal @calculator.user_is_unemployed?, true
-            end
-
-            should "return false if the user has not been made unemployed" do
-              @calculator.have_you_been_made_unemployed = "no"
-              assert_equal @calculator.user_is_unemployed?, false
-            end
-          end
-
-          context "user is self-employed" do
-            setup do
-              @calculator.self_employed = "yes"
-            end
-
-            should "return false if the user has been made unemployed" do
-              @calculator.have_you_been_made_unemployed = "yes_1"
-              assert_equal @calculator.user_is_unemployed?, false
-            end
-
-            should "return false if the user is going to be made unemployed" do
-              @calculator.have_you_been_made_unemployed = "yes_2"
-              assert_equal @calculator.user_is_unemployed?, false
-            end
-
-            should "return false if the user is unsure if they are going to be made unemployed" do
-              @calculator.have_you_been_made_unemployed = "not_sure"
-              assert_equal @calculator.user_is_unemployed?, false
-            end
-
-            should "return false if the user has not been made unemployed" do
-              @calculator.have_you_been_made_unemployed = "no"
-              assert_equal @calculator.user_is_unemployed?, false
-            end
-          end
-        end
-
-        context "user is ill" do
-          setup do
-            @calculator.are_you_off_work_ill = "yes"
-          end
-
-          context "user is not self-employed" do
-            setup do
-              @calculator.self_employed = "no"
-            end
-
-            should "return true if the user has been made unemployed" do
-              @calculator.have_you_been_made_unemployed = "yes_1"
-              assert_equal @calculator.user_is_unemployed?, true
-            end
-
-            should "return true if the user is going to be made unemployed" do
-              @calculator.have_you_been_made_unemployed = "yes_2"
-              assert_equal @calculator.user_is_unemployed?, true
-            end
-
-            should "return true if the user is unsure if they are going to be made unemployed" do
-              @calculator.have_you_been_made_unemployed = "not_sure"
-              assert_equal @calculator.user_is_unemployed?, true
-            end
-
-            should "return true if the user has not been made unemployed" do
-              @calculator.have_you_been_made_unemployed = "no"
-              assert_equal @calculator.user_is_unemployed?, true
-            end
-          end
-
-          context "user is self-employed" do
-            setup do
-              @calculator.self_employed = "yes"
-            end
-
-            should "return true if the user has been made unemployed" do
-              @calculator.have_you_been_made_unemployed = "yes_1"
-              assert_equal @calculator.user_is_unemployed?, true
-            end
-
-            should "return true if the user is going to be made unemployed" do
-              @calculator.have_you_been_made_unemployed = "yes_2"
-              assert_equal @calculator.user_is_unemployed?, true
-            end
-
-            should "return true if the user is unsure if they are going to be made unemployed" do
-              @calculator.have_you_been_made_unemployed = "not_sure"
-              assert_equal @calculator.user_is_unemployed?, true
-            end
-
-            should "return true if the user has not been made unemployed" do
-              @calculator.have_you_been_made_unemployed = "no"
-              assert_equal @calculator.user_is_unemployed?, true
-            end
-          end
-        end
-      end
-
-      context "user has not selected being_unemployed" do
-        should "return false" do
-          @calculator.need_help_with = ""
-          @calculator.are_you_off_work_ill = "yes"
-          @calculator.self_employed = "no"
-          @calculator.have_you_been_made_unemployed = "yes"
-          assert_equal @calculator.user_is_unemployed?, false
-        end
-      end
-    end
-
-    context "#user_needs_somewhere_to_live?" do
-      context "user has selected somewhere_to_live" do
-        setup do
-          @calculator.need_help_with = "somewhere_to_live"
-        end
-
-        context "user does have somewhere to live" do
-          setup do
-            @calculator.have_somewhere_to_live = "yes"
-          end
-
-          should "return true if the user has been evicted" do
-            @calculator.have_you_been_evicted = "yes"
-            assert_equal @calculator.user_needs_somewhere_to_live?, true
-          end
-
-          should "return true if the user going to be evicted" do
-            @calculator.have_you_been_evicted = "soon"
-            assert_equal @calculator.user_needs_somewhere_to_live?, true
-          end
-
-          should "return false if the user is not going to be evicted" do
-            @calculator.have_you_been_evicted = "no"
-            assert_equal @calculator.user_needs_somewhere_to_live?, false
-          end
-
-          should "return true if the user is unsure if they are going to be evicted" do
-            @calculator.have_you_been_evicted = "not_sure"
-            assert_equal @calculator.user_needs_somewhere_to_live?, true
-          end
-        end
-
-        context "user may not have somewhere to live" do
-          setup do
-            @calculator.have_somewhere_to_live = "yes_but"
-          end
-
-          should "return true if the user has been evicted" do
-            @calculator.have_you_been_evicted = "yes"
-            assert_equal @calculator.user_needs_somewhere_to_live?, true
-          end
-
-          should "return true if the user going to be evicted" do
-            @calculator.have_you_been_evicted = "soon"
-            assert_equal @calculator.user_needs_somewhere_to_live?, true
-          end
-
-          should "return true if the user is not going to be evicted" do
-            @calculator.have_you_been_evicted = "no"
-            assert_equal @calculator.user_needs_somewhere_to_live?, true
-          end
-
-          should "return true if the user is unsure if they are going to be evicted" do
-            @calculator.have_you_been_evicted = "not_sure"
-            assert_equal @calculator.user_needs_somewhere_to_live?, true
-          end
-        end
-
-        context "user does not have somewhere to live" do
-          setup do
-            @calculator.have_somewhere_to_live = "no"
-          end
-
-          should "return true if the user has been evicted" do
-            @calculator.have_you_been_evicted = "yes"
-            assert_equal @calculator.user_needs_somewhere_to_live?, true
-          end
-
-          should "return true if the user going to be evicted" do
-            @calculator.have_you_been_evicted = "soon"
-            assert_equal @calculator.user_needs_somewhere_to_live?, true
-          end
-
-          should "return true if the user is not going to be evicted" do
-            @calculator.have_you_been_evicted = "no"
-            assert_equal @calculator.user_needs_somewhere_to_live?, true
-          end
-
-          should "return true if the user is unsure if they are going to be evicted" do
-            @calculator.have_you_been_evicted = "not_sure"
-            assert_equal @calculator.user_needs_somewhere_to_live?, true
-          end
-        end
-
-        context "user unsure if they have somewhere to live" do
-          setup do
-            @calculator.have_somewhere_to_live = "not_sure"
-          end
-
-          should "return true if the user has been evicted" do
-            @calculator.have_you_been_evicted = "yes"
-            assert_equal @calculator.user_needs_somewhere_to_live?, true
-          end
-
-          should "return true if the user going to be evicted" do
-            @calculator.have_you_been_evicted = "soon"
-            assert_equal @calculator.user_needs_somewhere_to_live?, true
-          end
-
-          should "return true if the user is not going to be evicted" do
-            @calculator.have_you_been_evicted = "no"
-            assert_equal @calculator.user_needs_somewhere_to_live?, true
-          end
-
-          should "return true if the user is unsure if they are going to be evicted" do
-            @calculator.have_you_been_evicted = "not_sure"
-            assert_equal @calculator.user_needs_somewhere_to_live?, true
-          end
-        end
-      end
-
-      context "user has not selected somewhere_to_live" do
-        should "return false" do
-          @calculator.need_help_with = ""
-          @calculator.have_somewhere_to_live = "no"
-          @calculator.have_you_been_evicted = "yes"
-          assert_equal @calculator.user_needs_somewhere_to_live?, false
-        end
-      end
-    end
-
-    context "#user_has_mental_health_worries?" do
-      context "user has selected mental_health" do
-        setup do
-          @calculator.need_help_with = "mental_health"
-        end
-
-        should "return true if the user has mental health worries" do
-          @calculator.mental_health_worries = "yes"
-          assert_equal @calculator.user_has_mental_health_worries?, true
-        end
-
-        should "return true if the user is unsure if they have mental health worries" do
-          @calculator.mental_health_worries = "not_sure"
-          assert_equal @calculator.user_has_mental_health_worries?, true
-        end
-
-        should "return false if the user does not have any mental health worries" do
-          @calculator.mental_health_worries = "no"
-          assert_equal @calculator.user_has_mental_health_worries?, false
-        end
-      end
-
-      context "user has not selected mental_health" do
-        should "return false" do
-          @calculator.need_help_with = ""
-          @calculator.mental_health_worries = "yes"
-          assert_equal @calculator.user_has_mental_health_worries?, false
         end
       end
     end


### PR DESCRIPTION
## What & Why

This change fixes the following two issues that are affecting users of the Coronavirus Find Support flow result page.

1. It is possible to reach the results page without the no-results text being shown. An example of this behaviour is:

- "What do you need help with because of coronavirus?" : "Feeling unsafe where you live, or what to do if you’re worried about the safety of another adult or child"
- "Do you feel safe where you live?" : "Yes"
- "Where do you want to find information about?" : "England"

The expected response is that the user is shown the no-results text. However, a blank page is shown.

2. Sub-sections are not being correctly shown/hidden as appropriate and based on the users given responses. An example of this behaviour is:

- "What do you need help with because of coronavirus?" : "Getting food"
- "Are you finding it hard to afford food?" : "Yes"
- "Are you able to get food?" : "Yes"
- "Where do you want to find information about?" : "England"

The expected response is that the user is shown the "Getting food" group and the "If you’re finding it hard to afford food" sub-section, but not the "If you’re unable to get food" sub-section.  However, both sub-sections are displayed.

Integration tests have been added to expose any change in the correct behaviour of both of these issues.

## Trello cards

* [Fix no results page for find support](https://trello.com/c/eOrbGfyA/501-fix-no-results-page-for-find-support)
* [Fix showing/hiding sub sections on the find support results page](https://trello.com/c/6n82URX5/502-fix-showing-hiding-sub-sections-on-the-find-support-results-page)

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.


