### PR TITLE
Remove Mali and Samoa from marriage abroad tool

### DIFF
--- a/lib/smart_answer_flows/marriage-abroad.rb
+++ b/lib/smart_answer_flows/marriage-abroad.rb
@@ -16,7 +16,7 @@ module SmartAnswer
       status :published
       satisfies_need "463773ea-3629-4386-8511-06ec12351303"
 
-      exclude_countries = %w[holy-see british-antarctic-territory the-occupied-palestinian-territories]
+      exclude_countries = %w[samoa mali holy-see british-antarctic-territory the-occupied-palestinian-territories]
 
       # Q1
       country_select :country_of_ceremony?, exclude_countries: exclude_countries do


### PR DESCRIPTION
We should add them back once we have outcomes.

[Trello](https://trello.com/c/ULANmY65/2237-3-marriage-abroad-same-sex-answer-broken-in-smart-answers)

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.

- Changes to start pages are **not** continuously deployed, and are [deployed using a different process](https://github.com/alphagov/smart-answers/blob/master/doc/smart-answer-flow-development/publishing.md).
