### PR TITLE
Change to local council

### DIFF
--- a/lib/smart_answer_flows/find-coronavirus-support/outcomes/_paying_bills.erb
+++ b/lib/smart_answer_flows/find-coronavirus-support/outcomes/_paying_bills.erb
@@ -41,7 +41,7 @@
 
   [Find out if you can get help paying for childcare](https://www.gov.uk/get-childcare)
 
-  [Find out if you can get help in your local area](https://www.gov.uk/coronavirus-local-help)
+  [Find out if you can get help from your local council](https://www.gov.uk/coronavirus-local-help)
 
   #### Support and advice
 


### PR DESCRIPTION
Change 'local area' to 'local council'. 

It is more specific, tells people what they can get, and makes it consistent

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
