### PR TITLE
[DO NOT MERGE] Update the self assessment penalties calculator

### DIFF
--- a/lib/smart_answer/calculators/self_assessment_penalties.rb
+++ b/lib/smart_answer/calculators/self_assessment_penalties.rb
@@ -9,38 +9,36 @@ module SmartAnswer::Calculators
 
     DEADLINES = {
       online_filing_deadline: {
-        "2012-13": ONLINE_FILING_DEADLINE_YEAR.starting_in(2014).begins_on,
         "2013-14": ONLINE_FILING_DEADLINE_YEAR.starting_in(2015).begins_on,
         "2014-15": ONLINE_FILING_DEADLINE_YEAR.starting_in(2016).begins_on,
         "2015-16": ONLINE_FILING_DEADLINE_YEAR.starting_in(2017).begins_on,
         "2016-17": ONLINE_FILING_DEADLINE_YEAR.starting_in(2018).begins_on,
         "2017-18": ONLINE_FILING_DEADLINE_YEAR.starting_in(2019).begins_on,
         "2018-19": ONLINE_FILING_DEADLINE_YEAR.starting_in(2020).begins_on,
+        "2019-20": ONLINE_FILING_DEADLINE_YEAR.starting_in(2021).begins_on,
       },
       offline_filing_deadline: {
-        "2012-13": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2013).begins_on,
         "2013-14": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2014).begins_on,
         "2014-15": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2015).begins_on,
         "2015-16": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2016).begins_on,
         "2016-17": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2017).begins_on,
         "2017-18": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2018).begins_on,
         "2018-19": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2019).begins_on,
+        "2019-20": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2020).begins_on,
       },
       payment_deadline: {
-        "2012-13": PAYMENT_DEADLINE_YEAR.starting_in(2014).begins_on,
         "2013-14": PAYMENT_DEADLINE_YEAR.starting_in(2015).begins_on,
         "2014-15": PAYMENT_DEADLINE_YEAR.starting_in(2016).begins_on,
         "2015-16": PAYMENT_DEADLINE_YEAR.starting_in(2017).begins_on,
         "2016-17": PAYMENT_DEADLINE_YEAR.starting_in(2018).begins_on,
         "2017-18": PAYMENT_DEADLINE_YEAR.starting_in(2019).begins_on,
         "2018-19": PAYMENT_DEADLINE_YEAR.starting_in(2020).begins_on,
+        "2019-20": PAYMENT_DEADLINE_YEAR.starting_in(2021).begins_on,
       },
     }.freeze
 
     def tax_year_range
       case tax_year
-      when "2012-13"
-        SmartAnswer::YearRange.tax_year.starting_in(2012)
       when "2013-14"
         SmartAnswer::YearRange.tax_year.starting_in(2013)
       when "2014-15"
@@ -53,6 +51,8 @@ module SmartAnswer::Calculators
         SmartAnswer::YearRange.tax_year.starting_in(2017)
       when "2018-19"
         SmartAnswer::YearRange.tax_year.starting_in(2018)
+      when "2019-20"
+        SmartAnswer::YearRange.tax_year.starting_in(2019)
       end
     end
 
@@ -62,8 +62,6 @@ module SmartAnswer::Calculators
 
     def one_year_after_start_date_for_penalties
       case tax_year
-      when "2012-13"
-        PENALTY_YEAR.starting_in(2015).begins_on
       when "2013-14"
         PENALTY_YEAR.starting_in(2016).begins_on
       when "2014-15"
@@ -76,6 +74,8 @@ module SmartAnswer::Calculators
         PENALTY_YEAR.starting_in(2020).begins_on
       when "2018-19"
         PENALTY_YEAR.starting_in(2021).begins_on
+      when "2019-20"
+        PENALTY_YEAR.starting_in(2022).begins_on
       end
     end
 

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties.rb
@@ -8,13 +8,13 @@ module SmartAnswer
       satisfies_need "e220b484-a097-4ed4-ae3d-ac982b10c8cd"
 
       radio :which_year? do
-        option :"2012-13"
         option :"2013-14"
         option :"2014-15"
         option :"2015-16"
         option :"2016-17"
         option :"2017-18"
         option :"2018-19"
+        option :"2019-20"
 
         on_response do |response|
           self.calculator = Calculators::SelfAssessmentPenalties.new

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties/questions/which_year.erb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties/questions/which_year.erb
@@ -3,11 +3,11 @@
 <% end %>
 
 <% options(
-  "2012-13": "6 April 2012 to 5 April 2013",
   "2013-14": "6 April 2013 to 5 April 2014",
   "2014-15": "6 April 2014 to 5 April 2015",
   "2015-16": "6 April 2015 to 5 April 2016",
   "2016-17": "6 April 2016 to 5 April 2017",
   "2017-18": "6 April 2017 to 5 April 2018",
   "2018-19": "6 April 2018 to 5 April 2019",
+  "2019-20": "6 April 2019 to 5 April 2020",
 ) %>

--- a/test/integration/smart_answer_flows/estimate_self_assessment_penalties_test.rb
+++ b/test/integration/smart_answer_flows/estimate_self_assessment_penalties_test.rb
@@ -5,17 +5,14 @@ require "smart_answer_flows/estimate-self-assessment-penalties"
 
 TEST_CALCULATOR_DATES = {
   online_filing_deadline: {
-    "2012-13": Date.new(2014, 1, 31),
     "2013-14": Date.new(2015, 1, 31),
     "2014-15": Date.new(2016, 1, 31),
   },
   offline_filing_deadline: {
-    "2012-13": Date.new(2013, 10, 31),
     "2013-14": Date.new(2014, 10, 31),
     "2014-15": Date.new(2015, 10, 31),
   },
   payment_deadline: {
-    "2012-13": Date.new(2014, 1, 31),
     "2013-14": Date.new(2015, 1, 31),
     "2014-15": Date.new(2016, 1, 31),
   },
@@ -31,9 +28,9 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
     assert_current_node :which_year?
   end
 
-  context "2012-13 entered" do
+  context "2013-14 entered" do
     setup do
-      add_response :"2012-13"
+      add_response :"2013-14"
     end
 
     should "ask whether self assessment tax return was submitted online or on paper" do
@@ -50,7 +47,7 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
       # testing error message 1
       context "test error if a date before range inserted" do
         setup do
-          add_response "2013-01-01"
+          add_response "2014-01-01"
         end
         should "raise an error message" do
           assert_current_node_is_error
@@ -59,7 +56,7 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
 
       context "a date before filing deadline" do
         setup do
-          add_response "2013-10-10"
+          add_response "2014-10-10"
         end
         should "ask when bill was paid" do
           assert_current_node :when_paid?
@@ -68,7 +65,7 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
 
         context "test error message for date input before filing date" do
           setup do
-            add_response "2013-10-09"
+            add_response "2014-10-09"
           end
           should "show filed and paid on time outcome" do
             assert_current_node_is_error
@@ -78,7 +75,7 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
         # testing paid on time
         context "paid on time" do
           setup do
-            add_response "2013-10-11"
+            add_response "2014-10-11"
           end
           should "show filed and paid on time outcome" do
             assert_current_node :filed_and_paid_on_time
@@ -87,7 +84,7 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
 
         context "paid late less than 3 months after" do
           setup do
-            add_response "2014-03-03"
+            add_response "2015-03-03"
           end
           should "ask how much your tax bill is" do
             assert_current_node :how_much_tax?
@@ -111,10 +108,10 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
   end
   context "check for over 365 days delay" do
     setup do
-      add_response :"2012-13"
+      add_response :"2013-14"
       add_response :online
-      add_response "2014-02-01"
-      add_response "2014-02-01"
+      add_response "2015-02-01"
+      add_response "2015-02-01"
       add_response "1000.00"
     end
 
@@ -124,9 +121,9 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
   end
 
   # beginning of quick tests
-  context "online return, tax year 2013-14" do
+  context "online return, tax year 2014-15" do
     setup do
-      add_response :"2012-13"
+      add_response :"2013-14"
       add_response :online
     end
     should "ask when bill was paid" do
@@ -136,8 +133,8 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
     # 100pounds fine (band 1)
     context "check 100 pounds fine (band 1)" do
       setup do
-        add_response "2014-02-01"
-        add_response "2014-02-01"
+        add_response "2015-02-01"
+        add_response "2015-02-01"
         add_response "0.00"
       end
       should "show results" do
@@ -149,8 +146,8 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
     # 100pounds fine + 10pounds per day (max 90 days, testing 1 day)(band 2)
     context "check 100pounds fine + 10pounds per day (max 90 days, testing 1 day) (band 2)" do
       setup do
-        add_response "2014-05-01"
-        add_response "2014-05-01"
+        add_response "2015-05-01"
+        add_response "2015-05-01"
         add_response "0.00"
       end
       should "show results" do
@@ -162,8 +159,8 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
     # #100pounds fine + 10pounds per day(max 90 days, testing 91 days)(band 2)
     context "check 100pounds fine + 10pounds per day (max 90 days, testing 92 days)(band 2)" do
       setup do
-        add_response "2014-07-31"
-        add_response "2014-07-31"
+        add_response "2015-07-31"
+        add_response "2015-07-31"
         add_response "0.00"
       end
       should "show results" do
@@ -175,8 +172,8 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
     # #300pounds fine + 1000pounds(previous fine)(band 3), taxdue <= 6002pounds
     context "300pounds fine + 1000pounds(previous fine)(band 3), taxdue < 6002pounds" do
       setup do
-        add_response "2014-08-01"
-        add_response "2014-08-01"
+        add_response "2015-08-01"
+        add_response "2015-08-01"
         add_response "0.00"
       end
       should "show results" do
@@ -188,8 +185,8 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
     # #5% fine + 1000pounds(previous fine)(band 3), taxdue > 6002pounds
     context "5% fine + 1000pounds(previous fine)(band 3), taxdue > 6002pounds" do
       setup do
-        add_response "2014-08-01"
-        add_response "2014-08-01"
+        add_response "2015-08-01"
+        add_response "2015-08-01"
         add_response "10000.00"
       end
       should "show results" do
@@ -204,8 +201,8 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
     # 300pounds fine + 1300pounds(previous fine)(band 4), taxdue <= 6002pounds
     context "300pounds fine + 1300pounds(previous fine)(band 4), taxdue <= 6002pounds" do
       setup do
-        add_response "2015-02-01"
-        add_response "2015-02-01"
+        add_response "2016-02-01"
+        add_response "2016-02-01"
         add_response "0.00"
       end
       should "show results" do
@@ -217,8 +214,8 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
     # #10% fine + 1000pounds(previous fine)(band 4), taxdue > 6002pounds
     context "10% fine + 1000pounds(previous fine)(band 4), taxdue > 6002pounds" do
       setup do
-        add_response "2015-02-01"
-        add_response "2015-02-01"
+        add_response "2016-02-01"
+        add_response "2016-02-01"
         add_response "10000.00"
       end
       should "show results" do

--- a/test/unit/calculators/self_assessment_penalties_test.rb
+++ b/test/unit/calculators/self_assessment_penalties_test.rb
@@ -5,47 +5,45 @@ module SmartAnswer::Calculators
     def setup
       test_calculator_dates = {
         online_filing_deadline: {
-          "2012-13": Date.new(2014, 1, 31),
           "2013-14": Date.new(2015, 1, 31),
           "2014-15": Date.new(2016, 1, 31),
           "2015-16": Date.new(2017, 1, 31),
           "2016-17": Date.new(2018, 1, 31),
           "2017-18": Date.new(2019, 1, 31),
+          "2018-19": Date.new(2020, 1, 31),
+          "2019-20": Date.new(2021, 1, 31),
         },
         offline_filing_deadline: {
-          "2012-13": Date.new(2013, 10, 31),
           "2013-14": Date.new(2014, 10, 31),
           "2014-15": Date.new(2015, 10, 31),
           "2015-16": Date.new(2016, 10, 31),
           "2016-17": Date.new(2017, 10, 31),
           "2017-18": Date.new(2018, 10, 31),
+          "2018-19": Date.new(2019, 10, 31),
+          "2019-20": Date.new(2020, 10, 31),
         },
         payment_deadline: {
-          "2012-13": Date.new(2014, 1, 31),
           "2013-14": Date.new(2015, 1, 31),
           "2014-15": Date.new(2016, 1, 31),
           "2015-16": Date.new(2017, 1, 31),
           "2016-17": Date.new(2018, 1, 31),
           "2017-18": Date.new(2019, 1, 31),
+          "2018-19": Date.new(2020, 1, 31),
+          "2019-20": Date.new(2021, 1, 31),
         },
       }
 
       @calculator = SelfAssessmentPenalties.new(
         submission_method: "online",
-        filing_date: Date.parse("2014-01-10"),
-        payment_date: Date.parse("2014-03-10"),
+        filing_date: Date.parse("2015-01-10"),
+        payment_date: Date.parse("2015-03-10"),
         estimated_bill: SmartAnswer::Money.new(5000),
         dates: test_calculator_dates,
-        tax_year: "2012-13",
+        tax_year: "2013-14",
       )
     end
 
     context "#start_of_next_year" do
-      should "return 2013-04-06 if tax-year is 2012-13" do
-        @calculator.tax_year = "2012-13"
-
-        assert_equal Date.new(2013, 4, 6), @calculator.start_of_next_tax_year
-      end
       should "return 2014-04-06 if tax-year is 2013-14" do
         @calculator.tax_year = "2013-14"
 
@@ -71,14 +69,19 @@ module SmartAnswer::Calculators
 
         assert_equal Date.new(2018, 4, 6), @calculator.start_of_next_tax_year
       end
+      should "return 2019-04-06 if tax-year is 2018-19" do
+        @calculator.tax_year = "2018-19"
+
+        assert_equal Date.new(2019, 4, 6), @calculator.start_of_next_tax_year
+      end
+      should "return 2020-04-06 if tax-year is 2019-20" do
+        @calculator.tax_year = "2019-20"
+
+        assert_equal Date.new(2020, 4, 6), @calculator.start_of_next_tax_year
+      end
     end
 
     context "one_year_after_start_date_for_penalties" do
-      should "return 2015-02-01 if tax-year is 2012-13" do
-        @calculator.tax_year = "2012-13"
-
-        assert_equal Date.new(2015, 2, 1), @calculator.one_year_after_start_date_for_penalties
-      end
       should "return 2016-02-01 if tax-year is 2013-14" do
         @calculator.tax_year = "2013-14"
 
@@ -103,6 +106,16 @@ module SmartAnswer::Calculators
         @calculator.tax_year = "2017-18"
 
         assert_equal Date.new(2020, 2, 1), @calculator.one_year_after_start_date_for_penalties
+      end
+      should "return 2021-02-01 if tax-year is 2018-19" do
+        @calculator.tax_year = "2018-19"
+
+        assert_equal Date.new(2021, 2, 1), @calculator.one_year_after_start_date_for_penalties
+      end
+      should "return 2022-02-01 if tax-year is 2019-20" do
+        @calculator.tax_year = "2019-20"
+
+        assert_equal Date.new(2022, 2, 1), @calculator.one_year_after_start_date_for_penalties
       end
     end
 
@@ -133,8 +146,8 @@ module SmartAnswer::Calculators
     context "online submission" do
       context "filed and paid on time" do
         setup do
-          @calculator.filing_date = Date.parse("2014-01-10")
-          @calculator.payment_date = Date.parse("2014-01-10")
+          @calculator.filing_date = Date.parse("2015-01-10")
+          @calculator.payment_date = Date.parse("2015-01-10")
         end
 
         should "confirm payment was made on time" do
@@ -149,37 +162,37 @@ module SmartAnswer::Calculators
 
         should "calculate late filing penalty" do
           # band one
-          @calculator.filing_date = Date.parse("2014-02-02")
+          @calculator.filing_date = Date.parse("2015-02-02")
           assert_equal 100, @calculator.late_filing_penalty
           # band two
-          @calculator.filing_date = Date.parse("2014-05-01")
+          @calculator.filing_date = Date.parse("2015-05-01")
           assert_equal 110, @calculator.late_filing_penalty
           # band three
-          @calculator.filing_date = Date.parse("2014-05-02")
+          @calculator.filing_date = Date.parse("2015-05-02")
           assert_equal 120, @calculator.late_filing_penalty
-          @calculator.filing_date = Date.parse("2014-06-06")
+          @calculator.filing_date = Date.parse("2015-06-06")
           assert_equal 470, @calculator.late_filing_penalty
-          @calculator.filing_date = Date.parse("2014-07-29")
+          @calculator.filing_date = Date.parse("2015-07-29")
           assert_equal 1000, @calculator.late_filing_penalty
           # band four
-          @calculator.filing_date = Date.parse("2014-09-06")
+          @calculator.filing_date = Date.parse("2015-09-06")
           assert_equal 1300, @calculator.late_filing_penalty
           # band four (1000 + 5% of estimated bill larger than £300)
           @calculator.estimated_bill = SmartAnswer::Money.new(11_000)
           assert_equal 1550, @calculator.late_filing_penalty
           # band five
           @calculator.estimated_bill = SmartAnswer::Money.new(0)
-          @calculator.filing_date = Date.parse("2015-02-02")
+          @calculator.filing_date = Date.parse("2016-02-02")
           assert_equal 1600, @calculator.late_filing_penalty
           # band five (1000 + 5% estimated bill larger than £600)
           @calculator.estimated_bill = SmartAnswer::Money.new(10_000)
           assert_equal 2000, @calculator.late_filing_penalty
           # from 6 to 12 months, tax <=6002
-          @calculator.filing_date = Date.parse("2014-10-31")
+          @calculator.filing_date = Date.parse("2015-10-31")
           @calculator.estimated_bill = SmartAnswer::Money.new(10_000)
           assert_equal 1500, @calculator.late_filing_penalty
           # from 6 to 12 months, tax >6002
-          @calculator.filing_date = Date.parse("2014-10-31")
+          @calculator.filing_date = Date.parse("2015-10-31")
           @calculator.estimated_bill = SmartAnswer::Money.new(10_000)
           assert_equal 1500, @calculator.late_filing_penalty
         end
@@ -187,48 +200,48 @@ module SmartAnswer::Calculators
         context "pay penalty before rate change on 23 Aug 2016" do
           should "calculate interest and late payment penalty" do
             @calculator.estimated_bill = SmartAnswer::Money.new(10_000)
-            @calculator.payment_date = Date.parse("2014-01-01")
+            @calculator.payment_date = Date.parse("2015-01-01")
             assert_equal 0, @calculator.interest
             # 1 day after the deadline
-            @calculator.payment_date = Date.parse("2014-02-01")
+            @calculator.payment_date = Date.parse("2015-02-01")
             assert_equal 0, @calculator.interest
             # 31 days after the deadline
-            @calculator.payment_date = Date.parse("2014-03-03")
+            @calculator.payment_date = Date.parse("2015-03-03")
             assert_equal 26.71, @calculator.interest
             assert_equal 500, @calculator.late_payment_penalty
             # should calculate PenaltyInterest1
-            @calculator.payment_date = Date.parse("2014-04-02")
+            @calculator.payment_date = Date.parse("2015-04-02")
             assert_equal 53.42, @calculator.interest # 50.14 + 0.04 penalty interest
             # one day before late payment penalty 2
-            @calculator.payment_date = Date.parse("2014-08-01")
+            @calculator.payment_date = Date.parse("2015-08-01")
             assert_equal 1000, @calculator.late_payment_penalty
             assert_equal 161.16, @calculator.interest
             # should calculate PenaltyInterest2
-            @calculator.payment_date = Date.parse("2014-09-02")
+            @calculator.payment_date = Date.parse("2015-09-02")
             assert_equal 1000, @calculator.late_payment_penalty
             assert_equal 189.66, @calculator.interest
             # one day before late payment penalty 3
-            @calculator.payment_date = Date.parse("2015-02-01")
+            @calculator.payment_date = Date.parse("2016-02-01")
             assert_equal 1500, @calculator.late_payment_penalty
             assert_equal 325, @calculator.interest
             # should apply late payment penalty 3
-            @calculator.payment_date = Date.parse("2015-02-02")
+            @calculator.payment_date = Date.parse("2016-02-02")
             assert_equal 1500, @calculator.late_payment_penalty
             assert_equal 325.89, @calculator.interest
             # should calculate PenaltyInterest3
-            @calculator.payment_date = Date.parse("2015-03-05")
+            @calculator.payment_date = Date.parse("2016-03-05")
             assert_equal 1500, @calculator.late_payment_penalty
-            assert_equal 353.49, @calculator.interest
+            assert_equal 354.37999999999997, @calculator.interest
           end
 
           should "calculate total owed (excludes filing penalty)" do
-            @calculator.payment_date = Date.parse("2014-02-02")
-            assert_equal 5000, @calculator.total_owed
-            @calculator.payment_date = Date.parse("2014-02-04")
-            assert_equal 5001, @calculator.total_owed
-            @calculator.payment_date = Date.parse("2014-08-01")
-            assert_equal 5580, @calculator.total_owed
             @calculator.payment_date = Date.parse("2015-02-02")
+            assert_equal 5000, @calculator.total_owed
+            @calculator.payment_date = Date.parse("2015-02-04")
+            assert_equal 5001, @calculator.total_owed
+            @calculator.payment_date = Date.parse("2015-08-01")
+            assert_equal 5580, @calculator.total_owed
+            @calculator.payment_date = Date.parse("2016-02-02")
             assert_equal 750, @calculator.late_payment_penalty
             assert_equal 5912, @calculator.total_owed
           end
@@ -281,8 +294,8 @@ module SmartAnswer::Calculators
       end
       context "filed and paid on time" do
         setup do
-          @calculator.filing_date = Date.parse("2012-10-30")
-          @calculator.payment_date = Date.parse("2013-01-30")
+          @calculator.filing_date = Date.parse("2013-10-30")
+          @calculator.payment_date = Date.parse("2014-01-30")
         end
 
         should "confirm payment was made on time" do
@@ -292,8 +305,8 @@ module SmartAnswer::Calculators
 
       context "filed or paid late" do
         setup do
-          @calculator.filing_date = Date.parse("2013-01-10")
-          @calculator.payment_date = Date.parse("2014-02-01")
+          @calculator.filing_date = Date.parse("2014-01-10")
+          @calculator.payment_date = Date.parse("2015-02-01")
         end
         should "confirm payment was made late" do
           assert_not @calculator.paid_on_time?


### PR DESCRIPTION
Update the calculator https://www.gov.uk/estimate-self-assessment-penalties/y to add 6 April 2019 to 5 April 2020 and remove 6 April 2012 to 5 April 2013. 
Schedule change to go live on 00.01 1 November 2020

[Trello](https://trello.com/c/scD8FGZ6/1909-self-assessment-penalties)

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.

- Changes to start pages are **not** continuously deployed, and are [deployed using a different process](https://github.com/alphagov/smart-answers/blob/master/doc/smart-answer-flow-development/publishing.md).
