### PR TITLE
Making restrictions clearer

### DIFF
--- a/lib/smart_answer_flows/business-coronavirus-support-finder/questions/closed_by_restrictions.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/questions/closed_by_restrictions.erb
@@ -7,8 +7,8 @@
 <% end %>
 
 <% options(
-  "local_1": "Yes, because of local restrictions anytime between 1 August and 5 November 2020",
-  "national": "Yes, because of national restrictions between 5 November and 1 December 2020 or because of national restrictions from 5 January 2021",
-  "local_2": "Yes, because of local restrictions anytime from 2 December 2020",
+  "local_1": "Yes - because of local restrictions anytime between 1 August and 5 November 2020",
+  "local_2": "Yes - because of local restrictions anytime from 2 December 2020 to 5 January 2021",
+  "national": "Yes - because of national restrictions between 5 November and 1 December 2020, or because of national restrictions from 5 January 2021",
   "none": "No",
 ) %>

--- a/lib/smart_answer_flows/business-coronavirus-support-finder/questions/closed_by_restrictions.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/questions/closed_by_restrictions.erb
@@ -8,7 +8,7 @@
 
 <% options(
   "local_1": "Yes - because of local restrictions anytime between 1 August and 5 November 2020",
-  "local_2": "Yes - because of local restrictions anytime from 2 December 2020 to 5 January 2021",
+  "local_2": "Yes - because of local restrictions anytime between 2 December 2020 and 5 January 2021",
   "national": "Yes - because of national restrictions between 5 November and 1 December 2020, or because of national restrictions from 5 January 2021",
   "none": "No",
 ) %>


### PR DESCRIPTION
I've moved yes answers to do with local restrictions together, as I think it makes it clearer
I think we need to add when the second local restrictions bullet ends - as we're no longer in local restrictions
Also added hyphens, think that helps because we can add a comma with the new or which we've added

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
