### PR TITLE
Updated 'If your partner is also British...'

### DIFF
--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/japan/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/japan/_opposite_sex.erb
@@ -8,7 +8,7 @@ Contact the relevant municipal office in Japan to find out about local laws, inc
 
 You need to go to the embassy in Tokyo to confirm that you’re legally allowed to get married. This is called swearing an affirmation or affidavit. Check with the municipal office how long you can use it to get married.
 
-If your partner is also British, they’ll need to swear their own affirmation.
+If your partner is also British, they’ll need to make their own separate appointment at the embassy and swear their own affirmation or affidavit.
 
 This costs <%= format_money calculator.consular_fee(:affidavit_or_affirmation_for_marriage) %> per person. You can pay in the [local currency](/government/publications/japan-consular-fees) with cash or card (Visa or Mastercard).
 


### PR DESCRIPTION
FROM
If your partner is also British, they’ll need to swear their own affirmation.

TO
If your partner is also British, they’ll need to make their own separate appointment at the embassy and swear their own affirmation or affidavit.

REASON
FCDO want to makes it clear that if a partner is also British, they need to have their own appointment.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.

- Changes to start pages are **not** continuously deployed, and are [deployed using a different process](https://github.com/alphagov/smart-answers/blob/master/doc/smart-answer-flow-development/publishing.md).
