### PR TITLE
Refactor MaternityCalculatorFlow to remove deprecated methods

### DIFF
--- a/lib/smart_answer/calculators/maternity_pay_calculator.rb
+++ b/lib/smart_answer/calculators/maternity_pay_calculator.rb
@@ -325,6 +325,10 @@ module SmartAnswer::Calculators
       average_weekly_earnings < lower_earning_limit
     end
 
+    def payday_offset_formatted
+      format_date_day payday_offset
+    end
+
   private
 
     def valid_payment_option?

--- a/lib/smart_answer_flows/maternity-paternity-calculator/adoption_calculator_flow.rb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/adoption_calculator_flow.rb
@@ -55,7 +55,7 @@ module SmartAnswer
             self.qualifying_week_start = calculator.adoption_qualifying_start
           end
 
-          validate :error_message do |_response|
+          validate :error_message do
             adoption_placement_date >= match_date
           end
 

--- a/lib/smart_answer_flows/maternity-paternity-calculator/outcomes/maternity_leave_and_pay_result.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/outcomes/maternity_leave_and_pay_result.erb
@@ -25,7 +25,7 @@
       ##Statutory Maternity Pay
 
       The employee is not entitled to Statutory Maternity Pay.
-      Their average weekly earnings are <%= format_money(average_weekly_earnings) %> (you can’t round this figure up or down). To qualify:
+      Their average weekly earnings are <%= format_money(calculator.average_weekly_earnings) %> (you can’t round this figure up or down). To qualify:
 
     <% else %>
       ##Statutory Maternity Pay
@@ -36,12 +36,11 @@
     <% case not_entitled_to_pay_reason %>
     <% when :must_earn_over_threshold %>
 
-      + <%= render partial: 'must_earn_over_threshold',
-                 locals: {
-                   average_weekly_earnings: average_weekly_earnings,
+      + <%= render 'must_earn_over_threshold',
+                   average_weekly_earnings: calculator.average_weekly_earnings,
                    relevant_period: relevant_period,
                    lower_earning_limit: lower_earning_limit
-                 } %>
+        %>
     <% when :not_worked_long_enough_and_not_on_payroll %>
 
       + they must have worked continually for you between <%= format_date(employment_start) %> and <%= format_date(qualifying_week_start) %>.
@@ -61,8 +60,8 @@
 
     Pay | Key facts
     -|-
-    Average weekly earnings | £<%= number_with_precision(average_weekly_earnings, precision: 7) %> (don't round this up or down)
-    Latest date to claim SMP | <%= format_date(notice_request_pay) %>
+    Average weekly earnings | £<%= number_with_precision(calculator.average_weekly_earnings, precision: 7) %> (don't round this up or down)
+    Latest date to claim SMP | <%= format_date(calculator.notice_request_pay) %>
     SMP start date due to pregnancy related illness| <%= format_date(ssp_stop) %>
     Proof of pregnancy | Usually within 21 days of the SMP start date (or as soon as possible if baby born early)
 

--- a/lib/smart_answer_flows/maternity-paternity-calculator/questions/date_leave_starts.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/questions/date_leave_starts.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% text_for :hint do %>
-  Based on the baby's due date, leave usually can’t start before <%= format_date(leave_earliest_start_date) %>.
+  Based on the baby's due date, leave usually can’t start before <%= format_date(calculator.leave_earliest_start_date) %>.
 <% end %>
 
 <% text_for :error_message do %>

--- a/lib/smart_answer_flows/maternity-paternity-calculator/questions/payday_eight_weeks.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/questions/payday_eight_weeks.erb
@@ -1,5 +1,5 @@
 <% text_for :title do %>
-  What was the last normal payday before <%= payday_offset_formatted %>?
+  What was the last normal payday before <%= calculator.payday_offset_formatted %>?
 <% end %>
 
 <% text_for :hint do %>
@@ -7,5 +7,5 @@
 <% end %>
 
 <% text_for :error_message do %>
-  You must enter a date before <%= payday_offset_formatted %>
+  You must enter a date before <%= calculator.payday_offset_formatted %>
 <% end %>


### PR DESCRIPTION
- Replace `calculate` and `save_input_as` with direct assignment to state within `on_response` block
- Use validate blocks rather than raising `SmartAnswer::InvalidResponse` directly
- Replace `precalculate` blocks with assignment to state within `on_response` block except within `outcome` blocks
- Remove unused response assignment in adoption calculator
- Use `calculator` method in place of `precalculate` assigned variable in erb files (however, tests fail if respective precalculate blocks removed, so these have been left in place)

[trello ticket](https://trello.com/c/RpgFrtyo/549-remove-deprecated-flow-methods-from-maternity-paternity-calculator)
