### PR TITLE
Rename `smart_answer` attribute to flow

### DIFF
--- a/app/controllers/session_answers_controller.rb
+++ b/app/controllers/session_answers_controller.rb
@@ -49,7 +49,7 @@ private
   def presenter
     @presenter ||= begin
       params.merge!(responses: session_store.hash, node_name: node_name)
-      FlowPresenter.new(params, smart_answer)
+      FlowPresenter.new(params, flow)
     end
   end
 
@@ -57,8 +57,8 @@ private
     @name ||= params[:id].gsub(/_/, "-").to_sym
   end
 
-  def smart_answer
-    @smart_answer ||= flow_registry.find(name.to_s)
+  def flow
+    @flow ||= SmartAnswer::FlowRegistry.instance.find(name.to_s)
   end
 
   def session_store
@@ -71,10 +71,6 @@ private
 
   def node_name
     @node_name ||= params[:node_slug].underscore if params[:node_slug].present?
-  end
-
-  def flow_registry
-    SmartAnswer::FlowRegistry.instance
   end
 
   def add_new_response_to_session


### PR DESCRIPTION
The attribute `smart_answer` in the session controller is confusingly named as it is a flow object and elsewhere in the codebase we use the attribute name `flow` instead.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.

- Changes to start pages are **not** continuously deployed, and are [deployed using a different process](https://github.com/alphagov/smart-answers/blob/master/doc/smart-answer-flow-development/publishing.md).
