### PR TITLE
Remove precalculate from part year profit tax credits flow

### DIFF
--- a/lib/smart_answer_flows/part-year-profit-tax-credits.rb
+++ b/lib/smart_answer_flows/part-year-profit-tax-credits.rb
@@ -59,8 +59,6 @@ module SmartAnswer
         option "yes"
         option "no"
 
-        precalculate(:accounting_year_begins_on) { calculator.accounting_year.begins_on }
-
         next_node do |response|
           if response == "yes"
             question :when_did_you_stop_trading?
@@ -73,9 +71,6 @@ module SmartAnswer
       date_question :when_did_you_stop_trading? do
         from { Calculators::PartYearProfitTaxCreditsCalculator::START_OR_STOP_TRADING_EARLIEST_DATE }
         to   { Calculators::PartYearProfitTaxCreditsCalculator::START_OR_STOP_TRADING_LATEST_DATE }
-
-        precalculate(:tax_year_begins_on) { calculator.tax_year.begins_on }
-        precalculate(:tax_year_ends_on)   { calculator.tax_year.ends_on }
 
         on_response do |response|
           calculator.stopped_trading_on = response
@@ -94,8 +89,6 @@ module SmartAnswer
         option "yes"
         option "no"
 
-        precalculate(:accounting_year_ends_on) { calculator.accounting_year.ends_on }
-
         next_node do |response|
           if response == "yes"
             question :what_is_your_taxable_profit?
@@ -108,8 +101,6 @@ module SmartAnswer
       date_question :when_did_you_start_trading? do
         from { Calculators::PartYearProfitTaxCreditsCalculator::START_OR_STOP_TRADING_EARLIEST_DATE }
         to   { Calculators::PartYearProfitTaxCreditsCalculator::START_OR_STOP_TRADING_LATEST_DATE }
-
-        precalculate(:award_period_ends_on) { calculator.award_period.ends_on }
 
         on_response do |response|
           calculator.started_trading_on = response
@@ -129,9 +120,6 @@ module SmartAnswer
       end
 
       money_question :what_is_your_taxable_profit? do
-        precalculate(:basis_period_begins_on) { calculator.basis_period.begins_on }
-        precalculate(:basis_period_ends_on)   { calculator.basis_period.ends_on }
-
         on_response do |response|
           calculator.taxable_profit = response
         end

--- a/lib/smart_answer_flows/part-year-profit-tax-credits/questions/did_you_start_trading_before_the_relevant_accounting_year.erb
+++ b/lib/smart_answer_flows/part-year-profit-tax-credits/questions/did_you_start_trading_before_the_relevant_accounting_year.erb
@@ -1,5 +1,5 @@
 <% text_for :title do %>
-  Did you start trading before <%= format_date(accounting_year_begins_on) %>?
+  Did you start trading before <%= format_date(calculator.accounting_year.begins_on) %>?
 <% end %>
 
 <% options(

--- a/lib/smart_answer_flows/part-year-profit-tax-credits/questions/do_your_accounts_cover_a_12_month_period.erb
+++ b/lib/smart_answer_flows/part-year-profit-tax-credits/questions/do_your_accounts_cover_a_12_month_period.erb
@@ -1,5 +1,5 @@
 <% text_for :title do %>
-  Do your accounts cover the 12 month period up to <%= format_date(accounting_year_ends_on) %>?
+  Do your accounts cover the 12 month period up to <%= format_date(calculator.accounting_year.ends_on) %>?
 <% end %>
 
 <% options(

--- a/lib/smart_answer_flows/part-year-profit-tax-credits/questions/what_is_your_taxable_profit.erb
+++ b/lib/smart_answer_flows/part-year-profit-tax-credits/questions/what_is_your_taxable_profit.erb
@@ -1,5 +1,5 @@
 <% text_for :title do %>
-  What is your actual or estimated taxable profit between <%= format_date(basis_period_begins_on) %> and <%= format_date(basis_period_ends_on) %>?
+  What is your actual or estimated taxable profit between <%= format_date(calculator.basis_period.begins_on) %> and <%= format_date(calculator.basis_period.ends_on) %>?
 <% end %>
 
 <% text_for :hint do %>

--- a/lib/smart_answer_flows/part-year-profit-tax-credits/questions/when_did_you_start_trading.erb
+++ b/lib/smart_answer_flows/part-year-profit-tax-credits/questions/when_did_you_start_trading.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% text_for :hint do %>
-  This date must be before <%= format_date(award_period_ends_on) %>.
+  This date must be before <%= format_date(calculator.award_period.ends_on) %>.
 <% end %>
 
 <% text_for :error_message do %>

--- a/lib/smart_answer_flows/part-year-profit-tax-credits/questions/when_did_you_stop_trading.erb
+++ b/lib/smart_answer_flows/part-year-profit-tax-credits/questions/when_did_you_stop_trading.erb
@@ -3,11 +3,11 @@
 <% end %>
 
 <% text_for :hint do %>
-  This date must be between <%= format_date(tax_year_begins_on) %> and <%= format_date(tax_year_ends_on) %>, which is the start and end dates of the tax year that your tax credit award ends in.
+  This date must be between <%= format_date(calculator.tax_year.begins_on) %> and <%= format_date(calculator.tax_year.ends_on) %>, which is the start and end dates of the tax year that your tax credit award ends in.
 <% end %>
 
 <% text_for :error_not_in_tax_year do %>
-  The date must be between <%= format_date(tax_year_begins_on) %> and <%= format_date(tax_year_ends_on) %>.
+  The date must be between <%= format_date(calculator.tax_year.begins_on) %> and <%= format_date(calculator.tax_year.ends_on) %>.
 <% end %>
 <% text_for :error_message do %>
   You need to enter a date to continue.

--- a/test/unit/smart_answer_flows/part_year_profit_tax_credits_flow_test.rb
+++ b/test/unit/smart_answer_flows/part_year_profit_tax_credits_flow_test.rb
@@ -120,10 +120,6 @@ module SmartAnswer
         )
       end
 
-      should "make accounting_year_begins_on available for interpolation in question title" do
-        assert_equal Date.parse("2015-04-06"), @precalculated_state.accounting_year_begins_on
-      end
-
       context "responding with yes" do
         setup do
           question = :did_you_start_trading_before_the_relevant_accounting_year?
@@ -179,10 +175,6 @@ module SmartAnswer
       should "set the to date of the date select to the constant defined in the calculator" do
         expected = Calculators::PartYearProfitTaxCreditsCalculator::START_OR_STOP_TRADING_LATEST_DATE
         assert_equal expected, @question.range.end
-      end
-
-      should "make award_period_ends_on available" do
-        assert_equal Date.parse("2015-08-01"), @new_state.award_period_ends_on
       end
 
       should "store parsed response on calculator as started_trading_on" do
@@ -260,14 +252,6 @@ module SmartAnswer
         assert_equal expected, @question.range.end
       end
 
-      should "make tax_year_begins_on available for interpolation in question title" do
-        assert_equal Date.parse("2015-04-06"), @precalculated_state.tax_year_begins_on
-      end
-
-      should "make tax_year_ends_on available for interpolation in question title" do
-        assert_equal Date.parse("2016-04-05"), @precalculated_state.tax_year_ends_on
-      end
-
       should "store parsed response on calculator as stopped_trading_on" do
         assert_equal Date.parse("2015-06-01"), @calculator.stopped_trading_on
       end
@@ -340,14 +324,6 @@ module SmartAnswer
           responding_with: "15000",
           initial_state: { calculator: @calculator },
         )
-      end
-
-      should "make basis_period_begins_on available for interpolation in question title" do
-        assert_equal Date.parse("2015-04-06"), @precalculated_state.basis_period_begins_on
-      end
-
-      should "make basis_period_ends_on available for interpolation in question title" do
-        assert_equal Date.parse("2016-04-05"), @precalculated_state.basis_period_ends_on
       end
 
       should "store parsed response on calculator as taxable_profit" do

--- a/test/unit/smart_answer_flows/part_year_profit_tax_credits_view_test.rb
+++ b/test/unit/smart_answer_flows/part_year_profit_tax_credits_view_test.rb
@@ -56,6 +56,11 @@ module SmartAnswer
         question = @flow.node(:do_your_accounts_cover_a_12_month_period?)
         @state = SmartAnswer::State.new(question)
         @state.accounting_year_ends_on = Date.parse("2016-04-05")
+        calculator_options = {
+          accounting_year: stub(ends_on: Date.parse("2016-04-05")),
+        }
+        @calculator = stub("calculator", calculator_options)
+        @state.calculator = @calculator
         @presenter = MultipleChoiceQuestionPresenter.new(question, nil, @state)
       end
 
@@ -78,8 +83,11 @@ module SmartAnswer
       setup do
         question = @flow.node(:what_is_your_taxable_profit?)
         @state = SmartAnswer::State.new(question)
-        @state.basis_period_begins_on = Date.parse("2015-04-06")
-        @state.basis_period_ends_on = Date.parse("2016-04-05")
+        calculator_options = {
+          basis_period: stub(begins_on: Date.parse("2015-04-06"), ends_on: Date.parse("2016-04-05")),
+        }
+        @calculator = stub("calculator", calculator_options)
+        @state.calculator = @calculator
         @presenter = QuestionPresenter.new(question, nil, @state)
       end
 
@@ -98,7 +106,11 @@ module SmartAnswer
       setup do
         question = @flow.node(:did_you_start_trading_before_the_relevant_accounting_year?)
         @state = SmartAnswer::State.new(question)
-        @state.accounting_year_begins_on = Date.parse("2015-04-06")
+        calculator_options = {
+          accounting_year: stub(begins_on: Date.parse("2015-04-06")),
+        }
+        @calculator = stub("calculator", calculator_options)
+        @state.calculator = @calculator
         @presenter = MultipleChoiceQuestionPresenter.new(question, nil, @state)
       end
 
@@ -121,8 +133,11 @@ module SmartAnswer
       setup do
         question = @flow.node(:when_did_you_stop_trading?)
         @state = SmartAnswer::State.new(question)
-        @state.tax_year_begins_on = Date.parse("2015-04-06")
-        @state.tax_year_ends_on = Date.parse("2016-04-05")
+        calculator_options = {
+          tax_year: stub(begins_on: Date.parse("2015-04-06"), ends_on: Date.parse("2016-04-05")),
+        }
+        @calculator = stub("calculator", calculator_options)
+        @state.calculator = @calculator
         @presenter = QuestionPresenter.new(question, nil, @state)
       end
 
@@ -147,7 +162,11 @@ module SmartAnswer
       setup do
         question = @flow.node(:when_did_you_start_trading?)
         @state = SmartAnswer::State.new(question)
-        @state.award_period_ends_on = Date.parse("2015-08-01")
+        calculator_options = {
+          award_period: stub(ends_on: Date.parse("2015-08-01")),
+        }
+        @calculator = stub("calculator", calculator_options)
+        @state.calculator = @calculator
         @presenter = QuestionPresenter.new(question, nil, @state)
       end
 


### PR DESCRIPTION
The precalculate method has been deprecated from flow definitions.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.

- Changes to start pages are **not** continuously deployed, and are [deployed using a different process](https://github.com/alphagov/smart-answers/blob/master/doc/smart-answer-flow-development/publishing.md).
