### PR TITLE
Remove ability to specify different button text

### DIFF
--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -11,7 +11,6 @@ class FlowPresenter
            :start_page_content_id,
            :flow_content_id,
            :need_it,
-           :button_text,
            :use_session?,
            :questions,
            :use_escape_button?,

--- a/app/views/smart_answers/question.html.erb
+++ b/app/views/smart_answers/question.html.erb
@@ -41,7 +41,7 @@
 
         <input type="hidden" name="next" value="1" />
         <%= render "govuk_publishing_components/components/button", {
-          text: @presenter.button_text,
+          text: "Continue",
           margin_bottom: true
         } %>
       </div>

--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -72,10 +72,6 @@ module SmartAnswer
       ActiveModel::Type::Boolean.new.cast(@hide_previous_answers_on_results_page)
     end
 
-    def button_text(text = "Continue")
-      @button_text ||= text
-    end
-
     def satisfies_need(need_content_id)
       self.need_content_id = need_content_id
     end

--- a/lib/smart_answer_flows/find-coronavirus-support.rb
+++ b/lib/smart_answer_flows/find-coronavirus-support.rb
@@ -8,7 +8,6 @@ module SmartAnswer
       use_session true
       use_escape_button true
       hide_previous_answers_on_results_page true
-      button_text "Continue"
 
       # ======================================================================
       # What do you need help with because of coronavirus?

--- a/test/fixtures/smart_answer_flows/custom-button.rb
+++ b/test/fixtures/smart_answer_flows/custom-button.rb
@@ -3,7 +3,6 @@ module SmartAnswer
     def define
       name "custom-button"
       status :draft
-      button_text "Continue"
 
       value_question :user_input? do
       end

--- a/test/unit/flow_test.rb
+++ b/test/unit/flow_test.rb
@@ -115,21 +115,6 @@ class FlowTest < ActiveSupport::TestCase
     assert_not smart_answer.hide_previous_answers_on_results_page?
   end
 
-  test "Can set button text" do
-    text = "continue"
-    smart_answer = SmartAnswer::Flow.new do
-      button_text text
-    end
-
-    assert_equal text, smart_answer.button_text
-  end
-
-  test "Uses default when not set button text" do
-    smart_answer = SmartAnswer::Flow.new
-
-    assert_equal "Continue", smart_answer.button_text
-  end
-
   test "Can set the start page content_id" do
     s = SmartAnswer::Flow.new do
       start_page_content_id "587920ff-b854-4adb-9334-451b45652467"


### PR DESCRIPTION
The functionality to specify button text on questions pages was added to change the text to "Continue" for the "Find coronavirus support" flow.

Recently we've changed all Smart Answer flows to use the question button text to be "Continue" instead of "Next step". This made this functionality unused. Removing to simplify the codebase and prevent snowflake patterns from being introduced in the future.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
