### PR TITLE
Remove deprecated methods from benefit-cap-calculator flow

### DIFF
--- a/lib/smart_answer/calculators/benefit_cap_calculator_configuration.rb
+++ b/lib/smart_answer/calculators/benefit_cap_calculator_configuration.rb
@@ -1,5 +1,17 @@
 module SmartAnswer::Calculators
   class BenefitCapCalculatorConfiguration
+    def self.new_housing_benefit_amount(housing_benefit_amount, total_over_cap)
+      housing_benefit_amount.to_f - total_over_cap.to_f
+    end
+
+    def self.new_housing_benefit(amount)
+      amount = sprintf("%.2f", amount)
+      if amount < "0.5"
+        amount = sprintf("%.2f", 0.5)
+      end
+      amount
+    end
+
     def self.weekly_benefit_caps(region = :national)
       data.fetch(:weekly_benefit_caps)[region].with_indifferent_access
     end

--- a/lib/smart_answer/calculators/benefit_cap_calculator_configuration.rb
+++ b/lib/smart_answer/calculators/benefit_cap_calculator_configuration.rb
@@ -1,63 +1,59 @@
 module SmartAnswer::Calculators
   class BenefitCapCalculatorConfiguration
-    attr_accessor :exempted_benefits
-
-    def weekly_benefit_caps(region = :national)
+    def self.weekly_benefit_caps(region = :national)
       data.fetch(:weekly_benefit_caps)[region].with_indifferent_access
     end
 
-    def weekly_benefit_cap_descriptions(region = :national)
+    def self.weekly_benefit_cap_descriptions(region = :national)
       weekly_benefit_caps(region).each_with_object(HashWithIndifferentAccess.new) do |(key, value), weekly_benefit_cap_description|
         weekly_benefit_cap_description[key] = value.fetch(:description)
       end
     end
 
-    def weekly_benefit_cap_amount(family_type, region = :national)
+    def self.weekly_benefit_cap_amount(family_type, region = :national)
       weekly_benefit_caps(region).fetch(family_type)[:amount]
     end
 
-    def benefits
+    def self.benefits
       data.fetch(:benefits).with_indifferent_access
     end
 
-    def exempt_benefits
+    def self.exempt_benefits
       data.fetch(:exempt_benefits)
     end
 
-    def exempted_benefits?
+    def self.exempted_benefits?(exempted_benefits)
       ListValidator.new(exempt_benefits.keys).all_valid?(exempted_benefits)
     end
 
-    def questions
+    def self.questions
       benefits.each_with_object(HashWithIndifferentAccess.new) do |(key, value), benefits_and_questions|
         benefits_and_questions[key] = value.fetch(:question)
       end
     end
 
-    def descriptions
+    def self.descriptions
       benefits.each_with_object(HashWithIndifferentAccess.new) do |(key, value), benefits_and_descriptions|
         benefits_and_descriptions[key] = value.fetch(:description)
       end
     end
 
-    def region(postcode)
+    def self.region(postcode)
       london?(postcode) ? :london : :national
     end
 
-    def london?(postcode)
+    def self.london?(postcode)
       area(postcode).any? do |result|
         result["type"] == "EUR" && result["name"] == "London"
       end
     end
 
-    def area(postcode)
+    def self.area(postcode)
       response = GdsApi.imminence.areas_for_postcode(postcode)&.to_hash
       OpenStruct.new(response).results || []
     end
 
-  private
-
-    def data
+    def self.data
       @data ||= YAML.load_file(Rails.root.join("config/smart_answers/benefit_cap_data.yml")).with_indifferent_access
     end
   end

--- a/lib/smart_answer/calculators/benefit_cap_calculator_configuration.rb
+++ b/lib/smart_answer/calculators/benefit_cap_calculator_configuration.rb
@@ -1,10 +1,31 @@
 module SmartAnswer::Calculators
-  class BenefitCapCalculatorConfiguration
-    def self.new_housing_benefit_amount(housing_benefit_amount, total_over_cap)
+  module BenefitCapCalculatorConfiguration
+    def self.data
+      @data ||= begin
+        filepath = Rails.root.join("config/smart_answers/benefit_cap_data.yml")
+        YAML.load_file(filepath).with_indifferent_access
+      end
+    end
+
+  module_function
+
+    def benefits
+      data.fetch(:benefits).with_indifferent_access
+    end
+
+    def exempt_benefits
+      data.fetch(:exempt_benefits)
+    end
+
+    def weekly_benefit_caps(region = :national)
+      data.fetch(:weekly_benefit_caps)[region].with_indifferent_access
+    end
+
+    def new_housing_benefit_amount(housing_benefit_amount, total_over_cap)
       housing_benefit_amount.to_f - total_over_cap.to_f
     end
 
-    def self.new_housing_benefit(amount)
+    def new_housing_benefit(amount)
       amount = sprintf("%.2f", amount)
       if amount < "0.5"
         amount = sprintf("%.2f", 0.5)
@@ -12,61 +33,45 @@ module SmartAnswer::Calculators
       amount
     end
 
-    def self.weekly_benefit_caps(region = :national)
-      data.fetch(:weekly_benefit_caps)[region].with_indifferent_access
-    end
-
-    def self.weekly_benefit_cap_descriptions(region = :national)
+    def weekly_benefit_cap_descriptions(region = :national)
       weekly_benefit_caps(region).each_with_object(HashWithIndifferentAccess.new) do |(key, value), weekly_benefit_cap_description|
         weekly_benefit_cap_description[key] = value.fetch(:description)
       end
     end
 
-    def self.weekly_benefit_cap_amount(family_type, region = :national)
+    def weekly_benefit_cap_amount(family_type, region = :national)
       weekly_benefit_caps(region).fetch(family_type)[:amount]
     end
 
-    def self.benefits
-      data.fetch(:benefits).with_indifferent_access
-    end
-
-    def self.exempt_benefits
-      data.fetch(:exempt_benefits)
-    end
-
-    def self.exempted_benefits?(exempted_benefits)
+    def exempted_benefits?(exempted_benefits)
       ListValidator.new(exempt_benefits.keys).all_valid?(exempted_benefits)
     end
 
-    def self.questions
+    def questions
       benefits.each_with_object(HashWithIndifferentAccess.new) do |(key, value), benefits_and_questions|
         benefits_and_questions[key] = value.fetch(:question)
       end
     end
 
-    def self.descriptions
+    def descriptions
       benefits.each_with_object(HashWithIndifferentAccess.new) do |(key, value), benefits_and_descriptions|
         benefits_and_descriptions[key] = value.fetch(:description)
       end
     end
 
-    def self.region(postcode)
+    def region(postcode)
       london?(postcode) ? :london : :national
     end
 
-    def self.london?(postcode)
+    def london?(postcode)
       area(postcode).any? do |result|
         result["type"] == "EUR" && result["name"] == "London"
       end
     end
 
-    def self.area(postcode)
+    def area(postcode)
       response = GdsApi.imminence.areas_for_postcode(postcode)&.to_hash
       OpenStruct.new(response).results || []
-    end
-
-    def self.data
-      @data ||= YAML.load_file(Rails.root.join("config/smart_answers/benefit_cap_data.yml")).with_indifferent_access
     end
   end
 end

--- a/lib/smart_answer_flows/benefit-cap-calculator.rb
+++ b/lib/smart_answer_flows/benefit-cap-calculator.rb
@@ -7,7 +7,7 @@ module SmartAnswer
       status :published
       satisfies_need "8474ef2f-6bc2-44be-8883-8a795d728c51"
 
-      config = Calculators::BenefitCapCalculatorConfiguration.new
+      config = Calculators::BenefitCapCalculatorConfiguration
 
       # Q1
       radio :receive_housing_benefit? do
@@ -15,6 +15,7 @@ module SmartAnswer
         option :no
 
         on_response do |response|
+          self.config = config
           self.housing_benefit = response
         end
 
@@ -52,15 +53,14 @@ module SmartAnswer
           option exempt_benefit
         end
 
-        on_response do |response|
-          config.exempted_benefits = response.split(",")
+        on_response do
           self.benefit_options = config.descriptions.merge(none_above: "None of the above")
           self.total_benefits = 0
           self.benefit_cap = 0
         end
 
-        next_node do
-          if config.exempted_benefits?
+        next_node do |response|
+          if config.exempted_benefits?(response.split(","))
             outcome :outcome_not_affected_exemptions
           else
             question :receiving_non_exemption_benefits?

--- a/lib/smart_answer_flows/benefit-cap-calculator.rb
+++ b/lib/smart_answer_flows/benefit-cap-calculator.rb
@@ -115,10 +115,6 @@ module SmartAnswer
 
       # Q6
       radio :single_couple_lone_parent? do
-        precalculate :weekly_benefit_cap_descriptions do
-          config.weekly_benefit_cap_descriptions
-        end
-
         config.weekly_benefit_caps.each_key do |weekly_benefit_cap|
           option weekly_benefit_cap
         end
@@ -165,37 +161,14 @@ module SmartAnswer
       outcome :outcome_not_affected_no_housing_benefit
 
       ## Outcome 8
-      outcome :outcome_affected_greater_than_cap_london do
-        precalculate :new_housing_benefit_amount do
-          housing_benefit_amount.to_f - total_over_cap.to_f
-        end
-
-        precalculate :new_housing_benefit do
-          amount = sprintf("%.2f", new_housing_benefit_amount)
-          if amount < "0.5"
-            amount = sprintf("%.2f", 0.5)
-          end
-          amount
-        end
-      end
+      outcome :outcome_affected_greater_than_cap_london
 
       ## Outcome 10
-      outcome :outcome_affected_greater_than_cap_national do
-        precalculate :new_housing_benefit_amount do
-          housing_benefit_amount.to_f - total_over_cap.to_f
-        end
-
-        precalculate :new_housing_benefit do
-          amount = sprintf("%.2f", new_housing_benefit_amount)
-          if amount < "0.5"
-            amount = sprintf("%.2f", 0.5)
-          end
-          amount
-        end
-      end
+      outcome :outcome_affected_greater_than_cap_national
 
       ## Outcome 9
       outcome :outcome_not_affected_less_than_cap_london
+
       ## Outcome 11
       outcome :outcome_not_affected_less_than_cap_national
     end

--- a/lib/smart_answer_flows/benefit-cap-calculator.rb
+++ b/lib/smart_answer_flows/benefit-cap-calculator.rb
@@ -14,7 +14,9 @@ module SmartAnswer
         option :yes
         option :no
 
-        save_input_as :housing_benefit
+        on_response do |response|
+          self.housing_benefit = response
+        end
 
         next_node do |response|
           if response == "yes"
@@ -112,7 +114,9 @@ module SmartAnswer
 
       # Q5p
       money_question :housing_benefit_amount? do
-        save_input_as :housing_benefit_amount
+        on_response do |response|
+          self.housing_benefit_amount = response
+        end
 
         calculate :total_benefits do |response|
           total_benefits + response.to_f
@@ -137,7 +141,9 @@ module SmartAnswer
           option weekly_benefit_cap
         end
 
-        save_input_as :family_type
+        on_response do |response|
+          self.family_type = response
+        end
 
         next_node do
           question :enter_postcode?

--- a/lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_affected_greater_than_cap_london.erb
+++ b/lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_affected_greater_than_cap_london.erb
@@ -3,6 +3,11 @@
 
 <% end %>
 
+<%
+  new_housing_benefit_amount = config.new_housing_benefit_amount(housing_benefit_amount, total_over_cap)
+  new_housing_benefit = config.new_housing_benefit(new_housing_benefit_amount)
+%>
+
 <% govspeak_for :body do %>
 
   Your weekly benefits | Greater London benefit cap

--- a/lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_affected_greater_than_cap_national.erb
+++ b/lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_affected_greater_than_cap_national.erb
@@ -3,6 +3,11 @@
 
 <% end %>
 
+<%
+  new_housing_benefit_amount = config.new_housing_benefit_amount(housing_benefit_amount, total_over_cap)
+  new_housing_benefit = config.new_housing_benefit(new_housing_benefit_amount)
+%>
+
 <% govspeak_for :body do %>
 
   Your weekly benefits | Outside London benefit cap

--- a/lib/smart_answer_flows/benefit-cap-calculator/questions/single_couple_lone_parent.erb
+++ b/lib/smart_answer_flows/benefit-cap-calculator/questions/single_couple_lone_parent.erb
@@ -2,4 +2,4 @@
   Are you:
 <% end %>
 
-<% options(weekly_benefit_cap_descriptions) %>
+<% options(config.weekly_benefit_cap_descriptions) %>

--- a/test/unit/calculators/benefit_cap_calculator_configuration_test.rb
+++ b/test/unit/calculators/benefit_cap_calculator_configuration_test.rb
@@ -4,7 +4,7 @@ module SmartAnswer::Calculators
   class BenefitCapCalculatorConfigurationTest < ActiveSupport::TestCase
     context BenefitCapCalculatorConfiguration do
       setup do
-        @config = BenefitCapCalculatorConfiguration.new
+        @config = BenefitCapCalculatorConfiguration
       end
 
       context "national weekly_benefit_caps" do
@@ -50,7 +50,7 @@ module SmartAnswer::Calculators
 
       context "Flow configuration" do
         setup do
-          BenefitCapCalculatorConfiguration.any_instance.stubs(:data).returns(
+          BenefitCapCalculatorConfiguration.stubs(:data).returns(
             weekly_benefit_caps: {
               national: {
                 first: {


### PR DESCRIPTION
This removes the save_input_as, precalculate and calculate methods from the flow definition for benefit-cap-calculator. These methods have been deprecated.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.

- Changes to start pages are **not** continuously deployed, and are [deployed using a different process](https://github.com/alphagov/smart-answers/blob/master/doc/smart-answer-flow-development/publishing.md).
