### PR TITLE
Refactor VatPaymentDeadlinesFlow flow to remove deprecated methods

### DIFF
--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,0 +1,18 @@
+# Time Formats
+# ============
+#
+# Adds named date and time formats for time.to_s and date.to_s
+#
+# To display the current date and time in all the formats in your current environment:
+#
+#   Date::DATE_FORMATS.keys.push(:default).each{|k| puts "#{k}: #{Date.today.to_s(k)}"}
+#   Time::DATE_FORMATS.keys.push(:default).each{|k| puts "#{k}: #{Time.now.to_s(k)}"}
+#
+# For examples time = Time.local(2009,12,4,15,30,27)
+
+shared_formats = {
+  govuk_date: "%-d %B %Y", # '4 December 2009'
+}
+
+Time::DATE_FORMATS.merge! shared_formats
+Date::DATE_FORMATS.merge! shared_formats

--- a/lib/smart_answer/calculators/vat_payment_deadlines.rb
+++ b/lib/smart_answer/calculators/vat_payment_deadlines.rb
@@ -2,50 +2,47 @@ require "working_days"
 
 module SmartAnswer::Calculators
   class VatPaymentDeadlines
-    def initialize(period_end_date, payment_method)
-      @period_end_date = period_end_date
-      @payment_method = payment_method
-    end
+    attr_accessor :payment_method, :period_end_date
 
     def last_payment_date
-      case @payment_method
+      case payment_method
       when "direct-debit"
-        payment_date = end_of_month_after(@period_end_date) + 7.days
+        payment_date = end_of_month_after(period_end_date) + 7.days
         payment_date -= 1 until payment_date.workday?
         2.working_days.before(payment_date)
       when "online-telephone-banking"
-        end_of_month_after(@period_end_date) + 7.days
+        end_of_month_after(period_end_date) + 7.days
       when "online-debit-credit-card", "bacs-direct-credit", "bank-giro"
         2.working_days.before(funds_received_by)
       when "chaps"
-        payment_date = end_of_month_after(@period_end_date) + 7.days
+        payment_date = end_of_month_after(period_end_date) + 7.days
         payment_date -= 1 until payment_date.workday?
         payment_date
       when "cheque"
-        6.working_days.before(0.working_days.before(end_of_month_after(@period_end_date)))
+        6.working_days.before(0.working_days.before(end_of_month_after(period_end_date)))
       else
         raise ArgumentError, "Invalid payment method"
       end
     end
 
     def funds_received_by
-      case @payment_method
+      case payment_method
       when "direct-debit"
-        3.working_days.after(end_of_month_after(@period_end_date) + 7.days)
+        3.working_days.after(end_of_month_after(period_end_date) + 7.days)
       when "online-telephone-banking"
         # This doesn't really apply to online banking, but the flow expects this
         # to always return a date.
         last_payment_date
       when "online-debit-credit-card", "bacs-direct-credit", "bank-giro"
         # Select previous working day if not a work_day
-        0.working_days.before(end_of_month_after(@period_end_date) + 7.days)
+        0.working_days.before(end_of_month_after(period_end_date) + 7.days)
       when "chaps"
-        receiving_by_date = end_of_month_after(@period_end_date) + 7.days
+        receiving_by_date = end_of_month_after(period_end_date) + 7.days
         receiving_by_date -= 1 until receiving_by_date.workday?
         receiving_by_date
       when "cheque"
         # Select previous working day if not a work_day
-        0.working_days.before(end_of_month_after(@period_end_date))
+        0.working_days.before(end_of_month_after(period_end_date))
       else
         raise ArgumentError, "Invalid payment method"
       end

--- a/lib/smart_answer_flows/vat-payment-deadlines/outcomes/result_bacs_direct_credit.erb
+++ b/lib/smart_answer_flows/vat-payment-deadlines/outcomes/result_bacs_direct_credit.erb
@@ -3,9 +3,9 @@
 <% end %>
 
 <% govspeak_for :body do %>
-  The last date you can pay is <%= last_payment_date %>.
+  The last date you can pay is <%= calculator.last_payment_date.to_s(:govuk_date) %>.
 
-  The money must have cleared by <%= funds_received_by %>.
+  The money must have cleared by <%= calculator.funds_received_by.to_s(:govuk_date)%>.
 
   You need your VAT registration number as the payment reference.
 

--- a/lib/smart_answer_flows/vat-payment-deadlines/outcomes/result_bank_giro.erb
+++ b/lib/smart_answer_flows/vat-payment-deadlines/outcomes/result_bank_giro.erb
@@ -3,9 +3,9 @@
 <% end %>
 
 <% govspeak_for :body do %>
-  The last date you can pay is <%= last_payment_date %>.
+  The last date you can pay is <%= calculator.last_payment_date.to_s(:govuk_date) %>.
 
-  The money must have cleared by <%= funds_received_by %>.
+  The money must have cleared by <%= calculator.funds_received_by.to_s(:govuk_date) %>.
 
   You’ll need a book of paying-in slips from HMRC with your VAT number and HRMC’s account details.
 

--- a/lib/smart_answer_flows/vat-payment-deadlines/outcomes/result_chaps.erb
+++ b/lib/smart_answer_flows/vat-payment-deadlines/outcomes/result_chaps.erb
@@ -3,9 +3,9 @@
 <% end %>
 
 <% govspeak_for :body do %>
-  The last date you can pay is <%= last_payment_date %>.
+  The last date you can pay is <%= calculator.last_payment_date.to_s(:govuk_date) %>.
 
-  HMRC must receive the money by <%= funds_received_by %>.
+  HMRC must receive the money by <%= calculator.funds_received_by.to_s(:govuk_date) %>.
 
   You need your VAT registration number as the payment reference.
 

--- a/lib/smart_answer_flows/vat-payment-deadlines/outcomes/result_cheque.erb
+++ b/lib/smart_answer_flows/vat-payment-deadlines/outcomes/result_cheque.erb
@@ -5,9 +5,9 @@
 <% govspeak_for :body do %>
   You can only pay by cheque if you’re exempt from submitting online VAT returns. If you need to pay by cheque for any other reason, pay by Bank Giro.
 
-  The last day you can post your cheque is <%= last_posting_date %>.
+  The last day you can post your cheque is <%= calculator.last_payment_date.to_s(:govuk_date) %>.
 
-  Your cheque must have cleared by <%= funds_cleared_by %>.
+  Your cheque must have cleared by <%= calculator.funds_received_by.to_s(:govuk_date) %>.
 
   ^The date your cheque clears is the day when your payment reach HRMC’s account. It’s not the day when they get your cheque in the post.^
 

--- a/lib/smart_answer_flows/vat-payment-deadlines/outcomes/result_direct_debit.erb
+++ b/lib/smart_answer_flows/vat-payment-deadlines/outcomes/result_direct_debit.erb
@@ -3,9 +3,9 @@
 <% end %>
 
 <% govspeak_for :body do %>
-  The last date you can set up a direct debit is <%= last_dd_setup_date %>.
+  The last date you can set up a direct debit is <%= calculator.last_payment_date.to_s(:govuk_date) %>.
 
-  The date the money will be taken from your account is <%= funds_taken %>.
+  The date the money will be taken from your account is <%= calculator.funds_received_by.to_s(:govuk_date) %>.
 
   ^You must set up your direct debit before you submit your next VAT online return.^
 

--- a/lib/smart_answer_flows/vat-payment-deadlines/outcomes/result_online_debit_credit_card.erb
+++ b/lib/smart_answer_flows/vat-payment-deadlines/outcomes/result_online_debit_credit_card.erb
@@ -3,9 +3,9 @@
 <% end %>
 
 <% govspeak_for :body do %>
-  The last date you can pay is <%= last_payment_date %>.
+  The last date you can pay is <%= calculator.last_payment_date.to_s(:govuk_date) %>.
 
-  The money must have cleared by <%= funds_received_by %>.
+  The money must have cleared by <%= calculator.funds_received_by.to_s(:govuk_date) %>.
 
   Read more about [how to pay your VAT.](/pay-vat)
 <% end %>

--- a/lib/smart_answer_flows/vat-payment-deadlines/outcomes/result_online_telephone_banking.erb
+++ b/lib/smart_answer_flows/vat-payment-deadlines/outcomes/result_online_telephone_banking.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% govspeak_for :body do %>
-  The last date you can pay is <%= last_payment_date %>.
+  The last date you can pay is <%= calculator.last_payment_date.to_s(:govuk_date) %>.
 
   You need your VAT registration number as the payment reference.
 

--- a/test/unit/calculators/vat_payment_deadlines_test.rb
+++ b/test/unit/calculators/vat_payment_deadlines_test.rb
@@ -7,50 +7,57 @@ module SmartAnswer::Calculators
         .to_return(body: File.open(fixture_file("bank_holidays.json")))
     end
 
+    def new_calculator(date, payment_method)
+      calculator = VatPaymentDeadlines.new
+      calculator.period_end_date = Date.parse(date)
+      calculator.payment_method = payment_method
+      calculator
+    end
+
     context "payment dates for direct-debit" do
       should "calculate last_payment_date where end of month is not a work day" do
-        %w[direct-debit].each do |pay_method|
-          calc = VatPaymentDeadlines.new(Date.parse("2013-10-31"), pay_method)
-          assert_equal Date.parse("2013-12-04"), calc.last_payment_date
+        payment_method = "direct-debit"
 
-          calc = VatPaymentDeadlines.new(Date.parse("2014-04-30"), pay_method)
-          assert_equal Date.parse("2014-06-04"), calc.last_payment_date
+        calc = new_calculator("2013-10-31", payment_method)
+        assert_equal Date.parse("2013-12-04"), calc.last_payment_date
 
-          calc = VatPaymentDeadlines.new(Date.parse("2014-07-31"), pay_method)
-          assert_equal Date.parse("2014-09-03"), calc.last_payment_date
-        end
+        calc = new_calculator("2014-04-30", payment_method)
+        assert_equal Date.parse("2014-06-04"), calc.last_payment_date
+
+        calc = new_calculator("2014-07-31", payment_method)
+        assert_equal Date.parse("2014-09-03"), calc.last_payment_date
       end
     end
 
     context "bank-giro" do
       should "calculate last_payment_date where end of month is not a work day" do
-        %w[bank-giro].each do |pay_method|
-          calc = VatPaymentDeadlines.new(Date.parse("2013-10-31"), pay_method)
-          assert_equal Date.parse("2013-12-04"), calc.last_payment_date
+        payment_method = "bank-giro"
 
-          calc = VatPaymentDeadlines.new(Date.parse("2014-04-30"), pay_method)
-          assert_equal Date.parse("2014-06-04"), calc.last_payment_date
+        calc = new_calculator("2013-10-31", payment_method)
+        assert_equal Date.parse("2013-12-04"), calc.last_payment_date
 
-          calc = VatPaymentDeadlines.new(Date.parse("2014-07-31"), pay_method)
-          assert_equal Date.parse("2014-09-03"), calc.last_payment_date
-        end
+        calc = new_calculator("2014-04-30", payment_method)
+        assert_equal Date.parse("2014-06-04"), calc.last_payment_date
+
+        calc = new_calculator("2014-07-31", payment_method)
+        assert_equal Date.parse("2014-09-03"), calc.last_payment_date
       end
     end
 
     context "dates for direct-debit" do
       should "calculate last_payment_date as end_of_month_after(end_date) + 7 calendar days - 2 working days" do
-        calc = VatPaymentDeadlines.new(Date.parse("2013-04-30"), "direct-debit")
+        calc = new_calculator("2013-04-30", "direct-debit")
         assert_equal Date.parse("2013-06-05"), calc.last_payment_date
       end
 
       should "calculate funds_received_by as end_of_month_after(end_date) + 7 calendar days + 3 working days where end_of_month_after(end_date) is a work day" do
-        calc = VatPaymentDeadlines.new(Date.parse("2013-04-30"), "direct-debit")
+        calc = new_calculator("2013-04-30", "direct-debit")
         assert_equal Date.parse("2013-06-05"), calc.last_payment_date
         assert_equal Date.parse("2013-06-12"), calc.funds_received_by
       end
 
       should "calculate funds_received_by as end_of_month_after(end_date) + 7 calendar days + 3 working days where end_of_month_after(end_date) is not a work day" do
-        calc = VatPaymentDeadlines.new(Date.parse("2014-04-30"), "direct-debit")
+        calc = new_calculator("2014-04-30", "direct-debit")
         assert_equal Date.parse("2014-06-04"), calc.last_payment_date
         assert_equal Date.parse("2014-06-11"), calc.funds_received_by
       end
@@ -62,19 +69,19 @@ module SmartAnswer::Calculators
       end
 
       should "calculate last_payment_date as end_of_month_after(end_date) + 7 days" do
-        calc = VatPaymentDeadlines.new(Date.parse("2013-04-30"), @method)
+        calc = new_calculator("2013-04-30", @method)
         assert_equal Date.parse("2013-06-07"), calc.last_payment_date
       end
 
       should "handle different month lengths correctly" do
         # 31st Jan + 1 month should be 28th Feb
-        calc = VatPaymentDeadlines.new(Date.parse("2013-01-31"), @method)
+        calc = new_calculator("2013-01-31", @method)
         assert_equal Date.parse("2013-03-07"), calc.last_payment_date
       end
 
       should "be last_payment_date for funds_received_by" do
         # This is called for all payment methods, so it needs to return a date
-        calc = VatPaymentDeadlines.new(Date.parse("2013-04-30"), @method)
+        calc = new_calculator("2013-04-30", @method)
         assert_equal calc.last_payment_date, calc.funds_received_by
       end
     end
@@ -82,17 +89,17 @@ module SmartAnswer::Calculators
     %w[online-debit-credit-card bacs-direct-credit bank-giro].each do |method|
       context "dates for #{method}" do
         should "calculate last_payment_date as end_of_month_after(end_date) + 7 calendar days - 3 working days" do
-          calc = VatPaymentDeadlines.new(Date.parse("2013-04-30"), method)
+          calc = new_calculator("2013-04-30", method)
           assert_equal Date.parse("2013-06-05"), calc.last_payment_date
         end
 
         should "calculate funds_received_by as end_of_month_after(end_date) + 7 days if that's a work day" do
-          calc = VatPaymentDeadlines.new(Date.parse("2013-04-30"), method)
+          calc = new_calculator("2013-04-30", method)
           assert_equal Date.parse("2013-06-07"), calc.funds_received_by
         end
 
         should "calculate funds_received_by as last working day before end_of_month_after(end_date) + 7 days if that's a non-work day" do
-          calc = VatPaymentDeadlines.new(Date.parse("2013-05-31"), method)
+          calc = new_calculator("2013-05-31", method)
           assert_equal Date.parse("2013-07-05"), calc.funds_received_by
         end
       end
@@ -104,27 +111,27 @@ module SmartAnswer::Calculators
       end
 
       should "The last date you can pay is [period_end_date + 1 calendar month + 7 calendar days. If the 7th is a BH or WE go back to the last preceding working day. Same for either payment date and funds_received_by date" do
-        calc = VatPaymentDeadlines.new(Date.parse("2013-11-30"), @method)
+        calc = new_calculator("2013-11-30", @method)
         assert_equal Date.parse("2014-01-07"), calc.last_payment_date
         assert_equal Date.parse("2014-01-07"), calc.funds_received_by
 
-        calc = VatPaymentDeadlines.new(Date.parse("2014-03-31"), @method)
+        calc = new_calculator("2014-03-31", @method)
         assert_equal Date.parse("2014-05-07"), calc.last_payment_date
         assert_equal Date.parse("2014-05-07"), calc.funds_received_by
 
-        calc = VatPaymentDeadlines.new(Date.parse("2014-11-30"), @method)
+        calc = new_calculator("2014-11-30", @method)
         assert_equal Date.parse("2015-01-07"), calc.last_payment_date
         assert_equal Date.parse("2015-01-07"), calc.funds_received_by
 
-        calc = VatPaymentDeadlines.new(Date.parse("2015-02-28"), @method)
+        calc = new_calculator("2015-02-28", @method)
         assert_equal Date.parse("2015-04-07"), calc.last_payment_date
         assert_equal Date.parse("2015-04-07"), calc.funds_received_by
 
-        calc = VatPaymentDeadlines.new(Date.parse("2015-03-31"), @method)
+        calc = new_calculator("2015-03-31", @method)
         assert_equal Date.parse("2015-05-07"), calc.last_payment_date
         assert_equal Date.parse("2015-05-07"), calc.funds_received_by
 
-        calc = VatPaymentDeadlines.new(Date.parse("2015-11-30"), @method)
+        calc = new_calculator("2015-11-30", @method)
         assert_equal Date.parse("2016-01-07"), calc.last_payment_date
         assert_equal Date.parse("2016-01-07"), calc.funds_received_by
       end
@@ -136,15 +143,15 @@ module SmartAnswer::Calculators
       end
 
       should "calculate last_payment_date as last working day of end_of_month_after(end_date) - 6 working days" do
-        calc = VatPaymentDeadlines.new(Date.parse("2013-04-30"), @method)
+        calc = new_calculator("2013-04-30", @method)
         assert_equal Date.parse("2013-05-22"), calc.last_payment_date
       end
 
       should "calculate funds_received_by as last working day of end_of_month_after(end_date)" do
-        calc = VatPaymentDeadlines.new(Date.parse("2013-04-30"), @method)
+        calc = new_calculator("2013-04-30", @method)
         assert_equal Date.parse("2013-05-31"), calc.funds_received_by
 
-        calc = VatPaymentDeadlines.new(Date.parse("2013-03-31"), @method)
+        calc = new_calculator("2013-03-31", @method)
         assert_equal Date.parse("2013-04-30"), calc.funds_received_by
       end
     end
@@ -152,13 +159,13 @@ module SmartAnswer::Calculators
     context "with an invalid payment method" do
       should "raise an ArgumentError for last_payment_date" do
         assert_raise ArgumentError do
-          VatPaymentDeadlines.new(Date.parse("2013-04-30"), "fooey").last_payment_date
+          new_calculator("2013-04-30", "fooey").last_payment_date
         end
       end
 
       should "raise an ArgumentError for funds_received_by" do
         assert_raise ArgumentError do
-          VatPaymentDeadlines.new(Date.parse("2013-04-30"), "fooey").funds_received_by
+          new_calculator("2013-04-30", "fooey").funds_received_by
         end
       end
     end


### PR DESCRIPTION
Part of a process of removing use of these flow methods to ease further
development of Smart Answers

- Remove calculate and precalculate methods from flow and move
  functionality to VatPaymentDeadlines calculator
- Use time formatting to simplify date formatting
- Remove aliasing of period_end_date and payment_method

[Trello ticket](https://trello.com/c/MldN2htH/530-remove-support-for-calculate-precalculate-and-saveinputas)
