### PR TITLE
Move the 'Start again' button to bottom of results page

### DIFF
--- a/app/views/smart_answers/_previous_answers.html.erb
+++ b/app/views/smart_answers/_previous_answers.html.erb
@@ -1,10 +1,20 @@
 <% if @presenter.current_question_number > 1 %>
   <table class="govuk-table previous-answers-table">
     <caption class="govuk-table__caption">
-      <h2 class="govuk-heading-m">Previous answers</h2>
+      <% if local_assigns[:hide_previous_answers] %>
+        <%= render "govuk_publishing_components/components/heading", {
+          text: "Change your answers",
+          heading_level: 2,
+          font_size: "l",
+          margin_bottom: 6
+        } %>
+      <% else %>
+        <h2 class="govuk-heading-m">Previous answers</h2>
+      <% end %>
+
       <p class="govuk-body">
-      <%= link_to "Start again", 
-        restart_flow_path(@presenter), 
+      <%= link_to "Start again",
+        restart_flow_path(@presenter),
         :class => "govuk-link",
         :data => {
           module: "track-click",
@@ -14,23 +24,26 @@
         } %>
       </p>
     </caption>
-    <thead class="govuk-table__head">
-      <tr class="govuk-table__row">
-        <th scope="col" class="govuk-table__header">Question</th>
-        <th scope="col" class="govuk-table__header">Answer</th>
-        <th scope="col" class="govuk-table__header">Change answer</th>
-      </tr>
-    </thead>
-    <tbody class="govuk-table__body">
-      <% @presenter.collapsed_questions.each_with_index do |question, number_questions_so_far| %>
-        <%= render(
-            'smart_answers/previous_answer',
-            question: question,
-            accepted_response: @presenter.accepted_responses[number_questions_so_far],
-            question_link: @presenter.change_collapsed_question_link(number_questions_so_far + 1, question),
-          )
-        %>
-      <% end %>
-    </tbody>
+
+    <% unless local_assigns[:hide_previous_answers] %>
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Question</th>
+          <th scope="col" class="govuk-table__header">Answer</th>
+          <th scope="col" class="govuk-table__header">Change answer</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <% @presenter.collapsed_questions.each_with_index do |question, number_questions_so_far| %>
+          <%= render(
+              'smart_answers/previous_answer',
+              question: question,
+              accepted_response: @presenter.accepted_responses[number_questions_so_far],
+              question_link: @presenter.change_collapsed_question_link(number_questions_so_far + 1, question),
+            )
+          %>
+        <% end %>
+      </tbody>
+    <% end %>
   </table>
 <% end %>

--- a/app/views/smart_answers/result.html.erb
+++ b/app/views/smart_answers/result.html.erb
@@ -16,8 +16,7 @@
   <div id="result-info" class="govuk-grid-column-two-thirds outcome">
     <%= render 'smart_answers/debug' %>
     <%= render "govuk_publishing_components/components/title", {
-      title: outcome.heading_title,
-      margin_bottom: @presenter.hide_previous_answers_on_results_page? ? 6 : nil
+      title: outcome.heading_title
     } %>
 
     <div class="govuk-!-margin-bottom-6 result-body" data-debug-template-path="<%= outcome.relative_erb_template_path %>">
@@ -26,20 +25,6 @@
           text: outcome.title,
           margin_bottom: 6
         } unless outcome.title_as_heading? %>
-      <% end %>
-
-      <% if @presenter.hide_previous_answers_on_results_page? %>
-        <p class="govuk-body govuk-!-margin-bottom-6">
-          <%= link_to "Start again",
-            restart_flow_path(@presenter),
-            :class => "govuk-link",
-            :data => {
-              module: "track-click",
-              "track-action": "Start again",
-              "track-category": "StartAgain",
-              "track-label": @presenter.current_node.title
-            } %>
-        </p>
       <% end %>
 
       <%= outcome.body %>
@@ -69,9 +54,7 @@
       });
     </script>
 
-    <% unless @presenter.hide_previous_answers_on_results_page? %>
-      <%= render 'smart_answers/previous_answers' %>
-    <% end %>
+    <%= render 'smart_answers/previous_answers', hide_previous_answers: @presenter.hide_previous_answers_on_results_page? %>
   </div>
 
   <% if defined?(@presenter.finished?) and @presenter.finished? %>


### PR DESCRIPTION
## What

The current position of the `Start again` link on the results page of the find support smart answer breaks up the flow of the text.

We should move it to the bottom of the page, below a header for `Change your answers`.

## Why

So that users can find what they need to know first, before selecting `Start again`.

So that people know why they would start again.

[Trello](https://trello.com/c/yyBjhiUR/534-move-the-start-again-button-to-the-bottom-of-the-answers-page)

## Screenshot

![screencapture-localhost-3010-find-coronavirus-support-s-results-2020-10-01-13_20_50](https://user-images.githubusercontent.com/44037625/94809231-2dc44480-03ea-11eb-9119-dea87ce7a6b1.png)


:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.
