### PR TITLE
Remove precalculate from shared maternity paternity flow

### DIFF
--- a/app/views/smart_answers/question.html.erb
+++ b/app/views/smart_answers/question.html.erb
@@ -37,7 +37,7 @@
 
         <%= render partial: "smart_answers/inputs/#{question.partial_template_name}", locals: { question: question } %>
 
-        <%= question.post_body %>
+        <%= content_tag(:div, question.post_body, class: "govuk-!-margin-bottom-4") if question.post_body.present? %>
 
         <input type="hidden" name="next" value="1" />
         <%= render "govuk_publishing_components/components/button", {

--- a/lib/smart_answer/calculators/maternity_pay_calculator.rb
+++ b/lib/smart_answer/calculators/maternity_pay_calculator.rb
@@ -73,8 +73,12 @@ module SmartAnswer::Calculators
       @ssp_stop = @expected_week.weeks_after(-4).begins_on
     end
 
-    def self.payment_options(period)
-      PAYMENT_OPTIONS.fetch(period, {})
+    def self.payment_options
+      PAYMENT_OPTIONS
+    end
+
+    def payment_options
+      self.class.payment_options
     end
 
     def number_of_payments

--- a/lib/smart_answer_flows/maternity-paternity-calculator/questions/earnings_for_pay_period_paternity.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/questions/earnings_for_pay_period_paternity.erb
@@ -9,5 +9,5 @@
 <%= render partial: 'earnings_question_error_message' %>
 
 <% content_for :post_body do %>
-  For leave starting after 25 April 2020: if your employee earned less than usual because they were 'on furlough' under the Coronavirus Job Retention Scheme, enter what they would have earned normally. 
+  For leave starting after 25 April 2020: if your employee earned less than usual because they were 'on furlough' under the Coronavirus Job Retention Scheme, enter what they would have earned normally.
 <% end %>

--- a/lib/smart_answer_flows/maternity-paternity-calculator/questions/how_many_payments_every_2_weeks.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/questions/how_many_payments_every_2_weeks.erb
@@ -2,4 +2,4 @@
   How many fortnightly payments did the employee receive between <%= relevant_period %>?
 <% end %>
 
-<% options(payment_options_every_2_weeks) %>
+<% options calculator.payment_options[:every_2_weeks] %>

--- a/lib/smart_answer_flows/maternity-paternity-calculator/questions/how_many_payments_every_4_weeks.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/questions/how_many_payments_every_4_weeks.erb
@@ -2,4 +2,4 @@
   How many payments did the employee receive between <%= relevant_period %>?
 <% end %>
 
-<% options(payment_options_every_4_weeks) %>
+<% options calculator.payment_options[:every_4_weeks] %>

--- a/lib/smart_answer_flows/maternity-paternity-calculator/questions/how_many_payments_monthly.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/questions/how_many_payments_monthly.erb
@@ -7,4 +7,4 @@
   Do not include bonuses or other one-off payments.
 <% end %>
 
-<% options(payment_options_monthly) %>
+<% options calculator.payment_options[:monthly] %>

--- a/lib/smart_answer_flows/maternity-paternity-calculator/questions/how_many_payments_weekly.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/questions/how_many_payments_weekly.erb
@@ -7,4 +7,4 @@
   Do not include bonuses or other one-off payments.
 <% end %>
 
-<% options(payment_options_weekly) %>
+<% options calculator.payment_options[:weekly] %>

--- a/lib/smart_answer_flows/maternity-paternity-calculator/shared_adoption_maternity_paternity_flow.rb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/shared_adoption_maternity_paternity_flow.rb
@@ -1,22 +1,15 @@
 module SmartAnswer
   class SharedAdoptionMaternityPaternityFlow < Flow
     def define
-      payment_options_weekly = Calculators::MaternityPayCalculator.payment_options("weekly")
-      payment_options_every_2_weeks = Calculators::MaternityPayCalculator.payment_options("every_2_weeks")
-      payment_options_every_4_weeks = Calculators::MaternityPayCalculator.payment_options("every_4_weeks")
-      payment_options_monthly = Calculators::MaternityPayCalculator.payment_options("monthly")
+      payment_options = Calculators::MaternityPayCalculator.payment_options
 
       # This question is being used in:
       # QM8 in MaternityCalculatorFlow
       # QP13 in PaternityCalculatorFlow
       # QA10 in AdoptionCalculatorFlow
       radio :how_many_payments_weekly? do
-        payment_options_weekly.each_key do |payment_option|
+        payment_options[:weekly].each_key do |payment_option|
           option payment_option
-        end
-
-        precalculate :payment_options_weekly do
-          payment_options_weekly
         end
 
         on_response do |response|
@@ -40,12 +33,8 @@ module SmartAnswer
       # QP13 in PaternityCalculatorFlow
       # QA10 in AdoptionCalculatorFlow
       radio :how_many_payments_every_2_weeks? do
-        payment_options_every_2_weeks.each_key do |payment_option|
+        payment_options[:every_2_weeks].each_key do |payment_option|
           option payment_option
-        end
-
-        precalculate :payment_options_every_2_weeks do
-          payment_options_every_2_weeks
         end
 
         on_response do |response|
@@ -69,12 +58,8 @@ module SmartAnswer
       # QP13 in PaternityCalculatorFlow
       # QA10 in AdoptionCalculatorFlow
       radio :how_many_payments_every_4_weeks? do
-        payment_options_every_4_weeks.each_key do |payment_option|
+        payment_options[:every_4_weeks].each_key do |payment_option|
           option payment_option
-        end
-
-        precalculate :payment_options_every_4_weeks do
-          payment_options_every_4_weeks
         end
 
         on_response do |response|
@@ -98,12 +83,8 @@ module SmartAnswer
       # QP13 in PaternityCalculatorFlow
       # QA10 in AdoptionCalculatorFlow
       radio :how_many_payments_monthly? do
-        payment_options_monthly.each_key do |payment_option|
+        payment_options[:monthly].each_key do |payment_option|
           option payment_option
-        end
-
-        precalculate :payment_options_monthly do
-          payment_options_monthly
         end
 
         on_response do |response|

--- a/test/unit/calculators/maternity_pay_calculator_test.rb
+++ b/test/unit/calculators/maternity_pay_calculator_test.rb
@@ -581,28 +581,28 @@ module SmartAnswer::Calculators
 
       context "payment_options" do
         should "return weekly payment options when supplied with weekly" do
-          weekly = MaternityPayCalculator.payment_options("weekly")
+          weekly = MaternityPayCalculator.payment_options["weekly"]
 
           assert_equal %w[8 9 10], weekly.keys
           assert_equal ["8 payments or fewer", "9 payments", "10 payments"], weekly.values
         end
 
         should "return monthly payment options when supplied with monthly" do
-          monthly = MaternityPayCalculator.payment_options("monthly")
+          monthly = MaternityPayCalculator.payment_options["monthly"]
 
           assert_equal %w[2 3], monthly.keys
           assert_equal ["1 or 2 payments", "3 payments"], monthly.values
         end
 
         should "return 2 weeks payment options when supplied with every 2 weeks" do
-          every_2_weeks = MaternityPayCalculator.payment_options("every_2_weeks")
+          every_2_weeks = MaternityPayCalculator.payment_options["every_2_weeks"]
 
           assert_equal %w[4 5], every_2_weeks.keys
           assert_equal ["4 payments or fewer", "5 payments"], every_2_weeks.values
         end
 
         should "return 4 weeks payment options when supplied with every 4 weeks" do
-          every_4_weeks = MaternityPayCalculator.payment_options("every_4_weeks")
+          every_4_weeks = MaternityPayCalculator.payment_options["every_4_weeks"]
 
           assert_equal %w[1 2], every_4_weeks.keys
           assert_equal ["1 payment", "2 payments"], every_4_weeks.values


### PR DESCRIPTION
- Allows `PAYMENT_OPTIONS` hash to be called directly from class method to remove number of intermediate methods required.
- Adds `payment_options` instance method so that hash can be accessed easily via calculator instance in erb files.
- Fixes issue where Next button appears inline with `post_body` when present

[Trello ticket](https://trello.com/c/RpgFrtyo/549-remove-deprecated-flow-methods-from-maternity-paternity-calculator)
