### PR TITLE
Use GovukTest to provide headless chrome selenium options

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,15 +34,15 @@ end
 
 group :development, :test do
   gem "byebug"
-  gem "jasmine", "~> 3.6.0"
+  gem "govuk_test"
+  gem "jasmine"
+  gem "jasmine_selenium_runner"
   gem "pry"
   gem "rubocop-govuk"
 end
 
 group :test do
   gem "ci_reporter"
-  gem "govuk_test"
-  gem "jasmine_selenium_runner", "~> 3.0.0", require: false
   gem "minitest"
   gem "minitest-focus"
   gem "mocha", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -375,8 +375,8 @@ DEPENDENCIES
   govuk_publishing_components
   govuk_test
   htmlentities
-  jasmine (~> 3.6.0)
-  jasmine_selenium_runner (~> 3.0.0)
+  jasmine
+  jasmine_selenium_runner
   json
   listen
   method_source

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,7 +198,7 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (4.0.6)
-    puma (5.0.0)
+    puma (5.0.2)
       nio4r (~> 2.0)
     rack (2.2.3)
     rack-test (1.1.0)

--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -1,27 +1,7 @@
-# Use this file to set/override Jasmine configuration options
-# You can remove it if you don't need it.
-# This file is loaded *after* jasmine.yml is interpreted.
-#
-# Example: using a different boot file.
-# Jasmine.configure do |config|
-#    config.boot_dir = '/absolute/path/to/boot_dir'
-#    config.boot_files = lambda { ['/absolute/path/to/boot_dir/file.js'] }
-# end
-#
-# Example: prevent PhantomJS auto install, uses PhantomJS already on your path.
+require "jasmine_selenium_runner/configure_jasmine"
 
-require "jasmine/runners/selenium"
-require "webdrivers/chromedriver"
-
-Jasmine.configure do |config|
-  config.prevent_phantom_js_auto_install = true
-
-  config.runner = lambda { |formatter, jasmine_server_url|
-    options = Selenium::WebDriver::Chrome::Options.new
-    options.headless!
-    options.add_argument("--no-sandbox")
-
-    webdriver = Selenium::WebDriver.for(:chrome, options: options)
-    Jasmine::Runners::Selenium.new(formatter, jasmine_server_url, webdriver, 50)
-  }
+class HeadlessChromeJasmineConfigurer < JasmineSeleniumRunner::ConfigureJasmine
+  def selenium_options
+    { options: GovukTest.headless_chrome_selenium_options }
+  end
 end

--- a/spec/javascripts/support/jasmine_selenium_runner.yml
+++ b/spec/javascripts/support/jasmine_selenium_runner.yml
@@ -1,0 +1,2 @@
+browser: chrome
+configuration_class: HeadlessChromeJasmineConfigurer


### PR DESCRIPTION
This changes the configuration mechanism for Jasmine selenium runner to use the approach advised in the gem (as per:
alphagov/content-publisher#2110) and also uses GovukTest as a means to share the headless chrome configuration.

This change is applied to provide govuk-docker compatibility for upcoming changes: alphagov/govuk-docker#394

It also removes some unnecessary version numbers from the Gemfile.