### PR TITLE
Fix typo in SmartAnswer::Calculators::MaternityPayCalculator

### DIFF
--- a/lib/smart_answer/calculators/maternity_pay_calculator.rb
+++ b/lib/smart_answer/calculators/maternity_pay_calculator.rb
@@ -350,7 +350,7 @@ module SmartAnswer::Calculators
       total_statutory_pay if above_lower_earning_limit
     end
 
-    def total_ssp
+    def total_spp
       total_statutory_pay if above_lower_earning_limit
     end
 


### PR DESCRIPTION
- method should be `total_spp`

