### PR TITLE
Reset session on starting a session flow anew

### DIFF
--- a/app/controllers/session_answers_controller.rb
+++ b/app/controllers/session_answers_controller.rb
@@ -2,6 +2,7 @@ class SessionAnswersController < ApplicationController
   before_action :set_cache_headers
 
   def start
+    session_store.clear
     redirect_to session_flow_path(id: params[:id], node_slug: next_node_slug)
   end
 

--- a/test/integration/session_answers_test.rb
+++ b/test/integration/session_answers_test.rb
@@ -26,6 +26,22 @@ class SessionAnswersTest < ActionDispatch::SystemTestCase
     end
   end
 
+  test "Returning to start of flow resets session" do
+    visit "coronavirus-find-support/s"
+    within "legend" do
+      assert_page_has_content "What do you need help with because of coronavirus?"
+    end
+    check("Not sure", visible: false)
+    click_on "Continue"
+    within "legend" do
+      assert_page_has_content "Do you feel safe where you live?"
+    end
+    visit "coronavirus-find-support/s"
+    within "legend" do
+      assert_page_has_content "What do you need help with because of coronavirus?"
+    end
+  end
+
   def assert_page_has_content(text)
     assert page.has_content?(text), "'#{text}' not found in page"
   end


### PR DESCRIPTION
It's confusing for users to be told that they are going to start a
service and be taken directly to the results. Also potentially it could
allow other people to view their results, if they attempt to do the
flow themselves.

[Trello ticket](https://trello.com/c/KxftKOFL/520-clear-existing-session-when-starting-flow-from-start-page)
