### PR TITLE
Use govuk design pattern for suffix labels on questions

### DIFF
--- a/app/presenters/money_question_presenter.rb
+++ b/app/presenters/money_question_presenter.rb
@@ -6,7 +6,7 @@ class MoneyQuestionPresenter < QuestionPresenter
   end
 
   def hint_text
-    text = [body, hint, suffix_label].reject(&:blank?).compact.join(", ")
+    text = [body, hint].reject(&:blank?).compact.join(", ")
     ActionView::Base.full_sanitizer.sanitize(text)
   end
 end

--- a/app/views/smart_answers/inputs/_money_question.html.erb
+++ b/app/views/smart_answers/inputs/_money_question.html.erb
@@ -9,6 +9,7 @@
   heading_size: "l",
   width: 10,
   hint: question.hint_text,
+  suffix: question.suffix_label,
   value: prefill_value_for(question),
   error_message: question.error
 } %>

--- a/test/unit/money_question_presenter_test.rb
+++ b/test/unit/money_question_presenter_test.rb
@@ -18,12 +18,12 @@ module SmartAnswer
       assert_equal "hint-text", @presenter.hint_text
     end
 
-    test "#hint_text also returns body and suffix_label if present" do
+    test "#hint_text also returns body if present" do
       @renderer.stubs(:content_for).with(:body).returns("body")
       @renderer.stubs(:content_for).with(:hint).returns("hint-text")
       @renderer.stubs(:content_for).with(:suffix_label).returns("suffix")
 
-      assert_equal "body, hint-text, suffix", @presenter.hint_text
+      assert_equal "body, hint-text", @presenter.hint_text
     end
 
     test "#caption returns the given caption when a caption is given" do


### PR DESCRIPTION
Update money questions by moving suffix label to input component suffix rather than part of hint text

An example showing the effect of this change:

![per_week_as_suffix](https://user-images.githubusercontent.com/213040/100763038-95980b00-33ec-11eb-9f14-156a76a73b49.png)

