### PR TITLE
Change question order within business coronavirus support finder

### DIFF
--- a/lib/smart_answer_flows/business-coronavirus-support-finder.rb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder.rb
@@ -124,8 +124,8 @@ module SmartAnswer
 
       checkbox_question :closed_by_restrictions? do
         option :local_1
-        option :national
         option :local_2
+        option :national
         none_option
 
         on_response do |response|


### PR DESCRIPTION
## What

Change the `closed_by_restrictions` question order in the `business-coronavirus-support-finder` flow.

## Why

Reflects the desired ordering.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
