### PR TITLE
Change tense for deferred VAT information

### DIFF
--- a/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.erb
@@ -7,7 +7,7 @@
   $CTA
   ### Deferring VAT
 
-  If you’re a UK VAT registered business and have a VAT payment due between 20 March 2020 and 30 June 2020, you have the option to defer payment until 31 March 2021.
+  If you’re a UK VAT registered business and had a VAT payment due between 20 March 2020 and 30 June 2020, you have the option to defer payment until 31 March 2021.
 
   [Check if you are eligible to defer your VAT payment](/guidance/deferral-of-vat-payments-due-to-coronavirus-covid-19)
   $CTA


### PR DESCRIPTION
The date for deferred VAT has passed - this puts the content in the past tense.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.

- Changes to start pages are **not** continuously deployed, and are [deployed using a different process](https://github.com/alphagov/smart-answers/blob/master/doc/smart-answer-flow-development/publishing.md).
