### PR TITLE
Add broken links checking in smart answers

### DIFF
--- a/lib/broken_link_report.rb
+++ b/lib/broken_link_report.rb
@@ -1,0 +1,67 @@
+class BrokenLinkReport
+  def self.for_erb_files_at(flows_root_path)
+    new(flows_root_path).summary_report
+  end
+
+  attr_reader :flows_root_path
+  def initialize(flows_root_path)
+    @flows_root_path = flows_root_path
+  end
+
+  def folder_paths
+    path_to_items_within_root_folder = File.join(flows_root_path, "*")
+    Dir.glob(path_to_items_within_root_folder).select { |file| File.directory?(file) }
+  end
+
+  def folders
+    @folders ||= folder_paths.map { |folder_path| Folder.new(folder_path) }
+  end
+
+  def summary_report
+    @summary_report ||= begin
+      report = folders.each_with_object([]) do |folder, content|
+        next unless folder.report
+        next if folder.totals.links == folder.totals.ok
+
+        content << "Flow: #{folder.name}"
+        content << "===================="
+        folder.links.each do |link|
+          next unless link.status == :broken || link.status == :caution
+
+          content << link.uri
+          content << link.problem_summary
+          content << link.errors.join("\n") if link.errors.present?
+          content << link.suggested_fix if link.suggested_fix.present?
+          content << ""
+        end
+        content << ""
+      end
+      report.join("\n")
+    end
+  end
+
+  class Folder
+    attr_reader :path
+    def initialize(path)
+      @path = path
+    end
+
+    def name
+      @name ||= File.basename(path)
+    end
+
+    def erb_files
+      Dir.glob(File.join(path, "**/*.erb"))
+    end
+
+    def texts
+      erb_files.map { |file_path| File.read(file_path) }
+    end
+
+    def link_checker
+      @link_checker ||= LinkChecker.new(texts)
+    end
+    delegate :report, to: :link_checker
+    delegate :totals, :links, to: :report, allow_nil: true
+  end
+end

--- a/lib/link_checker.rb
+++ b/lib/link_checker.rb
@@ -1,0 +1,56 @@
+class LinkChecker
+  attr_reader :texts
+
+  def initialize(texts)
+    @texts = texts
+  end
+
+  def urls
+    @urls ||= extract_urls
+  end
+
+  def report
+    return if urls.blank?
+
+    @report ||= generate_report
+  end
+
+private
+
+  def extract_urls
+    return Set[] if texts.blank?
+
+    urls = texts.map { |text| URI.extract(text, %w[http https]) }
+    urls.flatten!
+    urls.map! { |uri| remove_unmatched_closing_bracket_from_end(uri) }
+    urls.to_set
+  end
+
+  def remove_unmatched_closing_bracket_from_end(text)
+    text.gsub!(/\)[^\)\w]?$/, "") if unmatched_closing_bracket?(text)
+    text
+  end
+
+  def unmatched_closing_bracket?(text)
+    text.count("(") < text.count(")")
+  end
+
+  def generate_report
+    link_report = link_checker_api.create_batch(urls, checked_within: 5)
+    wait_time = 0.5
+
+    while link_report.status == :in_progress
+      sleep(wait_time)
+      link_report = link_checker_api.get_batch(link_report.id)
+      wait_time *= 2
+    end
+    link_report
+  end
+
+  def link_checker_api
+    @link_checker_api ||= GdsApi::LinkCheckerApi.new(
+      Plek.current.find("link-checker-api"),
+      bearer_token: ENV["LINK_CHECKER_API_BEARER_TOKEN"],
+    )
+  end
+end

--- a/test/fixtures/smart_answer_flows/flow-with-links/outcomes/results.erb
+++ b/test/fixtures/smart_answer_flows/flow-with-links/outcomes/results.erb
@@ -1,0 +1,14 @@
+<% text_for :title do %>
+  Here be links
+  <%= link_to "This link", "http://example.com/one" %>
+<% end %>
+
+<% govspeak_for :body do %>
+  This is some text.
+  [This is a link](https://example.com/two)
+  Some more text
+<% end %>
+
+<% html_for :body do %>
+  There is a link <a href="http://example.com/three">here</a>
+<% end %>

--- a/test/unit/broken_link_report_test.rb
+++ b/test/unit/broken_link_report_test.rb
@@ -1,0 +1,150 @@
+require "test_helper"
+require "minitest/autorun"
+
+class BrokenLinkReportTest < ActiveSupport::TestCase
+  def path
+    # Defaulting path to only flow-with-links flow to limit scope of most tests (simpler and faster)
+    @path ||= Rails.root.join "test/fixtures/smart_answer_flows/flow-with-links"
+  end
+
+  def broken_link_report
+    @broken_link_report ||= BrokenLinkReport.new(path)
+  end
+
+  def folder
+    @folder ||= BrokenLinkReport::Folder.new(path)
+  end
+
+  def erb_file_path
+    File.expand_path("outcomes/results.erb", path)
+  end
+
+  def erb_file_content
+    File.read erb_file_path
+  end
+
+  def totals
+    @totals ||= {
+      links: 1,
+      ok: 0,
+    }
+  end
+
+  def status
+    @status ||= :broken
+  end
+
+  def link
+    @link ||= OpenStruct.new(
+      status: status,
+      uri: "http://example.com/foo/bar",
+      problem_summary: "Whoops",
+      errors: ["It broke"],
+      suggested_fix: "Contact webmaster",
+    )
+  end
+
+  def links
+    @links ||= [link]
+  end
+
+  def report
+    @report ||= OpenStruct.new(
+      totals: OpenStruct.new(totals),
+      links: links,
+    )
+  end
+
+  def mock_link_checker
+    OpenStruct.new(report: report)
+  end
+
+  context ".for_erb_files_at" do
+    should "return the summary report for live flows" do
+      @path = Rails.root.join("lib/smart_answer_flows")
+      LinkChecker.stub :new, mock_link_checker do
+        report = BrokenLinkReport.for_erb_files_at(@path)
+        assert_equal broken_link_report.summary_report, report
+      end
+    end
+  end
+
+  context "#summary_report" do
+    should "include broken link" do
+      LinkChecker.stub :new, mock_link_checker do
+        assert_includes broken_link_report.summary_report, link.uri
+        assert_includes broken_link_report.summary_report, link.problem_summary
+        assert_includes broken_link_report.summary_report, link.errors.first
+        assert_includes broken_link_report.summary_report, link.suggested_fix
+      end
+    end
+
+    should "be blank if totals match" do
+      @totals = { links: 1, ok: 1 }
+      LinkChecker.stub :new, mock_link_checker do
+        assert broken_link_report.summary_report.blank?
+      end
+    end
+
+    should "not include link if status ok" do
+      @status = :ok
+      LinkChecker.stub :new, mock_link_checker do
+        assert_not_includes broken_link_report.summary_report, link.uri
+        assert_not_includes broken_link_report.summary_report, link.problem_summary
+        assert_not_includes broken_link_report.summary_report, link.errors.first
+        assert_not_includes broken_link_report.summary_report, link.suggested_fix
+      end
+    end
+  end
+
+  context "#folders" do
+    should "be instances of Folder" do
+      assert_kind_of BrokenLinkReport::Folder, broken_link_report.folders.first
+    end
+
+    should "contain a folder representing the child folder" do
+      assert_equal "outcomes", broken_link_report.folders.first.name
+    end
+
+    should "find many folders if path is to smart_answers_flows" do
+      @path = Rails.root.join "test/fixtures/smart_answer_flows"
+      assert broken_link_report.folders.length > 1
+    end
+
+    should "include flow-with-links as child if path is to smart_answers_flows" do
+      @path = Rails.root.join "test/fixtures/smart_answer_flows"
+      assert_includes broken_link_report.folders.map(&:name), "flow-with-links"
+    end
+  end
+
+  context "#folder_paths" do
+    should "be the child folders within the root folder" do
+      child_path = File.expand_path("outcomes", path)
+      assert_equal [child_path], broken_link_report.folder_paths
+    end
+  end
+
+  context "Folder#name" do
+    should "be the name of the parent folder" do
+      assert_equal "flow-with-links", folder.name
+    end
+  end
+
+  context "#erb_files" do
+    should "be the paths to erb files withing the folder" do
+      assert_equal [erb_file_path], folder.erb_files
+    end
+  end
+
+  context "Folder#texts" do
+    should "be an array of the text content for erb files in the folder" do
+      assert_equal [erb_file_content], folder.texts
+    end
+  end
+
+  context "Folder#link_checker" do
+    should "be an instance of line checker" do
+      assert_kind_of LinkChecker, folder.link_checker
+    end
+  end
+end

--- a/test/unit/link_checker_test.rb
+++ b/test/unit/link_checker_test.rb
@@ -1,0 +1,62 @@
+require "test_helper"
+require "gds_api/test_helpers/link_checker_api"
+
+class LinkCheckerTest < ActiveSupport::TestCase
+  include GdsApi::TestHelpers::LinkCheckerApi
+
+  def url
+    @url ||= "http://example.com"
+  end
+
+  def text
+    @text ||= %(There is a link <a href="#{url}">here</a>)
+  end
+
+  def link_checker
+    @link_checker ||= LinkChecker.new([text])
+  end
+
+  context "#urls" do
+    should "return set of urls in text" do
+      assert_equal Set[url], link_checker.urls
+    end
+
+    context "when text contains no links" do
+      should "return an empty set" do
+        @text = "No links"
+        assert_equal Set[], link_checker.urls
+      end
+    end
+
+    context "when text contains link markup" do
+      should "return set of urls in text" do
+        @text = "There is a link [here](#{url})"
+        assert_equal Set[url], link_checker.urls
+      end
+    end
+
+    context "when text contains link markup and url end with a bracket" do
+      should "return set of urls in text" do
+        @url = "http://example.com/this(thing)"
+        @text = "There is a link [here](#{url})"
+        assert_equal Set[url], link_checker.urls
+      end
+    end
+
+    context "when stings missing" do
+      should "return an empty set" do
+        @link_checker = LinkChecker.new(nil)
+        assert_equal Set[], link_checker.urls
+      end
+    end
+  end
+
+  context "#report" do
+    should "generate a report" do
+      stub_link_checker_api_create_batch(
+        uris: [url], checked_within: 5, status: :completed,
+      )
+      assert_equal url, link_checker.report.links.first.uri
+    end
+  end
+end


### PR DESCRIPTION
Add `LinkChecker` class
- Takes arrays of texts with urls and creates a report on them
- The report is generated by link-checker-api
  https://github.com/alphagov/link-checker-api

Add `BrokenLinkReport`
- Use BrokenLinkReport.call to generate a summary report on all the flows in lib/smart_answer_flows
- Use an instance of the class to run reports on individual flows or test folders, by passing into `new` the path of the folder containing the flow erb files
- Summary report provides summary, errors, suggested fix for each link, in erb file text, that is broken or may be broken
- Output is grouped by child folder name - which will match flow name if run at lib/smart_answer_flows

Example output (current report for find-coronavirus-support section of report)
```
Flow: find-coronavirus-support
====================
https://www.readyscotland.org/coronavirus/where-to-find-additional-support/
Bad Redirect

https://southallblacksisters.org.uk
Slow page
Contact the site administrator to see if they have an issue that can be fixed.

https://phw.nhs.wales/topics/latest-information-on-novel-coronavirus-covid-19/staying-well-at-home/how-are-you-feeling/
Security problem

https://www.nationaldahelpline.org.uk/Chat-to-us-online
Security problem
Contact the site administrator to see if they have an issue that can be fixed.

https://rapecrisis.org.uk/get-help
Bad Redirect
Link directly to: https://rapecrisis.org.uk/get-help/
```
The report can be generated for all the flows like this:
```ruby
BrokenLinkReport.for_erb_files_at Rails.root.join("lib/smart_answer_flows")
```

[Trello ticket](https://trello.com/c/36bzKnNO/400-broken-links-checking-in-smart-answers)