### PR TITLE
Remove previous answers from the results page

### DIFF
--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -16,6 +16,7 @@ class FlowPresenter
            :questions,
            :use_escape_button?,
            :show_escape_link?,
+           :hide_previous_answers_on_results_page?,
            to: :flow
 
   delegate :title, :meta_description, to: :start_node

--- a/app/views/smart_answers/result.html.erb
+++ b/app/views/smart_answers/result.html.erb
@@ -16,7 +16,8 @@
   <div id="result-info" class="govuk-grid-column-two-thirds outcome">
     <%= render 'smart_answers/debug' %>
     <%= render "govuk_publishing_components/components/title", {
-      title: outcome.heading_title
+      title: outcome.heading_title,
+      margin_bottom: @presenter.hide_previous_answers_on_results_page? ? 6 : nil
     } %>
 
     <div class="govuk-!-margin-bottom-6 result-body" data-debug-template-path="<%= outcome.relative_erb_template_path %>">
@@ -25,6 +26,20 @@
           text: outcome.title,
           margin_bottom: 6
         } unless outcome.title_as_heading? %>
+      <% end %>
+
+      <% if @presenter.hide_previous_answers_on_results_page? %>
+        <p class="govuk-body govuk-!-margin-bottom-6">
+          <%= link_to "Start again",
+            restart_flow_path(@presenter),
+            :class => "govuk-link",
+            :data => {
+              module: "track-click",
+              "track-action": "Start again",
+              "track-category": "StartAgain",
+              "track-label": @presenter.current_node.title
+            } %>
+        </p>
       <% end %>
 
       <%= outcome.body %>
@@ -54,7 +69,9 @@
       });
     </script>
 
-    <%= render 'smart_answers/previous_answers' %>
+    <% unless @presenter.hide_previous_answers_on_results_page? %>
+      <%= render 'smart_answers/previous_answers' %>
+    <% end %>
   </div>
 
   <% if defined?(@presenter.finished?) and @presenter.finished? %>

--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -64,6 +64,14 @@ module SmartAnswer
       use_session? && use_escape_button?
     end
 
+    def hide_previous_answers_on_results_page(hide_previous_answers_on_results_page) # rubocop:disable Style/TrivialAccessors
+      @hide_previous_answers_on_results_page = hide_previous_answers_on_results_page
+    end
+
+    def hide_previous_answers_on_results_page?
+      ActiveModel::Type::Boolean.new.cast(@hide_previous_answers_on_results_page)
+    end
+
     def button_text(text = "Next step")
       @button_text ||= text
     end

--- a/lib/smart_answer_flows/find-coronavirus-support.rb
+++ b/lib/smart_answer_flows/find-coronavirus-support.rb
@@ -7,6 +7,7 @@ module SmartAnswer
       status :draft
       use_session true
       use_escape_button true
+      hide_previous_answers_on_results_page true
       button_text "Continue"
 
       # ======================================================================

--- a/test/unit/flow_test.rb
+++ b/test/unit/flow_test.rb
@@ -85,6 +85,36 @@ class FlowTest < ActiveSupport::TestCase
     assert_not smart_answer.use_escape_button?
   end
 
+  test "can set flag to hide previous answers on results page" do
+    smart_answer = SmartAnswer::Flow.new do
+      hide_previous_answers_on_results_page true
+    end
+
+    assert smart_answer.hide_previous_answers_on_results_page?
+  end
+
+  test "can set flag to hide previous answers on results pagewith string" do
+    smart_answer = SmartAnswer::Flow.new do
+      hide_previous_answers_on_results_page "yes"
+    end
+
+    assert smart_answer.hide_previous_answers_on_results_page?
+  end
+
+  test "can set flag not to hide previous answers on results page" do
+    smart_answer = SmartAnswer::Flow.new do
+      hide_previous_answers_on_results_page "false"
+    end
+
+    assert_not smart_answer.hide_previous_answers_on_results_page?
+  end
+
+  test "defaults to show previous answers on results page" do
+    smart_answer = SmartAnswer::Flow.new
+
+    assert_not smart_answer.hide_previous_answers_on_results_page?
+  end
+
   test "Can set button text" do
     text = "continue"
     smart_answer = SmartAnswer::Flow.new do


### PR DESCRIPTION
What

We should remove the previous answers section on the results page, but keep the start again link. This makes the behaviour of navigation consistent with the current tool.

Why

There is a concern about the behaviour of the previous answers section on the results page of the find coronavirus support flow. This flow uses sessions, which means answers to all questions are remembered and the user does not have to re-answer subsequent questions if going back in the flow to change an answer. This could be potentially confusing if the user expects to see related questions that are dependent on an answer to an earlier question, i.e. need help with -> getting food, expects to see questions about getting food.

[Trello](https://trello.com/c/MJWNmKBy/525-remove-previous-answers-from-the-results-page)

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.
