### PR TITLE
Fix the "Not sure" user response to the "need_help_with" question flow

### DIFF
--- a/lib/smart_answer/calculators/coronavirus_find_support_calculator.rb
+++ b/lib/smart_answer/calculators/coronavirus_find_support_calculator.rb
@@ -75,6 +75,8 @@ module SmartAnswer::Calculators
     def needs_help_with?(given_help_item)
       return false if need_help_with.blank?
 
+      return true if need_help_with == "none"
+
       need_help_with.split(",").include? given_help_item
     end
 

--- a/test/integration/session_answers_test.rb
+++ b/test/integration/session_answers_test.rb
@@ -18,7 +18,7 @@ class SessionAnswersTest < ActionDispatch::SystemTestCase
     check("Not sure", visible: false)
     click_on "Continue"
     within "legend" do
-      assert_page_has_content "Where do you want to find information about?"
+      assert_page_has_content "Do you feel safe where you live?"
     end
     click_on "Change"
     within "legend" do

--- a/test/integration/smart_answer_flows/coronavirus_find_support_test.rb
+++ b/test/integration/smart_answer_flows/coronavirus_find_support_test.rb
@@ -11,9 +11,70 @@ class CoronavirusFindSupportFlowTest < ActiveSupport::TestCase
   end
 
   context "specific outcomes" do
-    should "show no specific information results for the minimal flow" do
+    should "ask the user to answer questions in all groups if none is selected for the need_help_with question" do
       assert_current_node :need_help_with
       add_response "none"
+
+      # ======================================================================
+      # Group: feeling_unsafe
+      # ======================================================================
+      assert_current_node :feel_safe
+      add_response "yes"
+
+      # ======================================================================
+      # Group: paying_bills
+      # ======================================================================
+      assert_current_node :afford_rent_mortgage_bills
+      add_response "no"
+
+      # ======================================================================
+      # Group: getting_food
+      # ======================================================================
+      assert_current_node :afford_food
+      add_response "no"
+      assert_current_node :get_food
+      add_response "yes"
+
+      # ======================================================================
+      # Group: being_unemployed
+      # ======================================================================
+      assert_current_node :self_employed
+      add_response "no"
+      assert_current_node :have_you_been_made_unemployed
+      add_response "no"
+
+      # ======================================================================
+      # Group: going_in_to_work
+      # ======================================================================
+      assert_current_node :worried_about_work
+      add_response "no"
+      assert_current_node :are_you_off_work_ill
+      add_response "no"
+
+      # ======================================================================
+      # Group: somewhere_to_live
+      # ======================================================================
+      assert_current_node :have_somewhere_to_live
+      add_response "yes"
+      assert_current_node :have_you_been_evicted
+      add_response "no"
+
+      # ======================================================================
+      # Group: mental_health
+      # ======================================================================
+      assert_current_node :mental_health_worries
+      add_response "no"
+
+      assert_current_node :nation
+      add_response "england"
+      assert_current_node :results
+    end
+
+    should "show no specific information results for the minimal flow" do
+      assert_current_node :need_help_with
+      add_response "feeling_unsafe"
+      assert_current_node :feel_safe
+      add_response "yes"
       assert_current_node :nation
       add_response "england"
       assert_current_node :results

--- a/test/unit/calculators/coronavirus_find_support_calculator_test.rb
+++ b/test/unit/calculators/coronavirus_find_support_calculator_test.rb
@@ -354,6 +354,11 @@ module SmartAnswer::Calculators
         @calculator.need_help_with = nil
         assert_equal @calculator.needs_help_with?("one"), false
       end
+
+      should "return true if the none item has been chosen" do
+        @calculator.need_help_with = "none"
+        assert_equal @calculator.needs_help_with?("one"), true
+      end
     end
 
     context "#needs_help_in?" do
@@ -380,6 +385,11 @@ module SmartAnswer::Calculators
 
     context "#next_question" do
       context "user is on the need_help_with? node" do
+        should "return feel_safe? when 'none' has been chosen" do
+          @calculator.need_help_with = "none"
+          assert_equal @calculator.next_question(:need_help_with), :feel_safe
+        end
+
         should "return feel_safe? when paying_bills has been chosen" do
           @calculator.need_help_with = "feeling_unsafe"
           assert_equal @calculator.next_question(:need_help_with), :feel_safe
@@ -413,11 +423,6 @@ module SmartAnswer::Calculators
         should "return mental_health_worries? when mental_health has been chosen" do
           @calculator.need_help_with = "mental_health"
           assert_equal @calculator.next_question(:need_help_with), :mental_health_worries
-        end
-
-        should "return nation? when there are no other selected options" do
-          @calculator.need_help_with = ""
-          assert_equal @calculator.next_question(:need_help_with), :nation
         end
       end
 


### PR DESCRIPTION
## What

When the user selects the `Not sure` option on the `What do you need help with?` question, the user should be routed through all question groups. However, it skips all the questions and goes straight to the `Nations` question.

## Why

To make the behaviour consistent with the current tool.

[Trello](https://trello.com/c/mEkHxd3H/513-fix-the-not-sure-flow-in-needs-help-with-question)

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.
