### PR TITLE
Ensure errors connecting to GdsApi are captured in Sentry

### DIFF
--- a/app/services/content_item_retriever.rb
+++ b/app/services/content_item_retriever.rb
@@ -5,7 +5,8 @@ class ContentItemRetriever
     end
 
     item_hash.with_indifferent_access
-  rescue GdsApi::HTTPNotFound, GdsApi::HTTPGone, GdsApi::HTTPInternalServerError
+  rescue GdsApi::BaseError => e
+    GovukError.notify(e)
     {}
   end
 end

--- a/test/unit/services/content_item_retriever_test.rb
+++ b/test/unit/services/content_item_retriever_test.rb
@@ -43,29 +43,49 @@ class ContentItemRetrieverTest < ActiveSupport::TestCase
     end
 
     context "when content item can't be found" do
-      should "return empty content item hash" do
+      setup do
         response = { status: 404, body: {}.to_json }
         stub_request(:get, @request_url).to_return(response)
+      end
 
+      should "return empty content item hash" do
         assert_equal ContentItemRetriever.fetch(@slug), {}
+      end
+
+      should "notify Sentry" do
+        GovukError.expects(:notify)
+        ContentItemRetriever.fetch(@slug)
       end
     end
 
     context "when content item can't be found" do
-      should "return empty content item hash" do
+      setup do
         response = { status: 410, body: {}.to_json }
         stub_request(:get, @request_url).to_return(response)
+      end
 
+      should "return empty content item hash" do
         assert_equal ContentItemRetriever.fetch(@slug), {}
+      end
+
+      should "notifies Sentry" do
+        GovukError.expects(:notify)
+        ContentItemRetriever.fetch(@slug)
       end
     end
 
     context "when content store unavailable" do
-      should "return empty content item hash" do
-        response = { status: 500, body: {}.to_json }
-        stub_request(:get, @request_url).to_return(response)
+      setup do
+        stub_content_store_isnt_available
+      end
 
+      should "return empty content item hash" do
         assert_equal ContentItemRetriever.fetch(@slug), {}
+      end
+
+      should "notifies Sentry" do
+        GovukError.expects(:notify)
+        ContentItemRetriever.fetch(@slug)
       end
     end
   end


### PR DESCRIPTION
Update ContentItemRetriever to rescue any GdsApi exception. Use `GdsApi::BaseError` as [all `GdsApi` exceptions inherit from `BaseError`](https://github.com/alphagov/gds-api-adapters/blob/master/lib/gds_api/exceptions.rb)

Notify Sentry (via [GovukError](https://github.com/alphagov/govuk_app_config#manual-error-reporting)) that exception has occurred.

On 27th Nov we had an incident that cause the content store to return 5xx, which subsequently caused errors in Smart Answers. However, these errors did not appear to be captured by Sentry. 

[Trello ticket](https://trello.com/c/kendYDw0/637-understand-why-5xx-errors-from-the-content-store-arent-seen-in-sentry)