### PR TITLE
Fix self-employment logic in find coronavirus support flow calculator

### DIFF
--- a/lib/smart_answer/calculators/find_coronavirus_support_calculator.rb
+++ b/lib/smart_answer/calculators/find_coronavirus_support_calculator.rb
@@ -38,6 +38,8 @@ module SmartAnswer::Calculators
         calculator.needs_help_with?("getting_food") && calculator.get_food != "yes"
       },
       have_you_been_made_unemployed: lambda { |calculator|
+        return false if calculator.have_you_been_made_unemployed.blank?
+
         calculator.needs_help_with?("being_unemployed") && calculator.have_you_been_made_unemployed != "no"
       },
       self_employed: lambda { |calculator|

--- a/lib/smart_answer/calculators/find_coronavirus_support_calculator.rb
+++ b/lib/smart_answer/calculators/find_coronavirus_support_calculator.rb
@@ -41,7 +41,7 @@ module SmartAnswer::Calculators
         calculator.needs_help_with?("being_unemployed") && calculator.have_you_been_made_unemployed != "no"
       },
       self_employed: lambda { |calculator|
-        calculator.needs_help_with?("being_unemployed") && calculator.self_employed != "yes"
+        calculator.needs_help_with?("being_unemployed") && calculator.self_employed != "no"
       },
       worried_about_work: lambda { |calculator|
         calculator.needs_help_with?("going_in_to_work") && calculator.worried_about_work != "no"
@@ -61,7 +61,7 @@ module SmartAnswer::Calculators
     }.freeze
 
     def show_group?(name)
-      GROUPS[name].map { |section| show_section?(section) }.any?
+      GROUPS[name].any? { |section| show_section?(section) }
     end
 
     def show_section?(name)
@@ -69,7 +69,7 @@ module SmartAnswer::Calculators
     end
 
     def has_results?
-      GROUPS.keys.map { |group| show_group?(group) }.any?
+      GROUPS.keys.any? { |group| show_group?(group) }
     end
 
     def needs_help_with?(given_help_item)

--- a/test/integration/session_answers_test.rb
+++ b/test/integration/session_answers_test.rb
@@ -27,7 +27,7 @@ class SessionAnswersTest < ActionDispatch::SystemTestCase
   end
 
   test "Returning to start of flow resets session" do
-    visit "coronavirus-find-support/s"
+    visit "find-coronavirus-support/s"
     within "legend" do
       assert_page_has_content "What do you need help with because of coronavirus?"
     end
@@ -36,7 +36,7 @@ class SessionAnswersTest < ActionDispatch::SystemTestCase
     within "legend" do
       assert_page_has_content "Do you feel safe where you live?"
     end
-    visit "coronavirus-find-support/s"
+    visit "find-coronavirus-support/s"
     within "legend" do
       assert_page_has_content "What do you need help with because of coronavirus?"
     end

--- a/test/unit/calculators/find_coronavirus_support_calculator_test.rb
+++ b/test/unit/calculators/find_coronavirus_support_calculator_test.rb
@@ -200,16 +200,23 @@ module SmartAnswer::Calculators
       end
 
       context "have_you_been_made_unemployed" do
-        should "return true when criteria is met" do
+        should "return true when user selects needing help with being unemployed" do
           @calculator.need_help_with = "being_unemployed"
-          @calculator.have_you_been_made_unemployed = "yes"
+          @calculator.have_you_been_made_unemployed = "yes_i_have_been_made_unemployed"
 
           assert @calculator.show_section?(:have_you_been_made_unemployed)
         end
 
-        should "return false when criteria is not met" do
+        should "return false when user selects not needing help with being unemployed" do
           @calculator.need_help_with = "being_unemployed"
           @calculator.have_you_been_made_unemployed = "no"
+
+          assert_not @calculator.show_section?(:have_you_been_made_unemployed)
+        end
+
+        should "return false when user selects not selected needing help with being unemployed" do
+          @calculator.need_help_with = "being_unemployed"
+          @calculator.have_you_been_made_unemployed = nil
 
           assert_not @calculator.show_section?(:have_you_been_made_unemployed)
         end

--- a/test/unit/calculators/find_coronavirus_support_calculator_test.rb
+++ b/test/unit/calculators/find_coronavirus_support_calculator_test.rb
@@ -58,10 +58,16 @@ module SmartAnswer::Calculators
       end
 
       context "being_unemployed" do
-        should "return true when criteria is met" do
+        should "return true when need help with being unemployed and unemployed" do
           @calculator.need_help_with = "being_unemployed"
           @calculator.have_you_been_made_unemployed = "yes"
-          @calculator.self_employed = "no"
+
+          assert @calculator.show_group?(:being_unemployed)
+        end
+
+        should "return true when need help with being unemployed and self-employed" do
+          @calculator.need_help_with = "being_unemployed"
+          @calculator.self_employed = "yes"
 
           assert @calculator.show_group?(:being_unemployed)
         end
@@ -69,7 +75,7 @@ module SmartAnswer::Calculators
         should "return false when criteria is not met" do
           @calculator.need_help_with = "being_unemployed"
           @calculator.have_you_been_made_unemployed = "no"
-          @calculator.self_employed = "yes"
+          @calculator.self_employed = "no"
 
           assert_not @calculator.show_group?(:being_unemployed)
         end
@@ -210,16 +216,23 @@ module SmartAnswer::Calculators
       end
 
       context "self_employed" do
-        should "return true when criteria is met" do
+        should "return true when need help with being unemployed and self-employed" do
           @calculator.need_help_with = "being_unemployed"
-          @calculator.self_employed = "no"
+          @calculator.self_employed = "yes"
+
+          assert @calculator.show_section?(:self_employed)
+        end
+
+        should "return true when need help with being unemployed and unsure about beign self-employed" do
+          @calculator.need_help_with = "being_unemployed"
+          @calculator.self_employed = "not_sure"
 
           assert @calculator.show_section?(:self_employed)
         end
 
         should "return false when criteria is not met" do
           @calculator.need_help_with = "being_unemployed"
-          @calculator.self_employed = "yes"
+          @calculator.self_employed = "no"
 
           assert_not @calculator.show_section?(:self_employed)
         end


### PR DESCRIPTION
Update logic so that self-employed section is displayed by user who has selected
self-employed or is not sure about being self-employed.

Also fix bug where merge after flow name renamed has not updates an integration test

[Trello card](https://trello.com/c/Xulfz8pX/521-fix-incorrect-logic-for-when-sections-are-being-shown)