### PR TITLE
Fix issue where node name doesn't matching page

### DIFF
--- a/app/controllers/session_answers_controller.rb
+++ b/app/controllers/session_answers_controller.rb
@@ -9,7 +9,12 @@ class SessionAnswersController < ApplicationController
   def show
     @title = presenter.title
     @content_item = ContentItemRetriever.fetch(name) if presenter.finished?
-    render "smart_answers/#{page_type}", formats: [:html]
+
+    if requested_node_matches_node_determined_from_session_data?
+      render "smart_answers/#{page_type}", formats: [:html]
+    else
+      redirect_to current_path_determined_from_session_data
+    end
   end
 
   def update
@@ -28,6 +33,14 @@ class SessionAnswersController < ApplicationController
   end
 
 private
+
+  def requested_node_matches_node_determined_from_session_data?
+    params[:node_slug] == presenter.node_slug
+  end
+
+  def current_path_determined_from_session_data
+    session_flow_path(id: params[:id], node_slug: presenter.node_slug)
+  end
 
   def set_cache_headers
     response.headers["Cache-Control"] = "private, no-store, max-age=0, must-revalidate"

--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -21,6 +21,8 @@ class FlowPresenter
 
   delegate :title, :meta_description, to: :start_node
 
+  delegate :node_slug, to: :current_node
+
   def initialize(params, flow)
     @params = params
     @flow = flow

--- a/test/controllers/session_answers_controller_test.rb
+++ b/test/controllers/session_answers_controller_test.rb
@@ -49,6 +49,16 @@ class SessionAnswersControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  context "GET /:id/s/:node_slug with later slug" do
+    setup do
+      get session_flow_path(id: flow_name, node_slug: nodes[1])
+    end
+
+    should "redirect later node to earlier node if session data not present" do
+      assert_redirected_to(session_flow_path(id: flow_name, node_slug: nodes[0]))
+    end
+  end
+
   def params
     { "response" => %w[getting_food], "next" => "1" }
   end


### PR DESCRIPTION
Add redirect in `session_answers#show action` if requested node not current
The redirect is to the node determined by the flow presenter from the session data.

[Trello ticket](https://trello.com/c/QpXnPT8z/546-fix-issue-where-node-name-doesnt-matching-page)
