### PR TITLE
Remove question marks from the Coronavirus Find Support flow Calculator tests

### DIFF
--- a/test/unit/calculators/coronavirus_find_support_calculator_test.rb
+++ b/test/unit/calculators/coronavirus_find_support_calculator_test.rb
@@ -384,190 +384,190 @@ module SmartAnswer::Calculators
     end
 
     context "#next_question" do
-      context "user is on the need_help_with? node" do
-        should "return feel_safe? when 'none' has been chosen" do
+      context "user is on the need_help_with node" do
+        should "return feel_safe when 'none' has been chosen" do
           @calculator.need_help_with = "none"
           assert_equal @calculator.next_question(:need_help_with), :feel_safe
         end
 
-        should "return feel_safe? when paying_bills has been chosen" do
+        should "return feel_safe when paying_bills has been chosen" do
           @calculator.need_help_with = "feeling_unsafe"
           assert_equal @calculator.next_question(:need_help_with), :feel_safe
         end
 
-        should "return afford_rent_mortgage_bills? when paying_bills has been chosen" do
+        should "return afford_rent_mortgage_bills when paying_bills has been chosen" do
           @calculator.need_help_with = "paying_bills"
           assert_equal @calculator.next_question(:need_help_with), :afford_rent_mortgage_bills
         end
 
-        should "return self_employed? when getting_food has been chosen" do
+        should "return self_employed when getting_food has been chosen" do
           @calculator.need_help_with = "getting_food"
           assert_equal @calculator.next_question(:need_help_with), :afford_food
         end
 
-        should "return self_employed? when being_unemployed has been chosen" do
+        should "return self_employed when being_unemployed has been chosen" do
           @calculator.need_help_with = "being_unemployed"
           assert_equal @calculator.next_question(:need_help_with), :self_employed
         end
 
-        should "return worried_about_work? when going_to_work has been chosen" do
+        should "return worried_about_work when going_to_work has been chosen" do
           @calculator.need_help_with = "going_to_work"
           assert_equal @calculator.next_question(:need_help_with), :worried_about_work
         end
 
-        should "return have_somewhere_to_live? when somewhere_to_live has been chosen" do
+        should "return have_somewhere_to_live when somewhere_to_live has been chosen" do
           @calculator.need_help_with = "somewhere_to_live"
           assert_equal @calculator.next_question(:need_help_with), :have_somewhere_to_live
         end
 
-        should "return mental_health_worries? when mental_health has been chosen" do
+        should "return mental_health_worries when mental_health has been chosen" do
           @calculator.need_help_with = "mental_health"
           assert_equal @calculator.next_question(:need_help_with), :mental_health_worries
         end
       end
 
-      context "user is on the feel_safe? node" do
-        should "return afford_rent_mortgage_bills? when paying_bills has been chosen" do
+      context "user is on the feel_safe node" do
+        should "return afford_rent_mortgage_bills when paying_bills has been chosen" do
           @calculator.need_help_with = "paying_bills"
           assert_equal @calculator.next_question(:feel_safe), :afford_rent_mortgage_bills
         end
 
-        should "return self_employed? when getting_food has been chosen" do
+        should "return self_employed when getting_food has been chosen" do
           @calculator.need_help_with = "getting_food"
           assert_equal @calculator.next_question(:feel_safe), :afford_food
         end
 
-        should "return self_employed? when being_unemployed has been chosen" do
+        should "return self_employed when being_unemployed has been chosen" do
           @calculator.need_help_with = "being_unemployed"
           assert_equal @calculator.next_question(:feel_safe), :self_employed
         end
 
-        should "return worried_about_work? when going_to_work has been chosen" do
+        should "return worried_about_work when going_to_work has been chosen" do
           @calculator.need_help_with = "going_to_work"
           assert_equal @calculator.next_question(:feel_safe), :worried_about_work
         end
 
-        should "return have_somewhere_to_live? when somewhere_to_live has been chosen" do
+        should "return have_somewhere_to_live when somewhere_to_live has been chosen" do
           @calculator.need_help_with = "somewhere_to_live"
           assert_equal @calculator.next_question(:feel_safe), :have_somewhere_to_live
         end
 
-        should "return mental_health_worries? when mental_health has been chosen" do
+        should "return mental_health_worries when mental_health has been chosen" do
           @calculator.need_help_with = "mental_health"
           assert_equal @calculator.next_question(:feel_safe), :mental_health_worries
         end
 
-        should "return nation? when there are no other selected options" do
+        should "return nation when there are no other selected options" do
           @calculator.need_help_with = ""
           assert_equal @calculator.next_question(:feel_safe), :nation
         end
       end
 
-      context "user is on the afford_rent_mortgage_bills? node" do
-        should "return self_employed? when getting_food has been chosen" do
+      context "user is on the afford_rent_mortgage_bills node" do
+        should "return self_employed when getting_food has been chosen" do
           @calculator.need_help_with = "getting_food"
           assert_equal @calculator.next_question(:afford_rent_mortgage_bills), :afford_food
         end
 
-        should "return self_employed? when being_unemployed has been chosen" do
+        should "return self_employed when being_unemployed has been chosen" do
           @calculator.need_help_with = "being_unemployed"
           assert_equal @calculator.next_question(:afford_rent_mortgage_bills), :self_employed
         end
 
-        should "return worried_about_work? when going_to_work has been chosen" do
+        should "return worried_about_work when going_to_work has been chosen" do
           @calculator.need_help_with = "going_to_work"
           assert_equal @calculator.next_question(:afford_rent_mortgage_bills), :worried_about_work
         end
 
-        should "return have_somewhere_to_live? when somewhere_to_live has been chosen" do
+        should "return have_somewhere_to_live when somewhere_to_live has been chosen" do
           @calculator.need_help_with = "somewhere_to_live"
           assert_equal @calculator.next_question(:afford_rent_mortgage_bills), :have_somewhere_to_live
         end
 
-        should "return mental_health_worries? when mental_health has been chosen" do
+        should "return mental_health_worries when mental_health has been chosen" do
           @calculator.need_help_with = "mental_health"
           assert_equal @calculator.next_question(:afford_rent_mortgage_bills), :mental_health_worries
         end
 
-        should "return nation? when there are no other selected options" do
+        should "return nation when there are no other selected options" do
           @calculator.need_help_with = ""
           assert_equal @calculator.next_question(:afford_rent_mortgage_bills), :nation
         end
       end
 
-      context "user is on the get_food? node" do
-        should "return self_employed? when being_unemployed has been chosen" do
+      context "user is on the get_food node" do
+        should "return self_employed when being_unemployed has been chosen" do
           @calculator.need_help_with = "being_unemployed"
           assert_equal @calculator.next_question(:get_food), :self_employed
         end
 
-        should "return worried_about_work? when going_to_work has been chosen" do
+        should "return worried_about_work when going_to_work has been chosen" do
           @calculator.need_help_with = "going_to_work"
           assert_equal @calculator.next_question(:get_food), :worried_about_work
         end
 
-        should "return have_somewhere_to_live? when somewhere_to_live has been chosen" do
+        should "return have_somewhere_to_live when somewhere_to_live has been chosen" do
           @calculator.need_help_with = "somewhere_to_live"
           assert_equal @calculator.next_question(:get_food), :have_somewhere_to_live
         end
 
-        should "return mental_health_worries? when mental_health has been chosen" do
+        should "return mental_health_worries when mental_health has been chosen" do
           @calculator.need_help_with = "mental_health"
           assert_equal @calculator.next_question(:get_food), :mental_health_worries
         end
 
-        should "return nation? when there are no other selected options" do
+        should "return nation when there are no other selected options" do
           @calculator.need_help_with = ""
           assert_equal @calculator.next_question(:get_food), :nation
         end
       end
 
-      context "user is on the have_you_been_made_unemployed? node" do
-        should "return worried_about_work? when going_to_work has been chosen" do
+      context "user is on the have_you_been_made_unemployed node" do
+        should "return worried_about_work when going_to_work has been chosen" do
           @calculator.need_help_with = "going_to_work"
           assert_equal @calculator.next_question(:have_you_been_made_unemployed), :worried_about_work
         end
 
-        should "return have_somewhere_to_live? when somewhere_to_live has been chosen" do
+        should "return have_somewhere_to_live when somewhere_to_live has been chosen" do
           @calculator.need_help_with = "somewhere_to_live"
           assert_equal @calculator.next_question(:have_you_been_made_unemployed), :have_somewhere_to_live
         end
 
-        should "return mental_health_worries? when mental_health has been chosen" do
+        should "return mental_health_worries when mental_health has been chosen" do
           @calculator.need_help_with = "mental_health"
           assert_equal @calculator.next_question(:have_you_been_made_unemployed), :mental_health_worries
         end
 
-        should "return nation? when there are no other selected options" do
+        should "return nation when there are no other selected options" do
           @calculator.need_help_with = ""
           assert_equal @calculator.next_question(:have_you_been_made_unemployed), :nation
         end
       end
 
-      context "user is on the are_you_off_work_ill? node" do
-        should "return have_somewhere_to_live? when somewhere_to_live has been chosen" do
+      context "user is on the are_you_off_work_ill node" do
+        should "return have_somewhere_to_live when somewhere_to_live has been chosen" do
           @calculator.need_help_with = "somewhere_to_live"
           assert_equal @calculator.next_question(:are_you_off_work_ill), :have_somewhere_to_live
         end
 
-        should "return mental_health_worries? when mental_health has been chosen" do
+        should "return mental_health_worries when mental_health has been chosen" do
           @calculator.need_help_with = "mental_health"
           assert_equal @calculator.next_question(:are_you_off_work_ill), :mental_health_worries
         end
 
-        should "return nation? when there are no other selected options" do
+        should "return nation when there are no other selected options" do
           @calculator.need_help_with = ""
           assert_equal @calculator.next_question(:are_you_off_work_ill), :nation
         end
       end
 
-      context "user is on the have_you_been_evicted? node" do
-        should "return mental_health_worries? when mental_health has been chosen" do
+      context "user is on the have_you_been_evicted node" do
+        should "return mental_health_worries when mental_health has been chosen" do
           @calculator.need_help_with = "mental_health"
           assert_equal @calculator.next_question(:have_you_been_evicted), :mental_health_worries
         end
 
-        should "return nation? when there are no other selected options" do
+        should "return nation when there are no other selected options" do
           @calculator.need_help_with = ""
           assert_equal @calculator.next_question(:have_you_been_evicted), :nation
         end


### PR DESCRIPTION
## What

Remove all question marks from the Coronavirus Find Support flow calculator tests `should` and `context` text descriptions.

## Why

Questions in the flow were defined with question marks (e.g. `:feel_safe?`). The question marks have since been removed. This change cleans up the test `should` and `context` text and makes the question names consistent throughout the flow.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.
