### PR TITLE
Change default button text from `Next step` to `Continue`

### DIFF
--- a/doc/smart-answer-flow-development/creating-a-new-smart-answer.md
+++ b/doc/smart-answer-flow-development/creating-a-new-smart-answer.md
@@ -109,7 +109,7 @@ $ touch lib/smart_answer_flows/example-smart-answer/questions/question_1.erb
 
 Although the question page template needs to exist, it doesn't actually need to contain anything!
 
-Assuming you're still running `rails server`, visit [http://localhost:3000/example-smart-answer][example-smart-answer] and you should see an empty page containing a text field and a "Next step" button.
+Assuming you're still running `rails server`, visit [http://localhost:3000/example-smart-answer][example-smart-answer] and you should see an empty page containing a text field and a "Continue" button.
 
 Open the new question page template in your editor and copy/paste the following content:
 
@@ -127,7 +127,7 @@ Refresh the Smart Answer in your browser to see this new content.
 
 Read more about [question page templates](/doc/smart-answers/erb-templates/question-templates.md).
 
-Enter any value in the text field and click "Next step". You should see an error message indicating that we're now missing an ERB template for the outcome.
+Enter any value in the text field and click "Continue". You should see an error message indicating that we're now missing an ERB template for the outcome.
 
 ### 4. Create an ERB outcome page template
 

--- a/doc/smart-answers/flow-definition.md
+++ b/doc/smart-answers/flow-definition.md
@@ -54,7 +54,6 @@ module SmartAnswer
       satisfies_need "7da2fa63-190c-446e-b3e5-94480f0e46e7" # relates the Smart Answer to a Need managed by Maslow
       external_related_links { title: "Child Maintenance Options - How much should be paid",
                                url: "http://www.cmoptions.org/en/maintenance/how-much.asp" } # External links associated to the Smart-Answer
-      button_text "Continue" # optional - replaces the default "Next step" button label with the passed in text
 
       # question & outcome definitions specified here
     end

--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -72,7 +72,7 @@ module SmartAnswer
       ActiveModel::Type::Boolean.new.cast(@hide_previous_answers_on_results_page)
     end
 
-    def button_text(text = "Next step")
+    def button_text(text = "Continue")
       @button_text ||= text
     end
 

--- a/lib/smart_answer_flows/benefit-cap-calculator/questions/receiving_exemption_benefits.erb
+++ b/lib/smart_answer_flows/benefit-cap-calculator/questions/receiving_exemption_benefits.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% text_for :hint do %>
-  If you do not receive any of these click 'Next step'.
+  If you do not receive any of these click 'Continue'.
 <% end %>
 
 <% options(exempt_benefits) %>

--- a/lib/smart_answer_flows/benefit-cap-calculator/questions/receiving_non_exemption_benefits.erb
+++ b/lib/smart_answer_flows/benefit-cap-calculator/questions/receiving_non_exemption_benefits.erb
@@ -5,5 +5,5 @@
 <% options(benefit_options) %>
 
 <% text_for :hint do %>
-  If you do not receive any of these click 'Next step'.
+  If you do not receive any of these click 'Continue'.
 <% end %>

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/questions/is_your_employee_getting.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/questions/is_your_employee_getting.erb
@@ -12,5 +12,5 @@
 ) %>
 
 <% text_for :hint do %>
-  If none apply just click ‘Next step’
+  If none apply just click ‘Continue’
 <% end %>

--- a/lib/smart_answer_flows/simplified-expenses-checker/questions/type_of_expense.erb
+++ b/lib/smart_answer_flows/simplified-expenses-checker/questions/type_of_expense.erb
@@ -11,7 +11,7 @@
 ) %>
 
 <% text_for :hint do %>
-  If you don't have any of these expenses go to 'Next step'.
+  If you don't have any of these expenses go to 'Continue'.
 <% end %>
 
 <% text_for :error_message do %>

--- a/lib/smart_answer_flows/uk-benefits-abroad/questions/do_either_of_the_following_apply.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/questions/do_either_of_the_following_apply.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% text_for :hint do %>
-  If you do not receive any of these click 'Next step'.
+  If you do not receive any of these click 'Continue'.
 
 <% end %>
 

--- a/lib/smart_answer_flows/uk-benefits-abroad/questions/is_any_of_the_following_apply.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/questions/is_any_of_the_following_apply.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% govspeak_for :body do %>
-  If none apply, click ‘Next Step’.
+  If none apply, click ‘Continue’.
 
 <% end %>
 

--- a/lib/smart_answer_flows/uk-benefits-abroad/questions/is_claiming_benefits.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/questions/is_claiming_benefits.erb
@@ -7,7 +7,7 @@
 <% end %>
 
 <% text_for :hint do %>
-  If no, click ‘Next Step’.
+  If no, click ‘Continue’.
 <% end %>
 
 <% options(calculator.premiums) %>

--- a/lib/smart_answer_flows/uk-benefits-abroad/questions/is_either_of_the_following.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/questions/is_either_of_the_following.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% text_for :hint do %>
-  If neither apply, click 'Next Step'.
+  If neither apply, click 'Continue'.
 
 <% end %>
 

--- a/lib/smart_answer_flows/uk-benefits-abroad/questions/is_work_or_sick_pay.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/questions/is_work_or_sick_pay.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% text_for :hint do %>
-  If you don’t receive either of these click 'Next step'.
+  If you don’t receive either of these click 'Continue'.
 
 <% end %>
 

--- a/lib/smart_answer_flows/uk-benefits-abroad/questions/tax_credits_currently_claiming.erb
+++ b/lib/smart_answer_flows/uk-benefits-abroad/questions/tax_credits_currently_claiming.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% text_for :hint do %>
-  If you don’t receive any of these click 'Next step'.
+  If you don’t receive any of these click 'Continue'.
 
 <% end %>
 

--- a/spec/features/smart_answer/am_i_getting_minimum_wage_spec.rb
+++ b/spec/features/smart_answer/am_i_getting_minimum_wage_spec.rb
@@ -47,39 +47,39 @@ RSpec.feature "SmartAnswer::AmIGettingMinimumWageFlow", type: :feature do
       expect(page).to have_selector("h1", text: headings.fetch(:what_would_you_like_to_check))
 
       choose "If you're getting the National Minimum Wage or the National Living Wage"
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:are_you_an_apprentice))
 
       choose "Not an apprentice"
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:how_old_are_you))
 
       fill_in "response", with: older_age
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:how_often_do_you_get_paid))
 
       fill_in "response", with: pay_frequency
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:how_many_hours_do_you_work))
 
       fill_in "response", with: hours_worked
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:how_much_are_you_paid_during_pay_period))
 
       fill_in "response", with: pay_above_minimum_wage
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:is_provided_with_accommodation))
 
       choose "No"
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:does_employer_charge_for_job_requirements))
 
       choose "No"
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:current_additional_work_outside_shift))
 
       choose "No"
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:flow_title))
     end
 
@@ -91,47 +91,47 @@ RSpec.feature "SmartAnswer::AmIGettingMinimumWageFlow", type: :feature do
       expect(page).to have_selector("h1", text: headings.fetch(:what_would_you_like_to_check))
 
       choose "If you're getting the National Minimum Wage or the National Living Wage"
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:are_you_an_apprentice))
 
       choose "Not an apprentice"
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:how_old_are_you))
 
       fill_in "response", with: older_age
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:how_often_do_you_get_paid))
 
       fill_in "response", with: pay_frequency
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:how_many_hours_do_you_work))
 
       fill_in "response", with: hours_worked
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:how_much_are_you_paid_during_pay_period))
 
       fill_in "response", with: pay_below_minimum_wage
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:is_provided_with_accommodation))
 
       choose "Yes, the accommodation is charged for"
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:current_accommodation_charge))
 
       fill_in "response", with: accommodation_charge
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:current_accommodation_usage))
 
       fill_in "response", with: days_per_week_in_accommodation
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:does_employer_charge_for_job_requirements))
 
       choose "No"
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:current_additional_work_outside_shift))
 
       choose "No"
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:flow_title))
     end
 
@@ -143,43 +143,43 @@ RSpec.feature "SmartAnswer::AmIGettingMinimumWageFlow", type: :feature do
       expect(page).to have_selector("h1", text: headings.fetch(:what_would_you_like_to_check))
 
       choose "If you're getting the National Minimum Wage or the National Living Wage"
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:are_you_an_apprentice))
 
       choose "Apprentice under 19"
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:how_often_do_you_get_paid))
 
       fill_in "response", with: pay_frequency
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:how_many_hours_do_you_work))
 
       fill_in "response", with: hours_worked
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:how_much_are_you_paid_during_pay_period))
 
       fill_in "response", with: pay_below_minimum_wage
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:is_provided_with_accommodation))
 
       choose "Yes, the accommodation is charged for"
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:current_accommodation_charge))
 
       fill_in "response", with: accommodation_charge
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:current_accommodation_usage))
 
       fill_in "response", with: days_per_week_in_accommodation
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:does_employer_charge_for_job_requirements))
 
       choose "No"
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:current_additional_work_outside_shift))
 
       choose "No"
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:flow_title))
     end
 
@@ -191,15 +191,15 @@ RSpec.feature "SmartAnswer::AmIGettingMinimumWageFlow", type: :feature do
       expect(page).to have_selector("h1", text: headings.fetch(:what_would_you_like_to_check))
 
       choose "If you're getting the National Minimum Wage or the National Living Wage"
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:are_you_an_apprentice))
 
       choose "Not an apprentice"
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:how_old_are_you))
 
       fill_in "response", with: under_age
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:flow_title))
     end
   end
@@ -228,39 +228,39 @@ RSpec.feature "SmartAnswer::AmIGettingMinimumWageFlow", type: :feature do
       expect(page).to have_selector("h1", text: headings.fetch(:what_would_you_like_to_check))
 
       choose "If an employer owes you payments from last year (April 2019 to March 2020)"
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:were_you_an_apprentice))
 
       choose "No"
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:how_old_were_you))
 
       fill_in "response", with: older_age
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:how_often_did_you_get_paid))
 
       fill_in "response", with: pay_frequency
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:how_many_hours_did_you_work))
 
       fill_in "response", with: hours_worked
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:how_much_were_you_paid_during_pay_period))
 
       fill_in "response", with: pay_above_minimum_wage
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:was_provided_with_accommodation))
 
       choose "No"
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:did_employer_charge_for_job_requirements))
 
       choose "No"
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:past_additional_work_outside_shift))
 
       choose "No"
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:flow_title))
     end
 
@@ -272,47 +272,47 @@ RSpec.feature "SmartAnswer::AmIGettingMinimumWageFlow", type: :feature do
       expect(page).to have_selector("h1", text: headings.fetch(:what_would_you_like_to_check))
 
       choose "If an employer owes you payments from last year (April 2019 to March 2020)"
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:were_you_an_apprentice))
 
       choose "No"
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:how_old_were_you))
 
       fill_in "response", with: older_age
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:how_often_did_you_get_paid))
 
       fill_in "response", with: pay_frequency
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:how_many_hours_did_you_work))
 
       fill_in "response", with: hours_worked
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:how_much_were_you_paid_during_pay_period))
 
       fill_in "response", with: pay_below_minimum_wage
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:was_provided_with_accommodation))
 
       choose "Yes, the accommodation was charged for"
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:past_accommodation_charge))
 
       fill_in "response", with: accommodation_charge
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:past_accommodation_usage))
 
       fill_in "response", with: days_per_week_in_accommodation
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:did_employer_charge_for_job_requirements))
 
       choose "No"
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:past_additional_work_outside_shift))
 
       choose "No"
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:flow_title))
     end
 
@@ -324,43 +324,43 @@ RSpec.feature "SmartAnswer::AmIGettingMinimumWageFlow", type: :feature do
       expect(page).to have_selector("h1", text: headings.fetch(:what_would_you_like_to_check))
 
       choose "If an employer owes you payments from last year (April 2019 to March 2020)"
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:were_you_an_apprentice))
 
       choose "Apprentice under 19"
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:how_often_did_you_get_paid))
 
       fill_in "response", with: pay_frequency
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:how_many_hours_did_you_work))
 
       fill_in "response", with: hours_worked
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:how_much_were_you_paid_during_pay_period))
 
       fill_in "response", with: pay_below_minimum_wage
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:was_provided_with_accommodation))
 
       choose "Yes, the accommodation was charged for"
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:past_accommodation_charge))
 
       fill_in "response", with: accommodation_charge
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:past_accommodation_usage))
 
       fill_in "response", with: days_per_week_in_accommodation
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:did_employer_charge_for_job_requirements))
 
       choose "No"
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:past_additional_work_outside_shift))
 
       choose "No"
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:flow_title))
     end
 
@@ -372,15 +372,15 @@ RSpec.feature "SmartAnswer::AmIGettingMinimumWageFlow", type: :feature do
       expect(page).to have_selector("h1", text: headings.fetch(:what_would_you_like_to_check))
 
       choose "If an employer owes you payments from last year (April 2019 to March 2020)"
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:were_you_an_apprentice))
 
       choose "No"
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:how_old_were_you))
 
       fill_in "response", with: under_age
-      click_button "Next step"
+      click_button "Continue"
       expect(page).to have_selector("h1", text: headings.fetch(:flow_title))
     end
   end

--- a/spec/features/smart_answer/business_coronavirus_support_finder_flow_spec.rb
+++ b/spec/features/smart_answer/business_coronavirus_support_finder_flow_spec.rb
@@ -32,39 +32,39 @@ RSpec.feature "SmartAnswer::BusinessCoronavirusSupportFinderFlow", type: :featur
     expect(page).to have_selector("h1", text: headings[:business_based])
 
     choose "England"
-    click_button "Next step"
+    click_button "Continue"
     expect(page).to have_selector("h1", text: headings[:business_size])
 
     choose "0 to 249 employees"
-    click_button "Next step"
+    click_button "Continue"
     expect(page).to have_selector("h1", text: headings[:annual_turnover])
 
     choose "My business is a start-up and is pre-revenue"
-    click_button "Next step"
+    click_button "Continue"
     expect(page).to have_selector("h1", text: headings[:paye_scheme])
 
     choose "Yes"
-    click_button "Next step"
+    click_button "Continue"
     expect(page).to have_selector("h1", text: headings[:self_employed])
 
     choose "Yes"
-    click_button "Next step"
+    click_button "Continue"
     expect(page).to have_selector("h1", text: headings[:non_domestic_property])
 
     choose "Under £51,000"
-    click_button "Next step"
+    click_button "Continue"
     expect(page).to have_selector("h1", text: headings[:sectors])
 
     check "Nurseries"
-    click_button "Next step"
+    click_button "Continue"
     expect(page).to have_selector("h1", text: headings[:restricted_sector])
 
     choose "No"
-    click_button "Next step"
+    click_button "Continue"
     expect(page).to have_selector("h1", text: headings[:closed_by_restrictions])
 
     check "No"
-    click_button "Next step"
+    click_button "Continue"
     expect(page).to have_selector("h1", text: headings[:flow_title])
     expect(page).to have_selector("h2", text: headings[:results])
   end

--- a/test/integration/engine/changing_answer_test.rb
+++ b/test/integration/engine/changing_answer_test.rb
@@ -9,13 +9,13 @@ class ChangingAnswerTest < EngineIntegrationTest
       visit "/country-and-date-sample/y"
 
       select "Belarus", from: "response"
-      click_on "Next step"
+      click_on "Continue"
 
       within("#current-question") { assert_page_has_content "What date did you move there?" }
       fill_in "response[day]", with: "5"
       fill_in "response[month]", with: "5"
       fill_in "response[year]", with: "1975"
-      click_on "Next step"
+      click_on "Continue"
 
       within("#current-question") { assert_page_has_content "Which country were you born in?" }
 
@@ -27,14 +27,14 @@ class ChangingAnswerTest < EngineIntegrationTest
       end
 
       select "Argentina", from: "response"
-      click_on "Next step"
+      click_on "Continue"
 
       assert_current_url "/country-and-date-sample/y/argentina"
 
       fill_in "response[day]", with: "10"
       fill_in "response[month]", with: "6"
       fill_in "response[year]", with: "1985"
-      click_on "Next step"
+      click_on "Continue"
 
       within("tbody tr.govuk-table__row:nth-child(2)") { click_on "Change" }
 
@@ -47,7 +47,7 @@ class ChangingAnswerTest < EngineIntegrationTest
       fill_in "response[day]", with: "15"
       fill_in "response[month]", with: "4"
       fill_in "response[year]", with: "2000"
-      click_on "Next step"
+      click_on "Continue"
 
       assert_current_url "/country-and-date-sample/y/argentina/2000-04-15"
     end
@@ -59,11 +59,11 @@ class ChangingAnswerTest < EngineIntegrationTest
 
       fill_in "response[amount]", with: "5000"
       select "month", from: "response[period]"
-      click_on "Next step"
+      click_on "Continue"
 
       within("#current-question") { assert_page_has_content "What size bonus do you want?" }
       fill_in "response", with: "1000000"
-      click_on "Next step"
+      click_on "Continue"
 
       within("#result-info") { assert_page_has_content "OK, here you go." }
       within("tbody tr.govuk-table__row:nth-child(1)") { click_on "Change" }
@@ -75,19 +75,19 @@ class ChangingAnswerTest < EngineIntegrationTest
 
       fill_in "response[amount]", with: "2000"
       select "week", from: "response[period]"
-      click_on "Next step"
+      click_on "Continue"
 
       assert_current_url "/money-and-salary-sample/y/2000.0-week"
 
       fill_in "response", with: "2000000"
-      click_on "Next step"
+      click_on "Continue"
 
       within("tbody tr.govuk-table__row:nth-child(2)") { click_on "Change" }
 
       within("#current-question") { assert page.has_field? "response", with: "2000000.0" }
 
       fill_in "response", with: "3000000"
-      click_on "Next step"
+      click_on "Continue"
 
       assert_current_url "/money-and-salary-sample/y/2000.0-week/3000000.0"
     end
@@ -98,15 +98,15 @@ class ChangingAnswerTest < EngineIntegrationTest
       visit "/bridge-of-death/y"
 
       fill_in "response", with: "Lancelot"
-      click_on "Next step"
+      click_on "Continue"
 
       within("#current-question") { assert_page_has_content "What...is your quest?" }
       choose("To seek the Holy Grail", visible: false)
-      click_on "Next step"
+      click_on "Continue"
 
       within("#current-question") { assert_page_has_content "What...is your favorite colour?" }
       choose("Blue", visible: false)
-      click_on "Next step"
+      click_on "Continue"
 
       within("#result-info") { assert_page_has_content "Right, off you go." }
       within("tbody tr.govuk-table__row:nth-child(1)") { click_on "Change" }
@@ -114,17 +114,17 @@ class ChangingAnswerTest < EngineIntegrationTest
       within("#current-question") { assert page.has_field? "response", with: "Lancelot" }
 
       fill_in "response", with: "Bors"
-      click_on "Next step"
+      click_on "Continue"
 
       assert_current_url "/bridge-of-death/y/Bors"
 
       within("#current-question") { assert_page_has_content "What...is your quest?" }
       choose("To seek the Holy Grail", visible: false)
-      click_on "Next step"
+      click_on "Continue"
 
       within("#current-question") { assert_page_has_content "What...is your favorite colour?" }
       choose("Blue", visible: false)
-      click_on "Next step"
+      click_on "Continue"
 
       within("#result-info") { assert_page_has_content "Right, off you go." }
       within("tbody tr.govuk-table__row:nth-child(2)") { click_on "Change" }
@@ -136,12 +136,12 @@ class ChangingAnswerTest < EngineIntegrationTest
       end
 
       choose("To rescue the princess", visible: false)
-      click_on "Next step"
+      click_on "Continue"
 
       assert_current_url "/bridge-of-death/y/Bors/to_rescue_the_princess"
 
       choose("Blue", visible: false)
-      click_on "Next step"
+      click_on "Continue"
 
       within("#result-info") { assert_page_has_content "Right, off you go." }
       within("tbody tr.govuk-table__row:nth-child(3)") { click_on "Change" }
@@ -153,7 +153,7 @@ class ChangingAnswerTest < EngineIntegrationTest
       end
 
       choose("Red", visible: false)
-      click_on "Next step"
+      click_on "Continue"
 
       assert_current_url "/bridge-of-death/y/Bors/to_rescue_the_princess/red"
     end
@@ -165,7 +165,7 @@ class ChangingAnswerTest < EngineIntegrationTest
 
       check("Peppers", visible: false)
       check("Pepperoni", visible: false)
-      click_on "Next step"
+      click_on "Continue"
 
       assert_current_url "/checkbox-sample/y/pepperoni,peppers"
 
@@ -179,7 +179,7 @@ class ChangingAnswerTest < EngineIntegrationTest
       end
 
       check("Ham", visible: false)
-      click_on "Next step"
+      click_on "Continue"
 
       assert_current_url "/checkbox-sample/y/ham,pepperoni,peppers"
     end
@@ -190,7 +190,7 @@ class ChangingAnswerTest < EngineIntegrationTest
       visit "/postcode-sample/y"
 
       fill_in "response", with: "B1 1PW"
-      click_on "Next step"
+      click_on "Continue"
 
       assert_current_url "/postcode-sample/y/B1%201PW"
 

--- a/test/integration/engine/checkbox_questions_test.rb
+++ b/test/integration/engine/checkbox_questions_test.rb
@@ -26,7 +26,7 @@ class CheckboxQuestionsTest < EngineIntegrationTest
 
       check("Ham", visible: false)
       check("Pepperoni", visible: false)
-      click_on "Next step"
+      click_on "Continue"
 
       assert_current_url "/checkbox-sample/y/ham,pepperoni"
 
@@ -52,7 +52,7 @@ class CheckboxQuestionsTest < EngineIntegrationTest
     should "allow selecting no options from a checkbox question" do
       visit "/checkbox-sample/y"
 
-      click_on "Next step"
+      click_on "Continue"
 
       assert_current_url "/checkbox-sample/y/none"
 
@@ -71,7 +71,7 @@ class CheckboxQuestionsTest < EngineIntegrationTest
 
       check("Definitely no toppings", visible: false)
 
-      click_on "Next step"
+      click_on "Continue"
 
       assert_current_url "/checkbox-sample/y/none/none"
 
@@ -85,7 +85,7 @@ class CheckboxQuestionsTest < EngineIntegrationTest
 
       assert_page_has_content "Are you sure you don't want any toppings?"
 
-      click_on "Next step"
+      click_on "Continue"
 
       assert_equal current_path, "/checkbox-sample/y/none"
 
@@ -105,7 +105,7 @@ class CheckboxQuestionsTest < EngineIntegrationTest
 
       check("Definitely no toppings", visible: false)
       assert_not page.has_checked_field?("Hmm I'm not sure, ask me again please")
-      click_on "Next step"
+      click_on "Continue"
 
       assert_current_url "/checkbox-sample/y/none/none"
     end
@@ -116,7 +116,7 @@ class CheckboxQuestionsTest < EngineIntegrationTest
 
     check("Ham", visible: false)
     check("Ice Cream!!!", visible: false)
-    click_on("Next step", visible: false)
+    click_on("Continue", visible: false)
 
     assert_current_url "/checkbox-sample/y/ham,ice_cream"
     within ".outcome:nth-child(1)" do

--- a/test/integration/engine/country_and_date_questions_test.rb
+++ b/test/integration/engine/country_and_date_questions_test.rb
@@ -52,7 +52,7 @@ class CountryAndDateQuestionsTest < EngineIntegrationTest
       end
 
       select "Belarus", from: "response"
-      click_on "Next step"
+      click_on "Continue"
 
       assert_current_url "/country-and-date-sample/y/belarus"
 
@@ -81,7 +81,7 @@ class CountryAndDateQuestionsTest < EngineIntegrationTest
       fill_in "Day", with: "5"
       fill_in "Month", with: "5"
       fill_in "Year", with: "1975"
-      click_on "Next step"
+      click_on "Continue"
 
       assert_current_url "/country-and-date-sample/y/belarus/1975-05-05"
 
@@ -115,7 +115,7 @@ class CountryAndDateQuestionsTest < EngineIntegrationTest
       end
 
       select "Venezuela", from: "response"
-      click_on "Next step"
+      click_on "Continue"
 
       assert_current_url "/country-and-date-sample/y/belarus/1975-05-05/venezuela"
 

--- a/test/integration/engine/html_escaping_user_input_test.rb
+++ b/test/integration/engine/html_escaping_user_input_test.rb
@@ -12,7 +12,7 @@ class HtmlEscapingUserInputTest < EngineIntegrationTest
       @javascript = "doSomethingNaughty();"
       unsafe_html = "<script id='naughty'>#{@javascript}"
       fill_in "User input", with: unsafe_html
-      click_on "Next step"
+      click_on "Continue"
     end
 
     should "escape user input interpolated into outcome ERB template" do

--- a/test/integration/engine/input_validation_test.rb
+++ b/test/integration/engine/input_validation_test.rb
@@ -8,7 +8,7 @@ class InputValidationTest < EngineIntegrationTest
       visit "/money-and-salary-sample/y"
 
       fill_in "response[amount]", with: "-123"
-      click_on "Next step"
+      click_on "Continue"
 
       within "#current-question" do
         assert_page_has_content "How much do you earn?"
@@ -18,12 +18,12 @@ class InputValidationTest < EngineIntegrationTest
 
       fill_in "response[amount]", with: "4000"
       select "month", from: "response[period]"
-      click_on "Next step"
+      click_on "Continue"
 
       assert_current_url "/money-and-salary-sample/y/4000.0-month"
 
       fill_in "response", with: "asdfasdf"
-      click_on "Next step"
+      click_on "Continue"
 
       within "#current-question" do
         assert_page_has_content "What size bonus do you want?"
@@ -32,7 +32,7 @@ class InputValidationTest < EngineIntegrationTest
       end
 
       fill_in "response", with: "50000"
-      click_on "Next step"
+      click_on "Continue"
 
       assert_current_url "/money-and-salary-sample/y/4000.0-month/50000.0"
     end
@@ -43,7 +43,7 @@ class InputValidationTest < EngineIntegrationTest
       visit "/money-and-salary-sample/y/4000.0-month"
 
       fill_in "response", with: "3000"
-      click_on "Next step"
+      click_on "Continue"
 
       within "#current-question" do
         assert_page_has_content "What size bonus do you want?"
@@ -52,7 +52,7 @@ class InputValidationTest < EngineIntegrationTest
       end
 
       fill_in "response", with: "50000"
-      click_on "Next step"
+      click_on "Continue"
 
       assert_current_url "/money-and-salary-sample/y/4000.0-month/50000.0"
 
@@ -68,7 +68,7 @@ class InputValidationTest < EngineIntegrationTest
       visit "/custom-errors-sample/y"
 
       fill_in "response", with: "asdfasdf"
-      click_on "Next step"
+      click_on "Continue"
 
       within "#current-question" do
         assert_page_has_content "How many things do you own?"

--- a/test/integration/engine/money_and_salary_questions_test.rb
+++ b/test/integration/engine/money_and_salary_questions_test.rb
@@ -20,7 +20,7 @@ class MoneyAndSalaryQuestionsTest < EngineIntegrationTest
 
       fill_in "response[amount]", with: "5000"
       select "month", from: "response[period]"
-      click_on "Next step"
+      click_on "Continue"
 
       assert_current_url "/money-and-salary-sample/y/5000.0-month"
 
@@ -44,7 +44,7 @@ class MoneyAndSalaryQuestionsTest < EngineIntegrationTest
       end
 
       fill_in "response", with: "1000000"
-      click_on "Next step"
+      click_on "Continue"
 
       assert_current_url "/money-and-salary-sample/y/5000.0-month/1000000.0"
 

--- a/test/integration/engine/multiple_choice_and_value_questions_test.rb
+++ b/test/integration/engine/multiple_choice_and_value_questions_test.rb
@@ -45,7 +45,7 @@ class MultipleChoiceAndValueQuestionsTest < EngineIntegrationTest
       end
 
       fill_in "response", with: "Lancelot"
-      click_on "Next step"
+      click_on "Continue"
 
       assert_current_url "/bridge-of-death/y/Lancelot"
 
@@ -75,7 +75,7 @@ class MultipleChoiceAndValueQuestionsTest < EngineIntegrationTest
       end
 
       choose("To seek the Holy Grail", visible: false)
-      click_on "Next step"
+      click_on "Continue"
 
       assert_current_url "/bridge-of-death/y/Lancelot/to_seek_the_holy_grail"
 
@@ -111,7 +111,7 @@ class MultipleChoiceAndValueQuestionsTest < EngineIntegrationTest
       end
 
       choose("Blue", visible: false)
-      click_on "Next step"
+      click_on "Continue"
 
       assert_current_url "/bridge-of-death/y/Lancelot/to_seek_the_holy_grail/blue"
 
@@ -151,10 +151,10 @@ class MultipleChoiceAndValueQuestionsTest < EngineIntegrationTest
     visit "/bridge-of-death/y"
 
     fill_in "response", with: "Robin"
-    click_on "Next step"
+    click_on "Continue"
 
     choose("To seek the Holy Grail", visible: false)
-    click_on "Next step"
+    click_on "Continue"
 
     assert_current_url "/bridge-of-death/y/Robin/to_seek_the_holy_grail"
 
@@ -185,7 +185,7 @@ class MultipleChoiceAndValueQuestionsTest < EngineIntegrationTest
     end
 
     fill_in "response", with: "I don't know THAT"
-    click_on "Next step"
+    click_on "Continue"
 
     within "#result-info" do
       within(".result-body h2.gem-c-heading") { assert_page_has_content "AAAAARRRRRRRRRRRRRRRRGGGGGHHH!!!!!!!" }

--- a/test/unit/flow_test.rb
+++ b/test/unit/flow_test.rb
@@ -127,7 +127,7 @@ class FlowTest < ActiveSupport::TestCase
   test "Uses default when not set button text" do
     smart_answer = SmartAnswer::Flow.new
 
-    assert_equal "Next step", smart_answer.button_text
+    assert_equal "Continue", smart_answer.button_text
   end
 
   test "Can set the start page content_id" do


### PR DESCRIPTION
This removes inconsistency between Smart Answer flows where the Find Coronavirus Support flow uses "Continue", where as all other flows use "Next step". Content designers have agreed that "Continue" is better wording for the button.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
