### PR TITLE
DRY up PR template as part of CD rollout

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,1 @@
-:warning: This application is Continuously Deployed: :warning:
-
-- Merged changes are automatically deployed to staging and production.
-
-- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.
-
-- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/smartanswers), after merging.
-
-- Changes to start pages are **not** continuously deployed, and are [deployed using a different process](https://github.com/alphagov/smart-answers/blob/master/doc/smart-answer-flow-development/publishing.md).
+⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


### PR DESCRIPTION
https://trello.com/c/ILpSOFhq/201-enable-cd-for-quick-win-and-possible-quick-win-apps

Previously this template bloated each PR and is about to become
commonplace across GOV.UK repos. We should still have some kind of
warning until most apps are automatically deployed, but we should
avoid repeating ourselves in each repo and PR, and instead refer to
the guidance, which contains the same information.

Note that this is a test of the change on an actively maintained
repo, in advance of applying it to others with CD enabled.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️