### PR TITLE
Remove Discretionary Grant Fund

### DIFF
--- a/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.erb
@@ -132,18 +132,6 @@
     $CTA
   <% end %>
 
-  <% if calculator.show?(:discretionary_grant) %>
-    $CTA
-    ### Discretionary Grant Fund
-
-    Small and micro businesses with fixed property costs that are not eligible for the Small Business Grant Fund or the Retail, Hospitality and Leisure Grant Fund may be eligible for the Discretionary Grant Scheme.
-
-    You can get a grant of £25,000, £10,000 or any amount under £10,000.
-
-    [Check if your business is eligible for the Discretionary Grant Fund](/guidance/apply-for-the-coronavirus-local-authority-discretionary-grants-fund)
-    $CTA
-  <% end %>
-
   <% if calculator.show?(:business_loan_scheme) %>
     $CTA
     ### Coronavirus Business Interruption Loan Scheme


### PR DESCRIPTION
Remove Discretionary Grant Fund as it is no longer open for applicants. GOV.UK page is withdrawn https://www.gov.uk/guidance/apply-for-the-coronavirus-local-authority-discretionary-grants-fund

Trello: https://trello.com/c/G247XNy9/560-look-at-removing-incorrect-content-in-the-smart-answer

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.
