### PR TITLE
Audit smart answers for possible component usage

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,6 +23,7 @@ $govuk-use-legacy-palette: false;
 @import "govuk_publishing_components/components/step-by-step-nav";
 @import "govuk_publishing_components/components/step-by-step-nav-related";
 @import "govuk_publishing_components/components/title";
+@import "govuk_publishing_components/components/warning-text";
 
 // not in suggested sass from component gem but still needed
 @import "govuk_publishing_components/components/table";

--- a/app/assets/stylesheets/visualise.css.scss
+++ b/app/assets/stylesheets/visualise.css.scss
@@ -22,11 +22,6 @@ $govuk-compatibility-govuktemplate: true;
 @import "govuk_publishing_components/components/step-by-step-nav-related";
 @import "govuk_publishing_components/components/title";
 
-.warning {
-  border-left: 6px solid red;
-  padding: 0.5em 2em;
-}
-
 .paper {
   min-height: 600px;
   margin: 2em auto;

--- a/app/views/smart_answers/_previous_answers.html.erb
+++ b/app/views/smart_answers/_previous_answers.html.erb
@@ -9,7 +9,12 @@
           margin_bottom: 6
         } %>
       <% else %>
-        <h2 class="govuk-heading-m">Your answers</h2>
+        <%= render "govuk_publishing_components/components/heading", {
+          text: "Your answers",
+          heading_level: 2,
+          font_size: "m",
+          margin_bottom: 4
+        } %>
       <% end %>
 
       <p class="govuk-body">

--- a/app/views/smart_answers/visualise.html.erb
+++ b/app/views/smart_answers/visualise.html.erb
@@ -24,7 +24,9 @@
 
     <p>This is a visualisation of the <%= link_to @presenter.title, smart_answer_path(params[:id]) %> questions and outcomes.</p>
     <% if ! @graph_presenter.visualisable? %>
-      <div class='warning'><p>This visualisation does not show all transitions correctly. It needs to be updated so that it can be visualised correctly.</p></div>
+      <%= render "govuk_publishing_components/components/warning_text", {
+        text: "This visualisation does not show all transitions correctly. It needs to be updated so that it can be visualised correctly."
+      } %>
     <% end %>
 
     <p>Having problems reading the visualisation? Changing the orientation may help.</p>

--- a/test/integration/engine/country_and_date_questions_test.rb
+++ b/test/integration/engine/country_and_date_questions_test.rb
@@ -149,7 +149,7 @@ class CountryAndDateQuestionsTest < EngineIntegrationTest
       end
 
       within "#result-info" do
-        within("h2.gem-c-heading") { assert_page_has_content "Great - you've lived in belarus for 37 years, and were born in venezuela!" }
+        within(".result-body h2.gem-c-heading") { assert_page_has_content "Great - you've lived in belarus for 37 years, and were born in venezuela!" }
       end
     end
   end # with_and_without_javascript

--- a/test/integration/engine/input_validation_test.rb
+++ b/test/integration/engine/input_validation_test.rb
@@ -57,7 +57,7 @@ class InputValidationTest < EngineIntegrationTest
       assert_current_url "/money-and-salary-sample/y/4000.0-month/50000.0"
 
       within "#result-info" do
-        within("h2.gem-c-heading") { assert_page_has_content "OK, here you go." }
+        within(".result-body h2.gem-c-heading") { assert_page_has_content "OK, here you go." }
         within(".info-notice") { assert_page_has_content "This is allowed because £50,000 is more than your annual salary of £48,000" }
       end
     end

--- a/test/integration/engine/money_and_salary_questions_test.rb
+++ b/test/integration/engine/money_and_salary_questions_test.rb
@@ -67,7 +67,7 @@ class MoneyAndSalaryQuestionsTest < EngineIntegrationTest
       end
 
       within "#result-info" do
-        within("h2.gem-c-heading") { assert_page_has_content "OK, here you go." }
+        within(".result-body h2.gem-c-heading") { assert_page_has_content "OK, here you go." }
         within(".info-notice") { assert_page_has_content "This is allowed because £1,000,000 is more than your annual salary of £60,000" }
       end
     end

--- a/test/integration/engine/multiple_choice_and_value_questions_test.rb
+++ b/test/integration/engine/multiple_choice_and_value_questions_test.rb
@@ -141,7 +141,7 @@ class MultipleChoiceAndValueQuestionsTest < EngineIntegrationTest
       end
 
       within "#result-info" do
-        within("h2.gem-c-heading") { assert_page_has_content "Right, off you go." }
+        within(".result-body h2.gem-c-heading") { assert_page_has_content "Right, off you go." }
         assert_page_has_content "Oh! Well, thank you. Thank you very much."
       end
     end
@@ -188,7 +188,7 @@ class MultipleChoiceAndValueQuestionsTest < EngineIntegrationTest
     click_on "Next step"
 
     within "#result-info" do
-      within("h2.gem-c-heading") { assert_page_has_content "AAAAARRRRRRRRRRRRRRRRGGGGGHHH!!!!!!!" }
+      within(".result-body h2.gem-c-heading") { assert_page_has_content "AAAAARRRRRRRRRRRRRRRRGGGGGHHH!!!!!!!" }
       within(".info-notice") { assert_page_has_content "Robin is thrown into the Gorge of Eternal Peril" }
     end
   end


### PR DESCRIPTION
## What
Replaces 2 instances of plain markup with the appropriate component from [govuk publishing components](https://components.publishing.service.gov.uk/component-guide). Specifically...

- The "Your answers" heading above the results so far through a given smart answer journey with the [heading component](https://components.publishing.service.gov.uk/component-guide/heading)
- The warning element on visualisation pages with the [warning text component](https://components.publishing.service.gov.uk/component-guide/warning_text)

## Why
This is part of ongoing work within the govuk accessibility team to ensure that our frontend apps are using our components gem as often as possible. This is to ensure that any required changes, such as for accessibility or performance, can be more easily rolled out to apps across govuk.

The change to the warning component is more explicit, however the warning text component similarly communicates what the existing warning element was intending so I made he decision to replace it to reduce the risk of a custom element sitting in isolation.

## Visual changes
### Before
![Screenshot 2021-01-08 at 11 18 16](https://user-images.githubusercontent.com/64783893/104009605-3f647780-51a3-11eb-91a5-ad2e9f4e4d32.png)

### After
![Screenshot 2021-01-08 at 11 17 12](https://user-images.githubusercontent.com/64783893/104009617-44292b80-51a3-11eb-9f0a-c435c3c0edd6.png)

[Card](https://trello.com/c/C4bcgNke/565-update-smart-answers-to-use-components)