### PR TITLE
Update link text to "Content files" for index page

### DIFF
--- a/app/helpers/index_helper.rb
+++ b/app/helpers/index_helper.rb
@@ -13,6 +13,6 @@ module IndexHelper
 
   def code_links(flow_name)
     tag.p(link_to("Definition", "https://www.github.com/alphagov/smart-answers/blob/master/lib/smart_answer_flows/#{flow_name}.rb")) +
-      tag.p(link_to("Templates", "https://www.github.com/alphagov/smart-answers/blob/master/lib/smart_answer_flows/#{flow_name}"))
+      tag.p(link_to("Content files", "https://www.github.com/alphagov/smart-answers/blob/master/lib/smart_answer_flows/#{flow_name}"))
   end
 end

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -54,10 +54,10 @@ class SmartAnswersControllerTest < ActionController::TestCase
     should "render links to code" do
       get :index
       assert_select "table td a[href='https://www.github.com/alphagov/smart-answers/blob/master/lib/smart_answer_flows/flow-a.rb']", text: "Definition"
-      assert_select "table td a[href='https://www.github.com/alphagov/smart-answers/blob/master/lib/smart_answer_flows/flow-a']", text: "Templates"
+      assert_select "table td a[href='https://www.github.com/alphagov/smart-answers/blob/master/lib/smart_answer_flows/flow-a']", text: "Content files"
 
       assert_select "table td a[href='https://www.github.com/alphagov/smart-answers/blob/master/lib/smart_answer_flows/flow-b.rb']", text: "Definition"
-      assert_select "table td a[href='https://www.github.com/alphagov/smart-answers/blob/master/lib/smart_answer_flows/flow-b']", text: "Templates"
+      assert_select "table td a[href='https://www.github.com/alphagov/smart-answers/blob/master/lib/smart_answer_flows/flow-b']", text: "Content files"
     end
   end
 


### PR DESCRIPTION
This change the link text for "Templates" to "Content file", to make it clearer what we are linking too. The content ERB files don't template anything, so it doesn't make sense.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.

- Changes to start pages are **not** continuously deployed, and are [deployed using a different process](https://github.com/alphagov/smart-answers/blob/master/doc/smart-answer-flow-development/publishing.md).
