### PR TITLE
Clarify that content changes must be manually deployed

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,3 +5,5 @@
 - Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.
 
 - Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.
+
+- Changes to start pages are **not** continuously deployed, and are [deployed using a different process](https://github.com/alphagov/smart-answers/blob/master/doc/smart-answer-flow-development/publishing.md).


### PR DESCRIPTION
The current PR template is misleading and can lead to some changes
not making it to production.
