### PR TITLE
Add rake task to send broken link report to Zendesk

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "govuk_app_config"
 
 gem "ast"
 gem "gds-api-adapters"
+gem "gds_zendesk"
 gem "govspeak"
 gem "govuk-content-schema-test-helpers"
 gem "govuk_publishing_components"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,9 @@ GEM
       null_logger
       plek (>= 1.9.0)
       rest-client (~> 2.0)
+    gds_zendesk (3.2.0)
+      null_logger (~> 0)
+      zendesk_api (~> 1.27)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     govspeak (6.5.6)
@@ -134,12 +137,14 @@ GEM
       selenium-webdriver (>= 3.142)
       webdrivers (>= 4)
     hashdiff (1.0.1)
+    hashie (4.1.0)
     htmlentities (4.3.4)
     http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
+    inflection (1.0.0)
     jasmine (3.6.0)
       jasmine-core (~> 3.6.0)
       phantomjs
@@ -360,6 +365,12 @@ GEM
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.4.0)
+    zendesk_api (1.28.0)
+      faraday (>= 0.9.0, < 2.0.0)
+      hashie (>= 3.5.2, < 5.0.0)
+      inflection
+      mime-types
+      multipart-post (~> 2.0)
 
 PLATFORMS
   ruby
@@ -371,6 +382,7 @@ DEPENDENCIES
   byebug
   ci_reporter
   gds-api-adapters
+  gds_zendesk
   govspeak
   govuk-content-schema-test-helpers
   govuk_app_config

--- a/config/initializers/gds_zendesk.rb
+++ b/config/initializers/gds_zendesk.rb
@@ -1,0 +1,4 @@
+ZENDESK_CREDENTIALS = {
+  "username" => ENV["ZENDESK_CLIENT_USERNAME"] || "username",
+  "password" => ENV["ZENDESK_CLIENT_PASSWORD"] || "password",
+}.freeze

--- a/lib/link_checker.rb
+++ b/lib/link_checker.rb
@@ -37,12 +37,12 @@ private
 
   def generate_report
     link_report = link_checker_api.create_batch(urls, checked_within: 5)
-    wait_time = 0.5
+    wait_time = 1
 
     while link_report.status == :in_progress
       sleep(wait_time)
       link_report = link_checker_api.get_batch(link_report.id)
-      wait_time *= 2
+      wait_time *= 1.5
     end
     link_report
   end

--- a/lib/support_ticket.rb
+++ b/lib/support_ticket.rb
@@ -1,0 +1,46 @@
+require "gds_zendesk/client"
+require "gds_zendesk/dummy_client"
+class SupportTicket
+  REQUESTER = {
+    name: "Smart Answers application",
+  }.freeze
+
+  TAGS = ["broken links"].freeze
+
+  PRIORITY = "normal".freeze
+
+  def self.client
+    @client ||= if Rails.env.development?
+                  GDSZendesk::DummyClient.new(logger: Rails.logger)
+                else
+                  credentials = ZENDESK_CREDENTIALS.merge(logger: Rails.logger)
+                  GDSZendesk::Client.new credentials
+                end
+  end
+
+  def self.send(*args)
+    new(*args).send
+  end
+
+  attr_reader :subject, :body, :requester_email
+
+  def initialize(subject:, body:, requester_email:)
+    @subject = subject
+    @body = body
+    @requester_email = requester_email
+  end
+
+  def payload
+    {
+      subject: subject,
+      priority: PRIORITY,
+      requester: REQUESTER.merge(email: requester_email),
+      tags: TAGS,
+      comment: { body: body },
+    }
+  end
+
+  def send
+    self.class.client.ticket.create!(payload)
+  end
+end

--- a/lib/tasks/links.rake
+++ b/lib/tasks/links.rake
@@ -1,114 +1,20 @@
-require "uri"
-require "net/http"
-
-def check_links(links_to_check, broken, file)
-  links_to_check.uniq.each do |link|
-    uri = URI.parse(link)
-    http = Net::HTTP.new(uri.host, uri.port)
-
-    if link.include?("https")
-      http.use_ssl = true
-      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-    end
-
-    response = http.get(uri.request_uri)
-
-    puts "Checking link: #{link}"
-    unless response.class == Net::HTTPOK
-      new_hash = { link: link, resp: response.code, file: file }
-      if response.code[0] == "3"
-        new_hash[:redirect] = response.header["location"]
-      end
-      broken.push(new_hash)
-    end
-  rescue StandardError => e
-    # this is here as sometimes we find wrong links through the Regexes
-    # dont need to do anything, just capture it to avoid the script breaking
-    p e
-  end
-  broken
-end
-
-def prefix_link(link)
-  unless link.include?("http")
-    link = "https://www.gov.uk#{link}"
-  end
-  link
-end
-
-def check_locales_file(contents)
-  links_to_check = []
-  contents.gsub(/\[(.+)\]\((.+)\)/) do
-    link = prefix_link(Regexp.last_match(2).gsub(/ "(.+)"$/, ""))
-    links_to_check << link
-  end
-  links_to_check
-end
-
-def check_data_file(contents)
-  links_to_check = []
-  contents.gsub(/: (\/.+)$/) do
-    link = prefix_link(Regexp.last_match(1))
-    links_to_check << link
-  end
-  links_to_check
-end
+SMART_ANSWER_FLOW_PATH = Rails.root.join "lib/smart_answer_flows"
 
 namespace :links do
   desc "Checks all URLs within Smart Answers for errors."
-  task %i[check file] => :environment do |_, args|
-    broken = []
-    pwd = Dir.pwd
+  task report: :environment do
+    puts BrokenLinkReport.for_erb_files_at(SMART_ANSWER_FLOW_PATH)
+  end
 
-    # check a single file the user has passed in
-    if args.file
-      file = args.file
-      puts "Checking #{file}"
-      links_to_check = check_locales_file(IO.read(file))
-      broken = check_links(links_to_check, broken, file)
-    else
-      base_path = File.expand_path("#{pwd}/lib")
-      Dir.glob("#{base_path}/smart_answer_flows/locales/**/*.yml") do |filename|
-        puts "Checking #{filename}"
-        links_to_check = check_locales_file(IO.read(filename))
-        broken = check_links(links_to_check, broken, filename)
-      end
+  # Usage: `rake links:send_report[someone@example.com]
+  desc "Checks all URLs within Smart Answers for errors, and send report to Zendesk."
+  task :send_report, [:requester_email] => :environment do |_t, args|
+    Rails.logger.info "Sending broken link report"
 
-      Dir.glob("#{base_path}/data/*.yml") do |filename|
-        puts "Checking #{filename}"
-        links_to_check = check_data_file(IO.read(filename))
-        broken = check_links(links_to_check, broken, filename)
-      end
-    end
-
-    File.open("log/broken_links.log", "w") { |f| f.puts broken }
-
-    fives = broken.select { |item| item[:resp][0] == "5" }
-    four_oh_fours = broken.select { |item| item[:resp][0] == "4" }
-    three_oh_threes = broken.select { |item| item[:resp][0] == "3" }
-
-    File.open("log/300_links.log", "w") { |f| f.puts three_oh_threes }
-
-    File.open("log/404_links.log", "w") { |f| f.puts four_oh_fours }
-
-    File.open("log/500_links.log", "w") { |f| f.puts fives }
-
-    if !three_oh_threes.empty?
-      puts "Warning: Found links that give a 3XX response. Look in log/300_links.log"
-    else
-      puts "No 3XX links found"
-    end
-
-    if !four_oh_fours.empty?
-      puts "Warning: Found 404s. Look in log/404_links.log"
-    else
-      puts "No 404s found"
-    end
-
-    if !fives.empty?
-      puts "Warning: Found links that give a 5XX response. Look in log/500_links.log"
-    else
-      puts "No 5XX links found"
-    end
+    SupportTicket.send(
+      subject: "Smart Answers Broken Link Report: #{Time.zone.today.to_s(:govuk_date)}",
+      body: BrokenLinkReport.for_erb_files_at(SMART_ANSWER_FLOW_PATH),
+      requester_email: args.requester_email,
+    )
   end
 end

--- a/test/unit/support_ticket_test.rb
+++ b/test/unit/support_ticket_test.rb
@@ -1,0 +1,54 @@
+require "test_helper"
+require "gds_zendesk/test_helpers"
+
+class SupportTicketTest < ActiveSupport::TestCase
+  include GDSZendesk::TestHelpers
+
+  def subject
+    @subject ||= "Ticket Subject"
+  end
+
+  def body
+    @body ||= "This is some ticket content"
+  end
+
+  def email
+    @email ||= "someone@example.com"
+  end
+
+  def support_ticket
+    @support_ticket ||= SupportTicket.new(subject: subject, body: body, requester_email: email)
+  end
+
+  context ".send" do
+    should "sends input via instance" do
+      self.valid_zendesk_credentials = ZENDESK_CREDENTIALS
+      stub_zendesk_ticket_creation(support_ticket.payload)
+
+      assert SupportTicket.send subject: subject, body: body, requester_email: email
+    end
+  end
+
+  context "#send" do
+    should "sends payload to gov uk zendesk" do
+      self.valid_zendesk_credentials = ZENDESK_CREDENTIALS
+      stub_zendesk_ticket_creation(support_ticket.payload)
+
+      assert support_ticket.send
+    end
+  end
+
+  context "#payload" do
+    should "include body" do
+      assert_equal body, support_ticket.payload.dig(:comment, :body)
+    end
+
+    should "include subject" do
+      assert_equal subject, support_ticket.payload[:subject]
+    end
+
+    should "include requester email" do
+      assert_equal email, support_ticket.payload.dig(:requester, :email)
+    end
+  end
+end


### PR DESCRIPTION
- A SupportTicket to send content to Zendesk
- Install gds_zendesk gem to simplify connection to Zendesk API
- Replace existing broken links task with one that utilises BrokenLinkReport
- Add task links:send_report to generate report and send it to Zendesk
- Tweak rate LinkChecker wait increases with each retry so more attempts
  occur initially.

[Trello ](https://trello.com/c/Z4KXC51b/572-send-link-checker-report-to-zendesk)