### PR TITLE
Use suffix label for value questions

### DIFF
--- a/app/presenters/value_question_presenter.rb
+++ b/app/presenters/value_question_presenter.rb
@@ -6,7 +6,7 @@ class ValueQuestionPresenter < QuestionPresenter
   end
 
   def hint_text
-    text = [body, hint, suffix_label].reject(&:blank?).compact.join(", ")
+    text = [body, hint].reject(&:blank?).compact.join(", ")
     ActionView::Base.full_sanitizer.sanitize(text)
   end
 end

--- a/app/views/smart_answers/inputs/_value_question.html.erb
+++ b/app/views/smart_answers/inputs/_value_question.html.erb
@@ -9,6 +9,7 @@
   heading_size: "l",
   width: 10,
   hint: question.hint_text,
+  suffix: question.suffix_label,
   value: prefill_value_for(question),
   error_message: question.error
 } %>

--- a/test/unit/value_question_presenter_test.rb
+++ b/test/unit/value_question_presenter_test.rb
@@ -18,12 +18,11 @@ module SmartAnswer
       assert_equal "hint-text", @presenter.hint_text
     end
 
-    test "#hint_text also returns body and suffix_label if present" do
+    test "#hint_text also returns body if present" do
       @renderer.stubs(:content_for).with(:body).returns("body")
       @renderer.stubs(:content_for).with(:hint).returns("hint-text")
-      @renderer.stubs(:content_for).with(:suffix_label).returns("suffix")
 
-      assert_equal "body, hint-text, suffix", @presenter.hint_text
+      assert_equal "body, hint-text", @presenter.hint_text
     end
 
     test "#caption returns the given caption when a caption is given" do


### PR DESCRIPTION
This switches suffix labels to use the GOV.UK design system for styling suffix labels, rather than displaying them in the question hint text.

Before:
<img width="614" alt="image" src="https://user-images.githubusercontent.com/11051676/101750293-b801e680-3ac6-11eb-9734-436f616239fa.png">

After:
<img width="614" alt="image" src="https://user-images.githubusercontent.com/11051676/101750217-9e609f00-3ac6-11eb-9f92-fae73abc2ac3.png">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
