### PR TITLE
Add test code coverage to smart answers

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,13 +3,11 @@ ENV["GOVUK_APP_DOMAIN"] = "test.gov.uk"
 
 require File.expand_path("../config/environment", __dir__)
 
-if ENV["TEST_COVERAGE"]
-  require "simplecov"
-  require "simplecov-rcov"
+require "simplecov"
+require "simplecov-rcov"
 
-  SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
-  SimpleCov.start "rails"
-end
+SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
+SimpleCov.start "rails"
 
 require "rails/test_help"
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,11 @@ SimpleCov.start "rails" do
     SimpleCov::Formatter::RcovFormatter,
     SimpleCov::Formatter::HTMLFormatter,
   ])
+
+  add_group "Presenters", "app/presenters"
+  add_group "Services", "app/services"
+  add_group "Smart Answer", "lib/smart_answer"
+  add_group "Smart Answer Flows", "lib/smart_answer_flows"
 end
 
 require "rails/test_help"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -52,6 +52,14 @@ class ActiveSupport::TestCase
   include GdsApi::TestHelpers::Worldwide
   include ActionDispatch::Assertions
   parallelize workers: 6
+
+  parallelize_setup do |worker|
+    SimpleCov.command_name "#{SimpleCov.command_name}-#{worker}"
+  end
+
+  parallelize_teardown do |_worker|
+    SimpleCov.result
+  end
 end
 
 require "slimmer/test"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,8 +6,12 @@ require File.expand_path("../config/environment", __dir__)
 require "simplecov"
 require "simplecov-rcov"
 
-SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
-SimpleCov.start "rails"
+SimpleCov.start "rails" do
+  formatter SimpleCov::Formatter::MultiFormatter.new([
+    SimpleCov::Formatter::RcovFormatter,
+    SimpleCov::Formatter::HTMLFormatter,
+  ])
+end
 
 require "rails/test_help"
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,6 +16,8 @@ SimpleCov.start "rails" do
   add_group "Services", "app/services"
   add_group "Smart Answer", "lib/smart_answer"
   add_group "Smart Answer Flows", "lib/smart_answer_flows"
+
+  SimpleCov.minimum_coverage 92
 end
 
 require "rails/test_help"


### PR DESCRIPTION
Test coverage already pre-exists in the Smart Answers repository.  However, unless you specify the `TEST_COVERAGE` environment variable at runtime (e.g. `TEST_COVERAGE=true bundle exec rake`) the coverage report is not generated.

We want to:

- always run the SimpleCov test coverage report when the test suite is run.  
- make an HTML version of the report available to help developers identify areas in the code where tests are missing or where coverage could be improved.  
- automatically test the application when deployed and report the percentage of coverage we have currently have.
- test and report on all source files.
- provide a minimum coverage level that we so that we do not drop below that level of coverage in the future.

[Trello](https://trello.com/c/GuzZWO1r/636-add-test-code-coverage-to-smart-answers)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
