### PR TITLE
Remove Retail, Hospitality and Leisure Grant and Small Business Grant funds

### DIFF
--- a/lib/smart_answer/calculators/business_coronavirus_support_finder_calculator.rb
+++ b/lib/smart_answer/calculators/business_coronavirus_support_finder_calculator.rb
@@ -31,12 +31,6 @@ module SmartAnswer::Calculators
           calculator.non_domestic_property != "none" &&
           calculator.sectors.include?("nurseries")
       },
-      small_business_grant_funding: lambda { |calculator|
-        calculator.business_based == "england" &&
-          calculator.business_size == "0_to_249" &&
-          calculator.non_domestic_property != "none" &&
-          calculator.rate_relief_march_2020 == "yes"
-      },
       discretionary_grant: lambda { |calculator|
         calculator.business_based == "england" &&
           calculator.business_size == "0_to_249" &&

--- a/lib/smart_answer/calculators/business_coronavirus_support_finder_calculator.rb
+++ b/lib/smart_answer/calculators/business_coronavirus_support_finder_calculator.rb
@@ -26,11 +26,6 @@ module SmartAnswer::Calculators
           calculator.non_domestic_property != "none" &&
           calculator.sectors.include?("retail_hospitality_or_leisure")
       },
-      retail_hospitality_leisure_grant_funding: lambda { |calculator|
-        calculator.business_based == "england" &&
-          calculator.non_domestic_property == "under_51k" &&
-          calculator.sectors.include?("retail_hospitality_or_leisure")
-      },
       nursery_support: lambda { |calculator|
         calculator.business_based == "england" &&
           calculator.non_domestic_property != "none" &&

--- a/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.erb
@@ -33,7 +33,7 @@
     $CTA
     ### Self-Employment Income Support Scheme
 
-    This scheme is now closed for the first grants. 
+    This scheme is now closed for the first grants.
 
     Applications for the second and final grant are now open. If you’re eligible and your business has been adversely affected on or after 14 July 2020, you must make your claim for the second grant on or before 19 October 2020.
     The scheme allows you to claim a second and final taxable grant worth 70% of your average monthly trading profits, paid out in a single instalment covering 3 months’ worth of profits, and capped at £6,570 in total.
@@ -75,28 +75,6 @@
     $CTA
   <% end %>
 
-  <% if calculator.show?(:retail_hospitality_leisure_grant_funding) %>
-    $CTA
-    ### Retail, Hospitality and Leisure Grant Fund
-
-    You may be eligible for a grant of up to £25,000 per property.
-
-    If your business has a property with a rateable value of £15,000 or under, you may be eligible for a grant of £10,000.
-
-    If your business has a property that has a rateable value of over £15,000 but less than £51,000, you may be eligible for a grant of £25,000.
-
-    You are eligible if your business:
-
-    - is based in England
-    - is in the retail, hospitality or leisure sector
-    - has a property that is wholly or mainly used as hospitality, retail, or leisure venue
-
-    Contact your local council if you think you are eligible for a grant but have not yet received it.
-
-    [Coronavirus guidance on business support grant funding](/government/publications/coronavirus-covid-19-business-support-grant-funding-guidance-for-businesses)
-    $CTA
-  <% end %>
-
   <% if calculator.show?(:nursery_support) %>
     $CTA
     ### Support for nursery businesses that pay business rates
@@ -108,28 +86,6 @@
     Local authority-run nurseries are not eligible.
 
     [Check if your nursery is eligible for business rates relief due to coronavirus (COVID‑19)](/guidance/check-if-your-nursery-is-eligible-for-business-rates-relief-due-to-coronavirus-covid-19)
-    $CTA
-  <% end %>
-
-  <% if calculator.show?(:small_business_grant_funding) %>
-    $CTA
-    ### Small Business Grant Funding
-
-    You may be eligible for a one-off grant of £10,000 if you are a small business that already pays little or no business rates because of:
-
-    - small business relief (SBBR)
-    - rural rate relief (RRR)
-    - tapered relief
-
-    You are eligible if:
-
-    - your business is based in England
-    - in receipt of small business rate relief or rural rate relief as of 11 March 2020
-    - you are a business that occupies a property
-
-    Contact your local council if you think you are eligible for a grant but have not yet received it.
-
-    [Coronavirus: business support grant funding guidance for businesses](/government/publications/coronavirus-covid-19-business-support-grant-funding-guidance-for-businesses)
     $CTA
   <% end %>
 

--- a/test/unit/calculators/business_coronavirus_support_calculator_test.rb
+++ b/test/unit/calculators/business_coronavirus_support_calculator_test.rb
@@ -88,33 +88,6 @@ module SmartAnswer::Calculators
         end
       end
 
-      context "retail_hospitality_leisure_grant_funding" do
-        setup do
-          @calculator.business_based = "england"
-          @calculator.non_domestic_property = "under_51k"
-          @calculator.sectors = %w[retail_hospitality_or_leisure]
-        end
-
-        should "return true when criteria met" do
-          assert @calculator.show?(:retail_hospitality_leisure_grant_funding)
-        end
-
-        should "return false when in a devolved administration" do
-          @calculator.business_based = "scotland"
-          assert_not @calculator.show?(:retail_hospitality_leisure_grant_funding)
-        end
-
-        should "return false when non-domestic property is valued over £51k" do
-          @calculator.non_domestic_property = "51k_and_over"
-          assert_not @calculator.show?(:retail_hospitality_leisure_grant_funding)
-        end
-
-        should "return false when not in supported business sector" do
-          @calculator.sectors = %w[nurseries]
-          assert_not @calculator.show?(:retail_hospitality_leisure_grant_funding)
-        end
-      end
-
       context "nursery_support" do
         setup do
           @calculator.business_based = "england"

--- a/test/unit/calculators/business_coronavirus_support_calculator_test.rb
+++ b/test/unit/calculators/business_coronavirus_support_calculator_test.rb
@@ -115,39 +115,6 @@ module SmartAnswer::Calculators
         end
       end
 
-      context "small_business_grant_funding" do
-        setup do
-          @calculator.business_based = "england"
-          @calculator.business_size = "0_to_249"
-          @calculator.non_domestic_property = "under_51k"
-          @calculator.rate_relief_march_2020 = "yes"
-        end
-
-        should "return true when criteria met" do
-          assert @calculator.show?(:small_business_grant_funding)
-        end
-
-        should "return false when based in devolved administration" do
-          @calculator.business_based = "scotland"
-          assert_not @calculator.show?(:small_business_grant_funding)
-        end
-
-        should "return false when business has over 249 employees" do
-          @calculator.business_size = "over_249"
-          assert_not @calculator.show?(:small_business_grant_funding)
-        end
-
-        should "return false when no non-domestic property" do
-          @calculator.non_domestic_property = "none"
-          assert_not @calculator.show?(:small_business_grant_funding)
-        end
-
-        should "return false when business is not in receipt of rate relief" do
-          @calculator.rate_relief_march_2020 = "no"
-          assert_not @calculator.show?(:small_business_grant_funding)
-        end
-      end
-
       context "discretionary_grant" do
         setup do
           @calculator.business_based = "england"


### PR DESCRIPTION
These schemes are no longer active. We need to remove them so the smart answer is accurate and users aren't confused.