### PR TITLE
Refactors paternity calculator flow.

### DIFF
--- a/lib/smart_answer/calculators/maternity_pay_calculator.rb
+++ b/lib/smart_answer/calculators/maternity_pay_calculator.rb
@@ -329,6 +329,27 @@ module SmartAnswer::Calculators
       format_date_day payday_offset
     end
 
+    def above_lower_earning_limit
+      average_weekly_earnings > lower_earning_limit
+    end
+
+    def pay_dates_and_pay
+      if above_lower_earning_limit
+        lines = paydates_and_pay.map do |date_and_pay|
+          %(#{date_and_pay[:date].strftime('%e %B %Y')}|£#{sprintf('%.2f', date_and_pay[:pay])})
+        end
+        lines.join("\n")
+      end
+    end
+
+    def total_sap
+      total_statutory_pay if above_lower_earning_limit
+    end
+
+    def total_ssp
+      total_statutory_pay if above_lower_earning_limit
+    end
+
   private
 
     def valid_payment_option?

--- a/lib/smart_answer_flows/maternity-paternity-calculator.rb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator.rb
@@ -26,7 +26,6 @@ module SmartAnswer
           self.monthly_pay_method = nil
           self.smp_calculation_method = nil
           self.sap_calculation_method = nil
-          self.above_lower_earning_limit = nil
           self.paternity_adoption = nil
           self.spp_calculation_method = nil
           self.has_contract = nil

--- a/lib/smart_answer_flows/maternity-paternity-calculator/adoption_calculator_flow.rb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/adoption_calculator_flow.rb
@@ -252,14 +252,10 @@ module SmartAnswer
         end
 
         outcome :adoption_leave_and_pay do
-          precalculate :above_lower_earning_limit do
-            calculator.average_weekly_earnings > calculator.lower_earning_limit
-          end
-
           precalculate :pay_method do
             calculator.pay_method = (
               if monthly_pay_method
-                if monthly_pay_method == "specific_date_each_month" && pay_day_in_month > 28
+                if monthly_pay_method == "specific_date_each_month" && calculator.pay_day_in_month > 28
                   "last_day_of_the_month"
                 else
                   monthly_pay_method
@@ -271,27 +267,7 @@ module SmartAnswer
               end
             )
           end
-
-          precalculate :pay_dates_and_pay do
-            if above_lower_earning_limit
-              lines = calculator.paydates_and_pay.map do |date_and_pay|
-                %(#{date_and_pay[:date].strftime('%e %B %Y')}|£#{sprintf('%.2f', date_and_pay[:pay])})
-              end
-              lines.join("\n")
-            end
-          end
-
-          precalculate :total_sap do
-            if above_lower_earning_limit
-              sprintf("%.2f", calculator.total_statutory_pay)
-            end
-          end
-
-          precalculate :average_weekly_earnings do
-            sprintf("%.2f", calculator.average_weekly_earnings)
-          end
         end
-
         outcome :adoption_not_entitled_to_leave_or_pay
       end
     end

--- a/lib/smart_answer_flows/maternity-paternity-calculator/outcomes/adoption_leave_and_pay.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/outcomes/adoption_leave_and_pay.erb
@@ -29,7 +29,7 @@
 
       + <%= render partial: 'must_earn_over_threshold',
                  locals: {
-                   average_weekly_earnings: average_weekly_earnings,
+                   average_weekly_earnings: calculator.average_weekly_earnings,
                    relevant_period: relevant_period,
                    lower_earning_limit: lower_earning_limit
                  } %>
@@ -44,12 +44,12 @@
 
     The employee is entitled to up to 39 weeks Statutory Adoption Pay (SAP) if they [claim SAP in time](/employers-adoption-pay-leave/notice-period) and give you [proof of the adoption](/employers-adoption-pay-leave/proof-of-adoption).
 
-    The employee’s average weekly earnings are: <%= format_money(average_weekly_earnings) %>.
+    The employee’s average weekly earnings are: <%= format_money(calculator.average_weekly_earnings) %>.
 
     Date | SAP amount
     -|-
-    <%= pay_dates_and_pay %>
-     | **Total SAP: <%= format_money(total_sap) %>**
+    <%= calculator.pay_dates_and_pay %>
+     | **Total SAP: <%= format_money(calculator.total_sap) %>**
 
     %This calculator doesn’t check eligibility for [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide).%
   <% end %>

--- a/lib/smart_answer_flows/maternity-paternity-calculator/outcomes/maternity_leave_and_pay_result.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/outcomes/maternity_leave_and_pay_result.erb
@@ -72,7 +72,7 @@
 
     Date | SMP amount
     -|-
-    <%= pay_dates_and_pay %>
+    <%= calculator.pay_dates_and_pay %>
      | **Total SMP: <%= format_money(total_smp) %>**
 
   <% end %>

--- a/lib/smart_answer_flows/maternity-paternity-calculator/outcomes/paternity_leave_and_pay.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/outcomes/paternity_leave_and_pay.erb
@@ -12,14 +12,14 @@
                } %>
   <% end %>
 
-  <% unless above_lower_earning_limit %>
+  <% unless calculator.above_lower_earning_limit %>
     <%= render partial: 'paternity_not_entitled_to_pay_intro' %>
 
     + <%= render partial: 'must_earn_over_threshold',
                locals: {
-                 average_weekly_earnings: average_weekly_earnings,
+                 average_weekly_earnings: calculator.average_weekly_earnings,
                  relevant_period: relevant_period,
-                 lower_earning_limit: lower_earning_limit
+                 lower_earning_limit: calculator.lower_earning_limit
                } %>
 
     <%= render partial: 'paternity_not_entitled_to_pay_outro' %>
@@ -29,28 +29,28 @@
 
       The employee is entitled to SAP.
 
-      Their average weekly earnings are: <%= format_money(average_weekly_earnings) %>
+      Their average weekly earnings are: <%= format_money(calculator.average_weekly_earnings) %>
 
       ## SAP calculation
 
       Date | SAP amount
       -|-
-      <%= pay_dates_and_pay %>
-       | **Total SAP: <%= format_money(total_spp) %>**
+      <%= calculator.pay_dates_and_pay %>
+       | **Total SAP: <%= format_money(calculator.total_sap) %>**
 
     <% else %>
       ##Statutory Paternity Pay (SPP)
 
       The employee is entitled to SPP.
 
-      Their average weekly earnings are: <%= format_money(average_weekly_earnings) %>
+      Their average weekly earnings are: <%= format_money(calculator.average_weekly_earnings) %>
 
       ## SPP calculation
 
       Date | SPP amount
       -|-
-      <%= pay_dates_and_pay %>
-       | **Total SPP: <%= format_money(total_spp) %>**
+      <%= calculator.pay_dates_and_pay %>
+       | **Total SPP: <%= format_money(calculator.total_spp) %>**
 
     <% end %>
 

--- a/lib/smart_answer_flows/maternity-paternity-calculator/questions/payday_eight_weeks_paternity.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/questions/payday_eight_weeks_paternity.erb
@@ -1,5 +1,5 @@
 <% text_for :title do %>
-  What was the last normal payday before <%= payday_offset_formatted %>
+  What was the last normal payday before <%= calculator.format_date_day(calculator.payday_offset) %>
 <% end %>
 
 <% text_for :hint do %>
@@ -7,5 +7,5 @@
 <% end %>
 
 <% text_for :error_message do %>
-  You must enter a date on or before <%= payday_offset_formatted %>
+  You must enter a date on or before <%= calculator.format_date_day(calculator.payday_offset) %>
 <% end %>

--- a/test/integration/smart_answer_flows/adoption_calculator_test.rb
+++ b/test/integration/smart_answer_flows/adoption_calculator_test.rb
@@ -129,7 +129,7 @@ class AdoptionCalculatorTest < ActiveSupport::TestCase
                                 # QA12
                                 should "go to outcome" do
                                   assert_current_node :adoption_leave_and_pay
-                                  assert_state_variable :average_weekly_earnings, "346.15"
+                                  assert_equal current_state.calculator.average_weekly_earnings.round(2), 346.15
                                 end
                               end
 
@@ -391,7 +391,7 @@ class AdoptionCalculatorTest < ActiveSupport::TestCase
                                 # QA12
                                 should "go to outcome" do
                                   assert_current_node :adoption_leave_and_pay
-                                  assert_state_variable :average_weekly_earnings, "346.15"
+                                  assert_equal current_state.calculator.average_weekly_earnings.round(2), 346.15
                                 end
                               end
 

--- a/test/integration/smart_answer_flows/paternity_calculator_test.rb
+++ b/test/integration/smart_answer_flows/paternity_calculator_test.rb
@@ -130,7 +130,6 @@ class PaternityCalculatorTest < ActiveSupport::TestCase
                             # QP11
                             should "ask for payday eight weeks before" do
                               assert_current_node :payday_eight_weeks_paternity?
-                              assert_state_variable :payday_offset, Date.parse("6 January 2013")
                             end
 
                             context "answer 1 November 2012" do
@@ -139,6 +138,7 @@ class PaternityCalculatorTest < ActiveSupport::TestCase
                               # QP12
                               should "ask for frequency of pay" do
                                 assert_current_node :pay_frequency_paternity?
+                                assert_state_variable :payday_offset, Date.parse("6 January 2013")
                               end
 
                               context "answer monthly" do
@@ -230,7 +230,6 @@ class PaternityCalculatorTest < ActiveSupport::TestCase
                                             setup { add_response "second" }
 
                                             should "give the result" do
-                                              assert_state_variable :pay_method, "a_certain_week_day_each_month"
                                               assert_current_node :paternity_leave_and_pay
                                             end
                                           end # QP20 end
@@ -245,7 +244,7 @@ class PaternityCalculatorTest < ActiveSupport::TestCase
                                       should "go to outcome" do
                                         assert_current_node :paternity_leave_and_pay
                                         assert_state_variable "has_contract", "yes"
-                                        assert_state_variable :pay_dates_and_pay, "18 June 2013|£103.85"
+                                        assert_equal current_state.calculator.pay_dates_and_pay, "18 June 2013|£103.85"
                                       end
                                     end # QP14 end SPP calculated weekly
                                   end
@@ -256,7 +255,7 @@ class PaternityCalculatorTest < ActiveSupport::TestCase
 
                                   should "go to outcome" do
                                     assert_state_variable :has_contract, "yes"
-                                    assert_state_variable :lower_earning_limit, "107.00"
+                                    assert_equal current_state.calculator.lower_earning_limit, 107
                                     assert_current_node :paternity_leave_and_pay
                                   end
                                 end # QP 13 end earnings less than 109 between relevant period
@@ -269,8 +268,8 @@ class PaternityCalculatorTest < ActiveSupport::TestCase
                                   add_response "8"
                                   add_response "usual_paydates"
                                   add_response "2013-01-01"
-                                  assert_state_variable :average_weekly_earnings, "625.00"
-                                  assert_state_variable :pay_dates_and_pay, "18 June 2013|£136.78"
+                                  assert_equal current_state.calculator.average_weekly_earnings, 625
+                                  assert_equal current_state.calculator.pay_dates_and_pay, "18 June 2013|£136.78"
                                   assert_current_node :paternity_leave_and_pay
                                 end
                               end
@@ -414,7 +413,7 @@ class PaternityCalculatorTest < ActiveSupport::TestCase
           assert_current_node :paternity_leave_and_pay
           assert_state_variable :relevant_period, "Saturday, 23 November 2013 and Friday, 17 January 2014"
           assert_state_variable :to_saturday_formatted, "Saturday, 18 January 2014"
-          assert_state_variable :lower_earning_limit, "109.00"
+          assert_equal current_state.calculator.lower_earning_limit, 109
         end
       end # QP0 no with 2013/2014 figures
 
@@ -437,7 +436,7 @@ class PaternityCalculatorTest < ActiveSupport::TestCase
           assert_current_node :paternity_leave_and_pay
           assert_state_variable :relevant_period, "Wednesday, 03 April 2013 and Sunday, 06 April 2014"
           assert_state_variable :to_saturday_formatted, "Saturday, 12 April 2014"
-          assert_state_variable :lower_earning_limit, "111.00"
+          assert_equal current_state.calculator.lower_earning_limit, 111
         end
       end # QP0 no with 2014/2015 figures
 
@@ -503,7 +502,7 @@ class PaternityCalculatorTest < ActiveSupport::TestCase
           add_response "925.0"
 
           assert_current_node :paternity_leave_and_pay
-          assert_state_variable "lower_earning_limit", sprintf("%.2f", 118)
+          assert_equal current_state.calculator.lower_earning_limit, 118
         end
 
         context "answer no to contract" do


### PR DESCRIPTION
This flow is part of the maternity paternity calculator smart answer.

Some of the refactors were also appied to the adoption calculator flow as the two share a lot of behaviour.

- Replace `save_as_input` with storing response directly on state object
- Replace `calculate` and `precalculate` with assignment within `on_response` blocks
- Remove `precalculate` calls in outcomes and move logic to calculators
- Use `validate` blocks instead of raising `SmartAnswer::InvalidResponse`
- Remove `sprintf` processing for attributes that are processed via `format_money` within erb process.

[Trello card](https://trello.com/c/RpgFrtyo/549-remove-deprecated-flow-methods-from-maternity-paternity-calculator)