### PR TITLE
Update start page content id to the current one

### DIFF
--- a/lib/smart_answer_flows/find-coronavirus-support.rb
+++ b/lib/smart_answer_flows/find-coronavirus-support.rb
@@ -2,7 +2,7 @@ module SmartAnswer
   class FindCoronavirusSupportFlow < Flow
     def define
       name "find-coronavirus-support"
-      start_page_content_id "6a6ab3c9-4612-4764-8f2f-2c534c3c6b19"
+      start_page_content_id "d67f2c92-d0f0-438b-9c81-c0059dd71baf"
       flow_content_id "31d81949-aa15-48cf-a7f1-f0d0a670e8db"
       status :draft
       use_session true

--- a/test/integration/session_answers_test.rb
+++ b/test/integration/session_answers_test.rb
@@ -27,7 +27,7 @@ class SessionAnswersTest < ActionDispatch::SystemTestCase
   end
 
   test "Returning to start of flow resets session" do
-    visit "coronavirus-find-support/s"
+    visit "find-coronavirus-support/s"
     within "legend" do
       assert_page_has_content "What do you need help with because of coronavirus?"
     end
@@ -36,7 +36,7 @@ class SessionAnswersTest < ActionDispatch::SystemTestCase
     within "legend" do
       assert_page_has_content "Do you feel safe where you live?"
     end
-    visit "coronavirus-find-support/s"
+    visit "find-coronavirus-support/s"
     within "legend" do
       assert_page_has_content "What do you need help with because of coronavirus?"
     end


### PR DESCRIPTION
We need to update the find support flow's start page content id to be the
same as the current start page at
www.gov.uk/api/content/find-coronavirus-support.

[Trello ticket](https://trello.com/c/EULvB9l1/515-update-start-page-content-id-to-the-current-one)