### PR TITLE
Removing link about lockdown easing

### DIFF
--- a/lib/smart_answer_flows/find-coronavirus-support/outcomes/_mental_health.erb
+++ b/lib/smart_answer_flows/find-coronavirus-support/outcomes/_mental_health.erb
@@ -9,8 +9,6 @@
 
   [Coping with mental health problems during coronavirus (Mind)](https://www.mind.org.uk/information-support/coronavirus/coping-with-mental-health-problems-during-coronavirus/)
 
-  [Managing feelings about lockdown easing (Mind)](https://www.mind.org.uk/information-support/coronavirus/managing-feelings-about-lockdown-easing/)
-
   [Help for mental health problems if you're LGBT+ (NHS)](https://www.nhs.uk/conditions/stress-anxiety-depression/mental-health-issues-if-you-are-gay-lesbian-or-bisexual)
 
   [Getting help with your mental health if you’re a young person (Young Minds)](https://youngminds.org.uk/find-help/looking-after-yourself/coronavirus-and-mental-health/)


### PR DESCRIPTION
Lockdown is not easing. 
Mind have useful resources but we already link to them. 
The NHS coronavirus and wellbeing link is good, and should be the main place people go, so removing this Mind link altogether means there are less links to chose from and the list is less long

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
