### PR TITLE
Complete removing deprecated flow methods from maternity paternity calculator flow

### DIFF
--- a/lib/smart_answer/calculators/maternity_pay_calculator.rb
+++ b/lib/smart_answer/calculators/maternity_pay_calculator.rb
@@ -32,7 +32,7 @@ module SmartAnswer::Calculators
                   :earnings_for_pay_period,
                   :on_payroll
 
-    attr_writer :pay_method
+    attr_writer :pay_method, :not_entitled_to_pay_reason
 
     DAYS_OF_THE_WEEK = %w[Sunday Monday Tuesday Wednesday Thursday Friday Saturday].freeze
     PAYMENT_OPTIONS = {
@@ -357,6 +357,10 @@ module SmartAnswer::Calculators
       total_statutory_pay if above_lower_earning_limit
     end
 
+    def total_smp
+      total_statutory_pay if not_entitled_to_pay_reason.blank?
+    end
+
     def pay_method
       @pay_method ||= if monthly_pay_method
                         if monthly_pay_method == "specific_date_each_month" && pay_day_in_month > 28
@@ -369,6 +373,16 @@ module SmartAnswer::Calculators
                       else
                         pay_pattern
                       end
+    end
+
+    def pay_below_threshold?
+      earnings_for_pay_period && average_weekly_earnings_under_lower_earning_limit?
+    end
+
+    def not_entitled_to_pay_reason
+      return :must_earn_over_threshold if pay_below_threshold?
+
+      @not_entitled_to_pay_reason
     end
 
   private

--- a/lib/smart_answer/calculators/maternity_pay_calculator.rb
+++ b/lib/smart_answer/calculators/maternity_pay_calculator.rb
@@ -17,12 +17,13 @@ module SmartAnswer::Calculators
     attr_accessor :employment_contract,
                   :leave_start_date,
                   :last_payday,
+                  :monthly_pay_method,
                   :pre_offset_payday,
                   :pay_date,
                   :pay_day_in_month,
                   :pay_day_in_week,
-                  :pay_method,
                   :pay_week_in_month,
+                  :period_calculation_method,
                   :work_days,
                   :date_of_birth,
                   :awe,
@@ -30,6 +31,8 @@ module SmartAnswer::Calculators
                   :payment_option,
                   :earnings_for_pay_period,
                   :on_payroll
+
+    attr_writer :pay_method
 
     DAYS_OF_THE_WEEK = %w[Sunday Monday Tuesday Wednesday Thursday Friday Saturday].freeze
     PAYMENT_OPTIONS = {
@@ -352,6 +355,20 @@ module SmartAnswer::Calculators
 
     def total_spp
       total_statutory_pay if above_lower_earning_limit
+    end
+
+    def pay_method
+      @pay_method ||= if monthly_pay_method
+                        if monthly_pay_method == "specific_date_each_month" && pay_day_in_month > 28
+                          "last_day_of_the_month"
+                        else
+                          monthly_pay_method
+                        end
+                      elsif period_calculation_method == "weekly_starting"
+                        period_calculation_method
+                      else
+                        pay_pattern
+                      end
     end
 
   private

--- a/lib/smart_answer_flows/maternity-paternity-calculator.rb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator.rb
@@ -24,10 +24,8 @@ module SmartAnswer
           self.leave_spp_claim_link = nil
           self.notice_of_leave_deadline = nil
           self.monthly_pay_method = nil
-          self.smp_calculation_method = nil
-          self.sap_calculation_method = nil
+          self.period_calculation_method = nil
           self.paternity_adoption = nil
-          self.spp_calculation_method = nil
           self.has_contract = nil
           self.paternity_employment_start = nil
         end

--- a/lib/smart_answer_flows/maternity-paternity-calculator/adoption_calculator_flow.rb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/adoption_calculator_flow.rb
@@ -237,11 +237,11 @@ module SmartAnswer
           option :usual_paydates
 
           on_response do |response|
-            self.sap_calculation_method = response
+            calculator.period_calculation_method = response
           end
 
           next_node do
-            if sap_calculation_method == "weekly_starting"
+            if calculator.period_calculation_method == "weekly_starting"
               outcome :adoption_leave_and_pay
             elsif calculator.pay_pattern == "monthly"
               question :monthly_pay_paternity?
@@ -251,23 +251,7 @@ module SmartAnswer
           end
         end
 
-        outcome :adoption_leave_and_pay do
-          precalculate :pay_method do
-            calculator.pay_method = (
-              if monthly_pay_method
-                if monthly_pay_method == "specific_date_each_month" && calculator.pay_day_in_month > 28
-                  "last_day_of_the_month"
-                else
-                  monthly_pay_method
-                end
-              elsif sap_calculation_method == "weekly_starting"
-                sap_calculation_method
-              else
-                calculator.pay_pattern
-              end
-            )
-          end
-        end
+        outcome :adoption_leave_and_pay
         outcome :adoption_not_entitled_to_leave_or_pay
       end
     end

--- a/lib/smart_answer_flows/maternity-paternity-calculator/maternity_calculator_flow.rb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/maternity_calculator_flow.rb
@@ -51,7 +51,7 @@ module SmartAnswer
 
           on_response do |response|
             self.has_employment_contract_between_dates = response
-            self.not_entitled_to_pay_reason = response == "no" ? :not_worked_long_enough_and_not_on_payroll : nil
+            calculator.not_entitled_to_pay_reason = response == "no" ? :not_worked_long_enough_and_not_on_payroll : nil
             self.to_saturday = calculator.qualifying_week.last
             self.to_saturday_formatted = calculator.format_date_day(to_saturday)
           end
@@ -277,53 +277,7 @@ module SmartAnswer
         end
 
         ## Maternity outcomes
-        outcome :maternity_leave_and_pay_result do
-          precalculate :smp_a do
-            sprintf("%.2f", calculator.statutory_maternity_rate_a)
-          end
-          precalculate :smp_b do
-            sprintf("%.2f", calculator.statutory_maternity_rate_b)
-          end
-          precalculate :lower_earning_limit do
-            sprintf("%.2f", calculator.lower_earning_limit)
-          end
-
-          precalculate :notice_request_pay do
-            calculator.notice_request_pay
-          end
-
-          precalculate :below_threshold do
-            calculator.earnings_for_pay_period &&
-              calculator.average_weekly_earnings_under_lower_earning_limit?
-          end
-
-          precalculate :not_entitled_to_pay_reason do
-            if below_threshold
-              :must_earn_over_threshold
-            else
-              not_entitled_to_pay_reason
-            end
-          end
-
-          precalculate :total_smp do
-            if not_entitled_to_pay_reason.blank?
-              sprintf("%.2f", calculator.total_statutory_pay)
-            end
-          end
-
-          precalculate :pay_dates_and_pay do
-            if not_entitled_to_pay_reason.blank?
-              lines = calculator.paydates_and_pay.map do |date_and_pay|
-                %(#{date_and_pay[:date].strftime('%e %B %Y')}|£#{sprintf('%.2f', date_and_pay[:pay])})
-              end
-              lines.join("\n")
-            end
-          end
-
-          precalculate :average_weekly_earnings do
-            calculator.average_weekly_earnings
-          end
-        end
+        outcome :maternity_leave_and_pay_result
       end
     end
   end

--- a/lib/smart_answer_flows/maternity-paternity-calculator/maternity_calculator_flow.rb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/maternity_calculator_flow.rb
@@ -162,11 +162,11 @@ module SmartAnswer
           option :usual_paydates
 
           on_response do |response|
-            self.smp_calculation_method = response
+            calculator.period_calculation_method = response
           end
 
           next_node do
-            if smp_calculation_method != "usual_paydates"
+            if calculator.period_calculation_method != "usual_paydates"
               outcome :maternity_leave_and_pay_result
             elsif calculator.pay_pattern == "monthly"
               question :when_in_the_month_is_the_employee_paid?
@@ -197,11 +197,11 @@ module SmartAnswer
           option :a_certain_week_day_each_month
 
           on_response do |response|
-            self.monthly_pay_method = response
+            calculator.monthly_pay_method = response
           end
 
-          next_node do |response|
-            case response
+          next_node do
+            case calculator.monthly_pay_method
             when "first_day_of_the_month", "last_day_of_the_month"
               outcome :maternity_leave_and_pay_result
             when "specific_date_each_month"
@@ -278,21 +278,6 @@ module SmartAnswer
 
         ## Maternity outcomes
         outcome :maternity_leave_and_pay_result do
-          precalculate :pay_method do
-            calculator.pay_method = (
-              if monthly_pay_method
-                if monthly_pay_method == "specific_date_each_month" && pay_day_in_month > 28
-                  "last_day_of_the_month"
-                else
-                  monthly_pay_method
-                end
-              elsif smp_calculation_method == "weekly_starting"
-                smp_calculation_method
-              elsif calculator.pay_pattern
-                calculator.pay_pattern
-              end
-            )
-          end
           precalculate :smp_a do
             sprintf("%.2f", calculator.statutory_maternity_rate_a)
           end

--- a/lib/smart_answer_flows/maternity-paternity-calculator/outcomes/adoption_leave_and_pay.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/outcomes/adoption_leave_and_pay.erb
@@ -31,7 +31,7 @@
                  locals: {
                    average_weekly_earnings: calculator.average_weekly_earnings,
                    relevant_period: relevant_period,
-                   lower_earning_limit: lower_earning_limit
+                   lower_earning_limit: calculator.lower_earning_limit
                  } %>
     <% end %>
     Send them form SAP1 within 7 days of your decision. They must get this form within 28 days of their pay request or the date they were matched with the child (whichever is earlier).

--- a/lib/smart_answer_flows/maternity-paternity-calculator/outcomes/maternity_leave_and_pay_result.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/outcomes/maternity_leave_and_pay_result.erb
@@ -20,7 +20,7 @@
 
   <% end %>
 
-  <% if not_entitled_to_pay_reason.present? %>
+  <% if calculator.not_entitled_to_pay_reason.present? %>
     <% if calculator.earnings_for_pay_period %>
       ##Statutory Maternity Pay
 
@@ -33,13 +33,13 @@
       The employee is not entitled to Statutory Maternity Pay. To qualify:
 
     <% end %>
-    <% case not_entitled_to_pay_reason %>
+    <% case calculator.not_entitled_to_pay_reason %>
     <% when :must_earn_over_threshold %>
 
       + <%= render 'must_earn_over_threshold',
                    average_weekly_earnings: calculator.average_weekly_earnings,
                    relevant_period: relevant_period,
-                   lower_earning_limit: lower_earning_limit
+                   lower_earning_limit: calculator.lower_earning_limit
         %>
     <% when :not_worked_long_enough_and_not_on_payroll %>
 
@@ -73,7 +73,7 @@
     Date | SMP amount
     -|-
     <%= calculator.pay_dates_and_pay %>
-     | **Total SMP: <%= format_money(total_smp) %>**
+     | **Total SMP: <%= format_money(calculator.total_smp) %>**
 
   <% end %>
 

--- a/lib/smart_answer_flows/maternity-paternity-calculator/paternity_calculator_flow.rb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/paternity_calculator_flow.rb
@@ -297,7 +297,6 @@ module SmartAnswer
 
           on_response do |response|
             calculator.pay_pattern = response
-            calculator.pay_method = calculator.pay_pattern
           end
 
           next_node do
@@ -335,11 +334,11 @@ module SmartAnswer
           option :usual_paydates
 
           on_response do |response|
-            self.spp_calculation_method = response
+            calculator.period_calculation_method = response
           end
 
           next_node do
-            if spp_calculation_method == "weekly_starting"
+            if calculator.period_calculation_method == "weekly_starting"
               outcome :paternity_leave_and_pay
             elsif calculator.pay_pattern == "monthly"
               question :monthly_pay_paternity?
@@ -374,6 +373,7 @@ module SmartAnswer
 
           on_response do |response|
             self.monthly_pay_method = response
+            calculator.monthly_pay_method = monthly_pay_method
           end
 
           next_node do
@@ -470,23 +470,7 @@ module SmartAnswer
         end
 
         # Paternity outcomes
-        outcome :paternity_leave_and_pay do
-          precalculate :pay_method do
-            calculator.pay_method = (
-              if monthly_pay_method
-                if monthly_pay_method == "specific_date_each_month" && calculator.pay_day_in_month > 28
-                  "last_day_of_the_month"
-                else
-                  monthly_pay_method
-                end
-              elsif spp_calculation_method == "weekly_starting"
-                spp_calculation_method
-              else
-                calculator.pay_pattern
-              end
-            )
-          end
-        end
+        outcome :paternity_leave_and_pay
         outcome :paternity_not_entitled_to_leave_or_pay
       end
     end

--- a/test/integration/smart_answer_flows/maternity_calculator_helper.rb
+++ b/test/integration/smart_answer_flows/maternity_calculator_helper.rb
@@ -1,8 +1,8 @@
 module MaternityCalculatorHelper
   def check_smp_calculation(dates_and_pay)
-    assert_state_variable :pay_dates_and_pay,
-                          dates_and_pay.map { |date, pay|
-                            "#{date}|#{pay}"
-                          }.join("\n")
+    assert_equal current_state.calculator.pay_dates_and_pay,
+                 dates_and_pay.map { |date, pay|
+                   "#{date}|#{pay}"
+                 }.join("\n")
   end
 end

--- a/test/integration/smart_answer_flows/maternity_calculator_test.rb
+++ b/test/integration/smart_answer_flows/maternity_calculator_test.rb
@@ -105,7 +105,7 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
           add_response "200"
           add_response "8"
           add_response "weekly_starting"
-          assert_state_variable "lower_earning_limit", sprintf("%.2f", 107)
+          assert_equal current_state.calculator.lower_earning_limit.round(2), 107
         end
         should "return lower_earning_limit of £102" do
           dd = Date.parse("1 January 2012")
@@ -118,7 +118,7 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
           add_response "200"
           add_response "9"
           add_response "weekly_starting"
-          assert_state_variable "lower_earning_limit", sprintf("%.2f", 102)
+          assert_equal current_state.calculator.lower_earning_limit.round(2), 102
         end
       end
 
@@ -230,10 +230,10 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
                             assert_state_variable "notice_of_leave_deadline", 15.weeks.ago(start_of_week).end_of_week + 6
                             assert_state_variable "pay_start_date", leave_start
                             assert_state_variable "pay_end_date", 39.weeks.since(leave_start) - 1
-                            assert_state_variable "average_weekly_earnings", 135.4
-                            assert_state_variable "smp_a", "121.86"
-                            assert_state_variable "smp_b", "121.86"
-                            assert_state_variable "total_smp", "4752.55"
+                            assert_equal current_state.calculator.average_weekly_earnings, 135.4
+                            assert_equal current_state.calculator.statutory_maternity_rate_a.round(2), 121.86
+                            assert_equal current_state.calculator.statutory_maternity_rate_b.round(2), 121.86
+                            assert_equal current_state.calculator.total_smp.round(2), 4752.55
                           end
                         end
                       end
@@ -294,15 +294,15 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
                       add_response "last_day_of_the_month"
                       leave_start = Date.parse("21 November 2012")
                       start_of_week = leave_start - leave_start.wday
-                      assert_state_variable "average_weekly_earnings", 124.9846153
+                      assert_equal current_state.calculator.average_weekly_earnings, 124.9846153
                       assert_state_variable "leave_start_date", leave_start
                       assert_state_variable "leave_end_date", 52.weeks.since(leave_start) - 1
                       assert_state_variable "notice_of_leave_deadline", next_saturday(15.weeks.ago(start_of_week))
                       assert_state_variable "pay_start_date", leave_start
                       assert_state_variable "pay_end_date", 39.weeks.since(leave_start) - 1
-                      assert_state_variable "smp_a", "112.49"
-                      assert_state_variable "smp_b", "112.49"
-                      assert_state_variable "total_smp", "4387.02"
+                      assert_equal current_state.calculator.statutory_maternity_rate_a.round(2), 112.49
+                      assert_equal current_state.calculator.statutory_maternity_rate_b.round(2), 112.49
+                      assert_equal current_state.calculator.total_smp.round(2), 4387.02
                     end
 
                     context "specific date each month" do
@@ -359,9 +359,9 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
                           end
 
                           should "calculate the dates and payment amounts" do
-                            assert_state_variable "average_weekly_earnings", 124.9846153
-                            assert_state_variable "smp_a", "112.49"
-                            assert_state_variable "smp_b", "112.49" # Uses the statutory maternity rate
+                            assert_equal current_state.calculator.average_weekly_earnings, 124.9846153
+                            assert_equal current_state.calculator.statutory_maternity_rate_a.round(2), 112.49
+                            assert_equal current_state.calculator.statutory_maternity_rate_b.round(2), 112.49
                           end
                         end
                       end
@@ -387,7 +387,7 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
               end
 
               should "state that you are not entitled to pay" do
-                assert_state_variable "not_entitled_to_pay_reason", :not_worked_long_enough_and_not_on_payroll
+                assert_equal current_state.calculator.not_entitled_to_pay_reason, :not_worked_long_enough_and_not_on_payroll
                 assert_current_node :maternity_leave_and_pay_result
               end
             end
@@ -398,7 +398,7 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
               end
 
               should "state that you are not entitled to pay" do
-                assert_state_variable "not_entitled_to_pay_reason", :not_worked_long_enough_and_not_on_payroll
+                assert_equal current_state.calculator.not_entitled_to_pay_reason, :not_worked_long_enough_and_not_on_payroll
                 assert_current_node :maternity_leave_and_pay_result
               end
             end
@@ -471,7 +471,7 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
 
         should "have a notice request pay date 28 days before the start date" do
           assert_state_variable "pay_start_date", Date.parse("2013-01-25")
-          assert_state_variable "notice_request_pay", Date.parse("2012-12-28")
+          assert_equal current_state.calculator.notice_request_pay, Date.parse("2012-12-28")
         end
       end
     end # April 9th
@@ -491,7 +491,7 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
 
       should "have LEL of 116" do
         assert_state_variable :to_saturday_formatted, "Saturday, 14 April 2018"
-        assert_state_variable "lower_earning_limit", sprintf("%.2f", 116)
+        assert_equal current_state.calculator.lower_earning_limit.round(2), 116
         assert_current_node :maternity_leave_and_pay_result
       end
     end
@@ -511,7 +511,7 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
 
       should "have LEL of 118" do
         assert_state_variable :to_saturday_formatted, "Saturday, 13 April 2019"
-        assert_state_variable "lower_earning_limit", sprintf("%.2f", 118)
+        assert_equal current_state.calculator.lower_earning_limit.round(2), 118
         assert_current_node :maternity_leave_and_pay_result
       end
     end
@@ -531,7 +531,7 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
 
       should "have LEL of 120" do
         assert_state_variable :to_saturday_formatted, "Saturday, 18 April 2020"
-        assert_state_variable "lower_earning_limit", sprintf("%.2f", 120)
+        assert_equal current_state.calculator.lower_earning_limit.round(2), 120
         assert_current_node :maternity_leave_and_pay_result
       end
     end
@@ -551,7 +551,7 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
 
       should "have LEL of 111" do
         assert_state_variable :to_saturday_formatted, "Saturday, 12 April 2014"
-        assert_state_variable "lower_earning_limit", sprintf("%.2f", 111)
+        assert_equal current_state.calculator.lower_earning_limit.round(2), 111
         assert_current_node :maternity_leave_and_pay_result
       end
     end
@@ -571,7 +571,7 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
 
       should "have LEL of 109" do
         assert_state_variable :to_saturday_formatted, "Saturday, 05 April 2014"
-        assert_state_variable "lower_earning_limit", sprintf("%.2f", 109)
+        assert_equal current_state.calculator.lower_earning_limit.round(2), 109
         assert_current_node :maternity_leave_and_pay_result
       end
     end
@@ -591,7 +591,7 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
 
       should "have LEL of 109" do
         assert_state_variable :to_saturday_formatted, "Saturday, 05 April 2014"
-        assert_state_variable "lower_earning_limit", sprintf("%.2f", 109)
+        assert_equal current_state.calculator.lower_earning_limit.round(2), 109
         assert_current_node :maternity_leave_and_pay_result
       end
     end
@@ -612,7 +612,7 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
 
       should "have LEL of 109" do
         assert_state_variable :to_saturday_formatted, "Saturday, 05 April 2014"
-        assert_state_variable "lower_earning_limit", sprintf("%.2f", 109)
+        assert_equal current_state.calculator.lower_earning_limit.round(2), 109
         assert_current_node :maternity_leave_and_pay_result
       end
     end
@@ -633,7 +633,7 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
 
       should "have LEL of 109" do
         assert_state_variable :to_saturday_formatted, "Saturday, 21 December 2013"
-        assert_state_variable "lower_earning_limit", sprintf("%.2f", 109)
+        assert_equal current_state.calculator.lower_earning_limit.round(2), 109
         assert_current_node :maternity_leave_and_pay_result
       end
     end
@@ -653,7 +653,7 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
 
       should "have LEL of 107" do
         assert_state_variable :to_saturday_formatted, "Saturday, 30 March 2013"
-        assert_state_variable "lower_earning_limit", sprintf("%.2f", 107)
+        assert_equal current_state.calculator.lower_earning_limit.round(2), 107
         assert_current_node :maternity_leave_and_pay_result
       end
     end
@@ -696,7 +696,7 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
         "30 April 2019" => "£242.43",
       )
 
-      assert_state_variable :total_smp, "5090.92"
+      assert_equal current_state.calculator.total_smp.round(2), 5090.92
     end
   end
 
@@ -736,7 +736,7 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
         "28 June 2019" => "£318.60",
       )
 
-      assert_state_variable :total_smp, "6259.03"
+      assert_equal current_state.calculator.total_smp.round(2), 6259.03
     end
   end
 
@@ -776,7 +776,7 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
         "29 March 2019" => "£394.06",
       )
 
-      assert_state_variable :total_smp, "6610.66"
+      assert_equal current_state.calculator.total_smp.round(2), 6610.66
     end
   end
 end

--- a/test/integration/smart_answer_flows/maternity_calculator_test.rb
+++ b/test/integration/smart_answer_flows/maternity_calculator_test.rb
@@ -219,7 +219,7 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
 
                           should "show the result node" do
                             assert_current_node :maternity_leave_and_pay_result
-                            assert_state_variable :pay_method, "weekly"
+                            assert_equal current_state.calculator.pay_method, "weekly"
                           end
 
                           should "calculate dates and pay amounts" do
@@ -281,13 +281,13 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
                     should "calculate the SMP for first day of the month" do
                       add_response "first_day_of_the_month"
                       assert_current_node :maternity_leave_and_pay_result
-                      assert_state_variable :monthly_pay_method, "first_day_of_the_month"
+                      assert_equal current_state.calculator.monthly_pay_method, "first_day_of_the_month"
                     end
 
                     should "calculate the SMP for last day of the month" do
                       add_response "last_day_of_the_month"
                       assert_current_node :maternity_leave_and_pay_result
-                      assert_state_variable :pay_method, "last_day_of_the_month"
+                      assert_equal current_state.calculator.pay_method, "last_day_of_the_month"
                     end
 
                     should "calculate the dates and payment amounts" do
@@ -321,7 +321,7 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
                       end
 
                       should "store this as pay_day_in_month" do
-                        assert_state_variable :monthly_pay_method, "last_working_day_of_the_month"
+                        assert_equal current_state.calculator.monthly_pay_method, "last_working_day_of_the_month"
                       end
 
                       should "ask what days the employee works" do
@@ -441,7 +441,7 @@ class MaternityCalculatorTest < ActiveSupport::TestCase
           add_response "29"
         end
         should "assume values over 28 as the last day of the month" do
-          assert_state_variable :pay_method, "last_day_of_the_month"
+          assert_equal current_state.calculator.pay_method, "last_day_of_the_month"
         end
       end
       context "calculate maternity with £4000 earnings" do

--- a/test/unit/smart_answer_flows/adoption_calculator_flow_test.rb
+++ b/test/unit/smart_answer_flows/adoption_calculator_flow_test.rb
@@ -374,8 +374,9 @@ module SmartAnswer
 
     context "when answering how_do_you_want_the_sap_calculated?" do
       setup do
+        calculator = Calculators::AdoptionPayCalculator.new(Time.zone.now)
         @question = TestNode.new(@flow, :how_do_you_want_the_sap_calculated?)
-          .with_stubbed_calculator
+          .with(calculator: calculator)
       end
 
       should "respond to 'weekly_starting' with adoption_leave_and_pay" do


### PR DESCRIPTION
Move `pay_method` definition to calculator
- Move `pay_method` from outcome `precalculator` within flows
- Move `monthly_pay_method` from `state` to `calculator`
- Refactor smp, sap and spp calculator methods to single shared `period_calculation_method` so they can share common `pay_method`
- Update tests to account for moved and renamed methods

Move precalculate methods to calculator for `maternity_leave_and_pay_result` outcome

Also fix assignment of `not_entitled_to_pay_reason` so as on calculator

[Trello card](https://trello.com/c/RpgFrtyo/549-remove-deprecated-flow-methods-from-maternity-paternity-calculator)