### PR TITLE
[DO NOT MERGE] Add gender options to State Pension calculator

### DIFF
--- a/lib/smart_answer/calculators/state_pension_age_calculator.rb
+++ b/lib/smart_answer/calculators/state_pension_age_calculator.rb
@@ -70,7 +70,7 @@ module SmartAnswer::Calculators
     end
 
     def non_binary?
-      %i[non_binary prefer_not_to_say].include?(gender)
+      %i[prefer_not_to_say].include?(gender)
     end
 
   private

--- a/lib/smart_answer/calculators/state_pension_age_calculator.rb
+++ b/lib/smart_answer/calculators/state_pension_age_calculator.rb
@@ -10,30 +10,23 @@ module SmartAnswer::Calculators
       @gender = answers[:gender] ? answers[:gender].to_sym : nil
     end
 
-    def state_pension_date
-      StatePensionDateQuery.state_pension_date(dob, gender)
+    def state_pension_date(gender_for_calculation = gender)
+      StatePensionDateQuery.state_pension_date(dob, gender_for_calculation)
     end
 
     def can_apply?
       Time.zone.today >= earliest_application_date
     end
 
-    def pension_on_feb_29?
-      state_pension_date.month == 2 && state_pension_date.day == 29
+    def pension_on_feb_29?(gender_for_calculation = gender)
+      pension_date = state_pension_date(gender_for_calculation)
+      pension_date.month == 2 && pension_date.day == 29
     end
 
-    def state_pension_age
-      if birthday_on_feb_29? && !pension_on_feb_29?
-        SmartAnswer::DateRange.new(
-          begins_on: dob,
-          ends_on: state_pension_date - 1.day,
-        ).friendly_time_diff
-      else
-        SmartAnswer::DateRange.new(
-          begins_on: dob,
-          ends_on: state_pension_date,
-        ).friendly_time_diff
-      end
+    def state_pension_age(gender_for_calculation = gender)
+      pension_date = state_pension_date(gender_for_calculation)
+      pension_date -= 1 if birthday_on_feb_29? && !pension_on_feb_29?(gender_for_calculation)
+      SmartAnswer::DateRange.new(begins_on: dob, ends_on: pension_date).friendly_time_diff
     end
 
     def birthday_on_feb_29?
@@ -74,6 +67,10 @@ module SmartAnswer::Calculators
 
     def pension_age_based_on_gender?
       dob < Date.parse("6 December 1953")
+    end
+
+    def non_binary?
+      %i[non_binary prefer_not_to_say].include?(gender)
     end
 
   private

--- a/lib/smart_answer_flows/state-pension-age.rb
+++ b/lib/smart_answer_flows/state-pension-age.rb
@@ -50,7 +50,6 @@ module SmartAnswer
       radio :gender? do
         option :male
         option :female
-        option :non_binary
         option :prefer_not_to_say
 
         next_node do |response|

--- a/lib/smart_answer_flows/state-pension-age.rb
+++ b/lib/smart_answer_flows/state-pension-age.rb
@@ -50,11 +50,15 @@ module SmartAnswer
       radio :gender? do
         option :male
         option :female
+        option :non_binary
+        option :prefer_not_to_say
 
         next_node do |response|
           calculator.gender = response.to_sym
 
-          if calculator.before_state_pension_date?
+          if calculator.non_binary?
+            outcome :has_reached_sp_age_non_binary
+          elsif calculator.before_state_pension_date?
             outcome :not_yet_reached_sp_age
           else
             outcome :has_reached_sp_age
@@ -67,6 +71,8 @@ module SmartAnswer
       outcome :not_yet_reached_sp_age
 
       outcome :has_reached_sp_age
+
+      outcome :has_reached_sp_age_non_binary
     end
   end
 end

--- a/lib/smart_answer_flows/state-pension-age/outcomes/has_reached_sp_age_non_binary.erb
+++ b/lib/smart_answer_flows/state-pension-age/outcomes/has_reached_sp_age_non_binary.erb
@@ -1,0 +1,16 @@
+<% govspeak_for :body do %>
+  Your State Pension age is worked out based on your legal sex. You can find this on your State Pension award letter.
+
+  If your legal sex is ‘female’, you’ll have reached State Pension age on <%= format_date(calculator.state_pension_date(:female)) %>, aged <%= calculator.state_pension_age(:female) %>.
+
+  If your legal sex is ‘male’, you’ll have reached State Pension age on <%= format_date(calculator.state_pension_date(:male)) %>, aged <%= calculator.state_pension_age(:male) %>.
+  
+  You should already have your pension claim pack.
+
+  Contact the Pension Service on 0800 731 7898 if you have not received it.
+
+  ##Pension Credit
+  You might get [Pension Credit](/pension-credit) if you’re retired and on a low income.
+
+  [Check if you’re eligible to claim Pension Credit](/pension-credit/eligibility).
+<% end %>

--- a/lib/smart_answer_flows/state-pension-age/outcomes/has_reached_sp_age_non_binary.erb
+++ b/lib/smart_answer_flows/state-pension-age/outcomes/has_reached_sp_age_non_binary.erb
@@ -1,9 +1,9 @@
 <% govspeak_for :body do %>
   Your State Pension age is worked out based on your legal sex. You can find this on your State Pension award letter.
 
-  If your legal sex is ‘female’, you’ll have reached State Pension age on <%= format_date(calculator.state_pension_date(:female)) %>, aged <%= calculator.state_pension_age(:female) %>.
+  If your legal sex is female, you’ll have reached State Pension age on <%= format_date(calculator.state_pension_date(:female)) %>, aged <%= calculator.state_pension_age(:female) %>.
 
-  If your legal sex is ‘male’, you’ll have reached State Pension age on <%= format_date(calculator.state_pension_date(:male)) %>, aged <%= calculator.state_pension_age(:male) %>.
+  If your legal sex is male, you’ll have reached State Pension age on <%= format_date(calculator.state_pension_date(:male)) %>, aged <%= calculator.state_pension_age(:male) %>.
   
   You should already have your pension claim pack.
 

--- a/lib/smart_answer_flows/state-pension-age/questions/gender.erb
+++ b/lib/smart_answer_flows/state-pension-age/questions/gender.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% text_for :hint do %>
-  Your State Pension age is worked out using your legal sex and age if you were born before 6 December 1953.
+  As you were born before 6 December 1953, your State Pension age is worked out using your legal sex and age.
 <% end %>
 
 <% options(

--- a/lib/smart_answer_flows/state-pension-age/questions/gender.erb
+++ b/lib/smart_answer_flows/state-pension-age/questions/gender.erb
@@ -1,8 +1,14 @@
 <% text_for :title do %>
-  Are you a man or a woman?
+  Are you male or female?
+<% end %>
+
+<% text_for :hint do %>
+  Your State Pension age is worked out using your legal sex and age if you were born before 6 December 1953.
 <% end %>
 
 <% options(
   "male": "Man",
-  "female": "Woman"
+  "female": "Woman",
+  "non_binary": "Non-binary",
+  "prefer_not_to_say": "Prefer not to say"
 ) %>

--- a/lib/smart_answer_flows/state-pension-age/questions/gender.erb
+++ b/lib/smart_answer_flows/state-pension-age/questions/gender.erb
@@ -9,5 +9,6 @@
 <% options(
   "male": "Male",
   "female": "Female",
+  "non_binary": "Non-binary",
   "prefer_not_to_say": "Prefer not to say"
 ) %>

--- a/lib/smart_answer_flows/state-pension-age/questions/gender.erb
+++ b/lib/smart_answer_flows/state-pension-age/questions/gender.erb
@@ -7,8 +7,8 @@
 <% end %>
 
 <% options(
-  "male": "Man",
-  "female": "Woman",
+  "male": "Male",
+  "female": "Female",
   "non_binary": "Non-binary",
   "prefer_not_to_say": "Prefer not to say"
 ) %>

--- a/lib/smart_answer_flows/state-pension-age/questions/gender.erb
+++ b/lib/smart_answer_flows/state-pension-age/questions/gender.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% text_for :hint do %>
-  As you were born before 6 December 1953, your State Pension age is worked out using your legal sex and age.
+  As you were born before 6 December 1953, your State Pension age is worked out using your legal sex and date of birth.
 <% end %>
 
 <% options(

--- a/lib/smart_answer_flows/state-pension-age/questions/gender.erb
+++ b/lib/smart_answer_flows/state-pension-age/questions/gender.erb
@@ -9,6 +9,5 @@
 <% options(
   "male": "Male",
   "female": "Female",
-  "non_binary": "Non-binary",
   "prefer_not_to_say": "Prefer not to say"
 ) %>

--- a/test/integration/smart_answer_flows/state_pension_age_test.rb
+++ b/test/integration/smart_answer_flows/state_pension_age_test.rb
@@ -58,6 +58,30 @@ class StatePensionAgeTest < ActiveSupport::TestCase
         assert_current_node :has_reached_sp_age
       end
     end
+
+    context "when gender is non-binary" do
+      setup do
+        add_response :age
+        add_response Date.parse("5th December 1953")
+        add_response :non_binary
+      end
+
+      should "display the outcome" do
+        assert_current_node :has_reached_sp_age_non_binary
+      end
+    end
+
+    context "when gender is prefer not to say" do
+      setup do
+        add_response :age
+        add_response Date.parse("5th December 1953")
+        add_response :prefer_not_to_say
+      end
+
+      should "display the outcome" do
+        assert_current_node :has_reached_sp_age_non_binary
+      end
+    end
   end
 
   # Calculating State Pension Age

--- a/test/integration/smart_answer_flows/state_pension_age_test.rb
+++ b/test/integration/smart_answer_flows/state_pension_age_test.rb
@@ -59,18 +59,6 @@ class StatePensionAgeTest < ActiveSupport::TestCase
       end
     end
 
-    context "when gender is non-binary" do
-      setup do
-        add_response :age
-        add_response Date.parse("5th December 1953")
-        add_response :non_binary
-      end
-
-      should "display the outcome" do
-        assert_current_node :has_reached_sp_age_non_binary
-      end
-    end
-
     context "when gender is prefer not to say" do
       setup do
         add_response :age


### PR DESCRIPTION
Adds non-binary and prefer not to say as gender options to the State
Pension calculator flow, a new outcome for these two options, updates the
calculator to handle these two new options.

[Trello](https://trello.com/c/rSdYn49f/2177-3-state-pension-calculator-update)

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.

- Changes to start pages are **not** continuously deployed, and are [deployed using a different process](https://github.com/alphagov/smart-answers/blob/master/doc/smart-answer-flow-development/publishing.md).
