### PR TITLE
Add error handling for content store 5xx errors

### DIFF
--- a/app/services/content_item_retriever.rb
+++ b/app/services/content_item_retriever.rb
@@ -5,7 +5,7 @@ class ContentItemRetriever
     end
 
     item_hash.with_indifferent_access
-  rescue GdsApi::HTTPNotFound, GdsApi::HTTPGone
+  rescue GdsApi::HTTPNotFound, GdsApi::HTTPGone, GdsApi::HTTPInternalServerError
     {}
   end
 end

--- a/test/unit/services/content_item_retriever_test.rb
+++ b/test/unit/services/content_item_retriever_test.rb
@@ -59,5 +59,14 @@ class ContentItemRetrieverTest < ActiveSupport::TestCase
         assert_equal ContentItemRetriever.fetch(@slug), {}
       end
     end
+
+    context "when content store unavailable" do
+      should "return empty content item hash" do
+        response = { status: 500, body: {}.to_json }
+        stub_request(:get, @request_url).to_return(response)
+
+        assert_equal ContentItemRetriever.fetch(@slug), {}
+      end
+    end
   end
 end


### PR DESCRIPTION
We only use the content store to render related links, this prevents the page from failing to to load if the content store becomes unavailable. Only the related links will be missing, but the page should still render.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.

- Changes to start pages are **not** continuously deployed, and are [deployed using a different process](https://github.com/alphagov/smart-answers/blob/master/doc/smart-answer-flow-development/publishing.md).
