### PR TITLE
Refactor InheritsSomeoneDiesWithoutWillFlow to remove deprecated methods

### DIFF
--- a/lib/smart_answer/calculators/inherits_someone_dies_without_will_calculator.rb
+++ b/lib/smart_answer/calculators/inherits_someone_dies_without_will_calculator.rb
@@ -1,0 +1,59 @@
+module SmartAnswer::Calculators
+  class InheritsSomeoneDiesWithoutWillCalculator
+    attr_accessor :region, :next_steps, :partner, :estate_over_250000, :estate_over_270000, :children, :parents,
+                  :siblings, :siblings_including_mixed_parents, :grandparents, :aunts_or_uncles, :half_siblings,
+                  :half_aunts_or_uncles, :great_aunts_or_uncles, :more_than_one_child
+
+    def estate_over_250000?
+      estate_over_250000 == "yes"
+    end
+
+    def estate_over_270000?
+      estate_over_270000 == "yes"
+    end
+
+    def children?
+      children == "yes"
+    end
+
+    def partner?
+      partner == "yes"
+    end
+
+    def parents?
+      parents == "yes"
+    end
+
+    def siblings?
+      siblings == "yes"
+    end
+
+    def siblings_including_mixed_parents?
+      siblings_including_mixed_parents == "yes"
+    end
+
+    def grandparents?
+      grandparents == "yes"
+    end
+
+    def aunts_or_uncles?
+      aunts_or_uncles == "yes"
+    end
+
+    def half_siblings?
+      half_siblings == "yes"
+    end
+
+    def half_aunts_or_uncles?
+      half_aunts_or_uncles == "yes"
+    end
+
+    def great_aunts_or_uncles?
+      great_aunts_or_uncles == "yes"
+    end
+
+    def more_than_one_child?
+      more_than_one_child == "yes"
+    end
+  end
+end

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_1.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_1.erb
@@ -3,5 +3,5 @@
 <% end %>
 
 <% govspeak_for :next_steps do %>
-  <%= render partial: 'next_step_links', locals: { next_steps: next_steps } %>
+  <%= render partial: 'next_step_links', locals: { next_steps: calculator.next_steps } %>
 <% end %>

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_2.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_2.erb
@@ -7,5 +7,5 @@
 <% end %>
 
 <% govspeak_for :next_steps do %>
-  <%= render partial: 'next_step_links', locals: { next_steps: next_steps } %>
+  <%= render partial: 'next_step_links', locals: { next_steps: calculator.next_steps } %>
 <% end %>

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_20.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_20.erb
@@ -12,5 +12,5 @@
 <% end %>
 
 <% govspeak_for :next_steps do %>
-  <%= render partial: 'next_step_links', locals: { next_steps: next_steps } %>
+  <%= render partial: 'next_step_links', locals: { next_steps: calculator.next_steps } %>
 <% end %>

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_23.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_23.erb
@@ -7,5 +7,5 @@
 <% end %>
 
 <% govspeak_for :next_steps do %>
-  <%= render partial: 'next_step_links', locals: { next_steps: next_steps } %>
+  <%= render partial: 'next_step_links', locals: { next_steps: calculator.next_steps } %>
 <% end %>

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_24.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_24.erb
@@ -7,5 +7,5 @@
 <% end %>
 
 <% govspeak_for :next_steps do %>
-  <%= render partial: 'next_step_links', locals: { next_steps: next_steps } %>
+  <%= render partial: 'next_step_links', locals: { next_steps: calculator.next_steps } %>
 <% end %>

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_25.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_25.erb
@@ -3,5 +3,5 @@
 <% end %>
 
 <% govspeak_for :next_steps do %>
-  <%= render partial: 'next_step_links', locals: { next_steps: next_steps } %>
+  <%= render partial: 'next_step_links', locals: { next_steps: [:ownerless_link] } %>
 <% end %>

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_3.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_3.erb
@@ -7,5 +7,5 @@
 <% end %>
 
 <% govspeak_for :next_steps do %>
-  <%= render partial: 'next_step_links', locals: { next_steps: next_steps } %>
+  <%= render partial: 'next_step_links', locals: { next_steps: calculator.next_steps } %>
 <% end %>

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_4.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_4.erb
@@ -7,5 +7,5 @@
 <% end %>
 
 <% govspeak_for :next_steps do %>
-  <%= render partial: 'next_step_links', locals: { next_steps: next_steps } %>
+  <%= render partial: 'next_step_links', locals: { next_steps: calculator.next_steps } %>
 <% end %>

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_40.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_40.erb
@@ -15,5 +15,5 @@
 <% end %>
 
 <% govspeak_for :next_steps do %>
-  <%= render partial: 'next_step_links', locals: { next_steps: next_steps } %>
+  <%= render partial: 'next_step_links', locals: { next_steps: calculator.next_steps } %>
 <% end %>

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_41.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_41.erb
@@ -15,5 +15,5 @@
 <% end %>
 
 <% govspeak_for :next_steps do %>
-  <%= render partial: 'next_step_links', locals: { next_steps: next_steps } %>
+  <%= render partial: 'next_step_links', locals: { next_steps: calculator.next_steps } %>
 <% end %>

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_42.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_42.erb
@@ -15,5 +15,5 @@
 <% end %>
 
 <% govspeak_for :next_steps do %>
-  <%= render partial: 'next_step_links', locals: { next_steps: next_steps } %>
+  <%= render partial: 'next_step_links', locals: { next_steps: calculator.next_steps } %>
 <% end %>

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_43.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_43.erb
@@ -17,5 +17,5 @@
 <% end %>
 
 <% govspeak_for :next_steps do %>
-  <%= render partial: 'next_step_links', locals: { next_steps: next_steps } %>
+  <%= render partial: 'next_step_links', locals: { next_steps: calculator.next_steps } %>
 <% end %>

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_44.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_44.erb
@@ -7,5 +7,5 @@
 <% end %>
 
 <% govspeak_for :next_steps do %>
-  <%= render partial: 'next_step_links', locals: { next_steps: next_steps } %>
+  <%= render partial: 'next_step_links', locals: { next_steps: calculator.next_steps } %>
 <% end %>

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_45.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_45.erb
@@ -7,5 +7,5 @@
 <% end %>
 
 <% govspeak_for :next_steps do %>
-  <%= render partial: 'next_step_links', locals: { next_steps: next_steps } %>
+  <%= render partial: 'next_step_links', locals: { next_steps: calculator.next_steps } %>
 <% end %>

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_46.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_46.erb
@@ -7,5 +7,5 @@
 <% end %>
 
 <% govspeak_for :next_steps do %>
-  <%= render partial: 'next_step_links', locals: { next_steps: next_steps } %>
+  <%= render partial: 'next_step_links', locals: { next_steps: [:ownerless_link] } %>
 <% end %>

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_5.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_5.erb
@@ -7,5 +7,5 @@
 <% end %>
 
 <% govspeak_for :next_steps do %>
-  <%= render partial: 'next_step_links', locals: { next_steps: next_steps } %>
+  <%= render partial: 'next_step_links', locals: { next_steps: calculator.next_steps } %>
 <% end %>

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_6.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_6.erb
@@ -7,5 +7,5 @@
 <% end %>
 
 <% govspeak_for :next_steps do %>
-  <%= render partial: 'next_step_links', locals: { next_steps: next_steps } %>
+  <%= render partial: 'next_step_links', locals: { next_steps: calculator.next_steps } %>
 <% end %>

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_60.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_60.erb
@@ -3,5 +3,5 @@
 <% end %>
 
 <% govspeak_for :next_steps do %>
-  <%= render partial: 'next_step_links', locals: { next_steps: next_steps } %>
+  <%= render partial: 'next_step_links', locals: { next_steps: calculator.next_steps } %>
 <% end %>

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_61.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_61.erb
@@ -13,5 +13,5 @@
 <% end %>
 
 <% govspeak_for :next_steps do %>
-  <%= render partial: 'next_step_links', locals: { next_steps: next_steps } %>
+  <%= render partial: 'next_step_links', locals: { next_steps: calculator.next_steps } %>
 <% end %>

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_62.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_62.erb
@@ -14,5 +14,5 @@
 <% end %>
 
 <% govspeak_for :next_steps do %>
-  <%= render partial: 'next_step_links', locals: { next_steps: next_steps } %>
+  <%= render partial: 'next_step_links', locals: { next_steps: calculator.next_steps } %>
 <% end %>

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_63.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_63.erb
@@ -11,5 +11,5 @@
 <% end %>
 
 <% govspeak_for :next_steps do %>
-  <%= render partial: 'next_step_links', locals: { next_steps: next_steps } %>
+  <%= render partial: 'next_step_links', locals: { next_steps: calculator.next_steps } %>
 <% end %>

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_64.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_64.erb
@@ -13,5 +13,5 @@
 <% end %>
 
 <% govspeak_for :next_steps do %>
-  <%= render partial: 'next_step_links', locals: { next_steps: next_steps } %>
+  <%= render partial: 'next_step_links', locals: { next_steps: calculator.next_steps } %>
 <% end %>

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_65.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_65.erb
@@ -3,5 +3,5 @@
 <% end %>
 
 <% govspeak_for :next_steps do %>
-  <%= render partial: 'next_step_links', locals: { next_steps: next_steps } %>
+  <%= render partial: 'next_step_links', locals: { next_steps: calculator.next_steps } %>
 <% end %>

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_66.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_66.erb
@@ -9,5 +9,5 @@
 <% end %>
 
 <% govspeak_for :next_steps do %>
-  <%= render partial: 'next_step_links', locals: { next_steps: next_steps } %>
+  <%= render partial: 'next_step_links', locals: { next_steps: calculator.next_steps } %>
 <% end %>

--- a/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_67.erb
+++ b/lib/smart_answer_flows/inherits-someone-dies-without-will/outcomes/outcome_67.erb
@@ -7,5 +7,5 @@
 <% end %>
 
 <% govspeak_for :next_steps do %>
-  <%= render partial: 'next_step_links', locals: { next_steps: next_steps } %>
+  <%= render partial: 'next_step_links', locals: { next_steps: [:ownerless_link] } %>
 <% end %>

--- a/test/unit/calculators/inherits_someone_dies_without_will_calculator_test.rb
+++ b/test/unit/calculators/inherits_someone_dies_without_will_calculator_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+
+module SmartAnswer::Calculators
+  class InheritsSomeoneDiesWithoutWillCalculatorTest < ActiveSupport::TestCase
+    def calculator
+      @calculator ||= InheritsSomeoneDiesWithoutWillCalculator.new
+    end
+
+    def methods
+      %i[
+        partner
+        estate_over_250000
+        estate_over_270000
+        children
+        parents
+        siblings
+        siblings_including_mixed_parents
+        grandparents
+        aunts_or_uncles
+        half_siblings
+        half_aunts_or_uncles
+        great_aunts_or_uncles
+        more_than_one_child
+      ]
+    end
+
+    context "boolean method" do
+      should "should return true with 'yes' response" do
+        methods.each do |method|
+          calculator.send "#{method}=", "yes"
+          assert calculator.send("#{method}?"), "calculator.#{method}? should return true"
+        end
+      end
+
+      should "should return false with 'no' response" do
+        methods.each do |method|
+          calculator.send "#{method}=", "no"
+          assert_not calculator.send("#{method}?"), "calculator.#{method}? should return false"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Remove deprecated methods `calculate`, `save_input_as`, and `precalculate`
- Store responses in new calculator `InheritsSomeoneDiesWithoutWillCalculator`
- Determine boolean to response in calculator
- Where `next_step` is fixed for `outcome` - define it in _erb_ file rather than with `precalculate`

[Trello ticket](https://trello.com/c/kkRK9kOP/545-remove-deprecated-flow-methods-from-inherits-someone-dies-without-will)
