### PR TITLE
Fix holiday entitlement tests

### DIFF
--- a/test/integration/smart_answer_flows/calculate_your_holiday_entitlement_test.rb
+++ b/test/integration/smart_answer_flows/calculate_your_holiday_entitlement_test.rb
@@ -7,7 +7,12 @@ class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
   include FlowTestHelper
 
   setup do
+    travel_to Time.zone.local(2020)
     setup_for_testing_flow SmartAnswer::CalculateYourHolidayEntitlementFlow
+  end
+
+  teardown do
+    travel_back
   end
 
   should "ask what the basis of the calculation is" do


### PR DESCRIPTION
These tests assume that the year is 2020 and have broken since the year is now 2021. This uses Rails test helpers to freeze time for these test.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
