### PR TITLE
Paternity Calculator content change

### DIFF
--- a/lib/smart_answer/calculators/paternity_adoption_pay_calculator.rb
+++ b/lib/smart_answer/calculators/paternity_adoption_pay_calculator.rb
@@ -19,6 +19,10 @@ module SmartAnswer::Calculators
       @matched_week = @expected_week
     end
 
+    def paternity_deadline
+      (adoption_placement_date + 55.days).strftime("%d-%m-%Y")
+    end
+
     def relevant_week
       @matched_week
     end

--- a/lib/smart_answer/calculators/paternity_pay_calculator.rb
+++ b/lib/smart_answer/calculators/paternity_pay_calculator.rb
@@ -12,6 +12,11 @@ module SmartAnswer::Calculators
       paternity_leave_duration == "one_week" ? 1 : 2
     end
 
+    def paternity_deadline
+      start_date = [date_of_birth, due_date].max
+      (start_date + 55.days).strftime("%d-%m-%Y")
+    end
+
   private
 
     def rate_for(date)

--- a/lib/smart_answer_flows/maternity-paternity-calculator/questions/employee_paternity_length.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/questions/employee_paternity_length.erb
@@ -2,6 +2,11 @@
   How long is the employee's paternity leave?
 <% end %>
 
+<% govspeak_for :body do %>
+  The last day of leave the employee will be eligible for statutory paternity pay is <%= calculator.paternity_deadline %>. 
+  If their leave falls outside this period, this calculator may not be accurate and you'll need to use your payroll software or [calculate payments manually](/guidance/statutory-paternity-pay-manually-calculate-your-employees-payments).
+<% end %>
+
 <% options(
   "one_week": "One week",
   "two_weeks": "Two weeks"

--- a/test/unit/calculators/paternity_pay_calculator_test.rb
+++ b/test/unit/calculators/paternity_pay_calculator_test.rb
@@ -56,6 +56,24 @@ module SmartAnswer::Calculators
           assert_equal (calculator.statutory_rate(date) * 2), calculator.paydates_and_pay.first[:pay]
         end
       end
+      context "for premature birth paternity dates" do
+        should "give paternity deadline based on due date" do
+          due_date = Date.parse("10 February 2021")
+          birth_date = Date.parse("8 February 2021")
+          calculator = PaternityPayCalculator.new(due_date)
+          calculator.date_of_birth = birth_date
+          assert_equal "06-04-2021", calculator.paternity_deadline
+        end
+      end
+      context "for paternity adoption leave dates" do
+        should "give paternity deadlne based on placement date" do
+          match_date = Date.parse("01 July 2020")
+          placement_date = Date.parse("01 August 2020")
+          calculator = PaternityAdoptionPayCalculator.new(match_date)
+          calculator.adoption_placement_date = placement_date
+          assert_equal "25-09-2020", calculator.paternity_deadline
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Quick content change to the Paternity calculator to reflect that
employees should be taking their Paternity within 56 days inclusive
of the birth date date of their baby, or due date if the baby was
born early.

https://trello.com/c/VZZTgbUO/2235-3-maternity-adoption-and-paternity-calculator-for-employers

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.

- Changes to start pages are **not** continuously deployed, and are [deployed using a different process](https://github.com/alphagov/smart-answers/blob/master/doc/smart-answer-flow-development/publishing.md).
