### PR TITLE
Update Check UK Visa outcomes for BNO Passport Holders

### DIFF
--- a/lib/smart_answer/calculators/uk_visa_calculator.rb
+++ b/lib/smart_answer/calculators/uk_visa_calculator.rb
@@ -42,6 +42,10 @@ module SmartAnswer::Calculators
       COUNTRY_GROUP_EPASSPORT_GATES.include?(@passport_country)
     end
 
+    def passport_country_in_british_national_overseas_list?
+      COUNTRY_GROUP_BRITISH_NATIONAL_OVERSEAS.include?(@passport_country)
+    end
+
     def passport_country_in_b1_b2_visa_exception_list?
       @passport_country == "syria"
     end
@@ -451,6 +455,11 @@ module SmartAnswer::Calculators
       singapore
       south-korea
       usa
+    ].freeze
+
+    COUNTRY_GROUP_BRITISH_NATIONAL_OVERSEAS = %w[
+      british-national-overseas
+      hong-kong-(british-national-overseas)
     ].freeze
   end
 end

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_marriage_nvn_ukot.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_marriage_nvn_ukot.erb
@@ -5,7 +5,13 @@
 <% govspeak_for :body do %>
   Apply for a [Marriage Visitor visa](/marriage-visa) if you and your partner want to get married or enter into a civil partnership in the UK.
 
-  If you want to live in the UK permanently, you must apply for a [family visa](/join-family-in-uk) if your partner:
+  <% if calculator.passport_country_in_british_national_overseas_list? %>
+    If you want to live in the UK permanently, you can apply for a [British National Overseas (BNO) visa](/guidance/hong-kong-british-national-overseas-visa-applications/).
+
+    You can also apply for a family visa, but the application fee is higher. You’re eligible for a family visa if your partner:
+  <% else %>
+    If you want to live in the UK permanently, you must apply for a [family visa](/join-family-in-uk) if your partner:
+  <% end %>
 
   + is a British citizen
   + is settled in the UK (called having ‘indefinite leave to remain’)

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_study_y.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_study_y.erb
@@ -12,4 +12,12 @@
   If you’re coming to study on a further or higher education course, apply for a [Student visa](/student-visa).
 
   Or if you’re aged 4 to 17 and coming to study at an independent school, apply for a [Child Student visa](/child-study-visa).
+
+  <% if calculator.passport_country_in_british_national_overseas_list? %>
+    You can also study with a [British National Overseas (BNO) visa](/guidance/hong-kong-british-national-overseas-visa-applications/). You can:
+
+    + apply without an offer of a place on a course
+    + change your course or start a new one without telling the Home Office
+    + settle permanently in the UK after 5 years
+  <% end %>
 <% end %>

--- a/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_work_y.erb
+++ b/lib/smart_answer_flows/check-uk-visa/outcomes/outcome_work_y.erb
@@ -7,6 +7,14 @@
 
   <%= render partial: 'stateless_or_refugee', locals: {calculator: calculator} %>
 
+  <% if calculator.passport_country_in_british_national_overseas_list? %>
+    ###British National Overseas (BNO) visa
+
+    You can apply for a [British National Overseas (BNO) visa](/guidance/hong-kong-british-national-overseas-visa-applications/) to live, work and study in the UK.
+
+    You do not need a job offer, unlike most work visas. You can do any type of work (except work as a professional sportsperson or sports coach).
+  <% end %>
+
   ###Skilled workers
 
   A ‘skilled worker’ visa may be suitable if you’ve been offered a:

--- a/test/unit/calculators/uk_visa_calculator_test.rb
+++ b/test/unit/calculators/uk_visa_calculator_test.rb
@@ -255,6 +255,20 @@ module SmartAnswer
         end
       end
 
+      context "#passport_country_in_british_national_overseas_list?" do
+        should "return true if passport_country is in list of countries that are British nationals overseas" do
+          calculator = UkVisaCalculator.new
+          calculator.passport_country = "british-national-overseas"
+          assert calculator.passport_country_in_british_national_overseas_list?
+        end
+
+        should "return false if passport_country is not in list of countries that are British nationals overseas" do
+          calculator = UkVisaCalculator.new
+          calculator.passport_country = "usa"
+          assert_not calculator.passport_country_in_british_national_overseas_list?
+        end
+      end
+
       context "#passport_country_in_b1_b2_visa_exception_list?" do
         should "return true if passport_country is in list of countries to which the b1/b2 visa exception applies" do
           calculator = UkVisaCalculator.new


### PR DESCRIPTION
This PR updates 4 Check UK Visa outcomes with some additional information for `British National Overseas` and `Hong Kong (British National Overseas)` passport holders.

[trello](https://trello.com/c/B6VwpuKM/2312-31-jan-check-if-you-need-a-uk-visa-hong-kong-british-nationals-overseas-visa)