### PR TITLE
Fix an empty suffix showing in money questions if no suffix specified

### DIFF
--- a/app/presenters/question_presenter.rb
+++ b/app/presenters/question_presenter.rb
@@ -45,7 +45,8 @@ class QuestionPresenter < NodePresenter
   end
 
   def suffix_label
-    @renderer.content_for(:suffix_label)
+    content = @renderer.content_for(:suffix_label)
+    content.presence
   end
 
   def has_labels?

--- a/test/unit/question_presenter_test.rb
+++ b/test/unit/question_presenter_test.rb
@@ -48,6 +48,12 @@ module SmartAnswer
       assert_equal "suffix-label-text", @presenter.suffix_label
     end
 
+    test "#suffix_label return nil if text empty" do
+      @renderer.stubs(:content_for).with(:suffix_label).returns(" ")
+
+      assert_nil @presenter.suffix_label
+    end
+
     test "#body returns content rendered for body block" do
       @renderer.stubs(:content_for).with(:body).returns("body-html")
 


### PR DESCRIPTION
A bug was introduced when money questions were set to use a suffix on the input component rather than adding the suffix text to the hint.

The bug is that an empty suffix box appears after the input.

![empty_money_question_suffix](https://user-images.githubusercontent.com/213040/101149938-8052f480-3617-11eb-8360-8e9b2cb44735.png)


This update fixes that bug by only adding the suffix when present, and thus removes the empty box

[Trello](https://trello.com/c/70RZ8gLI/650-fix-bug-where-empty-money-input-suffix-box-appeared-if-no-suffix-was-specified)