### PR TITLE
Add coronavirus restriction grants to business support flow

### DIFF
--- a/lib/smart_answer/calculators/business_coronavirus_support_finder_calculator.rb
+++ b/lib/smart_answer/calculators/business_coronavirus_support_finder_calculator.rb
@@ -7,7 +7,13 @@ module SmartAnswer::Calculators
                   :self_employed,
                   :non_domestic_property,
                   :sectors,
-                  :rate_relief_march_2020
+                  :rate_relief_march_2020,
+                  :restricted_sector,
+                  :closed_by_restrictions
+
+    def initialize
+      @closed_by_restrictions = []
+    end
 
     RULES = {
       job_retention_scheme: lambda { |calculator|
@@ -50,6 +56,25 @@ module SmartAnswer::Calculators
       },
       kickstart_scheme: lambda { |calculator|
         calculator.business_based != "northern_ireland"
+      },
+      lrsg_closed_addendum: lambda { |calculator|
+        calculator.business_based == "england" &&
+          calculator.closed_by_restrictions.include?("national")
+      },
+      lrsg_closed: lambda { |calculator|
+        calculator.business_based == "england" &&
+          calculator.closed_by_restrictions.include?("local")
+      },
+      lrsg_open: lambda { |calculator|
+        calculator.business_based == "england" &&
+          calculator.restricted_sector == "no"
+      },
+      lrsg_sector: lambda { |calculator|
+        calculator.business_based == "england" &&
+          calculator.restricted_sector == "yes"
+      },
+      additional_restrictions_grant: lambda { |calculator|
+        calculator.business_based == "england"
       },
     }.freeze
 

--- a/lib/smart_answer_flows/business-coronavirus-support-finder.rb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder.rb
@@ -90,7 +90,7 @@ module SmartAnswer
           if calculator.non_domestic_property != "none"
             question :sectors?
           else
-            outcome :results
+            question :restricted_sector?
           end
         end
       end
@@ -115,6 +115,41 @@ module SmartAnswer
 
         on_response do |response|
           calculator.rate_relief_march_2020 = response
+        end
+
+        next_node do
+          outcome :restricted_sector?
+        end
+      end
+
+      radio :restricted_sector? do
+        option :yes
+        option :no
+
+        on_response do |response|
+          calculator.restricted_sector = response
+        end
+
+        next_node do
+          if calculator.restricted_sector == "yes"
+            outcome :results
+          else
+            question :closed_by_restrictions?
+          end
+        end
+      end
+
+      checkbox_question :closed_by_restrictions? do
+        option :local_1
+        option :national
+        option :local_2
+        none_option
+
+        on_response do |response|
+          responses = response.split(",")
+
+          calculator.closed_by_restrictions << "local" if (%w[local_1 local_2] & responses).present?
+          calculator.closed_by_restrictions << "national" if responses.include?("national")
         end
 
         next_node do

--- a/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.erb
@@ -222,6 +222,83 @@
     $CTA
   <% end %>
 
+  <% if calculator.show?(:lrsg_closed_addendum) || calculator.show?(:lrsg_closed) || calculator.show?(:lrsg_open) || calculator.show?(:lrsg_sector) || calculator.show?(:additional_restrictions_grant) %>
+    ## Grants available from your local council
+
+    You might be eligible for grants from your council. There are schemes for businesses that were closed by law and schemes for businesses that stayed open.
+
+    <% if calculator.show?(:lrsg_closed_addendum) %>
+      $CTA
+      ### Local Restrictions Support Grant (Closed addendum) 
+
+      You might be able to get a grant from your local council if your business has been closed by law since 5 November 2020 because of national coronavirus restrictions. The grant covers your business being shut between 5 November and 2 December 2020.
+
+      How much you can get depends on the rateable value of your property.
+
+      [Check if your closed business is eligible for a coronavirus grant because of national restrictions](https://www.gov.uk/guidance/check-if-your-business-is-eligible-for-a-coronavirus-grant-due-to-national-restrictions-for-closed-businesses)
+      $CTA
+    <% end %>
+
+    <% if calculator.show?(:lrsg_closed) %>
+      $CTA
+      ### Local Restrictions Support Grant (Closed)
+
+      You might be able to get a grant from your local council if all or part of your business was closed by law at any time either:
+
+      - between 1 August and 5 November 2020
+      - after 2 December 2020
+
+      Your business must have been in a ‘high’ (tier 2) or ‘very high’ (tier 3) local alert level at the time. Ask your local council if you do not know what tier your business was in.
+
+      How much you can get depends on the rateable value of your property. 
+
+      You can claim for each 14 day period your business was closed for.
+
+      [Check if your business is eligible for a coronavirus grant for businesses closed by local restrictions](https://www.gov.uk/guidance/check-if-youre-eligible-for-the-coronavirus-local-restrictions-support-grant-for-closed-businesses)
+      $CTA
+    <% end %>
+
+    <% if calculator.show?(:lrsg_open) %>
+      $CTA
+      ### Local Restrictions Support Grant (Open)
+
+      You might be able to get a grant from your local council if your business stayed open between 1 August and 5 November 2020 in a ‘high’ (tier 2) or ‘very high’ (tier 3) local alert level. Check with your council if you do not know what alert level your area was in. You’ll need to demonstrate to the council that your business was negatively affected by coronavirus.
+
+      How much you get is decided by your council and will be based on the rateable value of your property.
+
+      [Check if your open business is eligible for the coronavirus Local Restrictions Support Grant](https://www.gov.uk/guidance/check-if-youre-eligible-for-the-coronavirus-local-restrictions-support-grant-for-open-businesses)
+      $CTA
+    <% end %>
+
+    <% if calculator.show?(:lrsg_sector) %>
+      $CTA
+      ### Local Restrictions Support Grant (Sector)
+
+      You might be able to get a grant from your local council if your night club, adult entertainment venue or dance hall has been closed by law since 16 March 2020 because of national coronavirus restrictions.
+
+      How much you can get depends on the rateable value of your property.
+
+      You can apply for each 14 day period your business has been closed for since 1 November 2020.
+
+      [Check if your business is eligible for a coronavirus grant because of national restrictions](https://www.gov.uk/guidance/check-if-your-nightclub-dance-hall-or-adult-entertainment-business-is-eligible-for-a-coronavirus-grant-due-to-national-restrictions)
+      $CTA
+    <% end %>
+
+    <% if calculator.show?(:additional_restrictions_grant) %>
+      $CTA
+      ### Additional Restrictions Grant
+
+      You might be able to get this grant from your local council if your business has been negatively affected by coronavirus. Your local council will decide which businesses are eligible and how much they are entitled to. Examples of what makes a business eligible could include:
+
+      - you do not pay business rates and your business was closed by law
+      - you supply an industry that had to close because of coronavirus, for example the retail, hospitality or leisure sector
+      - your business is in the events sector
+      
+      [Find out more about the coronavirus Additional Restrictions Grant](https://www.gov.uk/guidance/check-if-youre-eligible-for-the-coronavirus-additional-restrictions-grant)
+      $CTA
+    <% end %>
+  <% end %>
+
   <% if calculator.business_based == "scotland" %>
     $CTA
     Find out [what support is available in Scotland](https://findbusinesssupport.gov.scot/coronavirus-advice).

--- a/lib/smart_answer_flows/business-coronavirus-support-finder/questions/closed_by_restrictions.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/questions/closed_by_restrictions.erb
@@ -1,0 +1,14 @@
+<% text_for :title do %>
+  Has your business closed by law because of coronavirus?
+<% end %>
+
+<% text_for :hint do %>
+  Select all that apply
+<% end %>
+
+<% options(
+  "local_1": "Yes, because of local restrictions anytime between 1 August and 5 November 2020",
+  "national": "Yes, because of national restrictions between 5 November and 1 December 2020",
+  "local_2": "Yes, because of local restrictions anytime from 2 December 2020",
+  "none": "No",
+) %>

--- a/lib/smart_answer_flows/business-coronavirus-support-finder/questions/restricted_sector.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/questions/restricted_sector.erb
@@ -1,0 +1,8 @@
+<% text_for :title do %>
+  Is your business a nightclub, dance hall or adult entertainment venue?
+<% end %>
+
+<% options(
+  "yes": "Yes",
+  "no": "No",
+) %>

--- a/spec/features/smart_answer/business_coronavirus_support_finder_flow_spec.rb
+++ b/spec/features/smart_answer/business_coronavirus_support_finder_flow_spec.rb
@@ -15,7 +15,8 @@ RSpec.feature "SmartAnswer::BusinessCoronavirusSupportFinderFlow", type: :featur
       self_assessment_july_2020: "Are you due to pay a Self Assessment payment on account by 31 July 2020?",
       self_employed: "Are you self-employed?",
       what_size_was_your_buisness: "What size was your business as of 28 February?",
-      where_is_your_business_based: "Where is your business based?",
+      restricted_sector: "Is your business a nightclub, dance hall or adult entertainment venue?",
+      closed_by_restrictions: "Has your business closed by law because of coronavirus?",
       results: "Support you may be entitled to",
     }
   end
@@ -54,6 +55,14 @@ RSpec.feature "SmartAnswer::BusinessCoronavirusSupportFinderFlow", type: :featur
     expect(page).to have_selector("h1", text: headings[:non_domestic_property])
 
     choose "My business does not have any non-domestic property"
+    click_button "Next step"
+    expect(page).to have_selector("h1", text: headings[:restricted_sector])
+
+    choose "No"
+    click_button "Next step"
+    expect(page).to have_selector("h1", text: headings[:closed_by_restrictions])
+
+    check "No"
     click_button "Next step"
     expect(page).to have_selector("h1", text: headings[:flow_title])
     expect(page).to have_selector("h2", text: headings[:results])
@@ -95,6 +104,14 @@ RSpec.feature "SmartAnswer::BusinessCoronavirusSupportFinderFlow", type: :featur
     expect(page).to have_selector("h1", text: headings[:rate_relief_march_2020])
 
     choose "Yes"
+    click_button "Next step"
+    expect(page).to have_selector("h1", text: headings[:restricted_sector])
+
+    choose "No"
+    click_button "Next step"
+    expect(page).to have_selector("h1", text: headings[:closed_by_restrictions])
+
+    check "No"
     click_button "Next step"
     expect(page).to have_selector("h1", text: headings[:flow_title])
     expect(page).to have_selector("h2", text: headings[:results])

--- a/test/integration/smart_answer_flows/business_coronavirus_support_finder_test.rb
+++ b/test/integration/smart_answer_flows/business_coronavirus_support_finder_test.rb
@@ -28,6 +28,34 @@ class BusinessCoronavirusSupportFinderFlowTest < ActiveSupport::TestCase
       add_response "retail_hospitality_or_leisure"
       assert_current_node :rate_relief_march_2020?
       add_response "yes"
+      assert_current_node :restricted_sector?
+      add_response "no"
+      assert_current_node :closed_by_restrictions?
+      add_response "none"
+      assert_current_node :results
+    end
+  end
+
+  context "flow without closed by restrictions" do
+    should "reach results node" do
+      assert_current_node :business_based?
+      add_response "england"
+      assert_current_node :business_size?
+      add_response "0_to_249"
+      assert_current_node :annual_turnover?
+      add_response "500m_and_over"
+      assert_current_node :paye_scheme?
+      add_response "yes"
+      assert_current_node :self_employed?
+      add_response "yes"
+      assert_current_node :non_domestic_property?
+      add_response "51k_and_over"
+      assert_current_node :sectors?
+      add_response "retail_hospitality_or_leisure"
+      assert_current_node :rate_relief_march_2020?
+      add_response "yes"
+      assert_current_node :restricted_sector?
+      add_response "yes"
       assert_current_node :results
     end
   end
@@ -46,6 +74,30 @@ class BusinessCoronavirusSupportFinderFlowTest < ActiveSupport::TestCase
       add_response "no"
       assert_current_node :non_domestic_property?
       add_response "none"
+      assert_current_node :restricted_sector?
+      add_response "no"
+      assert_current_node :closed_by_restrictions?
+      add_response "none"
+      assert_current_node :results
+    end
+  end
+
+  context "flow without other sectors and closed by restrictions" do
+    should "reach results node" do
+      assert_current_node :business_based?
+      add_response "scotland"
+      assert_current_node :business_size?
+      add_response "over_249"
+      assert_current_node :annual_turnover?
+      add_response "45m_to_500m"
+      assert_current_node :paye_scheme?
+      add_response "no"
+      assert_current_node :self_employed?
+      add_response "no"
+      assert_current_node :non_domestic_property?
+      add_response "none"
+      assert_current_node :restricted_sector?
+      add_response "yes"
       assert_current_node :results
     end
   end

--- a/test/unit/calculators/business_coronavirus_support_calculator_test.rb
+++ b/test/unit/calculators/business_coronavirus_support_calculator_test.rb
@@ -216,6 +216,98 @@ module SmartAnswer::Calculators
           assert_not @calculator.show?(:kickstart_scheme)
         end
       end
+
+      context "lrsg_closed_addendum" do
+        should "return true when business closed by national restrictions and based in england" do
+          @calculator.business_based = "england"
+          @calculator.closed_by_restrictions << "national"
+          assert @calculator.show?(:lrsg_closed_addendum)
+        end
+
+        should "return false when business not based in england" do
+          @calculator.business_based = "scotland"
+          @calculator.closed_by_restrictions << "national"
+          assert_not @calculator.show?(:lrsg_closed_addendum)
+        end
+
+        should "return false when business not closed by national restrictions" do
+          @calculator.business_based = "england"
+          @calculator.closed_by_restrictions = []
+          assert_not @calculator.show?(:lrsg_closed_addendum)
+        end
+      end
+
+      context "lrsg_closed" do
+        should "return true when business closed by local restrictions and based in england" do
+          @calculator.business_based = "england"
+          @calculator.closed_by_restrictions << "local"
+          assert @calculator.show?(:lrsg_closed)
+        end
+
+        should "return false when business not based in england" do
+          @calculator.business_based = "scotland"
+          @calculator.closed_by_restrictions << "local"
+          assert_not @calculator.show?(:lrsg_closed)
+        end
+
+        should "return false when business not closed by local restrictions" do
+          @calculator.business_based = "england"
+          @calculator.closed_by_restrictions = []
+          assert_not @calculator.show?(:lrsg_closed)
+        end
+      end
+
+      context "lrsg_open" do
+        should "return true when business not closed by sector restrictions and based in england" do
+          @calculator.business_based = "england"
+          @calculator.restricted_sector = "no"
+          assert @calculator.show?(:lrsg_open)
+        end
+
+        should "return false when business not based in england" do
+          @calculator.business_based = "scotland"
+          @calculator.restricted_sector = "no"
+          assert_not @calculator.show?(:lrsg_open)
+        end
+
+        should "return false when business is closed by local restrictions" do
+          @calculator.business_based = "england"
+          @calculator.restricted_sector = "yes"
+          assert_not @calculator.show?(:lrsg_open)
+        end
+      end
+
+      context "lrsg_sector" do
+        should "return true when business closed by sector restrictions and based in england" do
+          @calculator.business_based = "england"
+          @calculator.restricted_sector = "yes"
+          assert @calculator.show?(:lrsg_sector)
+        end
+
+        should "return false when business not based in england" do
+          @calculator.business_based = "scotland"
+          @calculator.restricted_sector = "yes"
+          assert_not @calculator.show?(:lrsg_sector)
+        end
+
+        should "return false when business not closed by local restrictions" do
+          @calculator.business_based = "england"
+          @calculator.restricted_sector = "no"
+          assert_not @calculator.show?(:lrsg_sector)
+        end
+      end
+
+      context "additional_restrictions_grant" do
+        should "return true when business based in england" do
+          @calculator.business_based = "england"
+          assert @calculator.show?(:additional_restrictions_grant)
+        end
+
+        should "return false when business not based in england" do
+          @calculator.business_based = "scotland"
+          assert_not @calculator.show?(:additional_restrictions_grant)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This adds two new questions to the business support flow and 5 new grants now available. The new questions are to determine eligibility for the new grants.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.

- Changes to start pages are **not** continuously deployed, and are [deployed using a different process](https://github.com/alphagov/smart-answers/blob/master/doc/smart-answer-flow-development/publishing.md).
