### PR TITLE
Add "or" divider above none options in checkbox questions

### DIFF
--- a/app/presenters/checkbox_question_presenter.rb
+++ b/app/presenters/checkbox_question_presenter.rb
@@ -20,8 +20,12 @@ class CheckboxQuestionPresenter < QuestionWithOptionsPresenter
   end
 
   def checkboxes
-    options.map do |option|
-      {
+    options.each_with_object([]) do |option, items|
+      if option[:value] == "none"
+        items << :or
+      end
+
+      items << {
         label: option[:label],
         value: option[:value],
         hint: option[:hint_text],

--- a/test/unit/checkbox_question_presenter_test.rb
+++ b/test/unit/checkbox_question_presenter_test.rb
@@ -32,6 +32,21 @@ module SmartAnswer
       assert_equal([nil, nil, nil], @presenter.checkboxes.map { |c| c[:checked] })
     end
 
+    test "#checkboxes return array including an or divider for none options" do
+      @question.none_option
+      @renderer.stubs(:option).with(:none).returns({ label: "None" })
+
+      expected_value = [
+        { label: "Option 1", value: "option1", hint: nil, checked: nil, exclusive: nil },
+        { label: "Option 2", value: "option2", hint: "Hint 2", checked: nil, exclusive: nil },
+        { label: "Option 3", value: "option3", hint: nil, checked: nil, exclusive: nil },
+        :or,
+        { label: "None", value: "none", hint: nil, checked: nil, exclusive: true },
+      ]
+
+      assert_equal expected_value, @presenter.checkboxes
+    end
+
     test "#caption returns the given caption when a caption is given" do
       @renderer.stubs(:hide_caption).returns(false)
       @renderer.stubs(:content_for).with(:caption).returns("caption-text")


### PR DESCRIPTION
This adds the word "or" to separate the exclusive none option from the rest. This helps give users who use a screen reader more context about the behaviour of selecting the none option. This is because they might not be notified by the screen reader that previous option were automatically deselected when selecting "none".

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.

- Changes to start pages are **not** continuously deployed, and are [deployed using a different process](https://github.com/alphagov/smart-answers/blob/master/doc/smart-answer-flow-development/publishing.md).

![image](https://user-images.githubusercontent.com/11051676/97013702-40d9b880-1541-11eb-90a8-bfee7056a199.png)
