### PR TITLE
Changed council links

### DIFF
--- a/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.erb
@@ -90,7 +90,7 @@
     - leisure or assembly property - for example, a sports club, a gym or a spa
     - hospitality property - for example, a hotel, a guest house or self-catering accommodation
 
-    [Contact your local council](/find-local-council) if you think you’re eligible and you have not received the business rates discount.
+    [Contact your local council](/coronavirus-local-help) if you think you’re eligible and you have not received the business rates discount.
     $CTA
   <% end %>
 
@@ -104,7 +104,7 @@
 
     Local authority-run nurseries are not eligible.
 
-    [Contact your local council](/find-local-council) if you think you’re eligible and you have not received business rates relief.
+    [Contact your local council](/coronavirus-local-help) if you think you’re eligible and you have not received business rates relief.
     $CTA
   <% end %>
 


### PR DESCRIPTION
Change all instances of:
www.gov.uk/find-local-council

To:
www.gov.uk/coronavirus-local-help

REASON: 
It's a coronavirus specific service. 

https://trello.com/c/988x1IIO/632-link-to-local-council-coronavirus-lookup-rather-than-generic-local-council-one-in-business-support

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
