### PR TITLE
Remove deprecated methods from the calculate your holiday entitlement flow

### DIFF
--- a/lib/smart_answer/calculators/holiday_entitlement.rb
+++ b/lib/smart_answer/calculators/holiday_entitlement.rb
@@ -13,28 +13,62 @@ module SmartAnswer::Calculators
     DAYS_PER_LEAP_YEAR = 366.to_d
     STANDARD_WORKING_DAYS_PER_WEEK = 5.to_d
 
-    attr_reader :working_days_per_week,
-                :hours_per_week,
+    attr_accessor :calculation_basis,
+                  :holiday_period,
+                  :leave_year_start_date,
+                  :hours_per_shift
+
+    attr_reader :hours_per_week,
                 :start_date,
                 :leaving_date,
-                :leave_year_start_date,
+                :working_days_per_week,
                 :shifts_per_shift_pattern,
                 :days_per_shift_pattern
 
-    def initialize(working_days_per_week: 0,
-                   hours_per_week: 0,
-                   start_date: nil,
-                   leaving_date: nil,
-                   leave_year_start_date: nil,
-                   shifts_per_shift_pattern: 0,
-                   days_per_shift_pattern: 0)
-      @working_days_per_week = BigDecimal(working_days_per_week, 10)
-      @hours_per_week = BigDecimal(hours_per_week, 10)
-      @start_date = start_date
-      @leaving_date = leaving_date
-      @leave_year_start_date = leave_year_start_date || calculate_leave_year_start_date
-      @shifts_per_shift_pattern = BigDecimal(shifts_per_shift_pattern, 10)
-      @days_per_shift_pattern = BigDecimal(days_per_shift_pattern, 10)
+    def initialize
+      @leave_year_start_date = calculate_leave_year_start_date
+    end
+
+    def start_date=(date)
+      @start_date = date
+      @leave_year_start_date = calculate_leave_year_start_date
+    end
+
+    def leaving_date=(date)
+      @leaving_date = date
+      @leave_year_start_date = calculate_leave_year_start_date
+    end
+
+    def hours_per_week=(hours)
+      @hours_per_week = BigDecimal(hours, 10)
+    end
+
+    def working_days_per_week=(days)
+      @working_days_per_week = BigDecimal(days, 10)
+    end
+
+    def shifts_per_shift_pattern=(shifts)
+      @shifts_per_shift_pattern = BigDecimal(shifts, 10)
+    end
+
+    def days_per_shift_pattern=(days)
+      @days_per_shift_pattern = BigDecimal(days, 10)
+    end
+
+    def holiday_entitlement_hours
+      full_time_part_time_hours_and_minutes.first
+    end
+
+    def holiday_entitlement_minutes
+      full_time_part_time_hours_and_minutes.last
+    end
+
+    def hours_daily
+      compressed_hours_daily_average.first
+    end
+
+    def minutes_daily
+      compressed_hours_daily_average.last
     end
 
     def compressed_hours_daily_average

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/compressed_hours_done.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/compressed_hours_done.erb
@@ -1,8 +1,9 @@
 <% govspeak_for :body do %>
-  $!The statutory holiday entitlement is <%= "#{holiday_entitlement_hours} #{'hour'.pluralize(holiday_entitlement_hours)}" %> and <%= "#{holiday_entitlement_minutes} #{'minute'.pluralize(holiday_entitlement_minutes)}" %> holiday for the year. Rather than taking a day’s holiday it’s <%= "#{hours_daily} #{'hour'.pluralize(hours_daily)}" %> and <%= "#{minutes_daily} #{'minute'.pluralize(minutes_daily)}" %> holiday for each day otherwise worked.$!
+  $!The statutory holiday entitlement is <%= "#{calculator.holiday_entitlement_hours} #{'hour'.pluralize(calculator.holiday_entitlement_hours)}" %> and <%= "#{calculator.holiday_entitlement_minutes} #{'minute'.pluralize(calculator.holiday_entitlement_minutes)}" %> holiday for the year. Rather than taking a day’s holiday it’s <%= "#{calculator.hours_daily} #{'hour'.pluralize(calculator.hours_daily)}" %> and <%= "#{calculator.minutes_daily} #{'minute'.pluralize(calculator.minutes_daily)}" %> holiday for each day otherwise worked.$!
 
   <%= render partial: 'your_employer_with_rounding' %>
-  <% if holiday_period == "starting" %>
+  
+  <% if calculator.holiday_period == "starting" %>
     <%= render partial: "the_user_should_be_aware" %>
   <% end %>
 

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/days_per_week_done.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/days_per_week_done.erb
@@ -1,15 +1,15 @@
 <% govspeak_for :body do %>
-  $!The statutory holiday entitlement is <%= "#{holiday_entitlement_days} #{'day'.pluralize(holiday_entitlement_days)}" %> holiday.$!
+  $!The statutory holiday entitlement is <%= "#{calculator.formatted_full_time_part_time_days} #{'day'.pluralize(calculator.formatted_full_time_part_time_days)}" %> holiday.$!
 
-  <% if working_days_per_week > 5 %>
+  <% if calculator.working_days_per_week > 5 %>
     Even though more than 5 days a week are worked, the maximum statutory holiday entitlement is 28 days.
   <% end %>
 
   <%= render partial: "your_employer_with_rounding" %>
 
-  <% if holiday_period == "starting" %>
+  <% if calculator.holiday_period == "starting" %>
     <%= render partial: "the_user_should_be_aware" %>
   <% end %>
 
-   <%= render partial: "guidance_on_calculations" %>
+  <%= render partial: "guidance_on_calculations" %>
 <% end %>

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/hours_per_week_done.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/hours_per_week_done.erb
@@ -1,13 +1,13 @@
 <% govspeak_for :body do %>
-  $!The statutory entitlement is <%= "#{holiday_entitlement_hours} #{'hour'.pluralize(holiday_entitlement_hours)}" %> holiday.$!
+  $!The statutory entitlement is <%= "#{calculator.formatted_full_time_part_time_compressed_hours} #{'hour'.pluralize(calculator.formatted_full_time_part_time_compressed_hours)}" %> holiday.$!
 
-  <% if working_days_per_week > 5 %>
+  <% if calculator.working_days_per_week > 5 %>
     Even though more than 5 days a week are worked the maximum statutory holiday entitlement is 28 days.
   <% end %>
 
   <%= render partial: 'your_employer_with_rounding' %>
 
-  <% if holiday_period == "starting" %>
+  <% if calculator.holiday_period == "starting" %>
     <%= render partial: "the_user_should_be_aware" %>
   <% end %>
 

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/irregular_and_annualised_done.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/irregular_and_annualised_done.erb
@@ -1,5 +1,5 @@
 <% govspeak_for :body do %>
-  The statutory holiday entitlement is <%= holiday_entitlement %> weeks holiday.
+  The statutory holiday entitlement is <%= calculator.formatted_full_time_part_time_weeks %> weeks holiday.
 
   There are no regulations on how to convert the entitlement into days or hours for workers with irregular hours.
 
@@ -7,7 +7,7 @@
 
   <%= render partial: 'your_employer_with_rounding' %>
 
-  <% if holiday_period == 'starting' %>
+  <% if calculator.holiday_period == 'starting' %>
     <%= render partial: 'irregular_and_annualised_user_awareness' %>
   <% else %>
     <%= render partial: 'entitlement_restriction' %>

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/shift_worker_done.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/shift_worker_done.erb
@@ -1,12 +1,13 @@
 <% govspeak_for :body do %>
-  $!The statutory holiday entitlement is <%= "#{holiday_entitlement_shifts} #{'shift'.pluralize(holiday_entitlement_shifts)}" %> for the year. Each shift being <%= "#{hours_per_shift} #{'hour'.pluralize(hours_per_shift)}" %>.$!
+  $!The statutory holiday entitlement is <%= "#{calculator.shift_entitlement} #{'shift'.pluralize(calculator.shift_entitlement)}" %> for the year. Each shift being <%= "#{calculator.hours_per_shift} #{'hour'.pluralize(calculator.hours_per_shift)}" %>.$!
 
-  <% if shifts_per_week > 5 %>
+  <% if calculator.shifts_per_week > 5 %>
     Even though more than 5 shifts a week are worked the maximum statutory holiday entitlement is 28 shifts.
   <% end %>
 
   <%= render partial: 'shift_worker_your_employer_with_rounding' %>
-  <% if holiday_period == "starting" %>
+
+  <% if calculator.holiday_period == "starting" %>
     <%= render partial: "the_user_should_be_aware" %>
   <% end %>
 

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/questions/what_is_your_leaving_date.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/questions/what_is_your_leaving_date.erb
@@ -2,12 +2,12 @@
   What was the employment end date?
 <% end %>
 
-<% if start_date %>
+<% if calculator.start_date %>
   <% text_for :error_end_date_before_start_date do %>
-    Your end date can not be before your start date of <%="#{start_date.strftime('%d %B %Y')}"%>.
+    Your end date can not be before your start date of <%= calculator.start_date.strftime('%d %B %Y') %>.
   <% end %>
 
   <% text_for :error_end_date_outside_year_range do %>
-      Your employment end date must be within 1 year of your start date of <%="#{start_date.strftime('%d %B %Y')}"%>.
+      Your employment end date must be within 1 year of your start date of <%= calculator.start_date.strftime('%d %B %Y') %>.
   <% end %>
 <% end %>

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/questions/when_does_your_leave_year_start.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/questions/when_does_your_leave_year_start.erb
@@ -6,22 +6,22 @@
   This is usually in the employment contract. If it is not and the job was started after 1 October 1998, the leave year will start on the 1st day of the job. If the job was started on or before 1 October 1998, the leave year will start on 1 October.
 <% end %>
 
-<% if leaving_date%>
+<% if calculator.leaving_date %>
   <% text_for :error_end_date_before_start_date do %>
-    Your leave year start date must be earlier than your employment end date of <%="#{leaving_date.strftime('%d %B %Y')}"%>.
+    Your leave year start date must be earlier than your employment end date of <%= calculator.leaving_date.strftime('%d %B %Y') %>.
   <% end %>
 
   <% text_for :error_end_date_outside_leave_year_range do %>
-    Your employment end date of <%="#{leaving_date.strftime('%d %B %Y')}"%> must be within 1 year of the leave year start date.
+    Your employment end date of <%= calculator.leaving_date.strftime('%d %B %Y') %> must be within 1 year of the leave year start date.
   <% end %>
 <% end %>
 
-<% if start_date%>
+<% if calculator.start_date %>
   <% text_for :error_start_date_before_start_leave_year_date do %>
-    Your leave year start date must be earlier than your employment start date of <%="#{start_date.strftime('%d %B %Y')}"%>.
+    Your leave year start date must be earlier than your employment start date of <%= calculator.start_date.strftime('%d %B %Y') %>.
   <% end%>
 
   <% text_for :error_start_date_outside_leave_year_range do %>
-    Your employment start date of <%="#{start_date.strftime('%d %B %Y')}"%> must be within 1 year of the leave year start date.
+    Your employment start date of <%= calculator.start_date.strftime('%d %B %Y') %> must be within 1 year of the leave year start date.
   <% end %>
 <% end %>

--- a/test/integration/smart_answer_flows/calculate_your_holiday_entitlement_test.rb
+++ b/test/integration/smart_answer_flows/calculate_your_holiday_entitlement_test.rb
@@ -8,7 +8,6 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
 
   setup do
     setup_for_testing_flow SmartAnswer::CalculateYourHolidayEntitlementFlow
-    @stubbed_calculator = SmartAnswer::Calculators::HolidayEntitlement.new
   end
 
   should "ask what the basis of the calculation is" do
@@ -34,35 +33,15 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
       end
 
       should "calculate and be done when 5 days a week" do
-        SmartAnswer::Calculators::HolidayEntitlement
-          .expects(:new)
-          .with(
-            working_days_per_week: 5,
-            start_date: nil,
-            leaving_date: nil,
-            leave_year_start_date: nil,
-          ).returns(@stubbed_calculator)
-        @stubbed_calculator.expects(:formatted_full_time_part_time_days).returns("formatted days")
-
         add_response "5"
         assert_current_node :days_per_week_done
-        assert_state_variable :holiday_entitlement_days, "formatted days"
+        assert_equal "28", current_state.calculator.formatted_full_time_part_time_days
       end
 
       should "calculate and be done when more than 5 days a week" do
-        SmartAnswer::Calculators::HolidayEntitlement
-          .expects(:new)
-          .with(
-            working_days_per_week: 6,
-            start_date: nil,
-            leaving_date: nil,
-            leave_year_start_date: nil,
-          ).returns(@stubbed_calculator)
-        @stubbed_calculator.expects(:formatted_full_time_part_time_days).returns("formatted days")
-
         add_response "6"
         assert_current_node :days_per_week_done
-        assert_state_variable :holiday_entitlement_days, "formatted days"
+        assert_equal "28", current_state.calculator.formatted_full_time_part_time_days
       end
     end # full year
 
@@ -97,20 +76,11 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
             setup do
               add_response "5"
             end
-            should "calculate and be done part year when 5 days" do
-              SmartAnswer::Calculators::HolidayEntitlement
-                .expects(:new)
-                .with(
-                  working_days_per_week: 5,
-                  start_date: Date.parse("#{Time.zone.today.year}-03-14"),
-                  leaving_date: nil,
-                  leave_year_start_date: Date.parse("#{Time.zone.today.year}-03-02"),
-                ).returns(@stubbed_calculator)
-              @stubbed_calculator.expects(:formatted_full_time_part_time_days).returns("formatted days")
 
+            should "calculate and be done part year when 5 days" do
               assert_current_node :days_per_week_done
-              assert_state_variable :holiday_entitlement_days, "formatted days"
-              assert_state_variable :working_days_per_week, 5
+              assert_equal "28", current_state.calculator.formatted_full_time_part_time_days
+              assert_equal 5, current_state.calculator.working_days_per_week
             end
           end
 
@@ -118,20 +88,11 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
             setup do
               add_response "7"
             end
-            should "calculate and be done part year when 6 or 7 days" do
-              SmartAnswer::Calculators::HolidayEntitlement
-                .expects(:new)
-                .with(
-                  working_days_per_week: 7,
-                  start_date: Date.parse("#{Time.zone.today.year}-03-14"),
-                  leaving_date: nil,
-                  leave_year_start_date: Date.parse("#{Time.zone.today.year}-03-02"),
-                ).returns(@stubbed_calculator)
-              @stubbed_calculator.expects(:formatted_full_time_part_time_days).returns("formatted days")
 
+            should "calculate and be done part year when 6 or 7 days" do
               assert_current_node :days_per_week_done
-              assert_state_variable :holiday_entitlement_days, "formatted days"
-              assert_state_variable :working_days_per_week, 7
+              assert_equal "28", current_state.calculator.formatted_full_time_part_time_days
+              assert_equal 7, current_state.calculator.working_days_per_week
             end
           end
         end # with a leave year start date
@@ -169,20 +130,11 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
             setup do
               add_response "5"
             end
-            should "calculate and be done part year when 5 days" do
-              SmartAnswer::Calculators::HolidayEntitlement
-                .expects(:new)
-                .with(
-                  working_days_per_week: 5,
-                  start_date: nil,
-                  leaving_date: Date.parse("#{Time.zone.today.year}-07-14"),
-                  leave_year_start_date: Date.parse("#{Time.zone.today.year}-01-01"),
-                ).returns(@stubbed_calculator)
-              @stubbed_calculator.expects(:formatted_full_time_part_time_days).returns("formatted days")
 
+            should "calculate and be done part year when 5 days" do
               assert_current_node :days_per_week_done
-              assert_state_variable :holiday_entitlement_days, "formatted days"
-              assert_state_variable :working_days_per_week, 5
+              assert_equal "15", current_state.calculator.formatted_full_time_part_time_days
+              assert_equal 5, current_state.calculator.working_days_per_week
             end
           end
 
@@ -190,20 +142,11 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
             setup do
               add_response "6"
             end
-            should "calculate and be done part year when 6 days" do
-              SmartAnswer::Calculators::HolidayEntitlement
-                .expects(:new)
-                .with(
-                  working_days_per_week: 6,
-                  start_date: nil,
-                  leaving_date: Date.parse("#{Time.zone.today.year}-07-14"),
-                  leave_year_start_date: Date.parse("#{Time.zone.today.year}-01-01"),
-                ).returns(@stubbed_calculator)
-              @stubbed_calculator.expects(:formatted_full_time_part_time_days).returns("formatted days")
 
+            should "calculate and be done part year when 6 days" do
               assert_current_node :days_per_week_done
-              assert_state_variable :holiday_entitlement_days, "formatted days"
-              assert_state_variable :working_days_per_week, 6
+              assert_equal "15", current_state.calculator.formatted_full_time_part_time_days
+              assert_equal 6, current_state.calculator.working_days_per_week
             end
           end
         end # with a leave year start date
@@ -214,13 +157,16 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
       setup do
         add_response "starting-and-leaving"
       end
+
       should "ask what was the employment start date" do
         assert_current_node :what_is_your_starting_date?
       end
+
       context "add employment start date" do
         setup do
           add_response "#{Time.zone.today.year}-07-14"
         end
+
         should "ask what date employment finished" do
           assert_current_node :what_is_your_leaving_date?
         end
@@ -229,6 +175,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
           setup do
             add_response "#{Time.zone.today.year - 1}-10-14"
           end
+
           should "raise an invalid response" do
             assert_current_node :what_is_your_leaving_date?, error: true
           end
@@ -238,24 +185,16 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
           setup do
             add_response "#{Time.zone.today.year}-10-14"
           end
+
           should "ask you how many days worked per week" do
             assert_current_node :how_many_days_per_week?
           end
-          should "calculate and be done part year when 5 days" do
-            SmartAnswer::Calculators::HolidayEntitlement
-              .expects(:new)
-              .with(
-                working_days_per_week: 5,
-                start_date: Date.parse("#{Time.zone.today.year}-07-14"),
-                leaving_date: Date.parse("#{Time.zone.today.year}-10-14"),
-                leave_year_start_date: nil,
-              ).returns(@stubbed_calculator)
-            @stubbed_calculator.expects(:formatted_full_time_part_time_days).returns("formatted days")
 
+          should "calculate and be done part year when 5 days" do
             add_response "5"
             assert_current_node :days_per_week_done
-            assert_state_variable :holiday_entitlement_days, "formatted days"
-            assert_state_variable :working_days_per_week, 5
+            assert_equal "7.2", current_state.calculator.formatted_full_time_part_time_days
+            assert_equal 5, current_state.calculator.working_days_per_week
           end
         end
       end
@@ -266,95 +205,90 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
     setup do
       add_response "hours-worked-per-week"
     end
+
     should "ask the time period for the calculation" do
       assert_current_node :calculation_period?
     end
+
     context "answer full leave year" do
       setup do
         add_response "full-year"
       end
+
       should "ask the number of hours worked per week" do
         assert_current_node :how_many_hours_per_week?
       end
+
       context "answer 40 hours" do
         setup do
           add_response "40"
         end
+
         should "ask the number of days worked per week" do
           assert_current_node :how_many_days_per_week_for_hours?
         end
+
         context "answer 5 days" do
           setup do
             add_response "5"
           end
-          should "calculate the holiday entitlement" do
-            SmartAnswer::Calculators::HolidayEntitlement
-              .expects(:new)
-              .with(
-                hours_per_week: 40.0,
-                working_days_per_week: 5.0,
-                start_date: nil,
-                leaving_date: nil,
-                leave_year_start_date: nil,
-              ).returns(@stubbed_calculator)
-            @stubbed_calculator.expects(:formatted_full_time_part_time_compressed_hours).returns(224.0)
 
+          should "calculate the holiday entitlement" do
             assert_current_node :hours_per_week_done
-            assert_state_variable "holiday_entitlement_hours", 224
+            assert_equal "224", current_state.calculator.formatted_full_time_part_time_compressed_hours
           end
         end
       end
     end
+
     context "answer starting part way through the leave year" do
       setup do
         add_response "starting"
       end
+
       should "ask for the employment start date" do
         assert_current_node :what_is_your_starting_date?
       end
+
       context "answer June 1st this year" do
         setup do
           add_response "#{Time.zone.today.year}-06-01"
         end
+
         should "ask when the leave year started" do
           assert_current_node :when_does_your_leave_year_start?
         end
+
         context "answer Jan 1st this year" do
           setup do
             add_response "#{Time.zone.today.year}-01-01"
           end
+
           should "ask the number of hours worked per week" do
             assert_current_node :how_many_hours_per_week?
           end
+
           context "answer 40 hours" do
             setup do
               add_response "40"
             end
+
             should "ask the number of days worked per week" do
               assert_current_node :how_many_days_per_week_for_hours?
             end
+
             context "answer 5 days" do
               setup do
                 add_response "5"
               end
-              should "calculate the holiday entitlement" do
-                SmartAnswer::Calculators::HolidayEntitlement
-                  .expects(:new)
-                  .with(
-                    hours_per_week: 40.0,
-                    working_days_per_week: 5,
-                    start_date: Date.parse("#{Time.zone.today.year}-06-01"),
-                    leaving_date: nil,
-                    leave_year_start_date: Date.parse("#{Time.zone.today.year}-01-01"),
-                  )
-                  .returns(@stubbed_calculator)
-                @stubbed_calculator.expects(:formatted_full_time_part_time_compressed_hours).returns(132.0)
 
+              should "calculate the holiday entitlement" do
                 assert_current_node :hours_per_week_done
-                assert_state_variable "holiday_entitlement_hours", 132
+                assert_equal "132", current_state.calculator.formatted_full_time_part_time_compressed_hours
               end
             end
           end
+
           context "impossible working patterns" do
             should "be invalid if answer <= 0 hours entered" do
               add_response "0"
@@ -390,52 +324,50 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
       setup do
         add_response "leaving"
       end
+
       should "ask for the employment end date" do
         assert_current_node :what_is_your_leaving_date?
       end
+
       context "answer June 1st this year" do
         setup do
           add_response "#{Time.zone.today.year}-06-01"
         end
+
         should "ask when the leave year started" do
           assert_current_node :when_does_your_leave_year_start?
         end
+
         context "answer Jan 1st this year" do
           setup do
             add_response "#{Time.zone.today.year}-01-01"
           end
+
           should "ask the number of hours worked per week" do
             assert_current_node :how_many_hours_per_week?
           end
+
           context "answer 40 hours" do
             setup do
               add_response "40"
             end
+
             should "ask the number of days worked per week" do
               assert_current_node :how_many_days_per_week_for_hours?
             end
+
             context "answer 5 days" do
               setup do
                 add_response "5"
               end
-              should "calculate the holiday entitlement" do
-                SmartAnswer::Calculators::HolidayEntitlement
-                  .expects(:new)
-                  .with(
-                    hours_per_week: 40,
-                    working_days_per_week: 5,
-                    start_date: nil,
-                    leaving_date: Date.parse("#{Time.zone.today.year}-06-01"),
-                    leave_year_start_date: Date.parse("#{Time.zone.today.year}-01-01"),
-                  )
-                  .returns(@stubbed_calculator)
-                @stubbed_calculator.expects(:formatted_full_time_part_time_compressed_hours).returns(93.3)
 
+              should "calculate the holiday entitlement" do
                 assert_current_node :hours_per_week_done
-                assert_state_variable "holiday_entitlement_hours", 93.3
+                assert_equal "93.7", current_state.calculator.formatted_full_time_part_time_compressed_hours
               end
             end
           end
+
           # Dept Test 16
           context "impossible working patterns" do
             should "be invalid if 63 hours for 1 day entered (dept Test 16)" do
@@ -446,6 +378,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
           end
         end
       end
+
       # Dept Test 18
       context "answer 31 September next year - day that does not exist" do
         setup do
@@ -462,13 +395,16 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
       setup do
         add_response "starting-and-leaving"
       end
+
       should "ask for the employment start date" do
         assert_current_node :what_is_your_starting_date?
       end
+
       context "answer 'Jan 20th this year'" do
         setup do
           add_response "#{Time.zone.today.year}-01-20"
         end
+
         should "ask for the employment end date" do
           assert_current_node :what_is_your_leaving_date?
         end
@@ -477,6 +413,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
           setup do
             add_response "#{Time.zone.today.year - 1}-10-14"
           end
+
           should "raise an invalid response" do
             assert_current_node :what_is_your_leaving_date?, error: true
           end
@@ -486,34 +423,28 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
           setup do
             add_response "#{Time.zone.today.year}-07-18"
           end
+
           should "ask the number of hours worked per week" do
             assert_current_node :how_many_hours_per_week?
           end
+
           context "answer 40 hours" do
             setup do
               add_response "40"
             end
+
             should "ask the number of days worked per week" do
               assert_current_node :how_many_days_per_week_for_hours?
             end
+
             context "answer 5 days" do
               setup do
                 add_response "5"
               end
-              should "calculate the holiday entitlement" do
-                SmartAnswer::Calculators::HolidayEntitlement
-                  .expects(:new)
-                  .with(
-                    hours_per_week: 40,
-                    working_days_per_week: 5,
-                    start_date: Date.parse("#{Time.zone.today.year}-01-20"),
-                    leaving_date: Date.parse("#{Time.zone.today.year}-07-18"),
-                    leave_year_start_date: nil,
-                  ).returns(@stubbed_calculator)
-                @stubbed_calculator.expects(:formatted_full_time_part_time_compressed_hours).returns(110.5)
 
+              should "calculate the holiday entitlement" do
                 assert_current_node :hours_per_week_done
-                assert_state_variable "holiday_entitlement_hours", 110.5
+                assert_equal "110.8", current_state.calculator.formatted_full_time_part_time_compressed_hours
               end
             end
           end
@@ -526,33 +457,40 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
     setup do
       add_response "compressed-hours"
     end
+
     should "ask the time period for the calculation" do
       assert_current_node :calculation_period?
     end
+
     context "answer full leave year" do
       setup do
         add_response "full-year"
       end
+
       should "ask the number of hours worked per week" do
         assert_current_node :how_many_hours_per_week?
       end
+
       context "answer 40 hours" do
         setup do
           add_response "40"
         end
+
         should "ask the number of days worked per week" do
           assert_current_node :how_many_days_per_week_for_hours?
         end
+
         context "answer 5 days" do
           setup do
             add_response "5"
           end
+
           should "calculate the holiday entitlement" do
             assert_current_node :compressed_hours_done
-            assert_state_variable "holiday_entitlement_hours", 224
-            assert_state_variable "holiday_entitlement_minutes", 0
-            assert_state_variable "hours_daily", 8
-            assert_state_variable "minutes_daily", 0
+            assert_equal 224, current_state.calculator.holiday_entitlement_hours
+            assert_equal 0, current_state.calculator.holiday_entitlement_minutes
+            assert_equal 8, current_state.calculator.hours_daily
+            assert_equal 0, current_state.calculator.minutes_daily
           end
         end
       end
@@ -562,6 +500,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
       setup do
         add_response "starting"
       end
+
       should "ask for the employment start date" do
         assert_current_node :what_is_your_starting_date?
       end
@@ -571,6 +510,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
         setup do
           add_response "#{Time.zone.today.year + 1}-06-01"
         end
+
         should "ask when the leave year started" do
           assert_current_node :when_does_your_leave_year_start?
         end
@@ -579,6 +519,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
           setup do
             add_response "#{Time.zone.today.year - 1}-03-01"
           end
+
           should "be an invalid date" do
             assert_current_node :when_does_your_leave_year_start?, error: true
           end
@@ -589,6 +530,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
           setup do
             add_response "#{Time.zone.today.year}-03-01"
           end
+
           should "be an invalid date" do
             assert_current_node :when_does_your_leave_year_start?, error: true
           end
@@ -599,6 +541,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
         setup do
           add_response "#{Time.zone.today.year}-06-01"
         end
+
         should "ask when the leave year started" do
           assert_current_node :when_does_your_leave_year_start?
         end
@@ -607,6 +550,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
           setup do
             add_response "#{Time.zone.today.year}-01-01"
           end
+
           should "ask the number of hours worked per week" do
             assert_current_node :how_many_hours_per_week?
           end
@@ -627,19 +571,22 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
             setup do
               add_response "40"
             end
+
             should "ask the number of days worked per week" do
               assert_current_node :how_many_days_per_week_for_hours?
             end
+
             context "answer 5 days" do
               setup do
                 add_response "5"
               end
+
               should "calculate the holiday entitlement" do
                 assert_current_node :compressed_hours_done
-                assert_state_variable "holiday_entitlement_hours", 132
-                assert_state_variable "holiday_entitlement_minutes", 0
-                assert_state_variable "hours_daily", 8
-                assert_state_variable "minutes_daily", 0
+                assert_equal 132, current_state.calculator.holiday_entitlement_hours
+                assert_equal 0, current_state.calculator.holiday_entitlement_minutes
+                assert_equal 8, current_state.calculator.hours_daily
+                assert_equal 0, current_state.calculator.minutes_daily
               end
             end
           end
@@ -651,6 +598,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
       setup do
         add_response "leaving"
       end
+
       should "ask for the employment end date" do
         assert_current_node :what_is_your_leaving_date?
       end
@@ -659,6 +607,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
         setup do
           add_response "#{Time.zone.today.year + 1}-06-01"
         end
+
         should "ask when the leave year started" do
           assert_current_node :when_does_your_leave_year_start?
         end
@@ -668,6 +617,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
           setup do
             add_response "#{Time.zone.today.year}-03-01"
           end
+
           should "be an invalid date" do
             assert_current_node :when_does_your_leave_year_start?, error: true
           end
@@ -678,6 +628,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
           setup do
             add_response "#{Time.zone.today.year}-05-30"
           end
+
           should "be an invalid date" do
             assert_current_node :when_does_your_leave_year_start?, error: true
           end
@@ -688,6 +639,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
         setup do
           add_response "2017-06-01"
         end
+
         should "ask when the leave year started" do
           assert_current_node :when_does_your_leave_year_start?
         end
@@ -696,26 +648,31 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
           setup do
             add_response "2017-01-01"
           end
+
           should "ask the number of hours worked per week" do
             assert_current_node :how_many_hours_per_week?
           end
+
           context "answer 40 hours" do
             setup do
               add_response "40"
             end
+
             should "ask the number of days worked per week" do
               assert_current_node :how_many_days_per_week_for_hours?
             end
+
             context "answer 5 days" do
               setup do
                 add_response "5"
               end
+
               should "calculate the holiday entitlement" do
                 assert_current_node :compressed_hours_done
-                assert_state_variable "holiday_entitlement_hours", 93
-                assert_state_variable "holiday_entitlement_minutes", 18
-                assert_state_variable "hours_daily", 8
-                assert_state_variable "minutes_daily", 0
+                assert_equal 93, current_state.calculator.holiday_entitlement_hours
+                assert_equal 18, current_state.calculator.holiday_entitlement_minutes
+                assert_equal 8, current_state.calculator.hours_daily
+                assert_equal 0, current_state.calculator.minutes_daily
               end
             end
           end
@@ -745,6 +702,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
       setup do
         add_response "starting-and-leaving"
       end
+
       should "ask for the employment start date" do
         assert_current_node :what_is_your_starting_date?
       end
@@ -754,6 +712,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
         setup do
           add_response "#{Time.zone.today.year}-03-01"
         end
+
         should "ask for the employment end date" do
           assert_current_node :what_is_your_leaving_date?
         end
@@ -762,6 +721,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
           setup do
             add_response "#{Time.zone.today.year + 1}-06-01"
           end
+
           should "be an invalid date" do
             assert_current_node :what_is_your_leaving_date?, error: true
           end
@@ -772,6 +732,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
         setup do
           add_response "2019-01-20"
         end
+
         should "ask for the employment end date" do
           assert_current_node :what_is_your_leaving_date?
         end
@@ -780,6 +741,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
           setup do
             add_response "2018-10-14"
           end
+
           should "raise an invalid response" do
             assert_current_node :what_is_your_leaving_date?, error: true
           end
@@ -789,26 +751,31 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
           setup do
             add_response "2019-07-18"
           end
+
           should "ask the number of hours worked per week" do
             assert_current_node :how_many_hours_per_week?
           end
+
           context "answer 40 hours" do
             setup do
               add_response "40"
             end
+
             should "ask the number of days worked per week" do
               assert_current_node :how_many_days_per_week_for_hours?
             end
+
             context "answer 5 days" do
               setup do
                 add_response "5"
               end
+
               should "calculate the holiday entitlement" do
                 assert_current_node :compressed_hours_done
-                assert_state_variable "holiday_entitlement_hours", 110
-                assert_state_variable "holiday_entitlement_minutes", 30
-                assert_state_variable "hours_daily", 8
-                assert_state_variable "minutes_daily", 0
+                assert_equal 110, current_state.calculator.holiday_entitlement_hours
+                assert_equal 30, current_state.calculator.holiday_entitlement_minutes
+                assert_equal 8, current_state.calculator.hours_daily
+                assert_equal 0, current_state.calculator.minutes_daily
               end
             end
           end
@@ -821,6 +788,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
     setup do
       add_response "irregular-hours"
     end
+
     should "ask the time period for the calculation" do
       assert_current_node :calculation_period?
     end
@@ -829,17 +797,9 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
       setup do
         add_response "full-year"
       end
-      should "calculate the holiday entitlement" do
-        SmartAnswer::Calculators::HolidayEntitlement
-          .expects(:new)
-          .with(
-            start_date: nil,
-            leaving_date: nil,
-            leave_year_start_date: nil,
-          ).returns(@stubbed_calculator)
-        @stubbed_calculator.expects(:formatted_full_time_part_time_weeks).returns("5.6")
 
-        assert_state_variable "holiday_entitlement", "5.6"
+      should "calculate the holiday entitlement" do
+        assert_equal "5.6", current_state.calculator.formatted_full_time_part_time_weeks
         assert_current_node :irregular_and_annualised_done
       end
     end
@@ -848,32 +808,28 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
       setup do
         add_response "starting"
       end
+
       should "ask for the employment start date" do
         assert_current_node :what_is_your_starting_date?
       end
+
       context "answer June 1st this year" do
         setup do
           add_response "#{Time.zone.today.year}-06-01"
         end
+
         should "ask when the leave year started" do
           assert_current_node :when_does_your_leave_year_start?
         end
+
         context "answer Jan 1st this year" do
           setup do
             add_response "#{Time.zone.today.year}-01-01"
           end
-          should "calculate the holiday entitlement" do
-            SmartAnswer::Calculators::HolidayEntitlement
-              .expects(:new)
-              .with(
-                start_date: Date.parse("#{Time.zone.today.year}-06-01"),
-                leaving_date: nil,
-                leave_year_start_date: Date.parse("#{Time.zone.today.year}-01-01"),
-              ).returns(@stubbed_calculator)
-            @stubbed_calculator.expects(:formatted_full_time_part_time_weeks).returns("3.27")
 
+          should "calculate the holiday entitlement" do
             assert_current_node :irregular_and_annualised_done
-            assert_state_variable "holiday_entitlement", "3.27"
+            assert_equal "3.27", current_state.calculator.formatted_full_time_part_time_weeks
           end
         end
       end
@@ -883,32 +839,27 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
       setup do
         add_response "leaving"
       end
+
       should "ask for the employment end date" do
         assert_current_node :what_is_your_leaving_date?
       end
+
       context "answer June 1st this year" do
         setup do
           add_response "#{Time.zone.today.year}-06-01"
         end
+
         should "ask when the leave year started" do
           assert_current_node :when_does_your_leave_year_start?
         end
+
         context "answer Jan 01 this year" do
           setup do
             add_response "#{Time.zone.today.year}-01-01"
           end
 
           should "calculate the holiday entitlement" do
-            SmartAnswer::Calculators::HolidayEntitlement
-              .expects(:new)
-              .with(
-                start_date: nil,
-                leaving_date: Date.parse("#{Time.zone.today.year}-06-01"),
-                leave_year_start_date: Date.parse("#{Time.zone.today.year}-01-01"),
-              ).returns(@stubbed_calculator)
-            @stubbed_calculator.expects(:formatted_full_time_part_time_weeks).returns("2.34")
-
-            assert_state_variable "holiday_entitlement", "2.34"
+            assert_equal "2.35", current_state.calculator.formatted_full_time_part_time_weeks
             assert_current_node :irregular_and_annualised_done
           end
         end
@@ -919,13 +870,16 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
       setup do
         add_response "starting-and-leaving"
       end
+
       should "ask what was the employment start date" do
         assert_current_node :what_is_your_starting_date?
       end
+
       context "answer Jan 20th this year" do
         setup do
           add_response "#{Time.zone.today.year}-01-20"
         end
+
         should "ask what date employment finished" do
           assert_current_node :what_is_your_leaving_date?
         end
@@ -934,6 +888,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
           setup do
             add_response "#{Time.zone.today.year - 1}-10-14"
           end
+
           should "raise an invalid response" do
             assert_current_node :what_is_your_leaving_date?, error: true
           end
@@ -943,17 +898,9 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
           setup do
             add_response "#{Time.zone.today.year}-07-18"
           end
-          should "calculate the holiday entitlement" do
-            SmartAnswer::Calculators::HolidayEntitlement
-              .expects(:new)
-              .with(
-                start_date: Date.parse("#{Time.zone.today.year}-01-20"),
-                leaving_date: Date.parse("#{Time.zone.today.year}-07-18"),
-                leave_year_start_date: nil,
-              ).returns(@stubbed_calculator)
-            @stubbed_calculator.expects(:formatted_full_time_part_time_weeks).returns("2.77")
 
-            assert_state_variable "holiday_entitlement", "2.77"
+          should "calculate the holiday entitlement" do
+            assert_equal "2.77", current_state.calculator.formatted_full_time_part_time_weeks
             assert_current_node :irregular_and_annualised_done
           end
         end
@@ -965,6 +912,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
     setup do
       add_response "annualised-hours"
     end
+
     should "ask the time period for the calculation" do
       assert_current_node :calculation_period?
     end
@@ -973,17 +921,9 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
       setup do
         add_response "full-year"
       end
-      should "calculate the holiday entitlement" do
-        SmartAnswer::Calculators::HolidayEntitlement
-          .expects(:new)
-          .with(
-            start_date: nil,
-            leaving_date: nil,
-            leave_year_start_date: nil,
-          ).returns(@stubbed_calculator)
-        @stubbed_calculator.expects(:formatted_full_time_part_time_weeks).returns("5.6")
 
-        assert_state_variable "holiday_entitlement", "5.6"
+      should "calculate the holiday entitlement" do
+        assert_equal "5.6", current_state.calculator.formatted_full_time_part_time_weeks
         assert_current_node :irregular_and_annualised_done
       end
     end
@@ -992,32 +932,28 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
       setup do
         add_response "starting"
       end
+
       should "ask for the employment start date" do
         assert_current_node :what_is_your_starting_date?
       end
+
       context "answer June 1st this year" do
         setup do
           add_response "#{Time.zone.today.year}-06-01"
         end
+
         should "ask when the leave year started" do
           assert_current_node :when_does_your_leave_year_start?
         end
+
         context "answer Jan 1st this year" do
           setup do
             add_response "#{Time.zone.today.year}-01-01"
           end
-          should "calculate the holiday entitlement" do
-            SmartAnswer::Calculators::HolidayEntitlement
-              .expects(:new)
-              .with(
-                start_date: Date.parse("#{Time.zone.today.year}-06-01"),
-                leaving_date: nil,
-                leave_year_start_date: Date.parse("#{Time.zone.today.year}-01-01"),
-              ).returns(@stubbed_calculator)
-            @stubbed_calculator.expects(:formatted_full_time_part_time_weeks).returns("3.27")
 
+          should "calculate the holiday entitlement" do
             assert_current_node :irregular_and_annualised_done
-            assert_state_variable "holiday_entitlement", "3.27"
+            assert_equal "3.27", current_state.calculator.formatted_full_time_part_time_weeks
           end
         end
       end
@@ -1027,32 +963,27 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
       setup do
         add_response "leaving"
       end
+
       should "ask for the employment end date" do
         assert_current_node :what_is_your_leaving_date?
       end
+
       context "answer June 1st this year" do
         setup do
           add_response "#{Time.zone.today.year}-06-01"
         end
+
         should "ask when the leave year started" do
           assert_current_node :when_does_your_leave_year_start?
         end
+
         context "answer Jan 01 this year" do
           setup do
             add_response "#{Time.zone.today.year}-01-01"
           end
 
           should "calculate the holiday entitlement" do
-            SmartAnswer::Calculators::HolidayEntitlement
-              .expects(:new)
-              .with(
-                start_date: nil,
-                leaving_date: Date.parse("#{Time.zone.today.year}-06-01"),
-                leave_year_start_date: Date.parse("#{Time.zone.today.year}-01-01"),
-              ).returns(@stubbed_calculator)
-            @stubbed_calculator.expects(:formatted_full_time_part_time_weeks).returns("2.34")
-
-            assert_state_variable "holiday_entitlement", "2.34"
+            assert_equal "2.35", current_state.calculator.formatted_full_time_part_time_weeks
             assert_current_node :irregular_and_annualised_done
           end
         end
@@ -1063,13 +994,16 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
       setup do
         add_response "starting-and-leaving"
       end
+
       should "ask what was the employment start date" do
         assert_current_node :what_is_your_starting_date?
       end
+
       context "answer Jan 20th this year" do
         setup do
           add_response "#{Time.zone.today.year}-01-20"
         end
+
         should "ask what date employment finished" do
           assert_current_node :what_is_your_leaving_date?
         end
@@ -1078,6 +1012,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
           setup do
             add_response "#{Time.zone.today.year - 1}-01-20"
           end
+
           should "raise an invalid response" do
             assert_current_node :what_is_your_leaving_date?, error: true
           end
@@ -1087,17 +1022,9 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
           setup do
             add_response "#{Time.zone.today.year}-07-18"
           end
-          should "calculate the holiday entitlement" do
-            SmartAnswer::Calculators::HolidayEntitlement
-              .expects(:new)
-              .with(
-                start_date: Date.parse("#{Time.zone.today.year}-01-20"),
-                leaving_date: Date.parse("#{Time.zone.today.year}-07-18"),
-                leave_year_start_date: nil,
-              ).returns(@stubbed_calculator)
-            @stubbed_calculator.expects(:formatted_full_time_part_time_weeks).returns("2.77")
 
-            assert_state_variable "holiday_entitlement", "2.77"
+          should "calculate the holiday entitlement" do
+            assert_equal "2.77", current_state.calculator.formatted_full_time_part_time_weeks
             assert_current_node :irregular_and_annualised_done
           end
         end
@@ -1122,6 +1049,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
       should "ask how many hours in each shift" do
         assert_current_node :shift_worker_hours_per_shift?
       end
+
       context "with invalid hours" do
         context "with 0 hours" do
           setup do
@@ -1132,6 +1060,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
             assert_current_node :shift_worker_hours_per_shift?, error: true
           end
         end
+
         context "with over 24 hours" do
           setup do
             add_response "25"
@@ -1142,42 +1071,37 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
           end
         end
       end
+
       context "answer 6 hours" do
         setup do
           add_response "6"
         end
+
         should "ask how many shifts per shift pattern" do
           assert_current_node :shift_worker_shifts_per_shift_pattern?
         end
+
         context "answer 8 shifts" do
           setup do
             add_response "8"
           end
+
           should "ask how many days per shift pattern" do
             assert_current_node :shift_worker_days_per_shift_pattern?
           end
+
           context "answer 14 days" do
             setup do
               add_response "14"
             end
-            should "calculate the holiday entitlement" do
-              SmartAnswer::Calculators::HolidayEntitlement
-                .expects(:new)
-                .with(
-                  start_date: nil,
-                  leaving_date: nil,
-                  leave_year_start_date: nil,
-                  shifts_per_shift_pattern: 8,
-                  days_per_shift_pattern: 14,
-                ).returns(@stubbed_calculator)
-              @stubbed_calculator.expects(:shift_entitlement).returns(22.40)
 
+            should "calculate the holiday entitlement" do
               assert_current_node :shift_worker_done
 
-              assert_state_variable :hours_per_shift, 6
-              assert_state_variable :shifts_per_shift_pattern, 8
-              assert_state_variable :days_per_shift_pattern, 14
-              assert_state_variable :holiday_entitlement_shifts, 22.40
+              assert_equal 6, current_state.calculator.hours_per_shift
+              assert_equal 8, current_state.calculator.shifts_per_shift_pattern
+              assert_equal 14, current_state.calculator.days_per_shift_pattern
+              assert_equal "22.4", current_state.calculator.shift_entitlement
             end
           end
         end
@@ -1237,6 +1161,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
             should "ask how many shifts per shift pattern" do
               assert_current_node :shift_worker_shifts_per_shift_pattern?
             end
+
             context "answer 8 shifts" do
               setup do
                 add_response "8"
@@ -1250,24 +1175,14 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
                 setup do
                   add_response "14"
                 end
-                should "calculate the holiday entitlement" do
-                  SmartAnswer::Calculators::HolidayEntitlement
-                  .expects(:new)
-                  .with(
-                    start_date: Date.parse("#{Time.zone.today.year}-06-01"),
-                    leaving_date: nil,
-                    leave_year_start_date: Date.parse("#{Time.zone.today.year}-01-01"),
-                    shifts_per_shift_pattern: 8,
-                    days_per_shift_pattern: 14,
-                  ).returns(@stubbed_calculator)
-                  @stubbed_calculator.expects(:shift_entitlement).returns(13.5)
 
+                should "calculate the holiday entitlement" do
                   assert_current_node :shift_worker_done
 
-                  assert_state_variable :hours_per_shift, 6
-                  assert_state_variable :shifts_per_shift_pattern, 8
-                  assert_state_variable :days_per_shift_pattern, 14
-                  assert_state_variable :holiday_entitlement_shifts, 13.5
+                  assert_equal 6, current_state.calculator.hours_per_shift
+                  assert_equal 8, current_state.calculator.shifts_per_shift_pattern
+                  assert_equal 14, current_state.calculator.days_per_shift_pattern
+                  assert_equal "13.5", current_state.calculator.shift_entitlement
                 end
               end
             end
@@ -1327,23 +1242,12 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
                 end
 
                 should "calculate the holiday entitlement" do
-                  SmartAnswer::Calculators::HolidayEntitlement
-                  .expects(:new)
-                  .with(
-                    start_date: nil,
-                    leaving_date: Date.parse("#{Time.zone.today.year}-06-01"),
-                    leave_year_start_date: Date.parse("#{Time.zone.today.year}-01-01"),
-                    shifts_per_shift_pattern: 8,
-                    days_per_shift_pattern: 14,
-                  ).returns(@stubbed_calculator)
-                  @stubbed_calculator.expects(:shift_entitlement).returns(9.33)
-
                   assert_current_node :shift_worker_done
 
-                  assert_state_variable :hours_per_shift, 6
-                  assert_state_variable :shifts_per_shift_pattern, 8
-                  assert_state_variable :days_per_shift_pattern, 14
-                  assert_state_variable :holiday_entitlement_shifts, 9.33
+                  assert_equal 6, current_state.calculator.hours_per_shift
+                  assert_equal 8, current_state.calculator.shifts_per_shift_pattern
+                  assert_equal 14, current_state.calculator.days_per_shift_pattern
+                  assert_equal "9.37", current_state.calculator.shift_entitlement
                 end
               end
             end
@@ -1374,6 +1278,7 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
           setup do
             add_response "#{Time.zone.today.year - 1}-01-20"
           end
+
           should "raise an invalid response" do
             assert_current_node :what_is_your_leaving_date?, error: true
           end
@@ -1412,23 +1317,12 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
                 end
 
                 should "calculate the holiday entitlement" do
-                  SmartAnswer::Calculators::HolidayEntitlement
-                  .expects(:new)
-                  .with(
-                    start_date: Date.parse("#{Time.zone.today.year}-01-20"),
-                    leaving_date: Date.parse("#{Time.zone.today.year}-07-18"),
-                    leave_year_start_date: nil,
-                    shifts_per_shift_pattern: 8,
-                    days_per_shift_pattern: 14,
-                  ).returns(@stubbed_calculator)
-                  @stubbed_calculator.expects(:shift_entitlement).returns(11.05)
-
                   assert_current_node :shift_worker_done
 
-                  assert_state_variable :hours_per_shift, 6
-                  assert_state_variable :shifts_per_shift_pattern, 8
-                  assert_state_variable :days_per_shift_pattern, 14
-                  assert_state_variable :holiday_entitlement_shifts, 11.05
+                  assert_equal 6, current_state.calculator.hours_per_shift
+                  assert_equal 8, current_state.calculator.shifts_per_shift_pattern
+                  assert_equal 14, current_state.calculator.days_per_shift_pattern
+                  assert_equal "11.08", current_state.calculator.shift_entitlement
                 end
               end
             end

--- a/test/unit/calculators/holiday_entitlement_test.rb
+++ b/test/unit/calculators/holiday_entitlement_test.rb
@@ -2,55 +2,59 @@ require_relative "../../test_helper"
 
 module SmartAnswer::Calculators
   class HolidayEntitlementTest < ActiveSupport::TestCase
+    setup do
+      @calculator = HolidayEntitlement.new
+    end
+
     context "calculate entitlement on days worked per week" do
       context "for a full leave year" do
         # /days-worked-per-week/full-year/5.0
         should "for 5 days a week" do
-          calc = HolidayEntitlement.new(working_days_per_week: 5)
-          assert_equal "28", calc.formatted_full_time_part_time_days
+          @calculator.working_days_per_week = 5
+          assert_equal "28", @calculator.formatted_full_time_part_time_days
         end
 
         # /days-worked-per-week/full-year/5.0
         should "for more than 5 days a week" do
-          calc = HolidayEntitlement.new(working_days_per_week: 7)
-          assert_equal "28", calc.formatted_full_time_part_time_days
+          @calculator.working_days_per_week = 7
+          assert_equal "28", @calculator.formatted_full_time_part_time_days
         end
 
         # /days-worked-per-week/full-year/3.5
         should "for less than 5 days a week" do
-          calc = HolidayEntitlement.new(working_days_per_week: 3.5)
-          assert_equal "19.6", calc.formatted_full_time_part_time_days
+          @calculator.working_days_per_week = 3.5
+          assert_equal "19.6", @calculator.formatted_full_time_part_time_days
         end
 
         context "for department test data" do
           # Dept Test 1 - /days-worked-per-week/full-year/6.0
           should "for less than 5 days a week (dept Test 1)" do
-            calc = HolidayEntitlement.new(working_days_per_week: 6)
-            assert_equal "28", calc.formatted_full_time_part_time_days
+            @calculator.working_days_per_week = 6
+            assert_equal "28", @calculator.formatted_full_time_part_time_days
           end
 
           # Dept Test 2 - /days-worked-per-week/full-year/3.5
           should "for less than 5 days a week (dept Test 2)" do
-            calc = HolidayEntitlement.new(working_days_per_week: 3.5)
-            assert_equal "19.6", calc.formatted_full_time_part_time_days
+            @calculator.working_days_per_week = 3.5
+            assert_equal "19.6", @calculator.formatted_full_time_part_time_days
           end
 
           # Dept Test 3 - /days-worked-per-week/full-year/2.0
           should "for less than 5 days a week (dept Test 3)" do
-            calc = HolidayEntitlement.new(working_days_per_week: 2)
-            assert_equal "11.2", calc.formatted_full_time_part_time_days
+            @calculator.working_days_per_week = 2
+            assert_equal "11.2", @calculator.formatted_full_time_part_time_days
           end
 
           # Dept Test 4 - /days-worked-per-week/full-year/1.0
           should "for less than 5 days a week (dept Test 4)" do
-            calc = HolidayEntitlement.new(working_days_per_week: 1)
-            assert_equal "5.6", calc.formatted_full_time_part_time_days
+            @calculator.working_days_per_week = 1
+            assert_equal "5.6", @calculator.formatted_full_time_part_time_days
           end
 
           # Dept Test 5 - /days-worked-per-week/full-year/1.0
           should "for less than 5 days a week (dept Test 5)" do
-            calc = HolidayEntitlement.new(working_days_per_week: 0.5)
-            assert_equal "2.8", calc.formatted_full_time_part_time_days
+            @calculator.working_days_per_week = 0.5
+            assert_equal "2.8", @calculator.formatted_full_time_part_time_days
           end
 
           # Dept Test 6 is a data entry validation for entering 8 days a week covered in
@@ -62,150 +66,126 @@ module SmartAnswer::Calculators
         context "for a standard year" do
           # /days-worked-per-week/starting/2019-06-01/2019-01-01/5.0
           should "for 5 days a week" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-06-01"),
-              leave_year_start_date: Date.parse("2019-01-01"),
-              working_days_per_week: 5,
-            )
+            @calculator.start_date = Date.parse("2019-06-01")
+            @calculator.leave_year_start_date = Date.parse("2019-01-01")
+            @calculator.working_days_per_week = 5
 
-            assert_equal BigDecimal("0.5833333333").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("16.3333333333").round(10), calc.full_time_part_time_days.round(10)
-            assert_equal "16.5", calc.formatted_full_time_part_time_days
+            assert_equal BigDecimal("0.5833333333").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("16.3333333333").round(10), @calculator.full_time_part_time_days.round(10)
+            assert_equal "16.5", @calculator.formatted_full_time_part_time_days
           end
 
           # /days-worked-per-week/starting/2019-11-21/2019-04-01/3.0
           should "for less than 5 days a week" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-11-23"),
-              leave_year_start_date: Date.parse("2019-04-01"),
-              working_days_per_week: 3,
-            )
+            @calculator.start_date = Date.parse("2019-11-23")
+            @calculator.leave_year_start_date = Date.parse("2019-04-01")
+            @calculator.working_days_per_week = 3
 
-            assert_equal BigDecimal("0.4166666667").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("7.0").round(10), calc.full_time_part_time_days.round(10)
-            assert_equal "7", calc.formatted_full_time_part_time_days
+            assert_equal BigDecimal("0.4166666667").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("7.0").round(10), @calculator.full_time_part_time_days.round(10)
+            assert_equal "7", @calculator.formatted_full_time_part_time_days
           end
 
           # /days-worked-per-week/starting/2019-11-14/2019-01-01/6.0
           should "for more than 5 days a week" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-11-14"),
-              leave_year_start_date: Date.parse("2019-01-01"),
-              working_days_per_week: 6,
-            )
+            @calculator.start_date = Date.parse("2019-11-14")
+            @calculator.leave_year_start_date = Date.parse("2019-01-01")
+            @calculator.working_days_per_week = 6
 
-            assert_equal BigDecimal("0.1666666667").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("4.6666666667").round(10), calc.full_time_part_time_days.round(10)
-            assert_equal "5", calc.formatted_full_time_part_time_days
+            assert_equal BigDecimal("0.1666666667").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("4.6666666667").round(10), @calculator.full_time_part_time_days.round(10)
+            assert_equal "5", @calculator.formatted_full_time_part_time_days
           end
         end
 
         context "for a leap year" do
           # /days-worked-per-week/starting/2020-06-01/2020-01-01/5.0
           should "for 5 days a week" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-06-01"),
-              leave_year_start_date: Date.parse("2020-01-01"),
-              working_days_per_week: 5,
-            )
+            @calculator.start_date = Date.parse("2020-06-01")
+            @calculator.leave_year_start_date = Date.parse("2020-01-01")
+            @calculator.working_days_per_week = 5
 
-            assert_equal BigDecimal("0.5833333333").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("16.3333333333").round(10), calc.full_time_part_time_days.round(10)
-            assert_equal "16.5", calc.formatted_full_time_part_time_days
+            assert_equal BigDecimal("0.5833333333").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("16.3333333333").round(10), @calculator.full_time_part_time_days.round(10)
+            assert_equal "16.5", @calculator.formatted_full_time_part_time_days
           end
 
           # /days-worked-per-week/starting/2020-11-21/2020-04-01/3.0
           should "for less than 5 days a week" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-11-23"),
-              leave_year_start_date: Date.parse("2020-04-01"),
-              working_days_per_week: 3,
-            )
+            @calculator.start_date = Date.parse("2020-11-23")
+            @calculator.leave_year_start_date = Date.parse("2020-04-01")
+            @calculator.working_days_per_week = 3
 
-            assert_equal BigDecimal("0.4166666667").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("7.0").round(10), calc.full_time_part_time_days.round(10)
-            assert_equal "7", calc.formatted_full_time_part_time_days
+            assert_equal BigDecimal("0.4166666667").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("7.0").round(10), @calculator.full_time_part_time_days.round(10)
+            assert_equal "7", @calculator.formatted_full_time_part_time_days
           end
 
           # /days-worked-per-week/starting/2020-11-14/2020-01-01/6.0
           should "for more than 5 days a week" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-11-14"),
-              leave_year_start_date: Date.parse("2020-01-01"),
-              working_days_per_week: 6,
-            )
+            @calculator.start_date = Date.parse("2020-11-14")
+            @calculator.leave_year_start_date = Date.parse("2020-01-01")
+            @calculator.working_days_per_week = 6
 
-            assert_equal BigDecimal("0.1666666667").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("4.6666666667").round(10), calc.full_time_part_time_days.round(10)
-            assert_equal "5", calc.formatted_full_time_part_time_days
+            assert_equal BigDecimal("0.1666666667").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("4.6666666667").round(10), @calculator.full_time_part_time_days.round(10)
+            assert_equal "5", @calculator.formatted_full_time_part_time_days
           end
         end
 
         context "for department test data" do
           # Dept Test 7 - /days-worked-per-week/starting/2021-02-09/2020-08-01/3.0
           should "for less than 3 days a week (dept Test 7)" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2021-02-09"),
-              leave_year_start_date: Date.parse("2020-08-01"),
-              working_days_per_week: 3,
-            )
+            @calculator.start_date = Date.parse("2021-02-09")
+            @calculator.leave_year_start_date = Date.parse("2020-08-01")
+            @calculator.working_days_per_week = 3
 
-            assert_equal "8.5", calc.formatted_full_time_part_time_days
+            assert_equal "8.5", @calculator.formatted_full_time_part_time_days
           end
 
           # Dept Test 8 - /days-worked-per-week/starting/2019-09-23/2019-05-01/5.0
           should "for 5 days a week (dept Test 8)" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-09-23"),
-              leave_year_start_date: Date.parse("2019-05-01"),
-              working_days_per_week: 5,
-            )
+            @calculator.start_date = Date.parse("2019-09-23")
+            @calculator.leave_year_start_date = Date.parse("2019-05-01")
+            @calculator.working_days_per_week = 5
 
-            assert_equal "19", calc.formatted_full_time_part_time_days
+            assert_equal "19", @calculator.formatted_full_time_part_time_days
           end
 
           # Dept Test 9 - /days-worked-per-week/starting/2020-02-13/2019-07-01/1.0
           should "for 1 day a week (dept Test 9)" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-02-13"),
-              leave_year_start_date: Date.parse("2019-07-01"),
-              working_days_per_week: 1,
-            )
+            @calculator.start_date = Date.parse("2020-02-13")
+            @calculator.leave_year_start_date = Date.parse("2019-07-01")
+            @calculator.working_days_per_week = 1
 
-            assert_equal "2.5", calc.formatted_full_time_part_time_days
+            assert_equal "2.5", @calculator.formatted_full_time_part_time_days
           end
 
           # Dept Test 10 - /days-worked-per-week/starting/2018-10-28/2018-04-01/1.0
           should "for 1 day a week (dept Test 10)" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2018-10-28"),
-              leave_year_start_date: Date.parse("2018-04-01"),
-              working_days_per_week: 1,
-            )
+            @calculator.start_date = Date.parse("2018-10-28")
+            @calculator.leave_year_start_date = Date.parse("2018-04-01")
+            @calculator.working_days_per_week = 1
 
-            assert_equal "3", calc.formatted_full_time_part_time_days
+            assert_equal "3", @calculator.formatted_full_time_part_time_days
           end
 
           # Dept Test 11 - /days-worked-per-week/starting/2019-05-10/2018-06-06/2.0
           should "for 2 days a week (dept Test 11)" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-05-10"),
-              leave_year_start_date: Date.parse("2018-06-06"),
-              working_days_per_week: 2,
-            )
+            @calculator.start_date = Date.parse("2019-05-10")
+            @calculator.leave_year_start_date = Date.parse("2018-06-06")
+            @calculator.working_days_per_week = 2
 
-            assert_equal "1", calc.formatted_full_time_part_time_days
+            assert_equal "1", @calculator.formatted_full_time_part_time_days
           end
 
           # Dept Test 12 - /days-worked-per-week/starting/2020-03-03/2020-03-01/4.0
           should "for 4 days a week (dept Test 12)" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-03-03"),
-              leave_year_start_date: Date.parse("2020-03-01"),
-              working_days_per_week: 4,
-            )
+            @calculator.start_date = Date.parse("2020-03-03")
+            @calculator.leave_year_start_date = Date.parse("2020-03-01")
+            @calculator.working_days_per_week = 4
 
-            assert_equal "22.5", calc.formatted_full_time_part_time_days
+            assert_equal "22.5", @calculator.formatted_full_time_part_time_days
           end
         end
       end
@@ -214,147 +194,127 @@ module SmartAnswer::Calculators
         context "for a standard year" do
           # /days-worked-per-week/starting/2019-06-01/2019-01-01/5.0
           should "for 5 days a week" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2019-06-01"),
-              leave_year_start_date: Date.parse("2019-01-01"),
-              working_days_per_week: 5,
-            )
+            @calculator.leaving_date = Date.parse("2019-06-01")
+            @calculator.leave_year_start_date = Date.parse("2019-01-01")
+            @calculator.working_days_per_week = 5
 
-            assert_equal BigDecimal("0.4164383562").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("11.6602739726").round(10), calc.full_time_part_time_days.round(10)
-            assert_equal "11.7", calc.formatted_full_time_part_time_days
+            assert_equal BigDecimal("0.4164383562").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("11.6602739726").round(10), @calculator.full_time_part_time_days.round(10)
+            assert_equal "11.7", @calculator.formatted_full_time_part_time_days
           end
 
           # /days-worked-per-week/starting/2019-11-21/2019-04-01/3.0
           should "for less than 5 days a week" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2018-11-23"),
-              leave_year_start_date: Date.parse("2018-04-01"),
-              working_days_per_week: 3,
-            )
-            assert_equal BigDecimal("0.6493150685").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("10.9084931507").round(10), calc.full_time_part_time_days.round(10)
-            assert_equal "11", calc.formatted_full_time_part_time_days
+            @calculator.leaving_date = Date.parse("2018-11-23")
+            @calculator.leave_year_start_date = Date.parse("2018-04-01")
+            @calculator.working_days_per_week = 3
+
+            assert_equal BigDecimal("0.6493150685").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("10.9084931507").round(10), @calculator.full_time_part_time_days.round(10)
+            assert_equal "11", @calculator.formatted_full_time_part_time_days
           end
         end
 
         context "for a leap year" do
           # /days-worked-per-week/starting/2020-06-01/2020-01-01/5.0
           should "for 5 days a week" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2020-06-01"),
-              leave_year_start_date: Date.parse("2020-01-01"),
-              working_days_per_week: 5,
-            )
+            @calculator.leaving_date = Date.parse("2020-06-01")
+            @calculator.leave_year_start_date = Date.parse("2020-01-01")
+            @calculator.working_days_per_week = 5
 
-            assert_equal BigDecimal("0.4180327869").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("11.7049180328").round(10), calc.full_time_part_time_days.round(10)
-            assert_equal "11.8", calc.formatted_full_time_part_time_days
+            assert_equal BigDecimal("0.4180327869").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("11.7049180328").round(10), @calculator.full_time_part_time_days.round(10)
+            assert_equal "11.8", @calculator.formatted_full_time_part_time_days
           end
 
           # /days-worked-per-week/starting/2020-11-21/2020-04-01/3.0
           should "for less than 5 days a week" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2019-11-23"),
-              leave_year_start_date: Date.parse("2019-04-01"),
-              working_days_per_week: 3,
-            )
+            @calculator.leaving_date = Date.parse("2019-11-23")
+            @calculator.leave_year_start_date = Date.parse("2019-04-01")
+            @calculator.working_days_per_week = 3
 
-            assert_equal BigDecimal("0.6475409836").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("10.8786885246").round(10), calc.full_time_part_time_days.round(10)
-            assert_equal "10.9", calc.formatted_full_time_part_time_days
+            assert_equal BigDecimal("0.6475409836").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("10.8786885246").round(10), @calculator.full_time_part_time_days.round(10)
+            assert_equal "10.9", @calculator.formatted_full_time_part_time_days
           end
 
           # /days-worked-per-week/starting/2020-08-22/2020-01-01/6.0
           should "for more than 5 days a week" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2020-08-22"),
-              leave_year_start_date: Date.parse("2020-01-01"),
-              working_days_per_week: 6,
-            )
+            @calculator.leaving_date = Date.parse("2020-08-22")
+            @calculator.leave_year_start_date = Date.parse("2020-01-01")
+            @calculator.working_days_per_week = 6
 
-            assert_equal BigDecimal("0.6420765027").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("17.9781420765").round(10), calc.full_time_part_time_days.round(10)
-            assert_equal "18", calc.formatted_full_time_part_time_days
+            assert_equal BigDecimal("0.6420765027").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("17.9781420765").round(10), @calculator.full_time_part_time_days.round(10)
+            assert_equal "18", @calculator.formatted_full_time_part_time_days
           end
         end
 
         context "for department test data" do
           # /days-worked-per-week/leaving/2020-10-20/2020-05-01/5.0
           should "for 5 days a week (dept test 13)" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2020-10-20"),
-              leave_year_start_date: Date.parse("2020-05-01"),
-              working_days_per_week: 5,
-            )
+            @calculator.leaving_date = Date.parse("2020-10-20")
+            @calculator.leave_year_start_date = Date.parse("2020-05-01")
+            @calculator.working_days_per_week = 5
 
-            assert_equal BigDecimal("0.4739726027").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("13.2712328767").round(10), calc.full_time_part_time_days.round(10)
-            assert_equal "13.3", calc.formatted_full_time_part_time_days
+            assert_equal BigDecimal("0.4739726027").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("13.2712328767").round(10), @calculator.full_time_part_time_days.round(10)
+            assert_equal "13.3", @calculator.formatted_full_time_part_time_days
           end
 
           # /days-worked-per-week/leaving/2020-06-18/2019-12-01/6.0
           should "for 6 days a week (dept test 14)" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2020-06-18"),
-              leave_year_start_date: Date.parse("2019-12-01"),
-              working_days_per_week: 6,
-            )
-            assert_equal BigDecimal("0.5491803279").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("15.3770491803").round(10), calc.full_time_part_time_days.round(10)
-            assert_equal "15.4", calc.formatted_full_time_part_time_days
+            @calculator.leaving_date = Date.parse("2020-06-18")
+            @calculator.leave_year_start_date = Date.parse("2019-12-01")
+            @calculator.working_days_per_week = 6
+
+            assert_equal BigDecimal("0.5491803279").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("15.3770491803").round(10), @calculator.full_time_part_time_days.round(10)
+            assert_equal "15.4", @calculator.formatted_full_time_part_time_days
           end
 
           # /days-worked-per-week/leaving/2020-03-17/2019-06-01/7.0
           should "for 7days a week (dept test 15)" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2020-03-17"),
-              leave_year_start_date: Date.parse("2019-06-01"),
-              working_days_per_week: 7,
-            )
+            @calculator.leaving_date = Date.parse("2020-03-17")
+            @calculator.leave_year_start_date = Date.parse("2019-06-01")
+            @calculator.working_days_per_week = 7
 
-            assert_equal BigDecimal("0.7950819672").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("22.262295082").round(10), calc.full_time_part_time_days.round(10)
-            assert_equal "22.3", calc.formatted_full_time_part_time_days
+            assert_equal BigDecimal("0.7950819672").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("22.262295082").round(10), @calculator.full_time_part_time_days.round(10)
+            assert_equal "22.3", @calculator.formatted_full_time_part_time_days
           end
 
           # /days-worked-per-week/leaving/2019-09-06/2019-03-01/6.0
           should "for 6 days a week (dept test 16)" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2019-09-06"),
-              leave_year_start_date: Date.parse("2019-03-01"),
-              working_days_per_week: 6,
-            )
+            @calculator.leaving_date = Date.parse("2019-09-06")
+            @calculator.leave_year_start_date = Date.parse("2019-03-01")
+            @calculator.working_days_per_week = 6
 
-            assert_equal BigDecimal("0.5191256831").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("14.5355191257").round(10), calc.full_time_part_time_days.round(10)
-            assert_equal "14.6", calc.formatted_full_time_part_time_days
+            assert_equal BigDecimal("0.5191256831").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("14.5355191257").round(10), @calculator.full_time_part_time_days.round(10)
+            assert_equal "14.6", @calculator.formatted_full_time_part_time_days
           end
 
           # /days-worked-per-week/leaving/2018-02-01/2018-05-05/3.0
           should "for 3 days a week (dept test 17)" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2018-05-05"),
-              leave_year_start_date: Date.parse("2018-02-01"),
-              working_days_per_week: 3,
-            )
+            @calculator.leaving_date = Date.parse("2018-05-05")
+            @calculator.leave_year_start_date = Date.parse("2018-02-01")
+            @calculator.working_days_per_week = 3
 
-            assert_equal BigDecimal("0.2575342466").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("4.3265753425").round(10), calc.full_time_part_time_days.round(10)
-            assert_equal "4.4", calc.formatted_full_time_part_time_days
+            assert_equal BigDecimal("0.2575342466").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("4.3265753425").round(10), @calculator.full_time_part_time_days.round(10)
+            assert_equal "4.4", @calculator.formatted_full_time_part_time_days
           end
 
           # /days-worked-per-week/leaving/2020-06-04/2019-11-01/4.0
           should "for 4 days a week (dept test 18)" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2020-06-04"),
-              leave_year_start_date: Date.parse("2019-11-01"),
-              working_days_per_week: 4,
-            )
+            @calculator.leaving_date = Date.parse("2020-06-04")
+            @calculator.leave_year_start_date = Date.parse("2019-11-01")
+            @calculator.working_days_per_week = 4
 
-            assert_equal BigDecimal("0.5928961749").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("13.2808743169").round(10), calc.full_time_part_time_days.round(10)
-            assert_equal "13.3", calc.formatted_full_time_part_time_days
+            assert_equal BigDecimal("0.5928961749").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("13.2808743169").round(10), @calculator.full_time_part_time_days.round(10)
+            assert_equal "13.3", @calculator.formatted_full_time_part_time_days
           end
         end
       end
@@ -363,135 +323,113 @@ module SmartAnswer::Calculators
         context "for a standard year" do
           # /days-worked-per-week/starting/2020-01-20/2020-08-07/5.0
           should "for 5 days a week" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-01-20"),
-              leaving_date: Date.parse("2019-07-18"),
-              working_days_per_week: 5,
-            )
+            @calculator.start_date = Date.parse("2019-01-20")
+            @calculator.leaving_date = Date.parse("2019-07-18")
+            @calculator.working_days_per_week = 5
 
-            assert_equal BigDecimal("0.4931506849").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("13.8082191780822").round(10), calc.full_time_part_time_days.round(10)
-            assert_equal "13.9", calc.formatted_full_time_part_time_days
+            assert_equal BigDecimal("0.4931506849").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("13.8082191780822").round(10), @calculator.full_time_part_time_days.round(10)
+            assert_equal "13.9", @calculator.formatted_full_time_part_time_days
           end
 
           # /days-worked-per-week/starting/2019-11-23/2020-04-07/3.0
           should "for less than 5 days a week" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2018-11-23"),
-              leaving_date: Date.parse("2019-04-07"),
-              working_days_per_week: 3,
-            )
+            @calculator.start_date = Date.parse("2018-11-23")
+            @calculator.leaving_date = Date.parse("2019-04-07")
+            @calculator.working_days_per_week = 3
 
-            assert_equal BigDecimal("0.3726027397").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("6.2597260274").round(10), calc.full_time_part_time_days.round(10)
-            assert_equal "6.3", calc.formatted_full_time_part_time_days
+            assert_equal BigDecimal("0.3726027397").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("6.2597260274").round(10), @calculator.full_time_part_time_days.round(10)
+            assert_equal "6.3", @calculator.formatted_full_time_part_time_days
           end
 
           # /days-worked-per-week/starting/2019-08-22/2020-07-31/6.0
           should "for more than 5 days a week" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2018-08-22"),
-              leaving_date: Date.parse("2019-07-31"),
-              working_days_per_week: 6,
-            )
+            @calculator.start_date = Date.parse("2018-08-22")
+            @calculator.leaving_date = Date.parse("2019-07-31")
+            @calculator.working_days_per_week = 6
 
-            assert_equal BigDecimal("0.9424657534").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("26.3890410959").round(10), calc.full_time_part_time_days.round(10)
-            assert_equal "26.4", calc.formatted_full_time_part_time_days
+            assert_equal BigDecimal("0.9424657534").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("26.3890410959").round(10), @calculator.full_time_part_time_days.round(10)
+            assert_equal "26.4", @calculator.formatted_full_time_part_time_days
           end
         end
 
         context "for a leap year" do
           # /days-worked-per-week/starting/2020-01-20/2020-08-07/5.0
           should "for 5 days a week" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-01-20"),
-              leaving_date: Date.parse("2020-07-18"),
-              working_days_per_week: 5,
-            )
+            @calculator.start_date = Date.parse("2020-01-20")
+            @calculator.leaving_date = Date.parse("2020-07-18")
+            @calculator.working_days_per_week = 5
 
-            assert_equal BigDecimal("0.4945355191").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("13.8469945355").round(10), calc.full_time_part_time_days.round(10)
-            assert_equal "13.9", calc.formatted_full_time_part_time_days
+            assert_equal BigDecimal("0.4945355191").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("13.8469945355").round(10), @calculator.full_time_part_time_days.round(10)
+            assert_equal "13.9", @calculator.formatted_full_time_part_time_days
           end
 
           # /days-worked-per-week/starting/2019-11-23/2020-04-07/3.0
           should "for less than 5 days a week" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-11-23"),
-              leaving_date: Date.parse("2020-04-07"),
-              working_days_per_week: 3,
-            )
+            @calculator.start_date = Date.parse("2019-11-23")
+            @calculator.leaving_date = Date.parse("2020-04-07")
+            @calculator.working_days_per_week = 3
 
-            assert_equal BigDecimal("0.3743169399").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("6.2885245902").round(10), calc.full_time_part_time_days.round(10)
-            assert_equal "6.3", calc.formatted_full_time_part_time_days
+            assert_equal BigDecimal("0.3743169399").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("6.2885245902").round(10), @calculator.full_time_part_time_days.round(10)
+            assert_equal "6.3", @calculator.formatted_full_time_part_time_days
           end
 
           # /days-worked-per-week/starting/2019-08-22/2020-07-31/6.0
           should "for more than 5 days a week" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-08-22"),
-              leaving_date: Date.parse("2020-07-31"),
-              working_days_per_week: 6,
-            )
+            @calculator.start_date = Date.parse("2019-08-22")
+            @calculator.leaving_date = Date.parse("2020-07-31")
+            @calculator.working_days_per_week = 6
 
-            assert_equal BigDecimal("0.9426229508").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("26.3934426229508").round(10), calc.full_time_part_time_days.round(10)
-            assert_equal "26.4", calc.formatted_full_time_part_time_days
+            assert_equal BigDecimal("0.9426229508").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("26.3934426229508").round(10), @calculator.full_time_part_time_days.round(10)
+            assert_equal "26.4", @calculator.formatted_full_time_part_time_days
           end
         end
 
         context "for department test data" do
           # /days-worked-per-week/starting-and-leaving/2019-08-09/2020-01-01/2.0
           should "for  2 days a week (dept test 19)" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-08-09"),
-              leaving_date: Date.parse("2020-01-01"),
-              working_days_per_week: 2,
-            )
+            @calculator.start_date = Date.parse("2019-08-09")
+            @calculator.leaving_date = Date.parse("2020-01-01")
+            @calculator.working_days_per_week = 2
 
-            assert_equal "4.5", calc.formatted_full_time_part_time_days
+            assert_equal "4.5", @calculator.formatted_full_time_part_time_days
           end
           # /days-worked-per-week/starting-and-leaving/2019-11-01/2020-05-27/6.0
           should "for 6 days a week (dept test 20)" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-11-01"),
-              leaving_date: Date.parse("2020-05-27"),
-              working_days_per_week: 6,
-            )
+            @calculator.start_date = Date.parse("2019-11-01")
+            @calculator.leaving_date = Date.parse("2020-05-27")
+            @calculator.working_days_per_week = 6
 
-            assert_equal "16", calc.formatted_full_time_part_time_days
+            assert_equal "16", @calculator.formatted_full_time_part_time_days
           end
           # /days-worked-per-week/starting-and-leaving/2019-10-04/2020-06-23/6.0
           should "for 6 days a week (dept test 21)" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-10-04"),
-              leaving_date: Date.parse("2020-06-23"),
-              working_days_per_week: 6,
-            )
+            @calculator.start_date = Date.parse("2019-10-04")
+            @calculator.leaving_date = Date.parse("2020-06-23")
+            @calculator.working_days_per_week = 6
 
-            assert_equal "20.2", calc.formatted_full_time_part_time_days
+            assert_equal "20.2", @calculator.formatted_full_time_part_time_days
           end
           # /days-worked-per-week/starting-and-leaving/2019-10-03/2020-05-26/1.0
           should "for 1 day a week (dept test 22)" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-10-03"),
-              leaving_date: Date.parse("2020-05-26"),
-              working_days_per_week: 1,
-            )
+            @calculator.start_date = Date.parse("2019-10-03")
+            @calculator.leaving_date = Date.parse("2020-05-26")
+            @calculator.working_days_per_week = 1
 
-            assert_equal "3.7", calc.formatted_full_time_part_time_days
+            assert_equal "3.7", @calculator.formatted_full_time_part_time_days
           end
           # /days-worked-per-week/starting-and-leaving/2018-06-04/2018-11-13/7.0
           should "for 1 day a week (dept test 23)" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2018-06-04"),
-              leaving_date: Date.parse("2018-11-13"),
-              working_days_per_week: 7,
-            )
+            @calculator.start_date = Date.parse("2018-06-04")
+            @calculator.leaving_date = Date.parse("2018-11-13")
+            @calculator.working_days_per_week = 7
 
-            assert_equal "12.6", calc.formatted_full_time_part_time_days
+            assert_equal "12.6", @calculator.formatted_full_time_part_time_days
           end
 
           # Dept Test 24 is a data entry validation to ensure leave date is after start date covered in
@@ -504,43 +442,55 @@ module SmartAnswer::Calculators
       context "for compressed hours department test data" do
         # /compressed-hours/full-year/68.0/7.0
         should "for a full year (Test 1)" do
-          calc = HolidayEntitlement.new(working_days_per_week: 7, hours_per_week: 68)
-          assert_equal "272", calc.formatted_full_time_part_time_compressed_hours
-          assert_equal [272, 0], calc.full_time_part_time_hours_and_minutes
+          @calculator.working_days_per_week = 7
+          @calculator.hours_per_week = 68
+
+          assert_equal "272", @calculator.formatted_full_time_part_time_compressed_hours
+          assert_equal [272, 0], @calculator.full_time_part_time_hours_and_minutes
         end
 
         # /compressed-hours/full-year/73.0/7.0
         should "for a full year (Test 2)" do
-          calc = HolidayEntitlement.new(working_days_per_week: 7, hours_per_week: 73)
-          assert_equal "292", calc.formatted_full_time_part_time_compressed_hours
-          assert_equal [292, 0], calc.full_time_part_time_hours_and_minutes
+          @calculator.working_days_per_week = 7
+          @calculator.hours_per_week = 73
+
+          assert_equal "292", @calculator.formatted_full_time_part_time_compressed_hours
+          assert_equal [292, 0], @calculator.full_time_part_time_hours_and_minutes
         end
 
         # /compressed-hours/full-year/57.0/5.0
         should "for a full year (Test 3)" do
-          calc = HolidayEntitlement.new(working_days_per_week: 5, hours_per_week: 57)
-          assert_equal "319.2", calc.formatted_full_time_part_time_compressed_hours
-          assert_equal [319, 12], calc.full_time_part_time_hours_and_minutes
+          @calculator.working_days_per_week = 5
+          @calculator.hours_per_week = 57
+
+          assert_equal "319.2", @calculator.formatted_full_time_part_time_compressed_hours
+          assert_equal [319, 12], @calculator.full_time_part_time_hours_and_minutes
         end
 
         # /compressed-hours/full-year/80.0/6.0
         should "for a full year (Test 4)" do
-          calc = HolidayEntitlement.new(working_days_per_week: 6, hours_per_week: 80)
-          assert_equal "373.4", calc.formatted_full_time_part_time_compressed_hours
-          assert_equal [373, 24], calc.full_time_part_time_hours_and_minutes
+          @calculator.working_days_per_week = 6
+          @calculator.hours_per_week = 80
+
+          assert_equal "373.4", @calculator.formatted_full_time_part_time_compressed_hours
+          assert_equal [373, 24], @calculator.full_time_part_time_hours_and_minutes
         end
 
         # /compressed-hours/full-year/38.0/5.0
         should "for a full year (Test 5)" do
-          calc = HolidayEntitlement.new(working_days_per_week: 5, hours_per_week: 38)
-          assert_equal "212.8", calc.formatted_full_time_part_time_compressed_hours
-          assert_equal [212, 48], calc.full_time_part_time_hours_and_minutes
+          @calculator.working_days_per_week = 5
+          @calculator.hours_per_week = 38
+
+          assert_equal "212.8", @calculator.formatted_full_time_part_time_compressed_hours
+          assert_equal [212, 48], @calculator.full_time_part_time_hours_and_minutes
         end
 
         should "for a full year (Test 6)" do
-          calc = HolidayEntitlement.new(working_days_per_week: 4, hours_per_week: 40)
-          assert_equal "224", calc.formatted_full_time_part_time_compressed_hours
-          assert_equal [224, 0], calc.full_time_part_time_hours_and_minutes
+          @calculator.working_days_per_week = 4
+          @calculator.hours_per_week = 40
+
+          assert_equal "224", @calculator.formatted_full_time_part_time_compressed_hours
+          assert_equal [224, 0], @calculator.full_time_part_time_hours_and_minutes
         end
 
         # Test 7 is a data entry validation test implemented in
@@ -548,41 +498,35 @@ module SmartAnswer::Calculators
 
         #  /compressed-hours/starting/2020-07-14/2019-11-01/26.0/2.0
         should "for starting part way through a leave year (Test 8)" do
-          calc = HolidayEntitlement.new(
-            start_date: Date.parse("2020-07-14"),
-            leave_year_start_date: Date.parse("2019-11-01"),
-            working_days_per_week: 2,
-            hours_per_week: 26,
-          )
+          @calculator.start_date = Date.parse("2020-07-14")
+          @calculator.leave_year_start_date = Date.parse("2019-11-01")
+          @calculator.working_days_per_week = 2
+          @calculator.hours_per_week = 26
 
-          assert_equal "52", calc.formatted_full_time_part_time_compressed_hours
-          assert_equal [52, 0], calc.full_time_part_time_hours_and_minutes
+          assert_equal "52", @calculator.formatted_full_time_part_time_compressed_hours
+          assert_equal [52, 0], @calculator.full_time_part_time_hours_and_minutes
         end
 
         # /compressed-hours/starting/2018-09-12/2018-04-01/49.0/5.0
         should "for starting part way through a leave year (Test 9)" do
-          calc = HolidayEntitlement.new(
-            start_date: Date.parse("2018-09-12"),
-            leave_year_start_date: Date.parse("2018-04-01"),
-            working_days_per_week: 5,
-            hours_per_week: 49,
-          )
+          @calculator.start_date = Date.parse("2018-09-12")
+          @calculator.leave_year_start_date = Date.parse("2018-04-01")
+          @calculator.working_days_per_week = 5
+          @calculator.hours_per_week = 49
 
-          assert_equal "161.7", calc.formatted_full_time_part_time_compressed_hours
-          assert_equal [161, 42], calc.full_time_part_time_hours_and_minutes
+          assert_equal "161.7", @calculator.formatted_full_time_part_time_compressed_hours
+          assert_equal [161, 42], @calculator.full_time_part_time_hours_and_minutes
         end
 
         # /compressed-hours/starting/2019-11-08/2019-04-01/35.0/3.0
         should "for starting part way through a leave year (Test 10)" do
-          calc = HolidayEntitlement.new(
-            start_date: Date.parse("2019-11-08"),
-            leave_year_start_date: Date.parse("2019-04-01"),
-            working_days_per_week: 3,
-            hours_per_week: 35,
-          )
+          @calculator.start_date = Date.parse("2019-11-08")
+          @calculator.leave_year_start_date = Date.parse("2019-04-01")
+          @calculator.working_days_per_week = 3
+          @calculator.hours_per_week = 35
 
-          assert_equal "81.7", calc.formatted_full_time_part_time_compressed_hours
-          assert_equal [81, 42], calc.full_time_part_time_hours_and_minutes
+          assert_equal "81.7", @calculator.formatted_full_time_part_time_compressed_hours
+          assert_equal [81, 42], @calculator.full_time_part_time_hours_and_minutes
         end
 
         # Tests 11 and 12 are data entry validation tests implemented in
@@ -590,15 +534,13 @@ module SmartAnswer::Calculators
 
         # /compressed-hours/leaving/2019-07-10/2018-11-01/33.0/3.0
         should "for leaving part way through a leave year (Test 13)" do
-          calc = HolidayEntitlement.new(
-            leaving_date: Date.parse("2019-07-10"),
-            leave_year_start_date: Date.parse("2018-11-01"),
-            working_days_per_week: 3,
-            hours_per_week: 33,
-          )
+          @calculator.leaving_date = Date.parse("2019-07-10")
+          @calculator.leave_year_start_date = Date.parse("2018-11-01")
+          @calculator.working_days_per_week = 3
+          @calculator.hours_per_week = 33
 
-          assert_equal "127.6", calc.formatted_full_time_part_time_compressed_hours
-          assert_equal [127, 36], calc.full_time_part_time_hours_and_minutes
+          assert_equal "127.6", @calculator.formatted_full_time_part_time_compressed_hours
+          assert_equal [127, 36], @calculator.full_time_part_time_hours_and_minutes
         end
 
         # Test 14 is a data entry validation test implemented in
@@ -606,15 +548,13 @@ module SmartAnswer::Calculators
 
         # /compressed-hours/leaving/2020-03-18/2019-10-01/73.0/7.0
         should "for leaving part way through a leave year (Test 15)" do
-          calc = HolidayEntitlement.new(
-            leaving_date: Date.parse("2020-03-18"),
-            leave_year_start_date: Date.parse("2019-10-01"),
-            working_days_per_week: 7,
-            hours_per_week: 73,
-          )
+          @calculator.leaving_date = Date.parse("2020-03-18")
+          @calculator.leave_year_start_date = Date.parse("2019-10-01")
+          @calculator.working_days_per_week = 7
+          @calculator.hours_per_week = 73
 
-          assert_equal "135.7", calc.formatted_full_time_part_time_compressed_hours
-          assert_equal [135, 42], calc.full_time_part_time_hours_and_minutes
+          assert_equal "135.7", @calculator.formatted_full_time_part_time_compressed_hours
+          assert_equal [135, 42], @calculator.full_time_part_time_hours_and_minutes
         end
 
         # Tests 16-18 are a data entry validation tests implemented in
@@ -622,54 +562,46 @@ module SmartAnswer::Calculators
 
         # /compressed-hours/starting-and-leaving/2018-05-10/2018-12-04/35.0/3.0
         should "starting and leaving part way through a leave year (Test 19)" do
-          calc = HolidayEntitlement.new(
-            start_date: Date.parse("2018-05-10"),
-            leaving_date: Date.parse("2018-12-04"),
-            working_days_per_week: 3,
-            hours_per_week: 35,
-          )
+          @calculator.start_date = Date.parse("2018-05-10")
+          @calculator.leaving_date = Date.parse("2018-12-04")
+          @calculator.working_days_per_week = 3
+          @calculator.hours_per_week = 35
 
-          assert_equal "112.3", calc.formatted_full_time_part_time_compressed_hours
-          assert_equal [112, 18], calc.full_time_part_time_hours_and_minutes
+          assert_equal "112.3", @calculator.formatted_full_time_part_time_compressed_hours
+          assert_equal [112, 18], @calculator.full_time_part_time_hours_and_minutes
         end
 
         # /compressed-hours/starting-and-leaving/2018-04-02/2019-03-08/29.0/2.0
         should "starting and leaving part way through a leave year (Test 20)" do
-          calc = HolidayEntitlement.new(
-            start_date: Date.parse("2018-04-02"),
-            leaving_date: Date.parse("2019-03-08"),
-            working_days_per_week: 2,
-            hours_per_week: 29,
-          )
+          @calculator.start_date = Date.parse("2018-04-02")
+          @calculator.leaving_date = Date.parse("2019-03-08")
+          @calculator.working_days_per_week = 2
+          @calculator.hours_per_week = 29
 
-          assert_equal "151.8", calc.formatted_full_time_part_time_compressed_hours
-          assert_equal [151, 48], calc.full_time_part_time_hours_and_minutes
+          assert_equal "151.8", @calculator.formatted_full_time_part_time_compressed_hours
+          assert_equal [151, 48], @calculator.full_time_part_time_hours_and_minutes
         end
 
         # /compressed-hours/starting-and-leaving/2019-11-23/2020-06-07/47.0/6.0
         should "starting and leaving part way through a leave year (Test 21)" do
-          calc = HolidayEntitlement.new(
-            start_date: Date.parse("2019-11-23"),
-            leaving_date: Date.parse("2020-06-07"),
-            working_days_per_week: 6,
-            hours_per_week: 47,
-          )
+          @calculator.start_date = Date.parse("2019-11-23")
+          @calculator.leaving_date = Date.parse("2020-06-07")
+          @calculator.working_days_per_week = 6
+          @calculator.hours_per_week = 47
 
-          assert_equal "118.7", calc.formatted_full_time_part_time_compressed_hours
-          assert_equal [118, 42], calc.full_time_part_time_hours_and_minutes
+          assert_equal "118.7", @calculator.formatted_full_time_part_time_compressed_hours
+          assert_equal [118, 42], @calculator.full_time_part_time_hours_and_minutes
         end
 
         # /compressed-hours/starting-and-leaving/2019-10-30/2020-10-12/25.0/6.0
         should "starting and leaving part way through a leave year (Test 22)" do
-          calc = HolidayEntitlement.new(
-            start_date: Date.parse("2019-10-30"),
-            leaving_date: Date.parse("2020-10-12"),
-            working_days_per_week: 6,
-            hours_per_week: 25,
-          )
+          @calculator.start_date = Date.parse("2019-10-30")
+          @calculator.leaving_date = Date.parse("2020-10-12")
+          @calculator.working_days_per_week = 6
+          @calculator.hours_per_week = 25
 
-          assert_equal "111.3", calc.formatted_full_time_part_time_compressed_hours
-          assert_equal [111, 18], calc.full_time_part_time_hours_and_minutes
+          assert_equal "111.3", @calculator.formatted_full_time_part_time_compressed_hours
+          assert_equal [111, 18], @calculator.full_time_part_time_hours_and_minutes
         end
 
         # Test 23 is a data entry validation test implemented in
@@ -677,72 +609,88 @@ module SmartAnswer::Calculators
 
         # /compressed-hours/starting-and-leaving/2020-03-01/2020-06-01/37.5/5.0
         should "starting and leaving part way through a leave year (Test 24)" do
-          calc = HolidayEntitlement.new(
-            start_date: Date.parse("2020-03-01"),
-            leaving_date: Date.parse("2020-06-01"),
-            working_days_per_week: 5,
-            hours_per_week: 37.5,
-          )
+          @calculator.start_date = Date.parse("2020-03-01")
+          @calculator.leaving_date = Date.parse("2020-06-01")
+          @calculator.working_days_per_week = 5
+          @calculator.hours_per_week = 37.5
 
-          assert_equal "53.6", calc.formatted_full_time_part_time_compressed_hours
-          assert_equal [53, 36], calc.full_time_part_time_hours_and_minutes
+          assert_equal "53.6", @calculator.formatted_full_time_part_time_compressed_hours
+          assert_equal [53, 36], @calculator.full_time_part_time_hours_and_minutes
         end
       end
 
       context "for a full leave year" do
         should "for 40 hours over 5 days per week" do
-          calc = HolidayEntitlement.new(working_days_per_week: 5, hours_per_week: 40)
-          assert_equal "224", calc.formatted_full_time_part_time_compressed_hours
-          assert_equal [224, 0], calc.full_time_part_time_hours_and_minutes
+          @calculator.working_days_per_week = 5
+          @calculator.hours_per_week = 40
+
+          assert_equal "224", @calculator.formatted_full_time_part_time_compressed_hours
+          assert_equal [224, 0], @calculator.full_time_part_time_hours_and_minutes
         end
 
         should "for 25 hours over less than 5 days a week" do
-          calc = HolidayEntitlement.new(working_days_per_week: 3, hours_per_week: 25)
-          assert_equal "140", calc.formatted_full_time_part_time_compressed_hours
-          assert_equal [140, 0], calc.full_time_part_time_hours_and_minutes
+          @calculator.working_days_per_week = 3
+          @calculator.hours_per_week = 25
+
+          assert_equal "140", @calculator.formatted_full_time_part_time_compressed_hours
+          assert_equal [140, 0], @calculator.full_time_part_time_hours_and_minutes
         end
 
         should "for 36 hours over more than 5 days a week" do
-          calc = HolidayEntitlement.new(working_days_per_week: 6, hours_per_week: 36)
-          assert_equal "168", calc.formatted_full_time_part_time_compressed_hours
-          assert_equal [168, 0], calc.full_time_part_time_hours_and_minutes
+          @calculator.working_days_per_week = 6
+          @calculator.hours_per_week = 36
+
+          assert_equal "168", @calculator.formatted_full_time_part_time_compressed_hours
+          assert_equal [168, 0], @calculator.full_time_part_time_hours_and_minutes
         end
 
         context "for department test data" do
           # Test 1 - /hours-worked-per-week/full-year/80.0/7.0
           should "for 80 hours 7 days per week (dept Test 1)" do
-            calc = HolidayEntitlement.new(working_days_per_week: 7, hours_per_week: 80)
-            assert_equal "320", calc.formatted_full_time_part_time_compressed_hours
+            @calculator.working_days_per_week = 7
+            @calculator.hours_per_week = 80
+
+            assert_equal "320", @calculator.formatted_full_time_part_time_compressed_hours
           end
 
           # Test 2 - /hours-worked-per-week/full-year/49.0/4.0
           should "for 49 hours 4 days per week (dept Test 2)" do
-            calc = HolidayEntitlement.new(working_days_per_week: 4, hours_per_week: 49)
-            assert_equal "274.4", calc.formatted_full_time_part_time_compressed_hours
+            @calculator.working_days_per_week = 4
+            @calculator.hours_per_week = 49
+
+            assert_equal "274.4", @calculator.formatted_full_time_part_time_compressed_hours
           end
 
           # Test 3 - /hours-worked-per-week/full-year/76.0/6.0
           should "for 76 hours 6 days per week (dept Test 3)" do
-            calc = HolidayEntitlement.new(working_days_per_week: 6, hours_per_week: 76)
-            assert_equal "354.7", calc.formatted_full_time_part_time_compressed_hours
+            @calculator.working_days_per_week = 6
+            @calculator.hours_per_week = 76
+
+            assert_equal "354.7", @calculator.formatted_full_time_part_time_compressed_hours
           end
 
           # Test 4 - /hours-worked-per-week/full-year/55.0/5.0
           should "for 55 hours 3 days per week (dept Test 4)" do
-            calc = HolidayEntitlement.new(working_days_per_week: 3, hours_per_week: 55)
-            assert_equal "308", calc.formatted_full_time_part_time_compressed_hours
+            @calculator.working_days_per_week = 3
+            @calculator.hours_per_week = 55
+
+            assert_equal "308", @calculator.formatted_full_time_part_time_compressed_hours
           end
 
           # Test 5 - /hours-worked-per-week/full-year/13.0/2.0
           should "for 13 hours 2 days per week (dept Test 5)" do
-            calc = HolidayEntitlement.new(working_days_per_week: 2, hours_per_week: 13)
-            assert_equal "72.8", calc.formatted_full_time_part_time_compressed_hours
+            @calculator.working_days_per_week = 2
+            @calculator.hours_per_week = 13
+
+            assert_equal "72.8", @calculator.formatted_full_time_part_time_compressed_hours
           end
 
           # Test 6 - /hours-worked-per-week/full-year/45.0/5.0
           should "for 45 hours 5 days per week (dept Test 6)" do
-            calc = HolidayEntitlement.new(working_days_per_week: 5, hours_per_week: 45)
-            assert_equal "252", calc.formatted_full_time_part_time_compressed_hours
+            @calculator.working_days_per_week = 5
+            @calculator.hours_per_week = 45
+
+            assert_equal "252", @calculator.formatted_full_time_part_time_compressed_hours
           end
         end
       end
@@ -750,133 +698,113 @@ module SmartAnswer::Calculators
       context "starting part way through a leave year" do
         context "for a standard year" do
           should "for 40 hours over 5 days a week" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-06-01"),
-              leave_year_start_date: Date.parse("2019-01-01"),
-              working_days_per_week: 5,
-              hours_per_week: 40,
-            )
+            @calculator.start_date = Date.parse("2019-06-01")
+            @calculator.leave_year_start_date = Date.parse("2019-01-01")
+            @calculator.working_days_per_week = 5
+            @calculator.hours_per_week = 40
 
-            assert_equal BigDecimal("16.3333333333").round(10), calc.full_time_part_time_days.round(10)
-            assert_equal BigDecimal("16.5").round(10), calc.rounded_full_time_part_time_days.round(10)
-            assert_equal "132", calc.formatted_full_time_part_time_compressed_hours
-            assert_equal [132, 0], calc.full_time_part_time_hours_and_minutes
+            assert_equal BigDecimal("16.3333333333").round(10), @calculator.full_time_part_time_days.round(10)
+            assert_equal BigDecimal("16.5").round(10), @calculator.rounded_full_time_part_time_days.round(10)
+            assert_equal "132", @calculator.formatted_full_time_part_time_compressed_hours
+            assert_equal [132, 0], @calculator.full_time_part_time_hours_and_minutes
           end
 
           should "for 25 hours less than 5 days a week" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-11-23"),
-              leave_year_start_date: Date.parse("2020-04-01"),
-              working_days_per_week: 3,
-              hours_per_week: 25,
-            )
+            @calculator.start_date = Date.parse("2020-11-23")
+            @calculator.leave_year_start_date = Date.parse("2020-04-01")
+            @calculator.working_days_per_week = 3
+            @calculator.hours_per_week = 25
 
-            assert_equal BigDecimal("7").round(10), calc.full_time_part_time_days.round(10)
-            assert_equal BigDecimal("7").round(10), calc.rounded_full_time_part_time_days.round(10)
-            assert_equal "58.4", calc.formatted_full_time_part_time_compressed_hours
-            assert_equal [58, 24], calc.full_time_part_time_hours_and_minutes
+            assert_equal BigDecimal("7").round(10), @calculator.full_time_part_time_days.round(10)
+            assert_equal BigDecimal("7").round(10), @calculator.rounded_full_time_part_time_days.round(10)
+            assert_equal "58.4", @calculator.formatted_full_time_part_time_compressed_hours
+            assert_equal [58, 24], @calculator.full_time_part_time_hours_and_minutes
           end
 
           should "for 36 hours more than 5 days a week" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-11-14"),
-              leave_year_start_date: Date.parse("2019-01-01"),
-              working_days_per_week: 6,
-              hours_per_week: 36,
-            )
+            @calculator.start_date = Date.parse("2019-11-14")
+            @calculator.leave_year_start_date = Date.parse("2019-01-01")
+            @calculator.working_days_per_week = 6
+            @calculator.hours_per_week = 36
 
-            assert_equal BigDecimal("4.6666666667").round(10), calc.full_time_part_time_days.round(10)
-            assert_equal BigDecimal("5").round(10), calc.rounded_full_time_part_time_days.round(10)
-            assert_equal "30", calc.formatted_full_time_part_time_compressed_hours
-            assert_equal [30, 0], calc.full_time_part_time_hours_and_minutes
+            assert_equal BigDecimal("4.6666666667").round(10), @calculator.full_time_part_time_days.round(10)
+            assert_equal BigDecimal("5").round(10), @calculator.rounded_full_time_part_time_days.round(10)
+            assert_equal "30", @calculator.formatted_full_time_part_time_compressed_hours
+            assert_equal [30, 0], @calculator.full_time_part_time_hours_and_minutes
           end
         end
 
         context "for a leap year" do
           should "for 40 hours over 5 days a week" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-06-01"),
-              leave_year_start_date: Date.parse("2020-01-01"),
-              working_days_per_week: 5,
-              hours_per_week: 40,
-            )
+            @calculator.start_date = Date.parse("2020-06-01")
+            @calculator.leave_year_start_date = Date.parse("2020-01-01")
+            @calculator.working_days_per_week = 5
+            @calculator.hours_per_week = 40
 
-            assert_equal "132", calc.formatted_full_time_part_time_compressed_hours
-            assert_equal [132, 0], calc.full_time_part_time_hours_and_minutes
+            assert_equal "132", @calculator.formatted_full_time_part_time_compressed_hours
+            assert_equal [132, 0], @calculator.full_time_part_time_hours_and_minutes
           end
 
           should "for 25 hours less than 5 days a week" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-11-23"),
-              leave_year_start_date: Date.parse("2019-04-01"),
-              working_days_per_week: 3,
-              hours_per_week: 25,
-            )
+            @calculator.start_date = Date.parse("2019-11-23")
+            @calculator.leave_year_start_date = Date.parse("2019-04-01")
+            @calculator.working_days_per_week = 3
+            @calculator.hours_per_week = 25
 
-            assert_equal "58.4", calc.formatted_full_time_part_time_compressed_hours
-            assert_equal [58, 24], calc.full_time_part_time_hours_and_minutes
+            assert_equal "58.4", @calculator.formatted_full_time_part_time_compressed_hours
+            assert_equal [58, 24], @calculator.full_time_part_time_hours_and_minutes
           end
 
           should "for 36 hours more than 5 days a week" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-11-14"),
-              leave_year_start_date: Date.parse("2020-01-01"),
-              working_days_per_week: 6,
-              hours_per_week: 36,
-            )
+            @calculator.start_date = Date.parse("2020-11-14")
+            @calculator.leave_year_start_date = Date.parse("2020-01-01")
+            @calculator.working_days_per_week = 6
+            @calculator.hours_per_week = 36
 
-            assert_equal "30", calc.formatted_full_time_part_time_compressed_hours
-            assert_equal [30, 0], calc.full_time_part_time_hours_and_minutes
+            assert_equal "30", @calculator.formatted_full_time_part_time_compressed_hours
+            assert_equal [30, 0], @calculator.full_time_part_time_hours_and_minutes
           end
         end
 
         context "for department test data" do
           # Test 9 - /starting/2020-08-21/2019-11-01/69.0/6.0
           should "for 69 hours 6 days a week (Test 9)" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-08-21"),
-              leave_year_start_date: Date.parse("2019-11-01"),
-              working_days_per_week: 6,
-              hours_per_week: 69,
-            )
+            @calculator.start_date = Date.parse("2020-08-21")
+            @calculator.leave_year_start_date = Date.parse("2019-11-01")
+            @calculator.working_days_per_week = 6
+            @calculator.hours_per_week = 69
 
-            assert_equal "80.5", calc.formatted_full_time_part_time_compressed_hours
+            assert_equal "80.5", @calculator.formatted_full_time_part_time_compressed_hours
           end
 
           # Test 10 - /starting/2020-07-28/2020-01-01/50.0/6.0
           should "for 50 hours 6 days a week (Test 10)" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-07-28"),
-              leave_year_start_date: Date.parse("2020-01-01"),
-              working_days_per_week: 6,
-              hours_per_week: 50,
-            )
+            @calculator.start_date = Date.parse("2020-07-28")
+            @calculator.leave_year_start_date = Date.parse("2020-01-01")
+            @calculator.working_days_per_week = 6
+            @calculator.hours_per_week = 50
 
-            assert_equal "116.7", calc.formatted_full_time_part_time_compressed_hours
+            assert_equal "116.7", @calculator.formatted_full_time_part_time_compressed_hours
           end
 
           # Test 11 - /starting/2020-02-03/2019-11-01/14.0/5.0
           should "for 14 hours 5 days a week (Test 11)" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-02-03"),
-              leave_year_start_date: Date.parse("2019-11-01"),
-              working_days_per_week: 5,
-              hours_per_week: 14,
-            )
+            @calculator.start_date = Date.parse("2020-02-03")
+            @calculator.leave_year_start_date = Date.parse("2019-11-01")
+            @calculator.working_days_per_week = 5
+            @calculator.hours_per_week = 14
 
-            assert_equal "58.8", calc.formatted_full_time_part_time_compressed_hours
+            assert_equal "58.8", @calculator.formatted_full_time_part_time_compressed_hours
           end
 
           # Test 12 - /starting/2021-03-04/2020-08-03/50.0/6.0
           should "for 50 hours 6 days a week (Test 12)" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2021-03-04"),
-              leave_year_start_date: Date.parse("2020-08-03"),
-              working_days_per_week: 6,
-              hours_per_week: 50,
-            )
+            @calculator.start_date = Date.parse("2021-03-04")
+            @calculator.leave_year_start_date = Date.parse("2020-08-03")
+            @calculator.working_days_per_week = 6
+            @calculator.hours_per_week = 50
 
-            assert_equal "100", calc.formatted_full_time_part_time_compressed_hours
+            assert_equal "100", @calculator.formatted_full_time_part_time_compressed_hours
           end
         end
       end
@@ -884,137 +812,119 @@ module SmartAnswer::Calculators
       context "leaving part way through a leave year" do
         context "for a standard year" do
           should "for 40 hours over 5 days a week" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2019-06-01"),
-              leave_year_start_date: Date.parse("2019-01-01"),
-              working_days_per_week: 5,
-              hours_per_week: 40,
-            )
+            @calculator.leaving_date = Date.parse("2019-06-01")
+            @calculator.leave_year_start_date = Date.parse("2019-01-01")
+            @calculator.working_days_per_week = 5
+            @calculator.hours_per_week = 40
 
-            assert_equal BigDecimal("224").round(10), calc.full_time_part_time_hours.round(10)
-            assert_equal BigDecimal("93.2821917808").round(10), calc.pro_rated_hours.round(10)
-            assert_equal "93.3", calc.formatted_full_time_part_time_compressed_hours
-            assert_equal [93, 18], calc.full_time_part_time_hours_and_minutes
+            assert_equal BigDecimal("224").round(10), @calculator.full_time_part_time_hours.round(10)
+            assert_equal BigDecimal("93.2821917808").round(10), @calculator.pro_rated_hours.round(10)
+            assert_equal "93.3", @calculator.formatted_full_time_part_time_compressed_hours
+            assert_equal [93, 18], @calculator.full_time_part_time_hours_and_minutes
           end
 
           should "for 25 hours less than 5 days a week" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2020-11-23"),
-              leave_year_start_date: Date.parse("2020-04-01"),
-              working_days_per_week: 3,
-              hours_per_week: 25,
-            )
+            @calculator.leaving_date = Date.parse("2020-11-23")
+            @calculator.leave_year_start_date = Date.parse("2020-04-01")
+            @calculator.working_days_per_week = 3
+            @calculator.hours_per_week = 25
 
-            assert_equal BigDecimal("140").round(10), calc.full_time_part_time_hours.round(10)
-            assert_equal BigDecimal("90.9041095890").round(10), calc.pro_rated_hours.round(10)
-            assert_equal "91", calc.formatted_full_time_part_time_compressed_hours
-            assert_equal [91, 0], calc.full_time_part_time_hours_and_minutes
+            assert_equal BigDecimal("140").round(10), @calculator.full_time_part_time_hours.round(10)
+            assert_equal BigDecimal("90.9041095890").round(10), @calculator.pro_rated_hours.round(10)
+            assert_equal "91", @calculator.formatted_full_time_part_time_compressed_hours
+            assert_equal [91, 0], @calculator.full_time_part_time_hours_and_minutes
           end
 
           should "for 36 hours more than 5 days a week" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2019-08-22"),
-              leave_year_start_date: Date.parse("2019-01-01"),
-              working_days_per_week: 6,
-              hours_per_week: 36,
-            )
+            @calculator.leaving_date = Date.parse("2019-08-22")
+            @calculator.leave_year_start_date = Date.parse("2019-01-01")
+            @calculator.working_days_per_week = 6
+            @calculator.hours_per_week = 36
 
-            assert_equal BigDecimal("168").round(10), calc.full_time_part_time_hours.round(10)
-            assert_equal BigDecimal("107.7041095890").round(10), calc.pro_rated_hours.round(10)
-            assert_equal "107.8", calc.formatted_full_time_part_time_compressed_hours
-            assert_equal [107, 48], calc.full_time_part_time_hours_and_minutes
+            assert_equal BigDecimal("168").round(10), @calculator.full_time_part_time_hours.round(10)
+            assert_equal BigDecimal("107.7041095890").round(10), @calculator.pro_rated_hours.round(10)
+            assert_equal "107.8", @calculator.formatted_full_time_part_time_compressed_hours
+            assert_equal [107, 48], @calculator.full_time_part_time_hours_and_minutes
           end
         end
+
         context "for a leap year" do
           should "for 40 hours over 5 days a week" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2020-06-01"),
-              leave_year_start_date: Date.parse("2020-01-01"),
-              working_days_per_week: 5,
-              hours_per_week: 40,
-            )
+            @calculator.leaving_date = Date.parse("2020-06-01")
+            @calculator.leave_year_start_date = Date.parse("2020-01-01")
+            @calculator.working_days_per_week = 5
+            @calculator.hours_per_week = 40
 
-            assert_equal BigDecimal("224").round(10), calc.full_time_part_time_hours.round(10)
-            assert_equal BigDecimal("93.6393442623").round(10), calc.pro_rated_hours.round(10)
-            assert_equal "93.7", calc.formatted_full_time_part_time_compressed_hours
-            assert_equal [93, 42], calc.full_time_part_time_hours_and_minutes
+            assert_equal BigDecimal("224").round(10), @calculator.full_time_part_time_hours.round(10)
+            assert_equal BigDecimal("93.6393442623").round(10), @calculator.pro_rated_hours.round(10)
+            assert_equal "93.7", @calculator.formatted_full_time_part_time_compressed_hours
+            assert_equal [93, 42], @calculator.full_time_part_time_hours_and_minutes
           end
-          should "for 25 hours less than 5 days a week" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2019-11-23"),
-              leave_year_start_date: Date.parse("2019-04-01"),
-              working_days_per_week: 3,
-              hours_per_week: 25,
-            )
 
-            assert_equal BigDecimal("140").round(10), calc.full_time_part_time_hours.round(10)
-            assert_equal BigDecimal("90.6557377049").round(10), calc.pro_rated_hours.round(10)
-            assert_equal "90.7", calc.formatted_full_time_part_time_compressed_hours
-            assert_equal [90, 42], calc.full_time_part_time_hours_and_minutes
+          should "for 25 hours less than 5 days a week" do
+            @calculator.leaving_date = Date.parse("2019-11-23")
+            @calculator.leave_year_start_date = Date.parse("2019-04-01")
+            @calculator.working_days_per_week = 3
+            @calculator.hours_per_week = 25
+
+            assert_equal BigDecimal("140").round(10), @calculator.full_time_part_time_hours.round(10)
+            assert_equal BigDecimal("90.6557377049").round(10), @calculator.pro_rated_hours.round(10)
+            assert_equal "90.7", @calculator.formatted_full_time_part_time_compressed_hours
+            assert_equal [90, 42], @calculator.full_time_part_time_hours_and_minutes
           end
 
           should "for 36 hours more than 5 days a week" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2020-08-22"),
-              leave_year_start_date: Date.parse("2020-01-01"),
-              working_days_per_week: 6,
-              hours_per_week: 36,
-            )
+            @calculator.leaving_date = Date.parse("2020-08-22")
+            @calculator.leave_year_start_date = Date.parse("2020-01-01")
+            @calculator.working_days_per_week = 6
+            @calculator.hours_per_week = 36
 
-            assert_equal BigDecimal("168").round(10), calc.full_time_part_time_hours.round(10)
-            assert_equal BigDecimal("107.8688524590").round(10), calc.pro_rated_hours.round(10)
-            assert_equal "107.9", calc.formatted_full_time_part_time_compressed_hours
-            assert_equal [107, 54], calc.full_time_part_time_hours_and_minutes
+            assert_equal BigDecimal("168").round(10), @calculator.full_time_part_time_hours.round(10)
+            assert_equal BigDecimal("107.8688524590").round(10), @calculator.pro_rated_hours.round(10)
+            assert_equal "107.9", @calculator.formatted_full_time_part_time_compressed_hours
+            assert_equal [107, 54], @calculator.full_time_part_time_hours_and_minutes
           end
         end
 
         context "for department test data" do
           # Test 13 - /leaving/2020-02-11/2019-06-01/34.0/2.0
           should "for 34 hours 2 days a week (Test 13)" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2020-02-11"),
-              leave_year_start_date: Date.parse("2019-06-01"),
-              working_days_per_week: 2,
-              hours_per_week: 34,
-            )
+            @calculator.leaving_date = Date.parse("2020-02-11")
+            @calculator.leave_year_start_date = Date.parse("2019-06-01")
+            @calculator.working_days_per_week = 2
+            @calculator.hours_per_week = 34
 
-            assert_equal "133.2", calc.formatted_full_time_part_time_compressed_hours
+            assert_equal "133.2", @calculator.formatted_full_time_part_time_compressed_hours
           end
 
           # Test 14 - /leaving/2019-06-26/2018-10-01/47.0/2.0
           should "for 47 hours 2 days a week (Test 14)" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2019-06-26"),
-              leave_year_start_date: Date.parse("2018-10-01"),
-              working_days_per_week: 2,
-              hours_per_week: 47,
-            )
+            @calculator.leaving_date = Date.parse("2019-06-26")
+            @calculator.leave_year_start_date = Date.parse("2018-10-01")
+            @calculator.working_days_per_week = 2
+            @calculator.hours_per_week = 47
 
-            assert_equal "194", calc.formatted_full_time_part_time_compressed_hours
+            assert_equal "194", @calculator.formatted_full_time_part_time_compressed_hours
           end
 
           # Test 15 - /leaving/2020-04-19/2019-10-01/71.0/7.0
           should "for 71 hours 7 days a week (Test 15)" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2020-04-19"),
-              leave_year_start_date: Date.parse("2019-10-01"),
-              working_days_per_week: 7,
-              hours_per_week: 71,
-            )
+            @calculator.leaving_date = Date.parse("2020-04-19")
+            @calculator.leave_year_start_date = Date.parse("2019-10-01")
+            @calculator.working_days_per_week = 7
+            @calculator.hours_per_week = 71
 
-            assert_equal "156.8", calc.formatted_full_time_part_time_compressed_hours
+            assert_equal "156.8", @calculator.formatted_full_time_part_time_compressed_hours
           end
 
           # Test 17 - /leaving/2020-04-30/2019-06-01/63.0/5.0
           should "for 63 hours 5 days a week (Test 17)" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2020-04-30"),
-              leave_year_start_date: Date.parse("2019-06-01"),
-              working_days_per_week: 5,
-              hours_per_week: 63,
-            )
+            @calculator.leaving_date = Date.parse("2020-04-30")
+            @calculator.leave_year_start_date = Date.parse("2019-06-01")
+            @calculator.working_days_per_week = 5
+            @calculator.hours_per_week = 63
 
-            assert_equal "323", calc.formatted_full_time_part_time_compressed_hours
+            assert_equal "323", @calculator.formatted_full_time_part_time_compressed_hours
           end
         end
       end
@@ -1022,238 +932,215 @@ module SmartAnswer::Calculators
       context "starting and leaving part way through a leave year" do
         context "for a standard year" do
           should "for 40 hours over 5 days a week" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-01-20"),
-              leaving_date: Date.parse("2019-07-18"),
-              working_days_per_week: 5,
-              hours_per_week: 40,
-            )
+            @calculator.start_date = Date.parse("2019-01-20")
+            @calculator.leaving_date = Date.parse("2019-07-18")
+            @calculator.working_days_per_week = 5
+            @calculator.hours_per_week = 40
 
-            assert_equal BigDecimal("224").round(10), calc.full_time_part_time_hours.round(10)
-            assert_equal BigDecimal("110.4657534247").round(10), calc.pro_rated_hours.round(10)
-            assert_equal "110.5", calc.formatted_full_time_part_time_compressed_hours
-            assert_equal [110, 30], calc.full_time_part_time_hours_and_minutes
+            assert_equal BigDecimal("224").round(10), @calculator.full_time_part_time_hours.round(10)
+            assert_equal BigDecimal("110.4657534247").round(10), @calculator.pro_rated_hours.round(10)
+            assert_equal "110.5", @calculator.formatted_full_time_part_time_compressed_hours
+            assert_equal [110, 30], @calculator.full_time_part_time_hours_and_minutes
           end
 
           should "for 25 hours less than 5 days a week" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2018-11-23"),
-              leaving_date: Date.parse("2019-04-07"),
-              working_days_per_week: 3,
-              hours_per_week: 25,
-            )
+            @calculator.start_date = Date.parse("2018-11-23")
+            @calculator.leaving_date = Date.parse("2019-04-07")
+            @calculator.working_days_per_week = 3
+            @calculator.hours_per_week = 25
 
-            assert_equal BigDecimal("140").round(10), calc.full_time_part_time_hours.round(10)
-            assert_equal BigDecimal("52.1643835616").round(10), calc.pro_rated_hours.round(10)
-            assert_equal "52.2", calc.formatted_full_time_part_time_compressed_hours
-            assert_equal [52, 12], calc.full_time_part_time_hours_and_minutes
+            assert_equal BigDecimal("140").round(10), @calculator.full_time_part_time_hours.round(10)
+            assert_equal BigDecimal("52.1643835616").round(10), @calculator.pro_rated_hours.round(10)
+            assert_equal "52.2", @calculator.formatted_full_time_part_time_compressed_hours
+            assert_equal [52, 12], @calculator.full_time_part_time_hours_and_minutes
           end
 
           should "for 36 hours more than 5 days a week" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2018-08-22"),
-              leaving_date: Date.parse("2019-07-31"),
-              working_days_per_week: 6,
-              hours_per_week: 36,
-            )
+            @calculator.start_date = Date.parse("2018-08-22")
+            @calculator.leaving_date = Date.parse("2019-07-31")
+            @calculator.working_days_per_week = 6
+            @calculator.hours_per_week = 36
 
-            assert_equal BigDecimal("168").round(10), calc.full_time_part_time_hours.round(10)
-            assert_equal BigDecimal("158.3342465753").round(10), calc.pro_rated_hours.round(10)
-            assert_equal "158.4", calc.formatted_full_time_part_time_compressed_hours
-            assert_equal [158, 24], calc.full_time_part_time_hours_and_minutes
+            assert_equal BigDecimal("168").round(10), @calculator.full_time_part_time_hours.round(10)
+            assert_equal BigDecimal("158.3342465753").round(10), @calculator.pro_rated_hours.round(10)
+            assert_equal "158.4", @calculator.formatted_full_time_part_time_compressed_hours
+            assert_equal [158, 24], @calculator.full_time_part_time_hours_and_minutes
           end
         end
+
         context "for a leap year" do
           should "for 40 hours over 5 days a week" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-01-20"),
-              leaving_date: Date.parse("2020-07-18"),
-              working_days_per_week: 5,
-              hours_per_week: 40,
-            )
+            @calculator.start_date = Date.parse("2020-01-20")
+            @calculator.leaving_date = Date.parse("2020-07-18")
+            @calculator.working_days_per_week = 5
+            @calculator.hours_per_week = 40
 
-            assert_equal BigDecimal("224").round(10), calc.full_time_part_time_hours.round(10)
-            assert_equal BigDecimal("110.7759562842").round(10), calc.pro_rated_hours.round(10)
-            assert_equal "110.8", calc.formatted_full_time_part_time_compressed_hours
-            assert_equal [110, 48], calc.full_time_part_time_hours_and_minutes
+            assert_equal BigDecimal("224").round(10), @calculator.full_time_part_time_hours.round(10)
+            assert_equal BigDecimal("110.7759562842").round(10), @calculator.pro_rated_hours.round(10)
+            assert_equal "110.8", @calculator.formatted_full_time_part_time_compressed_hours
+            assert_equal [110, 48], @calculator.full_time_part_time_hours_and_minutes
           end
-          should "for 25 hours less than 5 days a week" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-11-23"),
-              leaving_date: Date.parse("2020-04-07"),
-              working_days_per_week: 3,
-              hours_per_week: 25,
-            )
 
-            assert_equal BigDecimal("140").round(10), calc.full_time_part_time_hours.round(10)
-            assert_equal BigDecimal("52.4043715847").round(10), calc.pro_rated_hours.round(10)
-            assert_equal "52.5", calc.formatted_full_time_part_time_compressed_hours
-            assert_equal [52, 30], calc.full_time_part_time_hours_and_minutes
+          should "for 25 hours less than 5 days a week" do
+            @calculator.start_date = Date.parse("2019-11-23")
+            @calculator.leaving_date = Date.parse("2020-04-07")
+            @calculator.working_days_per_week = 3
+            @calculator.hours_per_week = 25
+
+            assert_equal BigDecimal("140").round(10), @calculator.full_time_part_time_hours.round(10)
+            assert_equal BigDecimal("52.4043715847").round(10), @calculator.pro_rated_hours.round(10)
+            assert_equal "52.5", @calculator.formatted_full_time_part_time_compressed_hours
+            assert_equal [52, 30], @calculator.full_time_part_time_hours_and_minutes
           end
 
           should "for 36 hours more than 5 days a week" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-08-22"),
-              leaving_date: Date.parse("2020-07-31"),
-              working_days_per_week: 6,
-              hours_per_week: 36,
-            )
+            @calculator.start_date = Date.parse("2019-08-22")
+            @calculator.leaving_date = Date.parse("2020-07-31")
+            @calculator.working_days_per_week = 6
+            @calculator.hours_per_week = 36
 
-            assert_equal BigDecimal("168").round(10), calc.full_time_part_time_hours.round(10)
-            assert_equal BigDecimal("158.3606557377").round(10), calc.pro_rated_hours.round(10)
-            assert_equal "158.4", calc.formatted_full_time_part_time_compressed_hours
-            assert_equal [158, 24], calc.full_time_part_time_hours_and_minutes
+            assert_equal BigDecimal("168").round(10), @calculator.full_time_part_time_hours.round(10)
+            assert_equal BigDecimal("158.3606557377").round(10), @calculator.pro_rated_hours.round(10)
+            assert_equal "158.4", @calculator.formatted_full_time_part_time_compressed_hours
+            assert_equal [158, 24], @calculator.full_time_part_time_hours_and_minutes
           end
         end
 
         context "for department test data" do
           # Test 19 - /starting-and-leaving/2020-11-17/2021-01-21/55.0/3.0
           should "for 55 hours 3 days a week (Test 19)" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-11-17"),
-              leaving_date: Date.parse("2021-01-21"),
-              working_days_per_week: 3,
-              hours_per_week: 55,
-            )
+            @calculator.start_date = Date.parse("2020-11-17")
+            @calculator.leaving_date = Date.parse("2021-01-21")
+            @calculator.working_days_per_week = 3
+            @calculator.hours_per_week = 55
 
-            assert_equal "55.7", calc.formatted_full_time_part_time_compressed_hours
+            assert_equal "55.7", @calculator.formatted_full_time_part_time_compressed_hours
           end
 
           # Test 20 - /starting-and-leaving/2018-10-04/2018-12-14/25.0/6.0
           should "for 25 hours 6 days a week (Test 20)" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2018-10-04"),
-              leaving_date: Date.parse("2018-12-14"),
-              working_days_per_week: 6,
-              hours_per_week: 25,
-            )
+            @calculator.start_date = Date.parse("2018-10-04")
+            @calculator.leaving_date = Date.parse("2018-12-14")
+            @calculator.working_days_per_week = 6
+            @calculator.hours_per_week = 25
 
-            assert_equal "23.1", calc.formatted_full_time_part_time_compressed_hours
+            assert_equal "23.1", @calculator.formatted_full_time_part_time_compressed_hours
           end
 
           # Test 21 - /starting-and-leaving/2018-05-29/2019-01-22/61.0/3.0
           should "for 61 hours 3 days a week (Test 21)" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2018-05-29"),
-              leaving_date: Date.parse("2019-01-22"),
-              working_days_per_week: 3,
-              hours_per_week: 61,
-            )
+            @calculator.start_date = Date.parse("2018-05-29")
+            @calculator.leaving_date = Date.parse("2019-01-22")
+            @calculator.working_days_per_week = 3
+            @calculator.hours_per_week = 61
 
-            assert_equal "223.7", calc.formatted_full_time_part_time_compressed_hours
+            assert_equal "223.7", @calculator.formatted_full_time_part_time_compressed_hours
           end
 
           # Test 22 - /starting-and-leaving/2018-12-25/2019-11-08/26.0/6.0
           should "for 26 hours 6 days a week (Test 22)" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2018-12-25"),
-              leaving_date: Date.parse("2019-11-08"),
-              working_days_per_week: 6,
-              hours_per_week: 26,
-            )
+            @calculator.start_date = Date.parse("2018-12-25")
+            @calculator.leaving_date = Date.parse("2019-11-08")
+            @calculator.working_days_per_week = 6
+            @calculator.hours_per_week = 26
 
-            assert_equal "106.1", calc.formatted_full_time_part_time_compressed_hours
+            assert_equal "106.1", @calculator.formatted_full_time_part_time_compressed_hours
           end
 
           # Test 23 - /starting-and-leaving/2019-04-03/2020-03-04/44.0/6.0
           should "for 44 hours 6 days a week (Test 23)" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-04-03"),
-              leaving_date: Date.parse("2020-03-04"),
-              working_days_per_week: 6,
-              hours_per_week: 44,
-            )
+            @calculator.start_date = Date.parse("2019-04-03")
+            @calculator.leaving_date = Date.parse("2020-03-04")
+            @calculator.working_days_per_week = 6
+            @calculator.hours_per_week = 44
 
-            assert_equal "189.1", calc.formatted_full_time_part_time_compressed_hours
+            assert_equal "189.1", @calculator.formatted_full_time_part_time_compressed_hours
           end
 
           # Test 24 - /starting-and-leaving/2018-01-03/2018-04-04/32.0/4.0
           should "for 32 hours 4 days a week (Test 24)" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2018-01-03"),
-              leaving_date: Date.parse("2018-04-04"),
-              working_days_per_week: 4,
-              hours_per_week: 32,
-            )
+            @calculator.start_date = Date.parse("2018-01-03")
+            @calculator.leaving_date = Date.parse("2018-04-04")
+            @calculator.working_days_per_week = 4
+            @calculator.hours_per_week = 32
 
-            assert_equal "45.2", calc.formatted_full_time_part_time_compressed_hours
+            assert_equal "45.2", @calculator.formatted_full_time_part_time_compressed_hours
           end
         end
       end
     end
+
+    # TODO: These need converting like the above methods, but fix the issues with those first....
 
     context "calculate entitlement on shifts worked" do
       context "for a full leave year" do
         context "for department test data" do
           # Test 1 - /shift-worker/full-year/4/4/9.0
           should "for 4 shifts over 9 days (dept Test 1)" do
-            calc = HolidayEntitlement.new(
-              shifts_per_shift_pattern: 4,
-              days_per_shift_pattern: 9,
-            )
-            assert_equal "17.5", calc.shift_entitlement
+            @calculator.shifts_per_shift_pattern = 4
+            @calculator.days_per_shift_pattern = 9
+
+            assert_equal "17.5", @calculator.shift_entitlement
           end
 
           # Test 2 - /shift-worker/full-year/4/9/12.0
           should "for 9 shifts over 12 days (dept Test 2)" do
-            calc = HolidayEntitlement.new(
-              shifts_per_shift_pattern: 9,
-              days_per_shift_pattern: 12,
-            )
-            assert_equal "28", calc.shift_entitlement
+            @calculator.shifts_per_shift_pattern = 9
+            @calculator.days_per_shift_pattern = 12
+
+            assert_equal "28", @calculator.shift_entitlement
           end
 
           # Test 3 - /shift-worker/full-year/4/4/6.0
           should "for 4 shifts over 6 days (dept Test 3)" do
-            calc = HolidayEntitlement.new(
-              shifts_per_shift_pattern: 4,
-              days_per_shift_pattern: 6,
-            )
-            assert_equal "26.2", calc.shift_entitlement
+            @calculator.shifts_per_shift_pattern = 4
+            @calculator.days_per_shift_pattern = 6
+
+            assert_equal "26.2", @calculator.shift_entitlement
           end
 
           # Test 4 - /shift-worker/full-year/4/8/10.0
           should "for 8 shifts over 10 days (dept Test 4)" do
-            calc = HolidayEntitlement.new(
-              shifts_per_shift_pattern: 8,
-              days_per_shift_pattern: 10,
-            )
-            assert_equal "28", calc.shift_entitlement
+            @calculator.shifts_per_shift_pattern = 8
+            @calculator.days_per_shift_pattern = 10
+
+            assert_equal "28", @calculator.shift_entitlement
           end
 
           # Test 5 - /shift-worker/full-year/4/5/5.0
           should "for 5 shifts over 5 days (dept Test 5)" do
-            calc = HolidayEntitlement.new(
-              shifts_per_shift_pattern: 5,
-              days_per_shift_pattern: 5,
-            )
-            assert_equal "28", calc.shift_entitlement
+            @calculator.shifts_per_shift_pattern = 5
+            @calculator.days_per_shift_pattern = 5
+
+            assert_equal "28", @calculator.shift_entitlement
           end
 
           # Test 6 - /shift-worker/full-year/4/1/18.0
           should "for 1 shift over 18 days (dept Test 6)" do
-            calc = HolidayEntitlement.new(
-              shifts_per_shift_pattern: 1,
-              days_per_shift_pattern: 18,
-            )
-            assert_equal "2.2", calc.shift_entitlement
+            @calculator.shifts_per_shift_pattern = 1
+            @calculator.days_per_shift_pattern = 18
+
+            assert_equal "2.2", @calculator.shift_entitlement
           end
         end
 
         should "for 6 hours over 14 days with 4 days per week" do
-          calc = HolidayEntitlement.new(
-            shifts_per_shift_pattern: 8,
-            days_per_shift_pattern: 14,
-          )
-          assert_equal "22.4", calc.shift_entitlement
+          @calculator.shifts_per_shift_pattern = 8
+          @calculator.days_per_shift_pattern = 14
+
+          assert_equal "22.4", @calculator.shift_entitlement
         end
         should "for 25 hours over less than 5 days a week" do
-          calc = HolidayEntitlement.new(shifts_per_shift_pattern: 7, days_per_shift_pattern: 10)
-          assert_equal "27.5", calc.shift_entitlement
+          @calculator.shifts_per_shift_pattern = 7
+          @calculator.days_per_shift_pattern = 10
+
+          assert_equal "27.5", @calculator.shift_entitlement
         end
         should "for 36 hours over more than 5 days a week" do
-          calc = HolidayEntitlement.new(shifts_per_shift_pattern: 12, days_per_shift_pattern: 14)
-          assert_equal "28", calc.shift_entitlement
+          @calculator.shifts_per_shift_pattern = 12
+          @calculator.days_per_shift_pattern = 14
+
+          assert_equal "28", @calculator.shift_entitlement
         end
       end
 
@@ -1261,38 +1148,32 @@ module SmartAnswer::Calculators
         context "for department test data" do
           # Dept Test 7 - /shift-worker/starting/2020-08-31/2020-02-01/4.0/8/12.0
           should "for 8 shifts over 12 days (Test 7)" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-08-31"),
-              leave_year_start_date: Date.parse("2020-02-01"),
-              shifts_per_shift_pattern: 8,
-              days_per_shift_pattern: 12,
-            )
+            @calculator.start_date = Date.parse("2020-08-31")
+            @calculator.leave_year_start_date = Date.parse("2020-02-01")
+            @calculator.shifts_per_shift_pattern = 8
+            @calculator.days_per_shift_pattern = 12
 
-            assert_equal "13.5", calc.shift_entitlement
+            assert_equal "13.5", @calculator.shift_entitlement
           end
 
           # Dept Test 8 - /shift-worker/starting/2020-07-22/2020-01-01/4.0/8/14.0
           should "for 8 shifts over 14 days (Test 8)" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-07-22"),
-              leave_year_start_date: Date.parse("2020-01-01"),
-              shifts_per_shift_pattern: 8,
-              days_per_shift_pattern: 14,
-            )
+            @calculator.start_date = Date.parse("2020-07-22")
+            @calculator.leave_year_start_date = Date.parse("2020-01-01")
+            @calculator.shifts_per_shift_pattern = 8
+            @calculator.days_per_shift_pattern = 14
 
-            assert_equal "11.5", calc.shift_entitlement
+            assert_equal "11.5", @calculator.shift_entitlement
           end
 
           # Dept Test 9 - /shift-worker/starting/2020-06-20/2019-09-01/4.0/3/9.0
           should "for 3 shifts over 9 days (Test 9)" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-06-20"),
-              leave_year_start_date: Date.parse("2019-09-01"),
-              shifts_per_shift_pattern: 3,
-              days_per_shift_pattern: 9,
-            )
+            @calculator.start_date = Date.parse("2020-06-20")
+            @calculator.leave_year_start_date = Date.parse("2019-09-01")
+            @calculator.shifts_per_shift_pattern = 3
+            @calculator.days_per_shift_pattern = 9
 
-            assert_equal "3.5", calc.shift_entitlement
+            assert_equal "3.5", @calculator.shift_entitlement
           end
 
           # Test 10 is a data entry validation test implemented in
@@ -1300,96 +1181,80 @@ module SmartAnswer::Calculators
 
           # Dept Test 11 - /shift-worker/starting/2019-06-12/2019-03-19/4.0/6/7.0
           should "for 6 shifts over 7 days (Test 11)" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-06-12"),
-              leave_year_start_date: Date.parse("2019-03-19"),
-              shifts_per_shift_pattern: 6,
-              days_per_shift_pattern: 7,
-            )
+            @calculator.start_date = Date.parse("2019-06-12")
+            @calculator.leave_year_start_date = Date.parse("2019-03-19")
+            @calculator.shifts_per_shift_pattern = 6
+            @calculator.days_per_shift_pattern = 7
 
-            assert_equal "23.5", calc.shift_entitlement
+            assert_equal "23.5", @calculator.shift_entitlement
           end
 
           # Dept Test 12 - /shift-worker/starting/2020-12-08/2020-04-08/4.0/8/10.0
           should "for 8 shifts over 10 days (Test 12)" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-12-08"),
-              leave_year_start_date: Date.parse("2020-04-08"),
-              shifts_per_shift_pattern: 8,
-              days_per_shift_pattern: 10,
-            )
+            @calculator.start_date = Date.parse("2020-12-08")
+            @calculator.leave_year_start_date = Date.parse("2020-04-08")
+            @calculator.shifts_per_shift_pattern = 8
+            @calculator.days_per_shift_pattern = 10
 
-            assert_equal "9.5", calc.shift_entitlement
+            assert_equal "9.5", @calculator.shift_entitlement
           end
         end
 
         context "for a standard year" do
           should "for 4 shifts per week" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-06-01"),
-              leave_year_start_date: Date.parse("2019-01-01"),
-              shifts_per_shift_pattern: 8,
-              days_per_shift_pattern: 14,
-            )
+            @calculator.start_date = Date.parse("2019-06-01")
+            @calculator.leave_year_start_date = Date.parse("2019-01-01")
+            @calculator.shifts_per_shift_pattern = 8
+            @calculator.days_per_shift_pattern = 14
 
-            assert_equal "13.5", calc.shift_entitlement
+            assert_equal "13.5", @calculator.shift_entitlement
           end
 
           should "for 4.9 shifts per week" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-11-23"),
-              leave_year_start_date: Date.parse("2020-04-01"),
-              shifts_per_shift_pattern: 7,
-              days_per_shift_pattern: 10,
-            )
+            @calculator.start_date = Date.parse("2020-11-23")
+            @calculator.leave_year_start_date = Date.parse("2020-04-01")
+            @calculator.shifts_per_shift_pattern = 7
+            @calculator.days_per_shift_pattern = 10
 
-            assert_equal "11.5", calc.shift_entitlement
+            assert_equal "11.5", @calculator.shift_entitlement
           end
 
           should "for 6 shifts per week" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-11-14"),
-              leave_year_start_date: Date.parse("2019-01-01"),
-              shifts_per_shift_pattern: 12,
-              days_per_shift_pattern: 14,
-            )
+            @calculator.start_date = Date.parse("2019-11-14")
+            @calculator.leave_year_start_date = Date.parse("2019-01-01")
+            @calculator.shifts_per_shift_pattern = 12
+            @calculator.days_per_shift_pattern = 14
 
-            assert_equal "5", calc.shift_entitlement
+            assert_equal "5", @calculator.shift_entitlement
           end
         end
 
         context "for a leap year" do
           should "for 4 shifts per week" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-06-01"),
-              leave_year_start_date: Date.parse("2020-01-01"),
-              shifts_per_shift_pattern: 8,
-              days_per_shift_pattern: 14,
-            )
+            @calculator.start_date = Date.parse("2020-06-01")
+            @calculator.leave_year_start_date = Date.parse("2020-01-01")
+            @calculator.shifts_per_shift_pattern = 8
+            @calculator.days_per_shift_pattern = 14
 
-            assert_equal "13.5", calc.shift_entitlement
+            assert_equal "13.5", @calculator.shift_entitlement
           end
 
           should "for 4.9 shifts per week" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-11-23"),
-              leave_year_start_date: Date.parse("2019-04-01"),
-              shifts_per_shift_pattern: 7,
-              days_per_shift_pattern: 10,
-            )
+            @calculator.start_date = Date.parse("2019-11-23")
+            @calculator.leave_year_start_date = Date.parse("2019-04-01")
+            @calculator.shifts_per_shift_pattern = 7
+            @calculator.days_per_shift_pattern = 10
 
-            assert_equal "11.5", calc.shift_entitlement
+            assert_equal "11.5", @calculator.shift_entitlement
           end
 
           should "for 6 shifts per week" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-11-14"),
-              leave_year_start_date: Date.parse("2020-01-01"),
-              shifts_per_shift_pattern: 12,
-              days_per_shift_pattern: 14,
-            )
+            @calculator.start_date = Date.parse("2020-11-14")
+            @calculator.leave_year_start_date = Date.parse("2020-01-01")
+            @calculator.shifts_per_shift_pattern = 12
+            @calculator.days_per_shift_pattern = 14
 
-            assert_equal "5", calc.shift_entitlement
+            assert_equal "5", @calculator.shift_entitlement
           end
         end
       end
@@ -1398,143 +1263,120 @@ module SmartAnswer::Calculators
         context "for department test data" do
           # Dept Test 13 - /leaving/2020-10-13/2020-01-01/4.0/12/15.0
           should "for 12 shifts over 15 days (Test 13)" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2020-10-13"),
-              leave_year_start_date: Date.parse("2020-01-01"),
-              shifts_per_shift_pattern: 12,
-              days_per_shift_pattern: 15,
-            )
+            @calculator.leaving_date = Date.parse("2020-10-13")
+            @calculator.leave_year_start_date = Date.parse("2020-01-01")
+            @calculator.shifts_per_shift_pattern = 12
+            @calculator.days_per_shift_pattern = 15
 
-            assert_equal "21.96", calc.shift_entitlement
+            assert_equal "21.96", @calculator.shift_entitlement
           end
 
           # Dept Test 14 - /shift-worker/leaving/2020-12-01/2020-05-01/4.0/10/15.0
           should "for 10 shifts over 15 days (Test 14)" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2020-12-01"),
-              leave_year_start_date: Date.parse("2020-05-01"),
-              shifts_per_shift_pattern: 10,
-              days_per_shift_pattern: 15,
-            )
+            @calculator.leaving_date = Date.parse("2020-12-01")
+            @calculator.leave_year_start_date = Date.parse("2020-05-01")
+            @calculator.shifts_per_shift_pattern = 10
+            @calculator.days_per_shift_pattern = 15
 
-            assert_equal "15.40", calc.shift_entitlement
+            assert_equal "15.40", @calculator.shift_entitlement
           end
 
           # Dept Test 15 - /leaving/2019-08-19/2019-05-01/4.0/3/8.0
           should "for 3 shifts over 8 days (Test 15)" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2019-08-19"),
-              leave_year_start_date: Date.parse("2019-05-01"),
-              shifts_per_shift_pattern: 3,
-              days_per_shift_pattern: 8,
-            )
+            @calculator.leaving_date = Date.parse("2019-08-19")
+            @calculator.leave_year_start_date = Date.parse("2019-05-01")
+            @calculator.shifts_per_shift_pattern = 3
+            @calculator.days_per_shift_pattern = 8
 
-            assert_equal "4.46", calc.shift_entitlement
+            assert_equal "4.46", @calculator.shift_entitlement
           end
 
           # Dept Test 16 - /shift-worker/leaving/2019-09-17/2018-12-01/6.0/6/10.0
           should "for 6 shifts over 10 days (Test 16)" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2019-09-17"),
-              leave_year_start_date: Date.parse("2018-12-01"),
-              shifts_per_shift_pattern: 6,
-              days_per_shift_pattern: 10,
-            )
+            @calculator.leaving_date = Date.parse("2019-09-17")
+            @calculator.leave_year_start_date = Date.parse("2018-12-01")
+            @calculator.shifts_per_shift_pattern = 6
+            @calculator.days_per_shift_pattern = 10
 
-            assert_equal "18.76", calc.shift_entitlement
+            assert_equal "18.76", @calculator.shift_entitlement
           end
 
           # Dept Test 17 - /shift-worker/leaving/2019-04-01/2019-03-01/4.0/1/10.0
           should "for 1 shift over 10 days (Test 17)" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2019-04-01"),
-              leave_year_start_date: Date.parse("2019-03-01"),
-              shifts_per_shift_pattern: 1,
-              days_per_shift_pattern: 10,
-            )
+            @calculator.leaving_date = Date.parse("2019-04-01")
+            @calculator.leave_year_start_date = Date.parse("2019-03-01")
+            @calculator.shifts_per_shift_pattern = 1
+            @calculator.days_per_shift_pattern = 10
 
-            assert_equal "0.35", calc.shift_entitlement
+            assert_equal "0.35", @calculator.shift_entitlement
           end
 
           # Dept Test 18 - /shift-worker/leaving/2020-12-25/2020-09-01/4.0/2/15.0
           should "for 2 shifts over 15 days (Test 18)" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2020-12-25"),
-              leave_year_start_date: Date.parse("2020-09-01"),
-              shifts_per_shift_pattern: 2,
-              days_per_shift_pattern: 15,
-            )
+            @calculator.leaving_date = Date.parse("2020-12-25")
+            @calculator.leave_year_start_date = Date.parse("2020-09-01")
+            @calculator.shifts_per_shift_pattern = 2
+            @calculator.days_per_shift_pattern = 15
 
-            assert_equal "1.67", calc.shift_entitlement
+            assert_equal "1.67", @calculator.shift_entitlement
           end
         end
 
         context "for a standard year" do
           should "for 6 hours over 4 days a week" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2019-06-01"),
-              leave_year_start_date: Date.parse("2019-01-01"),
-              shifts_per_shift_pattern: 8,
-              days_per_shift_pattern: 14,
-            )
+            @calculator.leaving_date = Date.parse("2019-06-01")
+            @calculator.leave_year_start_date = Date.parse("2019-01-01")
+            @calculator.shifts_per_shift_pattern = 8
+            @calculator.days_per_shift_pattern = 14
 
-            assert_equal "9.33", calc.shift_entitlement
+            assert_equal "9.33", @calculator.shift_entitlement
           end
 
           should "for 25 hours over 4.9 days a week" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2020-11-23"),
-              leave_year_start_date: Date.parse("2020-04-01"),
-              shifts_per_shift_pattern: 7,
-              days_per_shift_pattern: 10,
-            )
+            @calculator.leaving_date = Date.parse("2020-11-23")
+            @calculator.leave_year_start_date = Date.parse("2020-04-01")
+            @calculator.shifts_per_shift_pattern = 7
+            @calculator.days_per_shift_pattern = 10
 
-            assert_equal "17.82", calc.shift_entitlement
+            assert_equal "17.82", @calculator.shift_entitlement
           end
 
           should "for 36 hours over 6 days a week" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2019-11-14"),
-              leave_year_start_date: Date.parse("2019-01-01"),
-              shifts_per_shift_pattern: 12,
-              days_per_shift_pattern: 14,
-            )
+            @calculator.leaving_date = Date.parse("2019-11-14")
+            @calculator.leave_year_start_date = Date.parse("2019-01-01")
+            @calculator.shifts_per_shift_pattern = 12
+            @calculator.days_per_shift_pattern = 14
 
-            assert_equal "24.40", calc.shift_entitlement
+            assert_equal "24.40", @calculator.shift_entitlement
           end
         end
+
         context "for a leap year" do
           should "for 6 hours over 4 days a week" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2020-06-01"),
-              leave_year_start_date: Date.parse("2020-01-01"),
-              shifts_per_shift_pattern: 8,
-              days_per_shift_pattern: 14,
-            )
+            @calculator.leaving_date = Date.parse("2020-06-01")
+            @calculator.leave_year_start_date = Date.parse("2020-01-01")
+            @calculator.shifts_per_shift_pattern = 8
+            @calculator.days_per_shift_pattern = 14
 
-            assert_equal "9.37", calc.shift_entitlement
+            assert_equal "9.37", @calculator.shift_entitlement
           end
 
           should "for 25 hours over 4.9 days a week" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2019-11-23"),
-              leave_year_start_date: Date.parse("2019-04-01"),
-              shifts_per_shift_pattern: 7,
-              days_per_shift_pattern: 10,
-            )
+            @calculator.leaving_date = Date.parse("2019-11-23")
+            @calculator.leave_year_start_date = Date.parse("2019-04-01")
+            @calculator.shifts_per_shift_pattern = 7
+            @calculator.days_per_shift_pattern = 10
 
-            assert_equal "17.77", calc.shift_entitlement
+            assert_equal "17.77", @calculator.shift_entitlement
           end
 
           should "for 36 hours over 6 days a week" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2020-11-14"),
-              leave_year_start_date: Date.parse("2020-01-01"),
-              shifts_per_shift_pattern: 12,
-              days_per_shift_pattern: 14,
-            )
+            @calculator.leaving_date = Date.parse("2020-11-14")
+            @calculator.leave_year_start_date = Date.parse("2020-01-01")
+            @calculator.shifts_per_shift_pattern = 12
+            @calculator.days_per_shift_pattern = 14
 
-            assert_equal "24.41", calc.shift_entitlement
+            assert_equal "24.41", @calculator.shift_entitlement
           end
         end
       end
@@ -1543,144 +1385,120 @@ module SmartAnswer::Calculators
         context "for department test data" do
           # Dept Test 19 - /starting-and-leaving/2018-12-08/2019-05-09/4.0/3/6.0
           should "for 3 shifts over 6 days (Test 19)" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2018-12-08"),
-              leaving_date: Date.parse("2019-05-09"),
-              shifts_per_shift_pattern: 3,
-              days_per_shift_pattern: 6,
-            )
+            @calculator.start_date = Date.parse("2018-12-08")
+            @calculator.leaving_date = Date.parse("2019-05-09")
+            @calculator.shifts_per_shift_pattern = 3
+            @calculator.days_per_shift_pattern = 6
 
-            assert_equal "8.22", calc.shift_entitlement
+            assert_equal "8.22", @calculator.shift_entitlement
           end
 
           # Dept Test 20 - /starting-and-leaving/2020-01-07/2020-10-17/4.0/7/10.0
           should "for 7 shifts over 10 days (Test 20)" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-01-07"),
-              leaving_date: Date.parse("2020-10-17"),
-              shifts_per_shift_pattern: 7,
-              days_per_shift_pattern: 10,
-            )
+            @calculator.start_date = Date.parse("2020-01-07")
+            @calculator.leaving_date = Date.parse("2020-10-17")
+            @calculator.shifts_per_shift_pattern = 7
+            @calculator.days_per_shift_pattern = 10
 
-            assert_equal "21.37", calc.shift_entitlement
+            assert_equal "21.37", @calculator.shift_entitlement
           end
 
           # Dept Test 21 - /starting-and-leaving/2018-02-19/2018-04-12/4.0/3/6.0
           should "for 3 shifts over 6 days (Test 21)" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2018-02-19"),
-              leaving_date: Date.parse("2018-04-12"),
-              shifts_per_shift_pattern: 3,
-              days_per_shift_pattern: 6,
-            )
+            @calculator.start_date = Date.parse("2018-02-19")
+            @calculator.leaving_date = Date.parse("2018-04-12")
+            @calculator.shifts_per_shift_pattern = 3
+            @calculator.days_per_shift_pattern = 6
 
-            assert_equal "2.85", calc.shift_entitlement
+            assert_equal "2.85", @calculator.shift_entitlement
           end
 
           # Dept Test 22 - /starting-and-leaving/2019-07-07/2020-03-11/4.0/6/8.0
           should "for 6 shifts over 8 days (Test 22)" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-07-07"),
-              leaving_date: Date.parse("2020-03-11"),
-              shifts_per_shift_pattern: 6,
-              days_per_shift_pattern: 8,
-            )
+            @calculator.start_date = Date.parse("2019-07-07")
+            @calculator.leaving_date = Date.parse("2020-03-11")
+            @calculator.shifts_per_shift_pattern = 6
+            @calculator.days_per_shift_pattern = 8
 
-            assert_equal "19.05", calc.shift_entitlement
+            assert_equal "19.05", @calculator.shift_entitlement
           end
 
           # Dept Test 23 - /starting-and-leaving/2019-12-03/2020-09-09/4.0/10/11.0
           should "for 10 shifts over 11 days (Test 23)" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-12-03"),
-              leaving_date: Date.parse("2020-09-09"),
-              shifts_per_shift_pattern: 10,
-              days_per_shift_pattern: 11,
-            )
+            @calculator.start_date = Date.parse("2019-12-03")
+            @calculator.leaving_date = Date.parse("2020-09-09")
+            @calculator.shifts_per_shift_pattern = 10
+            @calculator.days_per_shift_pattern = 11
 
-            assert_equal "21.58", calc.shift_entitlement
+            assert_equal "21.58", @calculator.shift_entitlement
           end
 
           # Dept Test 24 - /starting-and-leaving/2019-08-04/2020-06-12/4.0/7/12.0
           should "for 7 shifts over 12 days (Test 24)" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-08-04"),
-              leaving_date: Date.parse("2020-06-12"),
-              shifts_per_shift_pattern: 7,
-              days_per_shift_pattern: 12,
-            )
+            @calculator.start_date = Date.parse("2019-08-04")
+            @calculator.leaving_date = Date.parse("2020-06-12")
+            @calculator.shifts_per_shift_pattern = 7
+            @calculator.days_per_shift_pattern = 12
 
-            assert_equal "19.62", calc.shift_entitlement
+            assert_equal "19.62", @calculator.shift_entitlement
           end
         end
 
         context "for a standard year" do
           should "for 6 hours over 4 days a week" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-01-20"),
-              leaving_date: Date.parse("2019-07-18"),
-              shifts_per_shift_pattern: 8,
-              days_per_shift_pattern: 14,
-            )
+            @calculator.start_date = Date.parse("2019-01-20")
+            @calculator.leaving_date = Date.parse("2019-07-18")
+            @calculator.shifts_per_shift_pattern = 8
+            @calculator.days_per_shift_pattern = 14
 
-            assert_equal "11.05", calc.shift_entitlement
+            assert_equal "11.05", @calculator.shift_entitlement
           end
 
           should "for 25 hours over 4.9 days a week" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-11-23"),
-              leaving_date: Date.parse("2021-04-07"),
-              shifts_per_shift_pattern: 7,
-              days_per_shift_pattern: 10,
-            )
+            @calculator.start_date = Date.parse("2020-11-23")
+            @calculator.leaving_date = Date.parse("2021-04-07")
+            @calculator.shifts_per_shift_pattern = 7
+            @calculator.days_per_shift_pattern = 10
 
-            assert_equal "10.23", calc.shift_entitlement
+            assert_equal "10.23", @calculator.shift_entitlement
           end
 
           should "for 36 hours over 6 days a week" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-08-22"),
-              leaving_date: Date.parse("2021-07-31"),
-              shifts_per_shift_pattern: 12,
-              days_per_shift_pattern: 14,
-            )
+            @calculator.start_date = Date.parse("2020-08-22")
+            @calculator.leaving_date = Date.parse("2021-07-31")
+            @calculator.shifts_per_shift_pattern = 12
+            @calculator.days_per_shift_pattern = 14
 
-            assert_equal "26.39", calc.shift_entitlement
+            assert_equal "26.39", @calculator.shift_entitlement
           end
         end
 
         context "for a leap year" do
           should "for 6 hours over 4 days a week" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-01-20"),
-              leaving_date: Date.parse("2020-07-18"),
-              shifts_per_shift_pattern: 8,
-              days_per_shift_pattern: 14,
-            )
+            @calculator.start_date = Date.parse("2020-01-20")
+            @calculator.leaving_date = Date.parse("2020-07-18")
+            @calculator.shifts_per_shift_pattern = 8
+            @calculator.days_per_shift_pattern = 14
 
-            assert_equal "11.08", calc.shift_entitlement
+            assert_equal "11.08", @calculator.shift_entitlement
           end
 
           should "for 25 hours over 4.9 days a week" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-11-23"),
-              leaving_date: Date.parse("2020-04-07"),
-              shifts_per_shift_pattern: 7,
-              days_per_shift_pattern: 10,
-            )
+            @calculator.start_date = Date.parse("2019-11-23")
+            @calculator.leaving_date = Date.parse("2020-04-07")
+            @calculator.shifts_per_shift_pattern = 7
+            @calculator.days_per_shift_pattern = 10
 
-            assert_equal "10.28", calc.shift_entitlement
+            assert_equal "10.28", @calculator.shift_entitlement
           end
 
           should "for 36 hours over 6 days a week" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-08-22"),
-              leaving_date: Date.parse("2020-07-31"),
-              shifts_per_shift_pattern: 12,
-              days_per_shift_pattern: 14,
-            )
+            @calculator.start_date = Date.parse("2019-08-22")
+            @calculator.leaving_date = Date.parse("2020-07-31")
+            @calculator.shifts_per_shift_pattern = 12
+            @calculator.days_per_shift_pattern = 14
 
-            assert_equal "26.40", calc.shift_entitlement
+            assert_equal "26.40", @calculator.shift_entitlement
           end
         end
       end
@@ -1690,145 +1508,124 @@ module SmartAnswer::Calculators
       context "for a full leave year" do
         # /irregular-hours/full-year
         should "return 5.6 weeks (dept test 1)" do
-          calc = HolidayEntitlement.new
-          assert_equal "5.6", calc.formatted_full_time_part_time_weeks
+          assert_equal "5.6", @calculator.formatted_full_time_part_time_weeks
         end
       end
 
       context "starting part way through a leave year" do
         context "for a standard year" do
           should "return 3.27 weeks when start_date is 2019-06-01 and leave_year_start_date is 2019-01-01" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-06-01"),
-              leave_year_start_date: Date.parse("2019-01-01"),
-            )
+            @calculator.start_date = Date.parse("2019-06-01")
+            @calculator.leave_year_start_date = Date.parse("2019-01-01")
 
-            assert_equal BigDecimal("0.5833333333").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("3.2666666667").round(10), calc.full_time_part_time_weeks.round(10)
-            assert_equal "3.27", calc.formatted_full_time_part_time_weeks
+            assert_equal BigDecimal("0.5833333333").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("3.2666666667").round(10), @calculator.full_time_part_time_weeks.round(10)
+            assert_equal "3.27", @calculator.formatted_full_time_part_time_weeks
           end
 
           should "return 2.34 weeks when start_date is 2020-11-23 and leave_year_start_date is 2020-04-01" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-11-23"),
-              leave_year_start_date: Date.parse("2020-04-01"),
-            )
+            @calculator.start_date = Date.parse("2020-11-23")
+            @calculator.leave_year_start_date = Date.parse("2020-04-01")
 
-            assert_equal BigDecimal("0.4166666667").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("2.3333333333").round(10), calc.full_time_part_time_weeks.round(10)
-            assert_equal "2.34", calc.formatted_full_time_part_time_weeks
+            assert_equal BigDecimal("0.4166666667").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("2.3333333333").round(10), @calculator.full_time_part_time_weeks.round(10)
+            assert_equal "2.34", @calculator.formatted_full_time_part_time_weeks
           end
 
           should "return 0.94 weeks when start_date is 2019-11-14 and leave_year_start_date is 2019-01-01" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-11-14"),
-              leave_year_start_date: Date.parse("2019-01-01"),
-            )
+            @calculator.start_date = Date.parse("2019-11-14")
+            @calculator.leave_year_start_date = Date.parse("2019-01-01")
 
-            assert_equal BigDecimal("0.1666666667").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("0.9333333333").round(10), calc.full_time_part_time_weeks.round(10)
-            assert_equal "0.94", calc.formatted_full_time_part_time_weeks
+            assert_equal BigDecimal("0.1666666667").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("0.9333333333").round(10), @calculator.full_time_part_time_weeks.round(10)
+            assert_equal "0.94", @calculator.formatted_full_time_part_time_weeks
           end
         end
 
         context "for a leap year" do
           should "return 3.27 weeks when start_date is 2020-06-01 and leave_year_start_date is 2020-01-01" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-06-01"),
-              leave_year_start_date: Date.parse("2020-01-01"),
-            )
+            @calculator.start_date = Date.parse("2020-06-01")
+            @calculator.leave_year_start_date = Date.parse("2020-01-01")
 
-            assert_equal BigDecimal("0.5833333333").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("3.2666666667").round(10), calc.full_time_part_time_weeks.round(10)
-            assert_equal "3.27", calc.formatted_full_time_part_time_weeks
+            assert_equal BigDecimal("0.5833333333").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("3.2666666667").round(10), @calculator.full_time_part_time_weeks.round(10)
+            assert_equal "3.27", @calculator.formatted_full_time_part_time_weeks
           end
 
           should "return 2.34 weeks when start_date is 2019-11-23 and leave_year_start_date is 2019-04-01" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-11-23"),
-              leave_year_start_date: Date.parse("2019-04-01"),
-            )
+            @calculator.start_date = Date.parse("2019-11-23")
+            @calculator.leave_year_start_date = Date.parse("2019-04-01")
 
-            assert_equal BigDecimal("0.4166666667").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("2.3333333333").round(10), calc.full_time_part_time_weeks.round(10)
-            assert_equal "2.34", calc.formatted_full_time_part_time_weeks
+            assert_equal BigDecimal("0.4166666667").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("2.3333333333").round(10), @calculator.full_time_part_time_weeks.round(10)
+            assert_equal "2.34", @calculator.formatted_full_time_part_time_weeks
           end
 
           should "return 0.94 weeks when start_date is 2020-11-14 and leave_year_start_date is 2020-01-01" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-11-14"),
-              leave_year_start_date: Date.parse("2020-01-01"),
-            )
+            @calculator.start_date = Date.parse("2020-11-14")
+            @calculator.leave_year_start_date = Date.parse("2020-01-01")
 
-            assert_equal BigDecimal("0.1666666667").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("0.9333333333").round(10), calc.full_time_part_time_weeks.round(10)
-            assert_equal "0.94", calc.formatted_full_time_part_time_weeks
+            assert_equal BigDecimal("0.1666666667").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("0.9333333333").round(10), @calculator.full_time_part_time_weeks.round(10)
+            assert_equal "0.94", @calculator.formatted_full_time_part_time_weeks
           end
         end
 
         context "for department test data" do
           # /irregular-hours/starting/2020-05-20/2019-10-01
           should "dept test 2" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-05-20"),
-              leave_year_start_date: Date.parse("2019-10-01"),
-            )
+            @calculator.start_date = Date.parse("2020-05-20")
+            @calculator.leave_year_start_date = Date.parse("2019-10-01")
 
-            assert_equal "2.34", calc.formatted_full_time_part_time_weeks
+            assert_equal "2.34", @calculator.formatted_full_time_part_time_weeks
           end
+
           # /irregular-hours/starting/2020-09-07/2020-01-01
           should "dept test 3" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-09-07"),
-              leave_year_start_date: Date.parse("2020-01-01"),
-            )
+            @calculator.start_date = Date.parse("2020-09-07")
+            @calculator.leave_year_start_date = Date.parse("2020-01-01")
 
-            assert_equal "1.87", calc.formatted_full_time_part_time_weeks
+            assert_equal "1.87", @calculator.formatted_full_time_part_time_weeks
           end
+
           # /irregular-hours/starting/2018-12-14/2018-03-01
           should "dept test 4" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2018-12-14"),
-              leave_year_start_date: Date.parse("2018-03-01"),
-            )
+            @calculator.start_date = Date.parse("2018-12-14")
+            @calculator.leave_year_start_date = Date.parse("2018-03-01")
 
-            assert_equal "1.40", calc.formatted_full_time_part_time_weeks
+            assert_equal "1.40", @calculator.formatted_full_time_part_time_weeks
           end
+
           # /irregular-hours/starting/2018-08-11/2019-01-01
           should "dept test 5" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2018-08-11"),
-              leave_year_start_date: Date.parse("2019-01-01"),
-            )
+            @calculator.start_date = Date.parse("2018-08-11")
+            @calculator.leave_year_start_date = Date.parse("2019-01-01")
 
-            assert_equal "2.34", calc.formatted_full_time_part_time_weeks
+            assert_equal "2.34", @calculator.formatted_full_time_part_time_weeks
           end
+
           # /irregular-hours/starting/2020-06-15/2019-10-01
           should "dept test 6" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-06-15"),
-              leave_year_start_date: Date.parse("2019-10-01"),
-            )
+            @calculator.start_date = Date.parse("2020-06-15")
+            @calculator.leave_year_start_date = Date.parse("2019-10-01")
 
-            assert_equal "1.87", calc.formatted_full_time_part_time_weeks
+            assert_equal "1.87", @calculator.formatted_full_time_part_time_weeks
           end
+
           # /irregular-hours/starting/2018-05-01/2018-02-26
           should "dept test 7" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2018-05-01"),
-              leave_year_start_date: Date.parse("2018-02-26"),
-            )
+            @calculator.start_date = Date.parse("2018-05-01")
+            @calculator.leave_year_start_date = Date.parse("2018-02-26")
 
-            assert_equal "4.67", calc.formatted_full_time_part_time_weeks
+            assert_equal "4.67", @calculator.formatted_full_time_part_time_weeks
           end
+
           # /irregular-hours/starting/2019-09-07/2019-07-05
           should "dept test 8" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-09-07"),
-              leave_year_start_date: Date.parse("2019-07-05"),
-            )
+            @calculator.start_date = Date.parse("2019-09-07")
+            @calculator.leave_year_start_date = Date.parse("2019-07-05")
 
-            assert_equal "4.67", calc.formatted_full_time_part_time_weeks
+            assert_equal "4.67", @calculator.formatted_full_time_part_time_weeks
           end
         end
       end
@@ -1836,128 +1633,109 @@ module SmartAnswer::Calculators
       context "leaving part way through a leave year" do
         context "for a standard year" do
           should "return 2.34 weeks when leaving_date is 2019-06-01 and leave_year_start_date is 2019-01-01" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2019-06-01"),
-              leave_year_start_date: Date.parse("2019-01-01"),
-            )
+            @calculator.leaving_date = Date.parse("2019-06-01")
+            @calculator.leave_year_start_date = Date.parse("2019-01-01")
 
-            assert_equal BigDecimal("0.4164383562").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("2.3320547945").round(10), calc.full_time_part_time_weeks.round(10)
-            assert_equal "2.34", calc.formatted_full_time_part_time_weeks
+            assert_equal BigDecimal("0.4164383562").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("2.3320547945").round(10), @calculator.full_time_part_time_weeks.round(10)
+            assert_equal "2.34", @calculator.formatted_full_time_part_time_weeks
           end
 
           should "return 3.64 weeks when leaving_date is 2020-11-23 and leave_year_start_date is 2020-04-01" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2020-11-23"),
-              leave_year_start_date: Date.parse("2020-04-01"),
-            )
+            @calculator.leaving_date = Date.parse("2020-11-23")
+            @calculator.leave_year_start_date = Date.parse("2020-04-01")
 
-            assert_equal BigDecimal("0.6493150685").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("3.6361643836").round(10), calc.full_time_part_time_weeks.round(10)
-            assert_equal "3.64", calc.formatted_full_time_part_time_weeks
+            assert_equal BigDecimal("0.6493150685").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("3.6361643836").round(10), @calculator.full_time_part_time_weeks.round(10)
+            assert_equal "3.64", @calculator.formatted_full_time_part_time_weeks
           end
 
           should "return 3.60 weeks when leaving_date is 2019-08-22 and leave_year_start_date is 2019-01-01" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2019-08-22"),
-              leave_year_start_date: Date.parse("2019-01-01"),
-            )
+            @calculator.leaving_date = Date.parse("2019-08-22")
+            @calculator.leave_year_start_date = Date.parse("2019-01-01")
 
-            assert_equal BigDecimal("0.6410958904").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("3.5901369863").round(10), calc.full_time_part_time_weeks.round(10)
-            assert_equal "3.60", calc.formatted_full_time_part_time_weeks
+            assert_equal BigDecimal("0.6410958904").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("3.5901369863").round(10), @calculator.full_time_part_time_weeks.round(10)
+            assert_equal "3.60", @calculator.formatted_full_time_part_time_weeks
           end
         end
 
         context "for a leap year" do
           should "return 2.35 weeks when leaving_date is 2020-06-01 and leave_year_start_date is 2020-01-01" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2020-06-01"),
-              leave_year_start_date: Date.parse("2020-01-01"),
-            )
+            @calculator.leaving_date = Date.parse("2020-06-01")
+            @calculator.leave_year_start_date = Date.parse("2020-01-01")
 
-            assert_equal BigDecimal("0.4180327869").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("2.3409836066").round(10), calc.full_time_part_time_weeks.round(10)
-            assert_equal "2.35", calc.formatted_full_time_part_time_weeks
+            assert_equal BigDecimal("0.4180327869").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("2.3409836066").round(10), @calculator.full_time_part_time_weeks.round(10)
+            assert_equal "2.35", @calculator.formatted_full_time_part_time_weeks
           end
 
           should "return 3.63 weeks when leaving_date is 2019-11-23 and leave_year_start_date is 2019-04-01" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2019-11-23"),
-              leave_year_start_date: Date.parse("2019-04-01"),
-            )
+            @calculator.leaving_date = Date.parse("2019-11-23")
+            @calculator.leave_year_start_date = Date.parse("2019-04-01")
 
-            assert_equal BigDecimal("0.6475409836").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("3.6262295082").round(10), calc.full_time_part_time_weeks.round(10)
-            assert_equal "3.63", calc.formatted_full_time_part_time_weeks
+            assert_equal BigDecimal("0.6475409836").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("3.6262295082").round(10), @calculator.full_time_part_time_weeks.round(10)
+            assert_equal "3.63", @calculator.formatted_full_time_part_time_weeks
           end
 
           should "return 3.60 weeks when leaving_date is 2020-08-22 and leave_year_start_date is 2020-01-01" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2020-08-22"),
-              leave_year_start_date: Date.parse("2020-01-01"),
-            )
+            @calculator.leaving_date = Date.parse("2020-08-22")
+            @calculator.leave_year_start_date = Date.parse("2020-01-01")
 
-            assert_equal BigDecimal("0.6420765027").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("3.5956284153").round(10), calc.full_time_part_time_weeks.round(10)
-            assert_equal "3.60", calc.formatted_full_time_part_time_weeks
+            assert_equal BigDecimal("0.6420765027").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("3.5956284153").round(10), @calculator.full_time_part_time_weeks.round(10)
+            assert_equal "3.60", @calculator.formatted_full_time_part_time_weeks
           end
         end
 
         context "for department test data" do
           # /irregular-hours/leaving/2018-08-29/2018-03-01
           should "dept test 9" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2018-08-29"),
-              leave_year_start_date: Date.parse("2018-03-01"),
-            )
+            @calculator.leaving_date = Date.parse("2018-08-29")
+            @calculator.leave_year_start_date = Date.parse("2018-03-01")
 
-            assert_equal "2.80", calc.formatted_full_time_part_time_weeks
+            assert_equal "2.80", @calculator.formatted_full_time_part_time_weeks
           end
+
           # /irregular-hours/leaving/2020-06-18/2010-12-01
           should "dept test 10" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2020-06-18"),
-              leave_year_start_date: Date.parse("2010-12-01"),
-            )
+            @calculator.leaving_date = Date.parse("2020-06-18")
+            @calculator.leave_year_start_date = Date.parse("2010-12-01")
 
-            assert_equal "3.08", calc.formatted_full_time_part_time_weeks
+            assert_equal "3.08", @calculator.formatted_full_time_part_time_weeks
           end
+
           # /irregular-hours/leaving/2019-09-20/2019-03-01
           should "dept test 11" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2019-09-20"),
-              leave_year_start_date: Date.parse("2019-03-01"),
-            )
+            @calculator.leaving_date = Date.parse("2019-09-20")
+            @calculator.leave_year_start_date = Date.parse("2019-03-01")
 
-            assert_equal "3.13", calc.formatted_full_time_part_time_weeks
+            assert_equal "3.13", @calculator.formatted_full_time_part_time_weeks
           end
+
           # /irregular-hours/leaving/2019-06-17/2018-10-01
           should "dept test 12" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2019-06-17"),
-              leave_year_start_date: Date.parse("2018-10-01"),
-            )
+            @calculator.leaving_date = Date.parse("2019-06-17")
+            @calculator.leave_year_start_date = Date.parse("2018-10-01")
 
-            assert_equal "3.99", calc.formatted_full_time_part_time_weeks
+            assert_equal "3.99", @calculator.formatted_full_time_part_time_weeks
           end
+
           # /irregular-hours/leaving/2020-09-20/2020-04-01
           should "dept test 13" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2020-09-20"),
-              leave_year_start_date: Date.parse("2020-04-01"),
-            )
+            @calculator.leaving_date = Date.parse("2020-09-20")
+            @calculator.leave_year_start_date = Date.parse("2020-04-01")
 
-            assert_equal "2.66", calc.formatted_full_time_part_time_weeks
+            assert_equal "2.66", @calculator.formatted_full_time_part_time_weeks
           end
+
           # /irregular-hours/leaving/2020-05-07/2020-03-07
           should "dept test 14" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2020-05-07"),
-              leave_year_start_date: Date.parse("2020-03-07"),
-            )
+            @calculator.leaving_date = Date.parse("2020-05-07")
+            @calculator.leave_year_start_date = Date.parse("2020-03-07")
 
-            assert_equal "0.96", calc.formatted_full_time_part_time_weeks
+            assert_equal "0.96", @calculator.formatted_full_time_part_time_weeks
           end
 
           # Dept Test 15 is a data entry validation to ensure leaving date is before leave year starts
@@ -1968,128 +1746,109 @@ module SmartAnswer::Calculators
       context "starting and leaving part way through a leave year" do
         context "for a standard year" do
           should "return 2.77 weeks when start_date is 2019-01-20 and leaving_date is 2019-07-18" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-01-20"),
-              leaving_date: Date.parse("2019-07-18"),
-            )
+            @calculator.start_date = Date.parse("2019-01-20")
+            @calculator.leaving_date = Date.parse("2019-07-18")
 
-            assert_equal BigDecimal("0.4931506849").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("2.7616438356").round(10), calc.full_time_part_time_weeks.round(10)
-            assert_equal "2.77", calc.formatted_full_time_part_time_weeks
+            assert_equal BigDecimal("0.4931506849").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("2.7616438356").round(10), @calculator.full_time_part_time_weeks.round(10)
+            assert_equal "2.77", @calculator.formatted_full_time_part_time_weeks
           end
 
           should "return 2.09 weeks when start_date is 2020-11-23 and leaving_date is 2021-04-07" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-11-23"),
-              leaving_date: Date.parse("2021-04-07"),
-            )
+            @calculator.start_date = Date.parse("2020-11-23")
+            @calculator.leaving_date = Date.parse("2021-04-07")
 
-            assert_equal BigDecimal("0.3726027397").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("2.0865753425").round(10), calc.full_time_part_time_weeks.round(10)
-            assert_equal "2.09", calc.formatted_full_time_part_time_weeks
+            assert_equal BigDecimal("0.3726027397").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("2.0865753425").round(10), @calculator.full_time_part_time_weeks.round(10)
+            assert_equal "2.09", @calculator.formatted_full_time_part_time_weeks
           end
 
           should "return 5.28 weeks when start_date is 2020-08-22 and leaving_date is 2021-07-31" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-08-22"),
-              leaving_date: Date.parse("2021-07-31"),
-            )
+            @calculator.start_date = Date.parse("2020-08-22")
+            @calculator.leaving_date = Date.parse("2021-07-31")
 
-            assert_equal BigDecimal("0.9424657534").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("5.2778082192").round(10), calc.full_time_part_time_weeks.round(10)
-            assert_equal "5.28", calc.formatted_full_time_part_time_weeks
+            assert_equal BigDecimal("0.9424657534").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("5.2778082192").round(10), @calculator.full_time_part_time_weeks.round(10)
+            assert_equal "5.28", @calculator.formatted_full_time_part_time_weeks
           end
         end
 
         context "for a leap year" do
           should "return 2.77 weeks when start_date is 2020-01-20 and leaving_date is 2020-07-18" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-01-20"),
-              leaving_date: Date.parse("2020-07-18"),
-            )
+            @calculator.start_date = Date.parse("2020-01-20")
+            @calculator.leaving_date = Date.parse("2020-07-18")
 
-            assert_equal BigDecimal("0.4945355191").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("2.7693989071").round(10), calc.full_time_part_time_weeks.round(10)
-            assert_equal "2.77", calc.formatted_full_time_part_time_weeks
+            assert_equal BigDecimal("0.4945355191").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("2.7693989071").round(10), @calculator.full_time_part_time_weeks.round(10)
+            assert_equal "2.77", @calculator.formatted_full_time_part_time_weeks
           end
 
           should "return 2.10 weeks when start_date is 2019-11-23 and leaving_date is 2020-04-07" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-11-23"),
-              leaving_date: Date.parse("2020-04-07"),
-            )
+            @calculator.start_date = Date.parse("2019-11-23")
+            @calculator.leaving_date = Date.parse("2020-04-07")
 
-            assert_equal BigDecimal("0.3743169399").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("2.0961748634").round(10), calc.full_time_part_time_weeks.round(10)
-            assert_equal "2.10", calc.formatted_full_time_part_time_weeks
+            assert_equal BigDecimal("0.3743169399").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("2.0961748634").round(10), @calculator.full_time_part_time_weeks.round(10)
+            assert_equal "2.10", @calculator.formatted_full_time_part_time_weeks
           end
 
           should "return 5.28 weeks when start_date is 2019-08-22 and leaving_date is 2020-07-31" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-08-22"),
-              leaving_date: Date.parse("2020-07-31"),
-            )
+            @calculator.start_date = Date.parse("2019-08-22")
+            @calculator.leaving_date = Date.parse("2020-07-31")
 
-            assert_equal BigDecimal("0.9426229508").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("5.2786885246").round(10), calc.full_time_part_time_weeks.round(10)
-            assert_equal "5.28", calc.formatted_full_time_part_time_weeks
+            assert_equal BigDecimal("0.9426229508").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("5.2786885246").round(10), @calculator.full_time_part_time_weeks.round(10)
+            assert_equal "5.28", @calculator.formatted_full_time_part_time_weeks
           end
         end
 
         context "for department test data" do
           # /irregular-hours/starting-and-leaving/2019-10-02/2020-06-30
           should "dept test 16" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-10-02"),
-              leaving_date: Date.parse("2020-06-30"),
-            )
+            @calculator.start_date = Date.parse("2019-10-02")
+            @calculator.leaving_date = Date.parse("2020-06-30")
 
-            assert_equal "4.18", calc.formatted_full_time_part_time_weeks
+            assert_equal "4.18", @calculator.formatted_full_time_part_time_weeks
           end
+
           # /irregular-hours/starting-and-leaving/2020-02-02/2020-11-24
           should "dept test 17" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-02-02"),
-              leaving_date: Date.parse("2020-11-24"),
-            )
+            @calculator.start_date = Date.parse("2020-02-02")
+            @calculator.leaving_date = Date.parse("2020-11-24")
 
-            assert_equal "4.55", calc.formatted_full_time_part_time_weeks
+            assert_equal "4.55", @calculator.formatted_full_time_part_time_weeks
           end
+
           # /irregular-hours/starting-and-leaving/2020-06-23/2020-08-10
           should "dept test 18" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-06-23"),
-              leaving_date: Date.parse("2020-08-10"),
-            )
+            @calculator.start_date = Date.parse("2020-06-23")
+            @calculator.leaving_date = Date.parse("2020-08-10")
 
-            assert_equal "0.76", calc.formatted_full_time_part_time_weeks
+            assert_equal "0.76", @calculator.formatted_full_time_part_time_weeks
           end
+
           # /irregular-hours/starting-and-leaving/2018-01-16/2018-07-12
           should "dept test 19" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2018-01-16"),
-              leaving_date: Date.parse("2018-07-12"),
-            )
+            @calculator.start_date = Date.parse("2018-01-16")
+            @calculator.leaving_date = Date.parse("2018-07-12")
 
-            assert_equal "2.74", calc.formatted_full_time_part_time_weeks
+            assert_equal "2.74", @calculator.formatted_full_time_part_time_weeks
           end
+
           # /irregular-hours/starting-and-leaving/2019-06-22/2020-03-03
           should "dept test 20" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-06-22"),
-              leaving_date: Date.parse("2020-03-03"),
-            )
+            @calculator.start_date = Date.parse("2019-06-22")
+            @calculator.leaving_date = Date.parse("2020-03-03")
 
-            assert_equal "3.92", calc.formatted_full_time_part_time_weeks
+            assert_equal "3.92", @calculator.formatted_full_time_part_time_weeks
           end
+
           # /irregular-hours/starting-and-leaving/2018-06-09/2019-02-01
           should "dept test 21" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2018-06-09"),
-              leaving_date: Date.parse("2019-02-01"),
-            )
+            @calculator.start_date = Date.parse("2018-06-09")
+            @calculator.leaving_date = Date.parse("2019-02-01")
 
-            assert_equal "3.66", calc.formatted_full_time_part_time_weeks
+            assert_equal "3.66", @calculator.formatted_full_time_part_time_weeks
           end
 
           # Dept Test 22 is a data entry validation to ensure leaving date is before leave year starts
@@ -2102,145 +1861,124 @@ module SmartAnswer::Calculators
       context "for a full leave year" do
         # /irregular-hours/full-year
         should "return 5.6 weeks (dept test 1)" do
-          calc = HolidayEntitlement.new
-          assert_equal "5.6", calc.formatted_full_time_part_time_weeks
+          assert_equal "5.6", @calculator.formatted_full_time_part_time_weeks
         end
       end
 
       context "starting part way through a leave year" do
         context "for a standard year" do
           should "return 3.27 weeks when start_date is 2019-06-01 and leave_year_start_date is 2019-01-01" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-06-01"),
-              leave_year_start_date: Date.parse("2019-01-01"),
-            )
+            @calculator.start_date = Date.parse("2019-06-01")
+            @calculator.leave_year_start_date = Date.parse("2019-01-01")
 
-            assert_equal BigDecimal("0.5833333333").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("3.2666666667").round(10), calc.full_time_part_time_weeks.round(10)
-            assert_equal "3.27", calc.formatted_full_time_part_time_weeks
+            assert_equal BigDecimal("0.5833333333").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("3.2666666667").round(10), @calculator.full_time_part_time_weeks.round(10)
+            assert_equal "3.27", @calculator.formatted_full_time_part_time_weeks
           end
 
           should "return 2.34 weeks when start_date is 2020-11-23 and leave_year_start_date is 2020-04-01" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-11-23"),
-              leave_year_start_date: Date.parse("2020-04-01"),
-            )
+            @calculator.start_date = Date.parse("2020-11-23")
+            @calculator.leave_year_start_date = Date.parse("2020-04-01")
 
-            assert_equal BigDecimal("0.4166666667").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("2.3333333333").round(10), calc.full_time_part_time_weeks.round(10)
-            assert_equal "2.34", calc.formatted_full_time_part_time_weeks
+            assert_equal BigDecimal("0.4166666667").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("2.3333333333").round(10), @calculator.full_time_part_time_weeks.round(10)
+            assert_equal "2.34", @calculator.formatted_full_time_part_time_weeks
           end
 
           should "return 0.94 weeks when start_date is 2019-11-14 and leave_year_start_date is 2019-01-01" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-11-14"),
-              leave_year_start_date: Date.parse("2019-01-01"),
-            )
+            @calculator.start_date = Date.parse("2019-11-14")
+            @calculator.leave_year_start_date = Date.parse("2019-01-01")
 
-            assert_equal BigDecimal("0.1666666667").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("0.9333333333").round(10), calc.full_time_part_time_weeks.round(10)
-            assert_equal "0.94", calc.formatted_full_time_part_time_weeks
+            assert_equal BigDecimal("0.1666666667").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("0.9333333333").round(10), @calculator.full_time_part_time_weeks.round(10)
+            assert_equal "0.94", @calculator.formatted_full_time_part_time_weeks
           end
         end
 
         context "for a leap year" do
           should "return 3.27 weeks when start_date is 2020-06-01 and leave_year_start_date is 2020-01-01" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-06-01"),
-              leave_year_start_date: Date.parse("2020-01-01"),
-            )
+            @calculator.start_date = Date.parse("2020-06-01")
+            @calculator.leave_year_start_date = Date.parse("2020-01-01")
 
-            assert_equal BigDecimal("0.5833333333").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("3.2666666667").round(10), calc.full_time_part_time_weeks.round(10)
-            assert_equal "3.27", calc.formatted_full_time_part_time_weeks
+            assert_equal BigDecimal("0.5833333333").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("3.2666666667").round(10), @calculator.full_time_part_time_weeks.round(10)
+            assert_equal "3.27", @calculator.formatted_full_time_part_time_weeks
           end
 
           should "return 2.34 weeks when start_date is 2019-11-23 and leave_year_start_date is 2019-04-01" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-11-23"),
-              leave_year_start_date: Date.parse("2019-04-01"),
-            )
+            @calculator.start_date = Date.parse("2019-11-23")
+            @calculator.leave_year_start_date = Date.parse("2019-04-01")
 
-            assert_equal BigDecimal("0.4166666667").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("2.3333333333").round(10), calc.full_time_part_time_weeks.round(10)
-            assert_equal "2.34", calc.formatted_full_time_part_time_weeks
+            assert_equal BigDecimal("0.4166666667").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("2.3333333333").round(10), @calculator.full_time_part_time_weeks.round(10)
+            assert_equal "2.34", @calculator.formatted_full_time_part_time_weeks
           end
 
           should "return 0.94 weeks when start_date is 2020-11-14 and leave_year_start_date is 2020-01-01" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-11-14"),
-              leave_year_start_date: Date.parse("2020-01-01"),
-            )
+            @calculator.start_date = Date.parse("2020-11-14")
+            @calculator.leave_year_start_date = Date.parse("2020-01-01")
 
-            assert_equal BigDecimal("0.1666666667").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("0.9333333333").round(10), calc.full_time_part_time_weeks.round(10)
-            assert_equal "0.94", calc.formatted_full_time_part_time_weeks
+            assert_equal BigDecimal("0.1666666667").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("0.9333333333").round(10), @calculator.full_time_part_time_weeks.round(10)
+            assert_equal "0.94", @calculator.formatted_full_time_part_time_weeks
           end
         end
 
         context "for department test data" do
           # /annualised-hours/starting/2020-05-29/2019-12-01
           should "dept test 2" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-05-29"),
-              leave_year_start_date: Date.parse("2019-12-01"),
-            )
+            @calculator.start_date = Date.parse("2020-05-29")
+            @calculator.leave_year_start_date = Date.parse("2019-12-01")
 
-            assert_equal "3.27", calc.formatted_full_time_part_time_weeks
+            assert_equal "3.27", @calculator.formatted_full_time_part_time_weeks
           end
+
           # /annualised-hours/starting/2020-09-03/2019-12-01
           should "dept test 3" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-09-03"),
-              leave_year_start_date: Date.parse("2019-12-01"),
-            )
+            @calculator.start_date = Date.parse("2020-09-03")
+            @calculator.leave_year_start_date = Date.parse("2019-12-01")
 
-            assert_equal "1.40", calc.formatted_full_time_part_time_weeks
+            assert_equal "1.40", @calculator.formatted_full_time_part_time_weeks
           end
+
           # /annualised-hours/starting/2019-03-01/2018-10-01
           should "dept test 4" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-03-01"),
-              leave_year_start_date: Date.parse("2018-10-01"),
-            )
+            @calculator.start_date = Date.parse("2019-03-01")
+            @calculator.leave_year_start_date = Date.parse("2018-10-01")
 
-            assert_equal "3.27", calc.formatted_full_time_part_time_weeks
+            assert_equal "3.27", @calculator.formatted_full_time_part_time_weeks
           end
+
           # /annualised-hours/starting/2020-06-05/2020-01-01
           should "dept test 5" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-06-05"),
-              leave_year_start_date: Date.parse("2020-01-01"),
-            )
+            @calculator.start_date = Date.parse("2020-06-05")
+            @calculator.leave_year_start_date = Date.parse("2020-01-01")
 
-            assert_equal "3.27", calc.formatted_full_time_part_time_weeks
+            assert_equal "3.27", @calculator.formatted_full_time_part_time_weeks
           end
+
           # /annualised-hours/starting/2019-04-07/2019-11-01
           should "dept test 6" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-04-07"),
-              leave_year_start_date: Date.parse("2019-11-01"),
-            )
+            @calculator.start_date = Date.parse("2019-04-07")
+            @calculator.leave_year_start_date = Date.parse("2019-11-01")
 
-            assert_equal "3.27", calc.formatted_full_time_part_time_weeks
+            assert_equal "3.27", @calculator.formatted_full_time_part_time_weeks
           end
+
           # /annualised-hours/starting/2019-09-23/2018-08-14
           should "dept test 7" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-09-23"),
-              leave_year_start_date: Date.parse("2018-08-14"),
-            )
+            @calculator.start_date = Date.parse("2019-09-23")
+            @calculator.leave_year_start_date = Date.parse("2018-08-14")
 
-            assert_equal "5.14", calc.formatted_full_time_part_time_weeks
+            assert_equal "5.14", @calculator.formatted_full_time_part_time_weeks
           end
+
           # /annualised-hours/starting/2020-02-16/2019-04-02
           should "dept test 8" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-02-16"),
-              leave_year_start_date: Date.parse("2019-04-02"),
-            )
+            @calculator.start_date = Date.parse("2020-02-16")
+            @calculator.leave_year_start_date = Date.parse("2019-04-02")
 
-            assert_equal "0.94", calc.formatted_full_time_part_time_weeks
+            assert_equal "0.94", @calculator.formatted_full_time_part_time_weeks
           end
         end
       end
@@ -2248,83 +1986,69 @@ module SmartAnswer::Calculators
       context "leaving part way through a leave year" do
         context "for a standard year" do
           should "return 2.34 weeks when leaving_date is 2019-06-01 and leave_year_start_date is 2019-01-01" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2019-06-01"),
-              leave_year_start_date: Date.parse("2019-01-01"),
-            )
+            @calculator.leaving_date = Date.parse("2019-06-01")
+            @calculator.leave_year_start_date = Date.parse("2019-01-01")
 
-            assert_equal BigDecimal("0.4164383562").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("2.3320547945").round(10), calc.full_time_part_time_weeks.round(10)
-            assert_equal "2.34", calc.formatted_full_time_part_time_weeks
+            assert_equal BigDecimal("0.4164383562").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("2.3320547945").round(10), @calculator.full_time_part_time_weeks.round(10)
+            assert_equal "2.34", @calculator.formatted_full_time_part_time_weeks
           end
 
           should "return 3.64 weeks when leaving_date is 2020-11-23 and leave_year_start_date is 2020-04-01" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2020-11-23"),
-              leave_year_start_date: Date.parse("2020-04-01"),
-            )
+            @calculator.leaving_date = Date.parse("2020-11-23")
+            @calculator.leave_year_start_date = Date.parse("2020-04-01")
 
-            assert_equal BigDecimal("0.6493150685").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("3.6361643836").round(10), calc.full_time_part_time_weeks.round(10)
-            assert_equal "3.64", calc.formatted_full_time_part_time_weeks
+            assert_equal BigDecimal("0.6493150685").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("3.6361643836").round(10), @calculator.full_time_part_time_weeks.round(10)
+            assert_equal "3.64", @calculator.formatted_full_time_part_time_weeks
           end
 
           should "return 3.60 weeks when leaving_date is 2019-08-22 and leave_year_start_date is 2019-01-01" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2019-08-22"),
-              leave_year_start_date: Date.parse("2019-01-01"),
-            )
+            @calculator.leaving_date = Date.parse("2019-08-22")
+            @calculator.leave_year_start_date = Date.parse("2019-01-01")
 
-            assert_equal BigDecimal("0.6410958904").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("3.5901369863").round(10), calc.full_time_part_time_weeks.round(10)
-            assert_equal "3.60", calc.formatted_full_time_part_time_weeks
+            assert_equal BigDecimal("0.6410958904").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("3.5901369863").round(10), @calculator.full_time_part_time_weeks.round(10)
+            assert_equal "3.60", @calculator.formatted_full_time_part_time_weeks
           end
         end
 
         context "for a leap year" do
           should "return 2.35 weeks when leaving_date is 2020-06-01 and leave_year_start_date is 2020-01-01" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2020-06-01"),
-              leave_year_start_date: Date.parse("2020-01-01"),
-            )
+            @calculator.leaving_date = Date.parse("2020-06-01")
+            @calculator.leave_year_start_date = Date.parse("2020-01-01")
 
-            assert_equal BigDecimal("0.4180327869").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("2.3409836066").round(10), calc.full_time_part_time_weeks.round(10)
-            assert_equal "2.35", calc.formatted_full_time_part_time_weeks
+            assert_equal BigDecimal("0.4180327869").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("2.3409836066").round(10), @calculator.full_time_part_time_weeks.round(10)
+            assert_equal "2.35", @calculator.formatted_full_time_part_time_weeks
           end
 
           should "return 3.63 weeks when leaving_date is 2019-11-23 and leave_year_start_date is 2019-04-01" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2019-11-23"),
-              leave_year_start_date: Date.parse("2019-04-01"),
-            )
+            @calculator.leaving_date = Date.parse("2019-11-23")
+            @calculator.leave_year_start_date = Date.parse("2019-04-01")
 
-            assert_equal BigDecimal("0.6475409836").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("3.6262295082").round(10), calc.full_time_part_time_weeks.round(10)
-            assert_equal "3.63", calc.formatted_full_time_part_time_weeks
+            assert_equal BigDecimal("0.6475409836").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("3.6262295082").round(10), @calculator.full_time_part_time_weeks.round(10)
+            assert_equal "3.63", @calculator.formatted_full_time_part_time_weeks
           end
 
           should "return 3.60 weeks when leaving_date is 2020-08-22 and leave_year_start_date is 2020-01-01" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2020-08-22"),
-              leave_year_start_date: Date.parse("2020-01-01"),
-            )
+            @calculator.leaving_date = Date.parse("2020-08-22")
+            @calculator.leave_year_start_date = Date.parse("2020-01-01")
 
-            assert_equal BigDecimal("0.6420765027").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("3.5956284153").round(10), calc.full_time_part_time_weeks.round(10)
-            assert_equal "3.60", calc.formatted_full_time_part_time_weeks
+            assert_equal BigDecimal("0.6420765027").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("3.5956284153").round(10), @calculator.full_time_part_time_weeks.round(10)
+            assert_equal "3.60", @calculator.formatted_full_time_part_time_weeks
           end
         end
 
         context "for department test data" do
           # /annualised-hours/leaving/2020-06-24/2019-12-01
           should "dept test 9" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2020-06-24"),
-              leave_year_start_date: Date.parse("2019-12-01"),
-            )
+            @calculator.leaving_date = Date.parse("2020-06-24")
+            @calculator.leave_year_start_date = Date.parse("2019-12-01")
 
-            assert_equal "3.17", calc.formatted_full_time_part_time_weeks
+            assert_equal "3.17", @calculator.formatted_full_time_part_time_weeks
           end
 
           # department test 10 is data validation to ensure leaving date is after leave year start
@@ -2332,48 +2056,42 @@ module SmartAnswer::Calculators
 
           # /annualised-hours/leaving/2018-12-30/2018-06-01
           should "dept test 11" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2018-12-30"),
-              leave_year_start_date: Date.parse("2018-06-01"),
-            )
+            @calculator.leaving_date = Date.parse("2018-12-30")
+            @calculator.leave_year_start_date = Date.parse("2018-06-01")
 
-            assert_equal "3.27", calc.formatted_full_time_part_time_weeks
+            assert_equal "3.27", @calculator.formatted_full_time_part_time_weeks
           end
+
           # /annualised-hours/leaving/2020-12-13/2020-08-01
           should "dept test 12" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2020-12-13"),
-              leave_year_start_date: Date.parse("2020-08-01"),
-            )
+            @calculator.leaving_date = Date.parse("2020-12-13")
+            @calculator.leave_year_start_date = Date.parse("2020-08-01")
 
-            assert_equal "2.08", calc.formatted_full_time_part_time_weeks
+            assert_equal "2.08", @calculator.formatted_full_time_part_time_weeks
           end
+
           # /annualised-hours/leaving/2020-08-31/2020-01-01
           should "dept test 13" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2020-08-31"),
-              leave_year_start_date: Date.parse("2020-01-01"),
-            )
+            @calculator.leaving_date = Date.parse("2020-08-31")
+            @calculator.leave_year_start_date = Date.parse("2020-01-01")
 
-            assert_equal "3.74", calc.formatted_full_time_part_time_weeks
+            assert_equal "3.74", @calculator.formatted_full_time_part_time_weeks
           end
+
           # /annualised-hours/leaving/2019-11-07/2019-08-05
           should "dept test 14" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2019-11-07"),
-              leave_year_start_date: Date.parse("2019-08-05"),
-            )
+            @calculator.leaving_date = Date.parse("2019-11-07")
+            @calculator.leave_year_start_date = Date.parse("2019-08-05")
 
-            assert_equal "1.46", calc.formatted_full_time_part_time_weeks
+            assert_equal "1.46", @calculator.formatted_full_time_part_time_weeks
           end
+
           # /annualised-hours/leaving/2020-06-18/2019-10-20
           should "dept test 15" do
-            calc = HolidayEntitlement.new(
-              leaving_date: Date.parse("2020-06-18"),
-              leave_year_start_date: Date.parse("2019-10-20"),
-            )
+            @calculator.leaving_date = Date.parse("2020-06-18")
+            @calculator.leave_year_start_date = Date.parse("2019-10-20")
 
-            assert_equal "3.72", calc.formatted_full_time_part_time_weeks
+            assert_equal "3.72", @calculator.formatted_full_time_part_time_weeks
           end
         end
       end
@@ -2381,137 +2099,117 @@ module SmartAnswer::Calculators
       context "starting and leaving part way through a leave year" do
         context "for a standard year" do
           should "return 2.77 weeks when start_date is 2019-01-20 and leaving_date is 2019-07-18" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-01-20"),
-              leaving_date: Date.parse("2019-07-18"),
-            )
+            @calculator.start_date = Date.parse("2019-01-20")
+            @calculator.leaving_date = Date.parse("2019-07-18")
 
-            assert_equal BigDecimal("0.4931506849").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("2.7616438356").round(10), calc.full_time_part_time_weeks.round(10)
-            assert_equal "2.77", calc.formatted_full_time_part_time_weeks
+            assert_equal BigDecimal("0.4931506849").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("2.7616438356").round(10), @calculator.full_time_part_time_weeks.round(10)
+            assert_equal "2.77", @calculator.formatted_full_time_part_time_weeks
           end
 
           should "return 2.09 weeks when start_date is 2020-11-23 and leaving_date is 2021-04-07" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-11-23"),
-              leaving_date: Date.parse("2021-04-07"),
-            )
+            @calculator.start_date = Date.parse("2020-11-23")
+            @calculator.leaving_date = Date.parse("2021-04-07")
 
-            assert_equal BigDecimal("0.3726027397").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("2.0865753425").round(10), calc.full_time_part_time_weeks.round(10)
-            assert_equal "2.09", calc.formatted_full_time_part_time_weeks
+            assert_equal BigDecimal("0.3726027397").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("2.0865753425").round(10), @calculator.full_time_part_time_weeks.round(10)
+            assert_equal "2.09", @calculator.formatted_full_time_part_time_weeks
           end
 
           should "return 5.28 weeks when start_date is 2020-08-22 and leaving_date is 2021-07-31" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-08-22"),
-              leaving_date: Date.parse("2021-07-31"),
-            )
+            @calculator.start_date = Date.parse("2020-08-22")
+            @calculator.leaving_date = Date.parse("2021-07-31")
 
-            assert_equal BigDecimal("0.9424657534").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("5.2778082192").round(10), calc.full_time_part_time_weeks.round(10)
-            assert_equal "5.28", calc.formatted_full_time_part_time_weeks
+            assert_equal BigDecimal("0.9424657534").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("5.2778082192").round(10), @calculator.full_time_part_time_weeks.round(10)
+            assert_equal "5.28", @calculator.formatted_full_time_part_time_weeks
           end
         end
 
         context "for a leap year" do
           should "return 2.77 weeks when start_date is 2020-01-20 and leaving_date is 2020-07-18" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-01-20"),
-              leaving_date: Date.parse("2020-07-18"),
-            )
+            @calculator.start_date = Date.parse("2020-01-20")
+            @calculator.leaving_date = Date.parse("2020-07-18")
 
-            assert_equal BigDecimal("0.4945355191").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("2.7693989071").round(10), calc.full_time_part_time_weeks.round(10)
-            assert_equal "2.77", calc.formatted_full_time_part_time_weeks
+            assert_equal BigDecimal("0.4945355191").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("2.7693989071").round(10), @calculator.full_time_part_time_weeks.round(10)
+            assert_equal "2.77", @calculator.formatted_full_time_part_time_weeks
           end
 
           should "return 2.10 weeks when start_date is 2019-11-23 and leaving_date is 2020-04-07" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-11-23"),
-              leaving_date: Date.parse("2020-04-07"),
-            )
+            @calculator.start_date = Date.parse("2019-11-23")
+            @calculator.leaving_date = Date.parse("2020-04-07")
 
-            assert_equal BigDecimal("0.3743169399").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("2.0961748634").round(10), calc.full_time_part_time_weeks.round(10)
-            assert_equal "2.10", calc.formatted_full_time_part_time_weeks
+            assert_equal BigDecimal("0.3743169399").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("2.0961748634").round(10), @calculator.full_time_part_time_weeks.round(10)
+            assert_equal "2.10", @calculator.formatted_full_time_part_time_weeks
           end
 
           should "return 5.28 weeks when start_date is 2019-08-22 and leaving_date is 2020-07-31" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-08-22"),
-              leaving_date: Date.parse("2020-07-31"),
-            )
+            @calculator.start_date = Date.parse("2019-08-22")
+            @calculator.leaving_date = Date.parse("2020-07-31")
 
-            assert_equal BigDecimal("0.9426229508").round(10), calc.fraction_of_year.round(10)
-            assert_equal BigDecimal("5.2786885246").round(10), calc.full_time_part_time_weeks.round(10)
-            assert_equal "5.28", calc.formatted_full_time_part_time_weeks
+            assert_equal BigDecimal("0.9426229508").round(10), @calculator.fraction_of_year.round(10)
+            assert_equal BigDecimal("5.2786885246").round(10), @calculator.full_time_part_time_weeks.round(10)
+            assert_equal "5.28", @calculator.formatted_full_time_part_time_weeks
           end
         end
 
         context "for department test data" do
           # /annualised-hours/starting-and-leaving/2019-01-12/2019-03-27
           should "dept test 16" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-01-12"),
-              leaving_date: Date.parse("2019-03-27"),
-            )
+            @calculator.start_date = Date.parse("2019-01-12")
+            @calculator.leaving_date = Date.parse("2019-03-27")
 
-            assert_equal "1.16", calc.formatted_full_time_part_time_weeks
+            assert_equal "1.16", @calculator.formatted_full_time_part_time_weeks
           end
+
           # /annualised-hours/starting-and-leaving/2018-12-10/2019-05-14
           should "dept test 17" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2018-12-10"),
-              leaving_date: Date.parse("2019-05-14"),
-            )
+            @calculator.start_date = Date.parse("2018-12-10")
+            @calculator.leaving_date = Date.parse("2019-05-14")
 
-            assert_equal "2.40", calc.formatted_full_time_part_time_weeks
+            assert_equal "2.40", @calculator.formatted_full_time_part_time_weeks
           end
+
           # /annualised-hours/starting-and-leaving/2018-08-30/2019-05-27
           should "dept test 18" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2018-08-30"),
-              leaving_date: Date.parse("2019-05-27"),
-            )
+            @calculator.start_date = Date.parse("2018-08-30")
+            @calculator.leaving_date = Date.parse("2019-05-27")
 
-            assert_equal "4.16", calc.formatted_full_time_part_time_weeks
+            assert_equal "4.16", @calculator.formatted_full_time_part_time_weeks
           end
+
           # /annualised-hours/starting-and-leaving/2019-10-07/2019-12-20
           should "dept test 19" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-10-07"),
-              leaving_date: Date.parse("2019-12-20"),
-            )
+            @calculator.start_date = Date.parse("2019-10-07")
+            @calculator.leaving_date = Date.parse("2019-12-20")
 
-            assert_equal "1.15", calc.formatted_full_time_part_time_weeks
+            assert_equal "1.15", @calculator.formatted_full_time_part_time_weeks
           end
+
           # /annualised-hours/starting-and-leaving/2019-07-29/2020-05-23
           should "dept test 20" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-07-29"),
-              leaving_date: Date.parse("2020-05-23"),
-            )
+            @calculator.start_date = Date.parse("2019-07-29")
+            @calculator.leaving_date = Date.parse("2020-05-23")
 
-            assert_equal "4.60", calc.formatted_full_time_part_time_weeks
+            assert_equal "4.60", @calculator.formatted_full_time_part_time_weeks
           end
+
           # /annualised-hours/starting-and-leaving/2020-01-01/2020-06-01
           should "dept test 21" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2020-01-01"),
-              leaving_date: Date.parse("2020-06-01"),
-            )
+            @calculator.start_date = Date.parse("2020-01-01")
+            @calculator.leaving_date = Date.parse("2020-06-01")
 
-            assert_equal "2.35", calc.formatted_full_time_part_time_weeks
+            assert_equal "2.35", @calculator.formatted_full_time_part_time_weeks
           end
+
           # /annualised-hours/starting-and-leaving/2019-04-06/2020-02-03
           should "dept test 22" do
-            calc = HolidayEntitlement.new(
-              start_date: Date.parse("2019-04-06"),
-              leaving_date: Date.parse("2020-02-03"),
-            )
+            @calculator.start_date = Date.parse("2019-04-06")
+            @calculator.leaving_date = Date.parse("2020-02-03")
 
-            assert_equal "4.66", calc.formatted_full_time_part_time_weeks
+            assert_equal "4.66", @calculator.formatted_full_time_part_time_weeks
           end
         end
       end


### PR DESCRIPTION
## What

We should remove support for the `calculate`, `precalculate` and `save_input_as` methods in flow definition for calculate-your-holiday-entitlement flow. 

## Why

These methods have been deprecated and their removal will reduce the complexity of the codebase. 

[Trello](https://trello.com/c/rBAEdQ2Q/587-remove-deprecated-flow-methods-from-calculate-your-holiday-entitlement)

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.

- Changes to start pages are **not** continuously deployed, and are [deployed using a different process](https://github.com/alphagov/smart-answers/blob/master/doc/smart-answer-flow-development/publishing.md).
