### PR TITLE
Remove deprecated methods from minimum wage and UK visa flows

### DIFF
--- a/lib/smart_answer/calculators/uk_visa_calculator.rb
+++ b/lib/smart_answer/calculators/uk_visa_calculator.rb
@@ -153,6 +153,14 @@ module SmartAnswer::Calculators
       @travelling_visiting_partner_family_member_answer == "yes"
     end
 
+    def study_or_work
+      if study_visit?
+        "study"
+      elsif work_visit?
+        "work"
+      end
+    end
+
     EXCLUDE_COUNTRIES = %w[
       american-samoa
       british-antarctic-territory

--- a/lib/smart_answer_flows/check-uk-visa.rb
+++ b/lib/smart_answer_flows/check-uk-visa.rb
@@ -15,9 +15,8 @@ module SmartAnswer
         on_response do |response|
           self.calculator = Calculators::UkVisaCalculator.new
           calculator.passport_country = response
+          self.purpose_of_visit_answer = nil
         end
-
-        calculate :purpose_of_visit_answer
 
         next_node do
           if calculator.passport_country_is_israel?
@@ -186,14 +185,6 @@ module SmartAnswer
       radio :staying_for_how_long? do
         option :six_months_or_less
         option :longer_than_six_months
-
-        precalculate :study_or_work do
-          if calculator.study_visit?
-            "study"
-          elsif calculator.work_visit?
-            "work"
-          end
-        end
 
         next_node do |response|
           case response

--- a/lib/smart_answer_flows/check-uk-visa/questions/staying_for_how_long.erb
+++ b/lib/smart_answer_flows/check-uk-visa/questions/staying_for_how_long.erb
@@ -1,5 +1,5 @@
 <% text_for :title do %>
-  How long are you planning to <%= study_or_work %> in the UK for?
+  How long are you planning to <%= calculator.study_or_work %> in the UK for?
 <% end %>
 
 <% options(

--- a/lib/smart_answer_flows/shared/minimum_wage_flow.rb
+++ b/lib/smart_answer_flows/shared/minimum_wage_flow.rb
@@ -161,11 +161,13 @@ module SmartAnswer
             calculator.valid_accommodation_charge?(response)
           end
 
+          on_response do |response|
+            self.accommodation_charge = response
+          end
+
           next_node do
             question :current_accommodation_usage?
           end
-
-          save_input_as :accommodation_charge
         end
 
         # Q7a Past
@@ -174,11 +176,13 @@ module SmartAnswer
             calculator.valid_accommodation_charge?(response)
           end
 
+          on_response do |response|
+            self.accommodation_charge = response
+          end
+
           next_node do
             question :past_accommodation_usage?
           end
-
-          save_input_as :accommodation_charge
         end
 
         # Q7b


### PR DESCRIPTION
This PR removes save_input_as and calculate methods from the flow definitions of the minimum wage and UK visa flows. They have been deprecated in favour of using the on response blocks.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.

- Changes to start pages are **not** continuously deployed, and are [deployed using a different process](https://github.com/alphagov/smart-answers/blob/master/doc/smart-answer-flow-development/publishing.md).
