### PR TITLE
Makes links to council lookup consistent

### DIFF
--- a/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.erb
@@ -106,7 +106,7 @@
 
     Local authority-run nurseries are not eligible.
 
-    Contact your [local council](/find-local-council) if you think you’re eligible and you have not received business rates relief.
+    [Contact your local council](/find-local-council) if you think you’re eligible and you have not received business rates relief.
     $CTA
   <% end %>
 


### PR DESCRIPTION
So we are linking to the same URL with the same link description for accessibility.

