### PR TITLE
Update "Not sure" to "None of these" on find support flow

### DIFF
--- a/lib/smart_answer/calculators/find_coronavirus_support_calculator.rb
+++ b/lib/smart_answer/calculators/find_coronavirus_support_calculator.rb
@@ -77,8 +77,6 @@ module SmartAnswer::Calculators
     def needs_help_with?(given_help_item)
       return false if need_help_with.blank?
 
-      return true if need_help_with == "none"
-
       need_help_with.split(",").include? given_help_item
     end
 

--- a/lib/smart_answer_flows/find-coronavirus-support/questions/need_help_with.erb
+++ b/lib/smart_answer_flows/find-coronavirus-support/questions/need_help_with.erb
@@ -16,9 +16,9 @@
   "going_to_work": "Being worried about working, or off work because you’re self-isolating",
   "somewhere_to_live": "Having somewhere to live",
   "mental_health": "Mental health and wellbeing, including information for children",
-  "none": "Not sure",
+  "none": "None of these",
 ) %>
 
 <% text_for :error_message do %>
-  Select what you need to find help with, or ‘Not sure’
+  Select what you need to find help with, or ‘None of these’
 <% end %>

--- a/test/integration/session_answers_test.rb
+++ b/test/integration/session_answers_test.rb
@@ -15,10 +15,10 @@ class SessionAnswersTest < ActionDispatch::SystemTestCase
     within "legend" do
       assert_page_has_content "What do you need help with because of coronavirus?"
     end
-    check("Not sure", visible: false)
+    check("None of these", visible: false)
     click_on "Continue"
     within "legend" do
-      assert_page_has_content "Do you feel safe where you live?"
+      assert_page_has_content "Where do you want to find information about?"
     end
     click_on "Change"
     within "legend" do
@@ -31,10 +31,10 @@ class SessionAnswersTest < ActionDispatch::SystemTestCase
     within "legend" do
       assert_page_has_content "What do you need help with because of coronavirus?"
     end
-    check("Not sure", visible: false)
+    check("None of these", visible: false)
     click_on "Continue"
     within "legend" do
-      assert_page_has_content "Do you feel safe where you live?"
+      assert_page_has_content "Where do you want to find information about?"
     end
     visit "find-coronavirus-support/s"
     within "legend" do

--- a/test/integration/smart_answer_flows/find_coronavirus_support_test.rb
+++ b/test/integration/smart_answer_flows/find_coronavirus_support_test.rb
@@ -11,60 +11,9 @@ class FindCoronavirusSupportFlowTest < ActiveSupport::TestCase
   end
 
   context "specific outcomes" do
-    should "ask the user to answer questions in all groups if none is selected for the need_help_with question" do
+    should "skip to nation question if none is selected for the need_help_with question" do
       assert_current_node :need_help_with
       add_response "none"
-
-      # ======================================================================
-      # Group: feeling_unsafe
-      # ======================================================================
-      assert_current_node :feel_safe
-      add_response "yes"
-
-      # ======================================================================
-      # Group: paying_bills
-      # ======================================================================
-      assert_current_node :afford_rent_mortgage_bills
-      add_response "no"
-
-      # ======================================================================
-      # Group: getting_food
-      # ======================================================================
-      assert_current_node :afford_food
-      add_response "no"
-      assert_current_node :get_food
-      add_response "yes"
-
-      # ======================================================================
-      # Group: being_unemployed
-      # ======================================================================
-      assert_current_node :self_employed
-      add_response "no"
-      assert_current_node :have_you_been_made_unemployed
-      add_response "no"
-
-      # ======================================================================
-      # Group: going_to_work
-      # ======================================================================
-      assert_current_node :worried_about_work
-      add_response "no"
-      assert_current_node :are_you_off_work_ill
-      add_response "no"
-
-      # ======================================================================
-      # Group: somewhere_to_live
-      # ======================================================================
-      assert_current_node :have_somewhere_to_live
-      add_response "yes"
-      assert_current_node :have_you_been_evicted
-      add_response "no"
-
-      # ======================================================================
-      # Group: mental_health
-      # ======================================================================
-      assert_current_node :mental_health_worries
-      add_response "no"
-
       assert_current_node :nation
       add_response "england"
       assert_current_node :results

--- a/test/unit/calculators/find_coronavirus_support_calculator_test.rb
+++ b/test/unit/calculators/find_coronavirus_support_calculator_test.rb
@@ -467,7 +467,7 @@ module SmartAnswer::Calculators
 
       should "return true if the none item has been chosen" do
         @calculator.need_help_with = "none"
-        assert_equal @calculator.needs_help_with?("one"), true
+        assert_equal @calculator.needs_help_with?("one"), false
       end
     end
 
@@ -497,7 +497,7 @@ module SmartAnswer::Calculators
       context "user is on the need_help_with node" do
         should "return feel_safe when 'none' has been chosen" do
           @calculator.need_help_with = "none"
-          assert_equal @calculator.next_question(:need_help_with), :feel_safe
+          assert_equal @calculator.next_question(:need_help_with), :nation
         end
 
         should "return feel_safe when paying_bills has been chosen" do


### PR DESCRIPTION
This changes the "Not sure" option on the "What do you need help with?" question to "None of these". Users are now taken directly to the "Where do you live?" question and then presented with a no results page.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.

- Changes to start pages are **not** continuously deployed, and are [deployed using a different process](https://github.com/alphagov/smart-answers/blob/master/doc/smart-answer-flow-development/publishing.md).
