### PR TITLE
Fix change your answer links in session flows

### DIFF
--- a/app/controllers/session_answers_controller.rb
+++ b/app/controllers/session_answers_controller.rb
@@ -36,7 +36,7 @@ private
 
   def presenter
     @presenter ||= begin
-      params.merge!(responses: session_store.hash)
+      params.merge!(responses: session_store.hash, node_name: node_name)
       FlowPresenter.new(params, smart_answer)
     end
   end

--- a/test/integration/session_answers_test.rb
+++ b/test/integration/session_answers_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+GovukTest.configure
+
+class SessionAnswersTest < ActionDispatch::SystemTestCase
+  setup do
+    Capybara.current_driver = :headless_chrome
+  end
+
+  teardown do
+    Capybara.use_default_driver
+  end
+
+  test "Change link returns previously visited page" do
+    visit "coronavirus-find-support/s"
+    within "legend" do
+      assert_page_has_content "What do you need help with because of coronavirus?"
+    end
+    check("Not sure", visible: false)
+    click_on "Continue"
+    within "legend" do
+      assert_page_has_content "Where do you want to find information about?"
+    end
+    click_on "Change"
+    within "legend" do
+      assert_page_has_content "What do you need help with because of coronavirus?"
+    end
+  end
+
+  def assert_page_has_content(text)
+    assert page.has_content?(text), "'#{text}' not found in page"
+  end
+end


### PR DESCRIPTION
Replacing the param :node_name with :node_slug meant node name was not
being passed to flow presenter. This fix passes the node name into params
before they are passed to the flow presenter.

`params[:node_name]` is passed from `FlowPresenter` to `Flow` where it is
used in the method `resolve_state` as `requested_node`. It needs to be 
present for the correct current state to be identified

An integration test is also added that ensures that the "Change" behaviour
works as expected.

[trello card](https://trello.com/c/MkLq2h6A/506-fix-change-your-answer-links)
