### PR TITLE
Remove deprecated flow methods from maternity paternity calculator (part 1)

### DIFF
--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -12,6 +12,7 @@
 
 shared_formats = {
   govuk_date: "%-d %B %Y", # '4 December 2009'
+  govuk_date_with_day: "%A, %d %B %Y", # 'Friday, 4 December 2009'
 }
 
 Time::DATE_FORMATS.merge! shared_formats

--- a/lib/smart_answer/calculators/adoption_pay_calculator.rb
+++ b/lib/smart_answer/calculators/adoption_pay_calculator.rb
@@ -1,7 +1,7 @@
 module SmartAnswer::Calculators
   class AdoptionPayCalculator < MaternityPayCalculator
-    attr_reader :adoption_placement_date, :match_date, :matched_week
-    attr_accessor :employee_has_contract_adoption
+    attr_reader :match_date, :matched_week
+    attr_accessor :adoption_placement_date, :employee_has_contract_adoption
 
     def initialize(match_date)
       @match_date = match_date
@@ -17,20 +17,26 @@ module SmartAnswer::Calculators
     end
 
     def relevant_week
-      @matched_week
+      matched_week
     end
 
-    def adoption_placement_date=(date)
-      @adoption_placement_date = date
-      @leave_earliest_start_date = 14.days.ago(date)
+    def leave_earliest_start_date(adoption_is_from_overseas = false)
+      return adoption_placement_date if adoption_is_from_overseas
+
+      14.days.ago(adoption_placement_date)
+    end
+
+    def leave_latest_start_date(adoption_is_from_overseas = false)
+      days_after = adoption_is_from_overseas ? 27 : 1
+      days_after.days.from_now(adoption_placement_date)
     end
 
     def adoption_qualifying_start
-      @match_date.sunday? ? @match_date : @match_date.beginning_of_week(:sunday)
+      match_date.sunday? ? match_date : match_date.beginning_of_week(:sunday)
     end
 
     def a_notice_leave
-      @match_date + 7
+      match_date + 7
     end
 
     def no_contract_not_on_payroll?
@@ -49,7 +55,7 @@ module SmartAnswer::Calculators
 
     def rate_for(date)
       awe = truncate((average_weekly_earnings.to_f / 100) * 90)
-      if date < 6.weeks.since(leave_start_date) && @match_date >= Date.parse("5 April 2015")
+      if date < 6.weeks.since(leave_start_date) && match_date >= Date.parse("5 April 2015")
         awe
       else
         [statutory_rate(date), awe].min

--- a/lib/smart_answer/calculators/maternity_pay_calculator.rb
+++ b/lib/smart_answer/calculators/maternity_pay_calculator.rb
@@ -105,11 +105,11 @@ module SmartAnswer::Calculators
     end
 
     def format_date(date)
-      date.strftime("%e %B %Y")
+      date.to_s(:govuk_date) if date
     end
 
     def format_date_day(date)
-      date.strftime("%A, %d %B %Y")
+      date.to_s(:govuk_date_with_day) if date
     end
 
     def payday_offset

--- a/lib/smart_answer_flows/maternity-paternity-calculator.rb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator.rb
@@ -14,24 +14,27 @@ module SmartAnswer
 
       ## Q1
       radio :what_type_of_leave? do
-        save_input_as :leave_type
         option :maternity
         option :paternity
         option :adoption
 
-        calculate :leave_spp_claim_link
-        calculate :notice_of_leave_deadline
-        calculate :monthly_pay_method
-        calculate :smp_calculation_method
-        calculate :sap_calculation_method
-        calculate :above_lower_earning_limit
-        calculate :paternity_adoption
-        calculate :spp_calculation_method
-        calculate :has_contract
-        calculate :paternity_employment_start
+        on_response do |response|
+          self.leave_type = response
 
-        next_node do |response|
-          case response
+          self.leave_spp_claim_link = nil
+          self.notice_of_leave_deadline = nil
+          self.monthly_pay_method = nil
+          self.smp_calculation_method = nil
+          self.sap_calculation_method = nil
+          self.above_lower_earning_limit = nil
+          self.paternity_adoption = nil
+          self.spp_calculation_method = nil
+          self.has_contract = nil
+          self.paternity_employment_start = nil
+        end
+
+        next_node do
+          case leave_type
           when "maternity"
             question :baby_due_date_maternity?
           when "paternity"

--- a/lib/smart_answer_flows/maternity-paternity-calculator/maternity_calculator_flow.rb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/maternity_calculator_flow.rb
@@ -226,7 +226,9 @@ module SmartAnswer
           option :last_working_day_of_the_month
           option :a_certain_week_day_each_month
 
-          save_input_as :monthly_pay_method
+          on_response do |response|
+            self.monthly_pay_method = response
+          end
 
           next_node do |response|
             case response

--- a/lib/smart_answer_flows/maternity-paternity-calculator/paternity_calculator_flow.rb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/paternity_calculator_flow.rb
@@ -422,7 +422,9 @@ module SmartAnswer
           option :last_working_day_of_the_month
           option :a_certain_week_day_each_month
 
-          save_input_as :monthly_pay_method
+          on_response do |response|
+            self.monthly_pay_method = response
+          end
 
           next_node do |response|
             if response == "specific_date_each_month"

--- a/test/unit/smart_answer_flows/adoption_calculator_flow_test.rb
+++ b/test/unit/smart_answer_flows/adoption_calculator_flow_test.rb
@@ -68,9 +68,13 @@ module SmartAnswer
 
     context "when answering date_of_adoption_placement?" do
       setup do
+        match_date = Date.parse("1 October 2017")
+        calculator = Calculators::AdoptionPayCalculator.new(match_date)
         @question = TestNode.new(@flow, :date_of_adoption_placement?)
-          .with_stubbed_calculator
-          .with(match_date: Date.parse("1 October 2017"))
+          .with(
+            match_date: match_date,
+            calculator: calculator,
+          )
       end
 
       context "with an adoption from the UK" do


### PR DESCRIPTION
Refactors two of the four flows that comprise the maternity paternity calculator smart answer

Flows refactored:
`SmartAnswers::MaternityPaternityCalculatorFlow`
`SmartAnswer::MaternityPaternityCalculatorFlow::AdoptionCalculatorFlow`

- Use state to store attributes, and calculator to store logic
- Replace `save_as_input` with storing response on state object
- Replace nil assignment of attributes via calculator with direct assignment to state within `on_response`.
- Use validate blocks instead of raising `SmartAnswer::InvalidResponse`
- Ensure consistent storage of `monthly_pay_method` across flows
- Fix issue where stubbed calculator not behaving correctly
- Add :govuk_date_with_day time format, and use these named format in preference to individual `strftime` calls

[Trello ticket](https://trello.com/c/RpgFrtyo/549-remove-deprecated-flow-methods-from-maternity-paternity-calculator)