### PR TITLE
Update track response JavaScript to track radio questions

### DIFF
--- a/app/assets/javascripts/modules/track-responses.js
+++ b/app/assets/javascripts/modules/track-responses.js
@@ -13,7 +13,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       return submittedForm.getAttribute('data-question-key');
     }
 
-    function getResponseLabelsForMultipleChoice(submittedForm) {
+    function getResponseLabelsForRadio(submittedForm) {
       var labels = []
       var checkedOptions = submittedForm.querySelectorAll('input:checked')
 
@@ -21,7 +21,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         checkedOptions.forEach(function (checkedOption) {
           var checkedOptionId = checkedOption.getAttribute('id')
           var checkedOptionLabel = submittedForm.querySelectorAll('label[for="' + checkedOptionId + '"]')
-          
+
           var eventLabel = checkedOptionLabel.length
             ? checkedOptionLabel[0].innerText.trim()
             : checkedOption.value
@@ -59,17 +59,17 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     function getResponseLabels(submittedForm) {
       var responseLabels = []
       var questionType = submittedForm.getAttribute('data-type')
-      
+
       switch (questionType) {
         case 'checkbox_question':
-        case 'multiple_choice_question':
-          responseLabels = getResponseLabelsForMultipleChoice(submittedForm)
+        case 'radio_question':
+          responseLabels = getResponseLabelsForRadio(submittedForm)
           break
-        
+
         case 'country_select_question':
           responseLabels = getResponseLabelsForSelectOption(submittedForm)
           break
-        
+
         default:
           break
       }

--- a/spec/javascripts/modules/track-responses.spec.js
+++ b/spec/javascripts/modules/track-responses.spec.js
@@ -17,7 +17,7 @@ describe('Track responses', function () {
       element.setAttribute('method', 'post')
 
       var fieldset = document.createElement('fieldset');
-  
+
       var checkboxes = [
         {label: "Construction label", value: "construction"},
         {label: "Accommodation label", value: "accommodation"},
@@ -106,7 +106,7 @@ describe('Track responses', function () {
       var element = document.createElement('form');
       element.setAttribute('onsubmit', 'event.preventDefault()')
       element.setAttribute('data-module', 'track-responses')
-      element.setAttribute('data-type', 'multiple_choice_question')
+      element.setAttribute('data-type', 'radio_question')
       element.setAttribute('data-question-key', 'question-key')
       element.setAttribute('method', 'post')
 


### PR DESCRIPTION
MultipleChoice questions have been renamed as Radio questions (see https://github.com/alphagov/smart-answers/pull/4911), but the tracking code was not updated to match.

This PR updates the tracking JavaScript and associated tests.

[Trello card](https://trello.com/c/N03RYWvO/630-fix-event-tracking-on-smart-answers)

