### PR TITLE
Update extended household links

### DIFF
--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/calculate_statutory_sick_pay.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/calculate_statutory_sick_pay.erb
@@ -22,7 +22,7 @@
   Do not use the calculator if your employee is self-isolating because either:
 
   - you’ve been [notified by the NHS or a public health authority](/guidance/nhs-test-and-trace-how-it-works) that you’ve been in contact with someone with coronavirus
-  - someone in your '[support bubble](/guidance/meeting-people-from-outside-your-household-from-4-july)' (or your 'extended household' if you live in [Scotland](https://www.gov.scot/publications/coronavirus-covid-19-phase-2-staying-safe-and-protecting-others/pages/meeting-others/) or [Wales](https://gov.wales/guidance-extended-households-coronavirus)) has symptoms or has tested positive for coronavirus 
+  - someone in your '[support bubble](/guidance/meeting-people-from-outside-your-household-from-4-july)' (or your 'extended household' if you live in [Scotland](https://www.gov.scot/publications/coronavirus-covid-19-phase-3-staying-safe-and-protecting-others/) or [Wales](https://gov.wales/visiting-people-private-homes-alert-level-3#section-58445) has symptoms or has tested positive for coronavirus 
 
   You'll need to [work out the SSP manually](/guidance/statutory-sick-pay-manually-calculate-your-employees-payments).
 

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/calculate_statutory_sick_pay.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/calculate_statutory_sick_pay.erb
@@ -22,7 +22,7 @@
   Do not use the calculator if your employee is self-isolating because either:
 
   - you’ve been [notified by the NHS or a public health authority](/guidance/nhs-test-and-trace-how-it-works) that you’ve been in contact with someone with coronavirus
-  - someone in your '[support bubble](/guidance/meeting-people-from-outside-your-household-from-4-july)' (or your 'extended household' if you live in [Scotland](https://www.gov.scot/publications/coronavirus-covid-19-phase-3-staying-safe-and-protecting-others/) or [Wales](https://gov.wales/visiting-people-private-homes-alert-level-3#section-58445) has symptoms or has tested positive for coronavirus 
+  - someone in your '[support bubble](/guidance/meeting-people-from-outside-your-household-from-4-july)' (or your 'extended household' if you live in [Scotland](https://www.gov.scot/publications/coronavirus-covid-19-protection-levels) or [Wales](https://gov.wales/visiting-people-private-homes-alert-level-3#section-58445) has symptoms or has tested positive for coronavirus 
 
   You'll need to [work out the SSP manually](/guidance/statutory-sick-pay-manually-calculate-your-employees-payments).
 


### PR DESCRIPTION
TRELLO CARD LINK: https://trello.com/c/tBfzLMQM/3295-broken-links-in-calculate-statutory-sick-pay-smart-answer

Line 25:

Replaced bad redirect link for Scotland extended household: (https://www.gov.scot/publications/coronavirus-covid-19-phase-2-staying-safe-and-protecting-others/pages/meeting-others/) with correct link (https://www.gov.scot/publications/coronavirus-covid-19-phase-3-staying-safe-and-protecting-others)

Line 25:

Replaced link leading to page not found (404) for Wales extended household (https://gov.wales/guidance-extended-households-coronavirus) with new link to correct guidance (https://gov.wales/visiting-people-private-homes-alert-level-3#section-58445)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
