### PR TITLE
Replace the phrase 'Previous answers' with 'Your answers' for consistency with Simple Smart Answers

### DIFF
--- a/app/views/smart_answers/_previous_answers.html.erb
+++ b/app/views/smart_answers/_previous_answers.html.erb
@@ -9,7 +9,7 @@
           margin_bottom: 6
         } %>
       <% else %>
-        <h2 class="govuk-heading-m">Previous answers</h2>
+        <h2 class="govuk-heading-m">Your answers</h2>
       <% end %>
 
       <p class="govuk-body">

--- a/doc/smart-answer-flow-development/creating-a-new-smart-answer.md
+++ b/doc/smart-answer-flow-development/creating-a-new-smart-answer.md
@@ -140,7 +140,7 @@ $ touch lib/smart_answer_flows/example-smart-answer/outcomes/outcome_1.erb
 
 Although the question page template needs to exist, it doesn't actually need to contain anything!
 
-Assuming you're still running `rails server`, visit [http://localhost:3000/example-smart-answer][example-smart-answer] and you should see an empty page containing a list of "Previous answers".
+Assuming you're still running `rails server`, visit [http://localhost:3000/example-smart-answer][example-smart-answer] and you should see an empty page containing a list of "Your answers".
 
 Open the new outcome page template in your editor and copy/paste the following content:
 


### PR DESCRIPTION
This is a simple word change to make the heading on previous answers in Smart answers match that in Simple Smart Answers. This was raised as a result of our accessibility audit as a potential fail as navigational elements of a site should be consistently named. This PR updates it in code and also where it is referred to in documentation.

https://trello.com/c/9rpj8wdU/442-inconsistent-naming-of-smart-answer-answers

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.

- Changes to start pages are **not** continuously deployed, and are [deployed using a different process](https://github.com/alphagov/smart-answers/blob/master/doc/smart-answer-flow-development/publishing.md).
