### PR TITLE
When loading `outcome maternity_leave_and_pay_result.erb` in the mate…

### DIFF
--- a/lib/smart_answer_flows/maternity-paternity-calculator/outcomes/maternity_leave_and_pay_result.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/outcomes/maternity_leave_and_pay_result.erb
@@ -9,7 +9,7 @@
     |Start                         | <%= format_date(leave_start_date) %>          |
     |End                           | <%= format_date(leave_end_date) %>            |
     |Latest date to [claim leave](/maternity-leave-pay-employees/notice-period "Notice period")    | <%= format_date(notice_of_leave_deadline) %>  |
-    |Earliest date leave can start | <%= format_date(leave_earliest_start_date) %> |
+    |Earliest date leave can start | <%= format_date(calculator.leave_earliest_start_date) %> |
 
   <% else %>
     ##Statutory Maternity Leave


### PR DESCRIPTION
When loading `outcome maternity_leave_and_pay_result.erb` in the maternity-paternity-calculator flow 
the error `ActionView::Template::Error - undefined local variable or method `leave_earliest_start_date'`
was occurring. This change fixes that error

