### PR TITLE
Edit marriage abroad booking links

### DIFF
--- a/lib/smart_answer_flows/marriage-abroad/outcomes/_contact_method.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/_contact_method.erb
@@ -55,7 +55,7 @@
   <% when 'montenegro' %>
     [Make an appointment at the embassy in Podgorica.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-podgorica/notice-of-marriage-or-civil-partnership/slot_picker)
   <% when 'morocco' %>
-    [Make an appointment at the embassy in Rabat.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rabat/oaths-affirmations-and-affidavits/slot_picker)
+    [Make an appointment at the embassy in Rabat.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=52&service=13)
   <% when 'nepal' %>
     [Make an appointment at the embassy in Kathmandu.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-kathmandu/notice-of-marriage-or-civil-partnership/slot_picker)
   <% when 'norway' %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/morocco/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/morocco/ceremony_country/partner_british/_opposite_sex.erb
@@ -9,7 +9,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Morocco to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, your partner’s passport and pay a fee.
 
-Make an appointment at the [embassy in Rabat](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rabat/oaths-affirmations-and-affidavits/slot_picker) or the [British Honorary Consulate Marrakech](https://www.consular-appointments.service.gov.uk/fco/#!/british-honorary-consulate-marrakech/oaths-affirmations-and-affidavits/slot_picker).
+Make an appointment at the [embassy in Rabat](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=52&service=13) or the [British Honorary Consulate Marrakech](https://www.consular-appointments.service.gov.uk/fco/#!/british-honorary-consulate-marrakech/oaths-affirmations-and-affidavits/slot_picker).
 
 ^Your partner must get an affirmation as well.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/morocco/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/morocco/ceremony_country/partner_british/_opposite_sex.erb
@@ -9,7 +9,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Morocco to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, your partner’s passport and pay a fee.
 
-Make an appointment at the [embassy in Rabat](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=52&service=13) or the [British Honorary Consulate Marrakech](https://www.consular-appointments.service.gov.uk/fco/#!/british-honorary-consulate-marrakech/oaths-affirmations-and-affidavits/slot_picker).
+Make an appointment at the [embassy in Rabat](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=52&service=13) or the [British Honorary Consulate Marrakech](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=54&service=13).
 
 ^Your partner must get an affirmation as well.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/morocco/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/morocco/ceremony_country/partner_local/_opposite_sex.erb
@@ -9,7 +9,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Morocco to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, your partner’s passport or Moroccan ID card and pay a fee.
 
-Make an appointment at the [embassy in Rabat](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rabat/oaths-affirmations-and-affidavits/slot_picker) or the [British Honorary Consulate Marrakech](https://www.consular-appointments.service.gov.uk/fco/#!/british-honorary-consulate-marrakech/oaths-affirmations-and-affidavits/slot_picker).
+Make an appointment at the [embassy in Rabat](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=52&service=13) or the [British Honorary Consulate Marrakech](https://www.consular-appointments.service.gov.uk/fco/#!/british-honorary-consulate-marrakech/oaths-affirmations-and-affidavits/slot_picker).
 
 ^Your partner must get an affirmation as well.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/morocco/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/morocco/ceremony_country/partner_local/_opposite_sex.erb
@@ -9,7 +9,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Morocco to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, your partner’s passport or Moroccan ID card and pay a fee.
 
-Make an appointment at the [embassy in Rabat](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=52&service=13) or the [British Honorary Consulate Marrakech](https://www.consular-appointments.service.gov.uk/fco/#!/british-honorary-consulate-marrakech/oaths-affirmations-and-affidavits/slot_picker).
+Make an appointment at the [embassy in Rabat](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=52&service=13) or the [British Honorary Consulate Marrakech](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=54&service=13).
 
 ^Your partner must get an affirmation as well.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/morocco/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/morocco/ceremony_country/partner_other/_opposite_sex.erb
@@ -9,7 +9,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Morocco to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, your partner’s passport and pay a fee.
 
-Make an appointment at the [embassy in Rabat](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rabat/oaths-affirmations-and-affidavits/slot_picker) or the [British Honorary Consulate Marrakech](https://www.consular-appointments.service.gov.uk/fco/#!/british-honorary-consulate-marrakech/oaths-affirmations-and-affidavits/slot_picker).
+Make an appointment at the [embassy in Rabat](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=52&service=13) or the [British Honorary Consulate Marrakech](https://www.consular-appointments.service.gov.uk/fco/#!/british-honorary-consulate-marrakech/oaths-affirmations-and-affidavits/slot_picker).
 
 ^Your partner must get an affirmation as well.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/morocco/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/morocco/ceremony_country/partner_other/_opposite_sex.erb
@@ -9,7 +9,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Morocco to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, your partner’s passport and pay a fee.
 
-Make an appointment at the [embassy in Rabat](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=52&service=13) or the [British Honorary Consulate Marrakech](https://www.consular-appointments.service.gov.uk/fco/#!/british-honorary-consulate-marrakech/oaths-affirmations-and-affidavits/slot_picker).
+Make an appointment at the [embassy in Rabat](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=52&service=13) or the [British Honorary Consulate Marrakech](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=54&service=13).
 
 ^Your partner must get an affirmation as well.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/morocco/third_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/morocco/third_country/partner_british/_opposite_sex.erb
@@ -11,7 +11,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Morocco to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, your partner’s passport and pay a fee.
 
-Make an appointment at the [embassy in Rabat](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rabat/oaths-affirmations-and-affidavits/slot_picker) or the [British Honorary Consulate Marrakech](https://www.consular-appointments.service.gov.uk/fco/#!/british-honorary-consulate-marrakech/oaths-affirmations-and-affidavits/slot_picker).
+Make an appointment at the [embassy in Rabat](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=52&service=13) or the [British Honorary Consulate Marrakech](https://www.consular-appointments.service.gov.uk/fco/#!/british-honorary-consulate-marrakech/oaths-affirmations-and-affidavits/slot_picker).
 
 ^Your partner must get an affirmation as well.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/morocco/third_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/morocco/third_country/partner_british/_opposite_sex.erb
@@ -11,7 +11,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Morocco to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, your partner’s passport and pay a fee.
 
-Make an appointment at the [embassy in Rabat](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=52&service=13) or the [British Honorary Consulate Marrakech](https://www.consular-appointments.service.gov.uk/fco/#!/british-honorary-consulate-marrakech/oaths-affirmations-and-affidavits/slot_picker).
+Make an appointment at the [embassy in Rabat](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=52&service=13) or the [British Honorary Consulate Marrakech](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=54&service=13).
 
 ^Your partner must get an affirmation as well.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/morocco/third_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/morocco/third_country/partner_local/_opposite_sex.erb
@@ -11,7 +11,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Morocco to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, your partner’s passport or Moroccan ID card and pay a fee.
 
-Make an appointment at the [embassy in Rabat](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rabat/oaths-affirmations-and-affidavits/slot_picker) or the [British Honorary Consulate Marrakech](https://www.consular-appointments.service.gov.uk/fco/#!/british-honorary-consulate-marrakech/oaths-affirmations-and-affidavits/slot_picker).
+Make an appointment at the [embassy in Rabat](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=52&service=13) or the [British Honorary Consulate Marrakech](https://www.consular-appointments.service.gov.uk/fco/#!/british-honorary-consulate-marrakech/oaths-affirmations-and-affidavits/slot_picker).
 
 ^Your partner must get an affirmation as well.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/morocco/third_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/morocco/third_country/partner_local/_opposite_sex.erb
@@ -11,7 +11,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Morocco to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, your partner’s passport or Moroccan ID card and pay a fee.
 
-Make an appointment at the [embassy in Rabat](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=52&service=13) or the [British Honorary Consulate Marrakech](https://www.consular-appointments.service.gov.uk/fco/#!/british-honorary-consulate-marrakech/oaths-affirmations-and-affidavits/slot_picker).
+Make an appointment at the [embassy in Rabat](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=52&service=13) or the [British Honorary Consulate Marrakech](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=54&service=13).
 
 ^Your partner must get an affirmation as well.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/morocco/third_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/morocco/third_country/partner_other/_opposite_sex.erb
@@ -11,7 +11,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Morocco to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, your partner’s passport and pay a fee.
 
-Make an appointment at the [embassy in Rabat](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rabat/oaths-affirmations-and-affidavits/slot_picker) or the [British Honorary Consulate Marrakech](https://www.consular-appointments.service.gov.uk/fco/#!/british-honorary-consulate-marrakech/oaths-affirmations-and-affidavits/slot_picker).
+Make an appointment at the [embassy in Rabat](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=52&service=13) or the [British Honorary Consulate Marrakech](https://www.consular-appointments.service.gov.uk/fco/#!/british-honorary-consulate-marrakech/oaths-affirmations-and-affidavits/slot_picker).
 
 ^Your partner must get an affirmation as well.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/morocco/third_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/morocco/third_country/partner_other/_opposite_sex.erb
@@ -11,7 +11,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Morocco to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, your partner’s passport and pay a fee.
 
-Make an appointment at the [embassy in Rabat](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=52&service=13) or the [British Honorary Consulate Marrakech](https://www.consular-appointments.service.gov.uk/fco/#!/british-honorary-consulate-marrakech/oaths-affirmations-and-affidavits/slot_picker).
+Make an appointment at the [embassy in Rabat](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=52&service=13) or the [British Honorary Consulate Marrakech](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=54&service=13).
 
 ^Your partner must get an affirmation as well.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/morocco/uk/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/morocco/uk/partner_british/_opposite_sex.erb
@@ -11,7 +11,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Morocco to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, your partner’s passport and pay a fee.
 
-Make an appointment at the [embassy in Rabat](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rabat/oaths-affirmations-and-affidavits/slot_picker) or the [British Honorary Consulate Marrakech](https://www.consular-appointments.service.gov.uk/fco/#!/british-honorary-consulate-marrakech/oaths-affirmations-and-affidavits/slot_picker).
+Make an appointment at the [embassy in Rabat](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=52&service=13) or the [British Honorary Consulate Marrakech](https://www.consular-appointments.service.gov.uk/fco/#!/british-honorary-consulate-marrakech/oaths-affirmations-and-affidavits/slot_picker).
 
 ^Your partner must get an affirmation as well.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/morocco/uk/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/morocco/uk/partner_british/_opposite_sex.erb
@@ -11,7 +11,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Morocco to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, your partner’s passport and pay a fee.
 
-Make an appointment at the [embassy in Rabat](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=52&service=13) or the [British Honorary Consulate Marrakech](https://www.consular-appointments.service.gov.uk/fco/#!/british-honorary-consulate-marrakech/oaths-affirmations-and-affidavits/slot_picker).
+Make an appointment at the [embassy in Rabat](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=52&service=13) or the [British Honorary Consulate Marrakech](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=54&service=13).
 
 ^Your partner must get an affirmation as well.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/morocco/uk/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/morocco/uk/partner_local/_opposite_sex.erb
@@ -11,7 +11,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Morocco to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, your partner’s passport or Moroccan ID card and pay a fee.
 
-Make an appointment at the [embassy in Rabat](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rabat/oaths-affirmations-and-affidavits/slot_picker) or the [British Honorary Consulate Marrakech](https://www.consular-appointments.service.gov.uk/fco/#!/british-honorary-consulate-marrakech/oaths-affirmations-and-affidavits/slot_picker).
+Make an appointment at the [embassy in Rabat](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=52&service=13) or the [British Honorary Consulate Marrakech](https://www.consular-appointments.service.gov.uk/fco/#!/british-honorary-consulate-marrakech/oaths-affirmations-and-affidavits/slot_picker).
 
 ^Your partner must get an affirmation as well.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/morocco/uk/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/morocco/uk/partner_local/_opposite_sex.erb
@@ -11,7 +11,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Morocco to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, your partner’s passport or Moroccan ID card and pay a fee.
 
-Make an appointment at the [embassy in Rabat](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=52&service=13) or the [British Honorary Consulate Marrakech](https://www.consular-appointments.service.gov.uk/fco/#!/british-honorary-consulate-marrakech/oaths-affirmations-and-affidavits/slot_picker).
+Make an appointment at the [embassy in Rabat](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=52&service=13) or the [British Honorary Consulate Marrakech](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=54&service=13).
 
 ^Your partner must get an affirmation as well.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/morocco/uk/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/morocco/uk/partner_other/_opposite_sex.erb
@@ -11,7 +11,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Morocco to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, your partner’s passport and pay a fee.
 
-Make an appointment at the [embassy in Rabat](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rabat/oaths-affirmations-and-affidavits/slot_picker) or the [British Honorary Consulate Marrakech](https://www.consular-appointments.service.gov.uk/fco/#!/british-honorary-consulate-marrakech/oaths-affirmations-and-affidavits/slot_picker).
+Make an appointment at the [embassy in Rabat](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=52&service=13) or the [British Honorary Consulate Marrakech](https://www.consular-appointments.service.gov.uk/fco/#!/british-honorary-consulate-marrakech/oaths-affirmations-and-affidavits/slot_picker).
 
 ^Your partner must get an affirmation as well.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/morocco/uk/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/morocco/uk/partner_other/_opposite_sex.erb
@@ -11,7 +11,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Morocco to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, your partner’s passport and pay a fee.
 
-Make an appointment at the [embassy in Rabat](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=52&service=13) or the [British Honorary Consulate Marrakech](https://www.consular-appointments.service.gov.uk/fco/#!/british-honorary-consulate-marrakech/oaths-affirmations-and-affidavits/slot_picker).
+Make an appointment at the [embassy in Rabat](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=52&service=13) or the [British Honorary Consulate Marrakech](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=54&service=13).
 
 ^Your partner must get an affirmation as well.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/thailand/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/thailand/_opposite_sex.erb
@@ -49,9 +49,9 @@ You need to:
 
 ##Book an appointment at the British Embassy in Bangkok
 
-You need to go to the British Embassy in Bangkok to swear your affirmation. 
+You need to go to the British Embassy in Bangkok to swear your affirmation.
 
-You’ll need to [book an appointment online](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bangkok/oaths-affirmations-and-affidavits/slot_picker).
+You’ll need to [book an appointment online](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=53&service=15).
 
 ###What to bring to your appointment
 


### PR DESCRIPTION
This is part of the work to update some links to the embassy/consulate booking service for Marriage Abroad smart answer outcomes.

FCDO are changing the supplier they use for these bookings so URLs are changing.

Trello card: https://trello.com/c/yoorhwiQ/2244-2-change-urls-in-marriage-abroad-smart-answer

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️