### PR TITLE
Fix inconsistencies with content in coronavirus find support flow

### DIFF
--- a/lib/smart_answer_flows/coronavirus-find-support/outcomes/_feeling_unsafe.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/outcomes/_feeling_unsafe.erb
@@ -1,3 +1,7 @@
+## Feeling unsafe
+
+### If you do not feel safe where you live or you’re worried about someone else
+
 If you’re in immediate danger call 999 and ask for the Police.
 
 If you’re in danger and unable to talk on the phone, call 999, then press 55 when prompted.

--- a/lib/smart_answer_flows/coronavirus-find-support/outcomes/_going_to_work.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/outcomes/_going_to_work.erb
@@ -1,4 +1,4 @@
-## Going in to work
+## Being worried about working, or off work because you’re self-isolating
 
 ### If you’re worried about going in to work
 

--- a/lib/smart_answer_flows/coronavirus-find-support/outcomes/_paying_bills.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/outcomes/_paying_bills.erb
@@ -1,4 +1,4 @@
-## Paying bills
+## Paying your rent, mortgage, or bills
 
 ### If you’re finding it hard to pay your rent, mortgage or bills
 

--- a/lib/smart_answer_flows/coronavirus-find-support/outcomes/_somewhere_to_live.erb
+++ b/lib/smart_answer_flows/coronavirus-find-support/outcomes/_somewhere_to_live.erb
@@ -24,8 +24,6 @@
 
 [Get help if you’re aged 16 to 25 (Centrepoint)](https://centrepoint.org.uk/youth-homelessness/get-help-now/)
 
-#### Support and advice
-
 <% if calculator.needs_help_in?("northern_ireland") %>
   [Get help from Housing Rights housing and debt helpline](https://www.housingadviceni.org/homeless/coronavirus)
 <% end %>


### PR DESCRIPTION
Changes have been made to the currently live *govuk-coronavirus-find-support* app which this flow is replacing. These changes
need to be made in the coronavirus find support flow to maintain consistency while the app is still live.

- Added "Feeling safe" and "If you do not feel safe where you live or
  you’re worried about someone else" headers for section results page
- Change results section header "Paying bills" to "Paying your rent,
  mortgage, or bills"
- Change results section header "Going in to work" to "Being worried
  about working, or off work because you’re self-isolating"
- Remove "Support and advice" header from the "If you do not have
  somewhere to live or might become homeless" section on results page

[Trello ticket](https://trello.com/c/AEEPgyCy/503-content-fixes-to-align-with-current-tool)
