### PR TITLE
Student Finance Calculator uprating, remove 2019 dates and amounts, add 2021 dates and amounts

### DIFF
--- a/lib/smart_answer/calculators/student_finance_calculator.rb
+++ b/lib/smart_answer/calculators/student_finance_calculator.rb
@@ -14,58 +14,58 @@ module SmartAnswer
                     :tuition_fee_amount
 
       LOAN_MAXIMUMS = {
-        "2019-2020" => {
-          "at-home" => 7_529,
-          "away-outside-london" => 8_944,
-          "away-in-london" => 11_672,
-        },
         "2020-2021" => {
           "at-home" => 7_747,
           "away-outside-london" => 9_203,
           "away-in-london" => 12_010,
         },
+        "2021-2022" => {
+          "at-home" => 7_987,
+          "away-outside-london" => 9_488,
+          "away-in-london" => 12_382,
+        },
       }.freeze
 
       REDUCED_MAINTENTANCE_LOAN_AMOUNTS = {
-        "2019-2020" => {
-          "at-home" => 1793,
-          "away-in-london" => 3354,
-          "away-outside-london" => 2389,
-        },
         "2020-2021" => {
           "at-home" => 1845,
           "away-in-london" => 3451,
           "away-outside-london" => 2458,
         },
+        "2021-2022" => {
+          "at-home" => 1902,
+          "away-in-london" => 3558,
+          "away-outside-london" => 2534,
+        },
       }.freeze
 
       CHILD_CARE_GRANTS = {
-        "2019-2020" => {
-          "one-child" => 169.31,
-          "more-than-one-child" => 290.27,
-        },
         "2020-2021" => {
           "one-child" => 174.22,
           "more-than-one-child" => 298.69,
         },
+        "2021-2022" => {
+          "one-child" => 179.62,
+          "more-than-one-child" => 307.95,
+        },
       }.freeze
 
-      CHILD_CARE_GRANTS_ONE_CHILD_HOUSEHOLD_INCOME = 18_786.43
-      CHILD_CARE_GRANTS_MORE_THAN_ONE_CHILD_HOUSEHOLD_INCOME = 26_649.87
+      CHILD_CARE_GRANTS_ONE_CHILD_HOUSEHOLD_INCOME = 19_067.23
+      CHILD_CARE_GRANTS_MORE_THAN_ONE_CHILD_HOUSEHOLD_INCOME = 27_131.79
 
       PARENTS_LEARNING_ALLOWANCE = {
-        "2019-2020" => 1_716,
         "2020-2021" => 1_766,
+        "2021-2022" => 1_821,
       }.freeze
 
-      PARENTS_LEARNING_HOUSEHOLD_INCOME = 18_441.98
+      PARENTS_LEARNING_HOUSEHOLD_INCOME = 18_551.98
 
       ADULT_DEPENDANT_ALLOWANCE = {
-        "2019-2020" => 3_007,
         "2020-2021" => 3_094,
+        "2021-2022" => 3_190,
       }.freeze
 
-      ADULT_DEPENDANT_HOUSEHOLD_INCOME = 14_933.98
+      ADULT_DEPENDANT_HOUSEHOLD_INCOME = 15_125.98
 
       TUITION_FEE_MAXIMUM = {
         "full-time" => 9_250,
@@ -73,28 +73,28 @@ module SmartAnswer
       }.freeze
 
       LOAN_MINIMUMS = {
-        "2019-2020" => {
-          "at-home" => 3_314,
-          "away-outside-london" => 4_168,
-          "away-in-london" => 5_812,
-        },
         "2020-2021" => {
           "at-home" => 3_410,
           "away-outside-london" => 4_289,
           "away-in-london" => 5_981,
         },
+        "2021-2022" => {
+          "at-home" => 3_516,
+          "away-outside-london" => 4_422,
+          "away-in-london" => 6_166,
+        },
       }.freeze
 
       INCOME_PENALTY_RATIO = {
-        "2019-2020" => {
-          "at-home" => 7.88,
-          "away-outside-london" => 7.79,
-          "away-in-london" => 7.66,
-        },
         "2020-2021" => {
           "at-home" => 7.66,
           "away-outside-london" => 7.58,
           "away-in-london" => 7.46,
+        },
+        "2021-2022" => {
+          "at-home" => 7.43,
+          "away-outside-london" => 7.36,
+          "away-in-london" => 7.24,
         },
       }.freeze
 

--- a/lib/smart_answer_flows/student-finance-calculator.rb
+++ b/lib/smart_answer_flows/student-finance-calculator.rb
@@ -9,8 +9,8 @@ module SmartAnswer
 
       # Q1
       radio :when_does_your_course_start? do
-        option :"2019-2020"
         option :"2020-2021"
+        option :"2021-2022"
 
         on_response do |response|
           self.calculator = Calculators::StudentFinanceCalculator.new

--- a/lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_eu_students.erb
+++ b/lib/smart_answer_flows/student-finance-calculator/outcomes/outcome_eu_students.erb
@@ -7,15 +7,11 @@
 
   The loan pays for the cost of your course and must be paid back.
 
-  <% if calculator.course_type == 'eu-full-time' %>
-    ##Living costs
+  ##Living costs
 
-    Most EU full-time students don't qualify for help with living costs (known as 'maintenance').
-  <% else %>
-    ##Living costs
+  You might be eligible for help with living costs (known as 'maintenance'), depending on your nationality, residency status and address history.
 
-    EU part-time students don't qualify for help with living costs (known as 'maintenance').
-  <% end %>
+  [Find out if you're eligible](/student-finance/eu-students).
 
   ##Extra help
 

--- a/lib/smart_answer_flows/student-finance-calculator/questions/when_does_your_course_start.erb
+++ b/lib/smart_answer_flows/student-finance-calculator/questions/when_does_your_course_start.erb
@@ -3,6 +3,6 @@
 <% end %>
 
 <% options(
-  "2019-2020": "Between September 2019 and August 2020",
   "2020-2021": "Between September 2020 and August 2021",
+  "2021-2022": "Between September 2021 and August 2022",
 ) %>

--- a/lib/smart_answer_flows/student-finance-calculator/student_finance_calculator.erb
+++ b/lib/smart_answer_flows/student-finance-calculator/student_finance_calculator.erb
@@ -9,8 +9,8 @@
 <% govspeak_for :body do %>
   This calculator is for students from England or the European Union (EU) starting a new undergraduate course in academic years:
 
-  + 2019 to 2020
   + 2020 to 2021
+  + 2021 to 2022
 
   Use the student finance calculator to estimate:
 

--- a/test/integration/smart_answer_flows/student_finance_calculator_test.rb
+++ b/test/integration/smart_answer_flows/student_finance_calculator_test.rb
@@ -22,7 +22,7 @@ class StudentFinanceCalculatorTest < ActiveSupport::TestCase
       assert_current_node :what_type_of_student_are_you?
     end
 
-    context "full-time uk student between 2018 and 2019" do
+    context "full-time uk student between 2020 and 2021" do
       setup do
         add_response "uk-full-time"
       end
@@ -99,7 +99,7 @@ class StudentFinanceCalculatorTest < ActiveSupport::TestCase
       end
     end
 
-    context "part-time uk student between 2018 and 2019" do
+    context "part-time uk student between 2020 and 2021" do
       should "ask how much your tuition fees are per year" do
         add_response "uk-part-time"
         assert_current_node :how_much_are_your_tuition_fees_per_year?
@@ -194,15 +194,15 @@ class StudentFinanceCalculatorTest < ActiveSupport::TestCase
     end
   end
 
-  context "course starting between 2019 and 2020" do
+  context "course starting between 2020 and 2021" do
     setup do
-      add_response "2019-2020"
+      add_response "2020-2021"
     end
     should "ask what sort of a student you are" do
       assert_current_node :what_type_of_student_are_you?
     end
 
-    context "full-time uk student between 2019 and 2020" do
+    context "full-time uk student between 2020 and 2021" do
       setup do
         add_response "uk-full-time"
       end
@@ -279,7 +279,7 @@ class StudentFinanceCalculatorTest < ActiveSupport::TestCase
       end
     end
 
-    context "part-time uk student between 2019 and 2020" do
+    context "part-time uk student between 2020 and 2021" do
       should "ask how much your tuition fees are per year" do
         add_response "uk-part-time"
         assert_current_node :how_much_are_your_tuition_fees_per_year?

--- a/test/unit/calculators/student_finance_calculator_test.rb
+++ b/test/unit/calculators/student_finance_calculator_test.rb
@@ -103,55 +103,6 @@ module SmartAnswer
         end
       end
 
-      context "childcare_grant" do
-        context "for one child" do
-          context "in 2020-2021" do
-            should "be £174.22" do
-              calculator = StudentFinanceCalculator.new(
-                course_start: "2020-2021",
-                household_income: 25_000,
-                residence: :unused_variable,
-              )
-              assert_equal 174.22, calculator.childcare_grant_one_child
-            end
-          end
-
-          context "in 2021-2022" do
-            should "be £179.62" do
-              calculator = StudentFinanceCalculator.new(
-                course_start: "2021-2022",
-                household_income: 25_000,
-                residence: :unused_variable,
-              )
-              assert_equal 179.62, calculator.childcare_grant_one_child
-            end
-          end
-        end
-        context "for more than one child" do
-          context "in 2020-2021" do
-            should "be £298.69" do
-              calculator = StudentFinanceCalculator.new(
-                course_start: "2020-2021",
-                household_income: 25_000,
-                residence: :unused_variable,
-              )
-              assert_equal 298.69, calculator.childcare_grant_more_than_one_child
-            end
-          end
-
-          context "in 2021-2022" do
-            should "be £307.95" do
-              calculator = StudentFinanceCalculator.new(
-                course_start: "2021-2022",
-                household_income: 25_000,
-                residence: :unused_variable,
-              )
-              assert_equal 307.95, calculator.childcare_grant_more_than_one_child
-            end
-          end
-        end
-      end
-
       context "#eligible_for_parent_learning_allowance?" do
         should "have low household income and no dependencies" do
           calculator = StudentFinanceCalculator.new(
@@ -184,26 +135,6 @@ module SmartAnswer
         end
       end
 
-      context "#parent_learning_allowance" do
-        should "be £1766 in 2020-2021" do
-          calculator = StudentFinanceCalculator.new(
-            course_start: "2020-2021",
-            household_income: 25_000,
-            residence: :unused_variable,
-          )
-          assert_equal 1766, calculator.parent_learning_allowance
-        end
-
-        should "be £1821 in 2021-2022" do
-          calculator = StudentFinanceCalculator.new(
-            course_start: "2021-2022",
-            household_income: 25_000,
-            residence: :unused_variable,
-          )
-          assert_equal 1821, calculator.parent_learning_allowance
-        end
-      end
-
       context "#eligible_for_adult_dependant_allowance?" do
         should "have low household income and no dependencies" do
           calculator = StudentFinanceCalculator.new(
@@ -233,26 +164,6 @@ module SmartAnswer
             uk_ft_circumstances: %w[dependant-adult],
           )
           assert_not calculator.eligible_for_adult_dependant_allowance?
-        end
-      end
-
-      context "#adult_dependant_allowance" do
-        should "be £3094 in 2020-2021" do
-          calculator = StudentFinanceCalculator.new(
-            course_start: "2020-2021",
-            household_income: 25_000,
-            residence: :unused_variable,
-          )
-          assert_equal 3094, calculator.adult_dependant_allowance
-        end
-
-        should "be £3190 in 2020-2021" do
-          calculator = StudentFinanceCalculator.new(
-            course_start: "2021-2022",
-            household_income: 25_000,
-            residence: :unused_variable,
-          )
-          assert_equal 3190, calculator.adult_dependant_allowance
         end
       end
 
@@ -298,489 +209,253 @@ module SmartAnswer
         end
       end
 
-      context "#maintenance_loan_amount" do
-        context "for students who started 2020-2021 living at home with parents" do
-          setup do
-            @course_start = "2020-2021"
-            @residence = "at-home"
-          end
+      context "in 2020-2021" do
+        current_year = "2020-2021"
 
-          should "give the maximum amount of £7747 if household income is £25k or below" do
-            calculator = StudentFinanceCalculator.new(
-              course_start: @course_start,
-              household_income: 25_000,
-              residence: @residence,
-              course_type: "uk-full-time",
-            )
-            assert_equal SmartAnswer::Money.new(7747).to_s, calculator.maintenance_loan_amount.to_s
-          end
-
-          should "reduce the maximum amount (£7747) by £1 for every complete £7.66 of income above £25k" do
-            # Samples taken from the document provided
-            {
-              30_000 => 7_095,
-              35_000 => 6_442,
-              40_000 => 5_789,
-              42_875 => 5_414,
-              45_000 => 5_137,
-              50_000 => 4_484,
-              55_000 => 3_831,
-              58_215 => 3_411,
-              60_000 => 3_410,
-              65_000 => 3_410,
-            }.each do |household_income, loan_amount|
+        context "childcare_grant" do
+          context "for one child" do
+            should "be £174.22" do
               calculator = StudentFinanceCalculator.new(
-                course_start: @course_start,
-                household_income: household_income,
-                residence: @residence,
-                course_type: "uk-full-time",
+                course_start: current_year,
+                household_income: 25_000,
+                residence: :unused_variable,
               )
-              assert_equal SmartAnswer::Money.new(loan_amount).to_s, calculator.maintenance_loan_amount.to_s
+              assert_equal 174.22, calculator.childcare_grant_one_child
             end
           end
 
-          should "cap the reductions and give the minimum loan of £3410 for high household income students" do
-            calculator = StudentFinanceCalculator.new(
-              course_start: @course_start,
-              household_income: 500_000,
-              residence: @residence,
-              course_type: "uk-full-time",
-            )
-            assert_equal SmartAnswer::Money.new(3_410).to_s, calculator.maintenance_loan_amount.to_s
+          context "for more than one child" do
+            should "be £298.69" do
+              calculator = StudentFinanceCalculator.new(
+                course_start: current_year,
+                household_income: 25_000,
+                residence: :unused_variable,
+              )
+              assert_equal 298.69, calculator.childcare_grant_more_than_one_child
+            end
           end
         end
 
-        context "for students who started 2020-2021 living away not in london" do
-          setup do
-            @course_start = "2020-2021"
-            @residence = "away-outside-london"
-          end
-
-          should "give the maximum amount of £9203 if household income is £25k or below" do
+        context "#parent_learning_allowance" do
+          should "be £1766" do
             calculator = StudentFinanceCalculator.new(
-              course_start: @course_start,
+              course_start: current_year,
               household_income: 25_000,
-              residence: @residence,
-              course_type: "uk-full-time",
+              residence: :unused_variable,
             )
-            assert_equal SmartAnswer::Money.new(9_203).to_s, calculator.maintenance_loan_amount.to_s
+            assert_equal 1766, calculator.parent_learning_allowance
           end
+        end
 
-          should "reduce the maximum amount (£9203) by £1 for every complete £7.58 of income above £25k" do
-            # Samples taken from the document provided
-            {
-              30_000 => 8_544,
-              35_000 => 7_884,
-              40_000 => 7_225,
-              42_875 => 6_845,
-              45_000 => 6_565,
-              50_000 => 5_905,
-              55_000 => 5_246,
-              60_000 => 4_586,
-              62_215 => 4_294,
-              65_000 => 4_289,
-              70_000 => 4_289,
-            }.each do |household_income, loan_amount|
+        context "#adult_dependant_allowance" do
+          should "be £3094" do
+            calculator = StudentFinanceCalculator.new(
+              course_start: current_year,
+              household_income: 25_000,
+              residence: :unused_variable,
+            )
+            assert_equal 3094, calculator.adult_dependant_allowance
+          end
+        end
+
+        context "#maintenance_loan_amount" do
+          context "for students who started 2020-2021 living at home with parents" do
+            setup do
+              @residence = "at-home"
+            end
+
+            should "give the maximum amount of £7747 if household income is £25k or below" do
               calculator = StudentFinanceCalculator.new(
-                course_start: @course_start,
-                household_income: household_income,
+                course_start: current_year,
+                household_income: 25_000,
                 residence: @residence,
                 course_type: "uk-full-time",
               )
-              assert_equal SmartAnswer::Money.new(loan_amount).to_s, calculator.maintenance_loan_amount.to_s
+              assert_equal SmartAnswer::Money.new(7747).to_s, calculator.maintenance_loan_amount.to_s
             end
-          end
 
-          should "cap the reductions and give the minimum loan of £4,289 for high household income students" do
-            calculator = StudentFinanceCalculator.new(
-              course_start: @course_start,
-              household_income: 500_000,
-              residence: @residence,
-              course_type: "uk-full-time",
-            )
-            assert_equal SmartAnswer::Money.new(4_289).to_s, calculator.maintenance_loan_amount.to_s
-          end
-        end
+            should "reduce the maximum amount (£7747) by £1 for every complete £7.66 of income above £25k" do
+              # Samples taken from the document provided
+              {
+                30_000 => 7_095,
+                35_000 => 6_442,
+                40_000 => 5_789,
+                42_875 => 5_414,
+                45_000 => 5_137,
+                50_000 => 4_484,
+                55_000 => 3_831,
+                58_215 => 3_411,
+                60_000 => 3_410,
+                65_000 => 3_410,
+              }.each do |household_income, loan_amount|
+                calculator = StudentFinanceCalculator.new(
+                  course_start: current_year,
+                  household_income: household_income,
+                  residence: @residence,
+                  course_type: "uk-full-time",
+                )
+                assert_equal SmartAnswer::Money.new(loan_amount).to_s, calculator.maintenance_loan_amount.to_s
+              end
+            end
 
-        context "for students who started 2020-2021 living away in london" do
-          setup do
-            @course_start = "2020-2021"
-            @residence = "away-in-london"
-          end
-
-          should "give the maximum amount of £12010 if household income is £25k or below" do
-            calculator = StudentFinanceCalculator.new(
-              course_start: @course_start,
-              household_income: 25_000,
-              residence: @residence,
-              course_type: "uk-full-time",
-            )
-            assert_equal SmartAnswer::Money.new(12_010).to_s, calculator.maintenance_loan_amount.to_s
-          end
-
-          should "reduce the maximum amount (£12010) by £1 for every complete £7.46 of income above £25k" do
-            # Samples taken from the document provided
-            {
-              30_000 => 11_340,
-              35_000 => 10_670,
-              40_000 => 10_000,
-              42_875 => 9_614,
-              45_000 => 9_330,
-              50_000 => 8_659,
-              55_000 => 7_989,
-              60_000 => 7_319,
-              65_000 => 6_649,
-              69_860 => 5_997,
-              70_000 => 5_981,
-            }.each do |household_income, loan_amount|
+            should "cap the reductions and give the minimum loan of £3410 for high household income students" do
               calculator = StudentFinanceCalculator.new(
-                course_start: @course_start,
-                household_income: household_income,
+                course_start: current_year,
+                household_income: 500_000,
                 residence: @residence,
                 course_type: "uk-full-time",
               )
-              assert_equal SmartAnswer::Money.new(loan_amount).to_s, calculator.maintenance_loan_amount.to_s
+              assert_equal SmartAnswer::Money.new(3_410).to_s, calculator.maintenance_loan_amount.to_s
             end
           end
 
-          should "cap the reductions and give the minimum loan of £5,981 for high household income students" do
-            calculator = StudentFinanceCalculator.new(
-              course_start: @course_start,
-              household_income: 500_000,
-              residence: @residence,
-              course_type: "uk-full-time",
-            )
-            assert_equal SmartAnswer::Money.new(5_981).to_s, calculator.maintenance_loan_amount.to_s
-          end
-        end
+          context "for students who started 2020-2021 living away not in london" do
+            setup do
+              @residence = "away-outside-london"
+            end
 
-        context "for 2020-2021 part-time students" do
-          setup do
-            @course_start = "2020-2021"
-            @course_type = "uk-part-time"
-          end
-
-          should "be weighted by course intensity" do
-            calculator = StudentFinanceCalculator.new(
-              course_start: @course_start,
-              household_income: 45_000,
-              residence: "away-in-london",
-              course_type: @course_type,
-              part_time_credits: 12,
-              full_time_credits: 20,
-            )
-            assert_equal SmartAnswer::Money.new(4_665.0).to_s, calculator.maintenance_loan_amount.to_s
-          end
-
-          should "be zero if course intensity is less than 25%" do
-            calculator = StudentFinanceCalculator.new(
-              course_start: @course_start,
-              household_income: 45_000,
-              residence: "away-in-london",
-              course_type: @course_type,
-              part_time_credits: 2,
-              full_time_credits: 10,
-            )
-            assert_equal SmartAnswer::Money.new(0).to_s, calculator.maintenance_loan_amount.to_s
-          end
-
-          should "be the same as a full-time course if intensity is 100%" do
-            calculator = StudentFinanceCalculator.new(
-              course_start: @course_start,
-              household_income: 60_000,
-              residence: "away-outside-london",
-              course_type: @course_type,
-              part_time_credits: 15,
-              full_time_credits: 15,
-            )
-            assert_equal SmartAnswer::Money.new(4586).to_s, calculator.maintenance_loan_amount.to_s
-          end
-        end
-      end
-
-      context "#reduced_maintenance_loan_for_healthcare" do
-        context "for 2020-2021" do
-          setup do
-            @course_start = "2020-2021"
-            @household_income = 25_000
-            @course_type = "uk-full-time"
-            @doctor_or_dentist = true
-          end
-
-          should "be £3451 for students living away from home in London" do
-            calculator = StudentFinanceCalculator.new(
-              course_start: @course_start,
-              household_income: @household_income,
-              course_type: @course_type,
-              residence: "away-in-london",
-              doctor_or_dentist: @doctor_or_dentist,
-            )
-
-            assert_equal 3451, calculator.reduced_maintenance_loan_for_healthcare
-          end
-
-          should "be £2458 for students living away from home outside London" do
-            calculator = StudentFinanceCalculator.new(
-              course_start: @course_start,
-              household_income: @household_income,
-              course_type: @course_type,
-              residence: "away-outside-london",
-              doctor_or_dentist: @doctor_or_dentist,
-            )
-
-            assert_equal 2458, calculator.reduced_maintenance_loan_for_healthcare
-          end
-
-          should "be £1845 for students living away from home outside London" do
-            calculator = StudentFinanceCalculator.new(
-              course_start: @course_start,
-              household_income: @household_income,
-              course_type: @course_type,
-              residence: "at-home",
-              doctor_or_dentist: @doctor_or_dentist,
-            )
-
-            assert_equal 1845, calculator.reduced_maintenance_loan_for_healthcare
-          end
-        end
-
-        context "for 2020-2021" do
-          setup do
-            @course_start = "2020-2021"
-            @household_income = 25_000
-            @course_type = "uk-full-time"
-            @doctor_or_dentist = true
-          end
-
-          should "be £3451 for students living away from home in London" do
-            calculator = StudentFinanceCalculator.new(
-              course_start: @course_start,
-              household_income: @household_income,
-              course_type: @course_type,
-              residence: "away-in-london",
-              doctor_or_dentist: @doctor_or_dentist,
-            )
-
-            assert_equal 3451, calculator.reduced_maintenance_loan_for_healthcare
-          end
-
-          should "be £2458 for students living away from home outside London" do
-            calculator = StudentFinanceCalculator.new(
-              course_start: @course_start,
-              household_income: @household_income,
-              course_type: @course_type,
-              residence: "away-outside-london",
-              doctor_or_dentist: @doctor_or_dentist,
-            )
-
-            assert_equal 2458, calculator.reduced_maintenance_loan_for_healthcare
-          end
-
-          should "be £1845 for students living away from home outside London" do
-            calculator = StudentFinanceCalculator.new(
-              course_start: @course_start,
-              household_income: @household_income,
-              course_type: @course_type,
-              residence: "at-home",
-              doctor_or_dentist: @doctor_or_dentist,
-            )
-
-            assert_equal 1845, calculator.reduced_maintenance_loan_for_healthcare
-          end
-        end
-      end
-
-      context "#maintenance_loan_amount" do
-        context "for students who started 2021-2022 living at home with parents" do
-          setup do
-            @course_start = "2021-2022"
-            @residence = "at-home"
-          end
-
-          should "give the maximum amount of 7987 if household income is £25k or below" do
-            calculator = StudentFinanceCalculator.new(
-              course_start: @course_start,
-              household_income: 25_000,
-              residence: @residence,
-              course_type: "uk-full-time",
-            )
-            assert_equal SmartAnswer::Money.new(7987).to_s, calculator.maintenance_loan_amount.to_s
-          end
-
-          should "reduce the maximum amount (£7987) by £1 for every complete £7.43 of income above £25k" do
-            {
-              30_000 => 7315,
-              35_000 => 6642,
-              40_000 => 5969,
-              42_875 => 5582,
-              45_000 => 5296,
-              50_000 => 4623,
-              55_000 => 3950,
-              58_215 => 3517,
-              60_000 => 3516,
-              65_000 => 3516,
-            }.each do |household_income, loan_amount|
+            should "give the maximum amount of £9203 if household income is £25k or below" do
               calculator = StudentFinanceCalculator.new(
-                course_start: @course_start,
-                household_income: household_income,
+                course_start: current_year,
+                household_income: 25_000,
                 residence: @residence,
                 course_type: "uk-full-time",
               )
-              assert_equal SmartAnswer::Money.new(loan_amount).to_s, calculator.maintenance_loan_amount.to_s
+              assert_equal SmartAnswer::Money.new(9_203).to_s, calculator.maintenance_loan_amount.to_s
             end
-          end
 
-          should "cap the reductions and give the minimum loan of £3516 for high household income students" do
-            calculator = StudentFinanceCalculator.new(
-              course_start: @course_start,
-              household_income: 500_000,
-              residence: @residence,
-              course_type: "uk-full-time",
-            )
-            assert_equal SmartAnswer::Money.new(3516).to_s, calculator.maintenance_loan_amount.to_s
-          end
-        end
+            should "reduce the maximum amount (£9203) by £1 for every complete £7.58 of income above £25k" do
+              # Samples taken from the document provided
+              {
+                30_000 => 8_544,
+                35_000 => 7_884,
+                40_000 => 7_225,
+                42_875 => 6_845,
+                45_000 => 6_565,
+                50_000 => 5_905,
+                55_000 => 5_246,
+                60_000 => 4_586,
+                62_215 => 4_294,
+                65_000 => 4_289,
+                70_000 => 4_289,
+              }.each do |household_income, loan_amount|
+                calculator = StudentFinanceCalculator.new(
+                  course_start: current_year,
+                  household_income: household_income,
+                  residence: @residence,
+                  course_type: "uk-full-time",
+                )
+                assert_equal SmartAnswer::Money.new(loan_amount).to_s, calculator.maintenance_loan_amount.to_s
+              end
+            end
 
-        context "for students who started 2021-2022 living away not in london" do
-          setup do
-            @course_start = "2021-2022"
-            @residence = "away-outside-london"
-          end
-
-          should "give the maximum amount of 9488 if household income is £25k or below" do
-            calculator = StudentFinanceCalculator.new(
-              course_start: @course_start,
-              household_income: 25_000,
-              residence: @residence,
-              course_type: "uk-full-time",
-            )
-            assert_equal SmartAnswer::Money.new(9_488).to_s, calculator.maintenance_loan_amount.to_s
-          end
-
-          should "reduce the maximum amount (£9488) by £1 for every complete £7.36 of income above £25k" do
-            # Samples taken from the document provided
-            {
-              30_000 => 8809,
-              35_000 => 8130,
-              40_000 => 7450,
-              42_875 => 7060,
-              45_000 => 6771,
-              50_000 => 6092,
-              55_000 => 5412,
-              60_000 => 4733,
-              62_215 => 4432,
-              65_000 => 4422,
-              70_000 => 4422,
-            }.each do |household_income, loan_amount|
+            should "cap the reductions and give the minimum loan of £4,289 for high household income students" do
               calculator = StudentFinanceCalculator.new(
-                course_start: @course_start,
-                household_income: household_income,
+                course_start: current_year,
+                household_income: 500_000,
                 residence: @residence,
                 course_type: "uk-full-time",
               )
-              assert_equal SmartAnswer::Money.new(loan_amount).to_s, calculator.maintenance_loan_amount.to_s
+              assert_equal SmartAnswer::Money.new(4_289).to_s, calculator.maintenance_loan_amount.to_s
             end
           end
 
-          should "cap the reductions and give the minimum loan of £4,422 for high household income students" do
-            calculator = StudentFinanceCalculator.new(
-              course_start: @course_start,
-              household_income: 500_000,
-              residence: @residence,
-              course_type: "uk-full-time",
-            )
-            assert_equal SmartAnswer::Money.new(4422).to_s, calculator.maintenance_loan_amount.to_s
-          end
-        end
+          context "for students who started 2020-2021 living away in london" do
+            setup do
+              @residence = "away-in-london"
+            end
 
-        context "for students who started 2021-2022 living away in london" do
-          setup do
-            @course_start = "2021-2022"
-            @residence = "away-in-london"
-          end
-
-          should "give the maximum amount of £12382 if household income is £25k or below" do
-            calculator = StudentFinanceCalculator.new(
-              course_start: @course_start,
-              household_income: 25_000,
-              residence: @residence,
-              course_type: "uk-full-time",
-            )
-            assert_equal SmartAnswer::Money.new(12_382).to_s, calculator.maintenance_loan_amount.to_s
-          end
-
-          should "reduce the maximum amount (£12382) by £1 for every complete £7.24 of income above £25k" do
-            # Samples taken from the document provided
-            {
-              30_000 => 11_692,
-              35_000 => 11_001,
-              40_000 => 10_311,
-              42_875 => 9914,
-              45_000 => 9620,
-              50_000 => 8929,
-              55_000 => 8239,
-              60_000 => 7548,
-              65_000 => 6858,
-              69_860 => 6186,
-              70_000 => 6167,
-              75_000 => 6166,
-            }.each do |household_income, loan_amount|
+            should "give the maximum amount of £12010 if household income is £25k or below" do
               calculator = StudentFinanceCalculator.new(
-                course_start: @course_start,
-                household_income: household_income,
+                course_start: current_year,
+                household_income: 25_000,
                 residence: @residence,
                 course_type: "uk-full-time",
               )
-              assert_equal SmartAnswer::Money.new(loan_amount).to_s, calculator.maintenance_loan_amount.to_s
+              assert_equal SmartAnswer::Money.new(12_010).to_s, calculator.maintenance_loan_amount.to_s
+            end
+
+            should "reduce the maximum amount (£12010) by £1 for every complete £7.46 of income above £25k" do
+              # Samples taken from the document provided
+              {
+                30_000 => 11_340,
+                35_000 => 10_670,
+                40_000 => 10_000,
+                42_875 => 9_614,
+                45_000 => 9_330,
+                50_000 => 8_659,
+                55_000 => 7_989,
+                60_000 => 7_319,
+                65_000 => 6_649,
+                69_860 => 5_997,
+                70_000 => 5_981,
+              }.each do |household_income, loan_amount|
+                calculator = StudentFinanceCalculator.new(
+                  course_start: current_year,
+                  household_income: household_income,
+                  residence: @residence,
+                  course_type: "uk-full-time",
+                )
+                assert_equal SmartAnswer::Money.new(loan_amount).to_s, calculator.maintenance_loan_amount.to_s
+              end
+            end
+
+            should "cap the reductions and give the minimum loan of £5,981 for high household income students" do
+              calculator = StudentFinanceCalculator.new(
+                course_start: current_year,
+                household_income: 500_000,
+                residence: @residence,
+                course_type: "uk-full-time",
+              )
+              assert_equal SmartAnswer::Money.new(5_981).to_s, calculator.maintenance_loan_amount.to_s
             end
           end
 
-          should "cap the reductions and give the minimum loan of £6166 for high household income students" do
-            calculator = StudentFinanceCalculator.new(
-              course_start: @course_start,
-              household_income: 500_000,
-              residence: @residence,
-              course_type: "uk-full-time",
-            )
-            assert_equal SmartAnswer::Money.new(6166).to_s, calculator.maintenance_loan_amount.to_s
-          end
-        end
+          context "for 2020-2021 part-time students" do
+            setup do
+              @course_type = "uk-part-time"
+            end
 
-        context "for 2021-2022 part-time students" do
-          setup do
-            @course_start = "2021-2022"
-            @course_type = "uk-part-time"
-          end
-
-          should "be weighted by course intensity" do
-            full_time_credits = 20
-            {
-              2 => 0.00,
-              6 => 2405.00,
-              7 => 3203.46,
-              10 => 4810.00,
-              14 => 6406.92,
-              15 => 7215.00,
-              20 => 9620.00,
-            }.each do |part_time_credits, loan_amount|
+            should "be weighted by course intensity" do
               calculator = StudentFinanceCalculator.new(
-                course_start: @course_start,
+                course_start: current_year,
                 household_income: 45_000,
                 residence: "away-in-london",
                 course_type: @course_type,
-                part_time_credits: part_time_credits,
-                full_time_credits: full_time_credits,
+                part_time_credits: 12,
+                full_time_credits: 20,
               )
-              assert_equal SmartAnswer::Money.new(loan_amount).to_s, calculator.maintenance_loan_amount.to_s
+              assert_equal SmartAnswer::Money.new(4_665.0).to_s, calculator.maintenance_loan_amount.to_s
+            end
+
+            should "be zero if course intensity is less than 25%" do
+              calculator = StudentFinanceCalculator.new(
+                course_start: current_year,
+                household_income: 45_000,
+                residence: "away-in-london",
+                course_type: @course_type,
+                part_time_credits: 2,
+                full_time_credits: 10,
+              )
+              assert_equal SmartAnswer::Money.new(0).to_s, calculator.maintenance_loan_amount.to_s
+            end
+
+            should "be the same as a full-time course if intensity is 100%" do
+              calculator = StudentFinanceCalculator.new(
+                course_start: current_year,
+                household_income: 60_000,
+                residence: "away-outside-london",
+                course_type: @course_type,
+                part_time_credits: 15,
+                full_time_credits: 15,
+              )
+              assert_equal SmartAnswer::Money.new(4586).to_s, calculator.maintenance_loan_amount.to_s
             end
           end
         end
-      end
 
-      context "#reduced_maintenance_loan_for_healthcare" do
-        context "for 2020-2021" do
+        context "#reduced_maintenance_loan_for_healthcare" do
           setup do
-            @course_start = "2020-2021"
             @household_income = 25_000
             @course_type = "uk-full-time"
             @doctor_or_dentist = true
@@ -788,7 +463,7 @@ module SmartAnswer
 
           should "be £3451 for students living away from home in London" do
             calculator = StudentFinanceCalculator.new(
-              course_start: @course_start,
+              course_start: current_year,
               household_income: @household_income,
               course_type: @course_type,
               residence: "away-in-london",
@@ -800,7 +475,7 @@ module SmartAnswer
 
           should "be £2458 for students living away from home outside London" do
             calculator = StudentFinanceCalculator.new(
-              course_start: @course_start,
+              course_start: current_year,
               household_income: @household_income,
               course_type: @course_type,
               residence: "away-outside-london",
@@ -812,7 +487,7 @@ module SmartAnswer
 
           should "be £1845 for students living away from home outside London" do
             calculator = StudentFinanceCalculator.new(
-              course_start: @course_start,
+              course_start: current_year,
               household_income: @household_income,
               course_type: @course_type,
               residence: "at-home",
@@ -823,9 +498,285 @@ module SmartAnswer
           end
         end
 
-        context "for 2021-2022" do
+        context "#reduced_maintenance_loan_for_healthcare" do
           setup do
-            @course_start = "2021-2022"
+            @household_income = 25_000
+            @course_type = "uk-full-time"
+            @doctor_or_dentist = true
+          end
+
+          should "be £3451 for students living away from home in London" do
+            calculator = StudentFinanceCalculator.new(
+              course_start: current_year,
+              household_income: @household_income,
+              course_type: @course_type,
+              residence: "away-in-london",
+              doctor_or_dentist: @doctor_or_dentist,
+            )
+
+            assert_equal 3451, calculator.reduced_maintenance_loan_for_healthcare
+          end
+
+          should "be £2458 for students living away from home outside London" do
+            calculator = StudentFinanceCalculator.new(
+              course_start: current_year,
+              household_income: @household_income,
+              course_type: @course_type,
+              residence: "away-outside-london",
+              doctor_or_dentist: @doctor_or_dentist,
+            )
+
+            assert_equal 2458, calculator.reduced_maintenance_loan_for_healthcare
+          end
+
+          should "be £1845 for students living away from home outside London" do
+            calculator = StudentFinanceCalculator.new(
+              course_start: current_year,
+              household_income: @household_income,
+              course_type: @course_type,
+              residence: "at-home",
+              doctor_or_dentist: @doctor_or_dentist,
+            )
+
+            assert_equal 1845, calculator.reduced_maintenance_loan_for_healthcare
+          end
+        end
+      end
+
+      context "in 2021-2022" do
+        current_year = "2021-2022"
+
+        context "childcare_grant" do
+          context "for one child" do
+            should "be £179.62" do
+              calculator = StudentFinanceCalculator.new(
+                course_start: current_year,
+                household_income: 25_000,
+                residence: :unused_variable,
+              )
+              assert_equal 179.62, calculator.childcare_grant_one_child
+            end
+          end
+
+          context "for more than one child" do
+            should "be £307.95" do
+              calculator = StudentFinanceCalculator.new(
+                course_start: current_year,
+                household_income: 25_000,
+                residence: :unused_variable,
+              )
+              assert_equal 307.95, calculator.childcare_grant_more_than_one_child
+            end
+          end
+        end
+
+        context "#parent_learning_allowance" do
+          should "be £1821" do
+            calculator = StudentFinanceCalculator.new(
+              course_start: current_year,
+              household_income: 25_000,
+              residence: :unused_variable,
+            )
+            assert_equal 1821, calculator.parent_learning_allowance
+          end
+        end
+
+        context "#adult_dependant_allowance" do
+          should "be £3190" do
+            calculator = StudentFinanceCalculator.new(
+              course_start: current_year,
+              household_income: 25_000,
+              residence: :unused_variable,
+            )
+            assert_equal 3190, calculator.adult_dependant_allowance
+          end
+        end
+
+        context "#maintenance_loan_amount" do
+          context "for students who started 2021-2022 living at home with parents" do
+            setup do
+              @residence = "at-home"
+            end
+
+            should "give the maximum amount of 7987 if household income is £25k or below" do
+              calculator = StudentFinanceCalculator.new(
+                course_start: current_year,
+                household_income: 25_000,
+                residence: @residence,
+                course_type: "uk-full-time",
+              )
+              assert_equal SmartAnswer::Money.new(7987).to_s, calculator.maintenance_loan_amount.to_s
+            end
+
+            should "reduce the maximum amount (£7987) by £1 for every complete £7.43 of income above £25k" do
+              {
+                30_000 => 7315,
+                35_000 => 6642,
+                40_000 => 5969,
+                42_875 => 5582,
+                45_000 => 5296,
+                50_000 => 4623,
+                55_000 => 3950,
+                58_215 => 3517,
+                60_000 => 3516,
+                65_000 => 3516,
+              }.each do |household_income, loan_amount|
+                calculator = StudentFinanceCalculator.new(
+                  course_start: current_year,
+                  household_income: household_income,
+                  residence: @residence,
+                  course_type: "uk-full-time",
+                )
+                assert_equal SmartAnswer::Money.new(loan_amount).to_s, calculator.maintenance_loan_amount.to_s
+              end
+            end
+
+            should "cap the reductions and give the minimum loan of £3516 for high household income students" do
+              calculator = StudentFinanceCalculator.new(
+                course_start: current_year,
+                household_income: 500_000,
+                residence: @residence,
+                course_type: "uk-full-time",
+              )
+              assert_equal SmartAnswer::Money.new(3516).to_s, calculator.maintenance_loan_amount.to_s
+            end
+          end
+
+          context "for students who started 2021-2022 living away not in london" do
+            setup do
+              @residence = "away-outside-london"
+            end
+
+            should "give the maximum amount of 9488 if household income is £25k or below" do
+              calculator = StudentFinanceCalculator.new(
+                course_start: current_year,
+                household_income: 25_000,
+                residence: @residence,
+                course_type: "uk-full-time",
+              )
+              assert_equal SmartAnswer::Money.new(9_488).to_s, calculator.maintenance_loan_amount.to_s
+            end
+
+            should "reduce the maximum amount (£9488) by £1 for every complete £7.36 of income above £25k" do
+              # Samples taken from the document provided
+              {
+                30_000 => 8809,
+                35_000 => 8130,
+                40_000 => 7450,
+                42_875 => 7060,
+                45_000 => 6771,
+                50_000 => 6092,
+                55_000 => 5412,
+                60_000 => 4733,
+                62_215 => 4432,
+                65_000 => 4422,
+                70_000 => 4422,
+              }.each do |household_income, loan_amount|
+                calculator = StudentFinanceCalculator.new(
+                  course_start: current_year,
+                  household_income: household_income,
+                  residence: @residence,
+                  course_type: "uk-full-time",
+                )
+                assert_equal SmartAnswer::Money.new(loan_amount).to_s, calculator.maintenance_loan_amount.to_s
+              end
+            end
+
+            should "cap the reductions and give the minimum loan of £4,422 for high household income students" do
+              calculator = StudentFinanceCalculator.new(
+                course_start: current_year,
+                household_income: 500_000,
+                residence: @residence,
+                course_type: "uk-full-time",
+              )
+              assert_equal SmartAnswer::Money.new(4422).to_s, calculator.maintenance_loan_amount.to_s
+            end
+          end
+
+          context "for students who started 2021-2022 living away in london" do
+            setup do
+              @residence = "away-in-london"
+            end
+
+            should "give the maximum amount of £12382 if household income is £25k or below" do
+              calculator = StudentFinanceCalculator.new(
+                course_start: current_year,
+                household_income: 25_000,
+                residence: @residence,
+                course_type: "uk-full-time",
+              )
+              assert_equal SmartAnswer::Money.new(12_382).to_s, calculator.maintenance_loan_amount.to_s
+            end
+
+            should "reduce the maximum amount (£12382) by £1 for every complete £7.24 of income above £25k" do
+              # Samples taken from the document provided
+              {
+                30_000 => 11_692,
+                35_000 => 11_001,
+                40_000 => 10_311,
+                42_875 => 9914,
+                45_000 => 9620,
+                50_000 => 8929,
+                55_000 => 8239,
+                60_000 => 7548,
+                65_000 => 6858,
+                69_860 => 6186,
+                70_000 => 6167,
+                75_000 => 6166,
+              }.each do |household_income, loan_amount|
+                calculator = StudentFinanceCalculator.new(
+                  course_start: current_year,
+                  household_income: household_income,
+                  residence: @residence,
+                  course_type: "uk-full-time",
+                )
+                assert_equal SmartAnswer::Money.new(loan_amount).to_s, calculator.maintenance_loan_amount.to_s
+              end
+            end
+
+            should "cap the reductions and give the minimum loan of £6166 for high household income students" do
+              calculator = StudentFinanceCalculator.new(
+                course_start: current_year,
+                household_income: 500_000,
+                residence: @residence,
+                course_type: "uk-full-time",
+              )
+              assert_equal SmartAnswer::Money.new(6166).to_s, calculator.maintenance_loan_amount.to_s
+            end
+          end
+
+          context "for 2021-2022 part-time students" do
+            setup do
+              @course_type = "uk-part-time"
+            end
+
+            should "be weighted by course intensity" do
+              full_time_credits = 20
+              {
+                2 => 0.00,
+                6 => 2405.00,
+                7 => 3203.46,
+                10 => 4810.00,
+                14 => 6406.92,
+                15 => 7215.00,
+                20 => 9620.00,
+              }.each do |part_time_credits, loan_amount|
+                calculator = StudentFinanceCalculator.new(
+                  course_start: current_year,
+                  household_income: 45_000,
+                  residence: "away-in-london",
+                  course_type: @course_type,
+                  part_time_credits: part_time_credits,
+                  full_time_credits: full_time_credits,
+                )
+                assert_equal SmartAnswer::Money.new(loan_amount).to_s, calculator.maintenance_loan_amount.to_s
+              end
+            end
+          end
+        end
+
+        context "#reduced_maintenance_loan_for_healthcare" do
+          setup do
             @household_income = 25_000
             @course_type = "uk-full-time"
             @doctor_or_dentist = true
@@ -833,7 +784,7 @@ module SmartAnswer
 
           should "be £3558 for students living away from home in London" do
             calculator = StudentFinanceCalculator.new(
-              course_start: @course_start,
+              course_start: current_year,
               household_income: @household_income,
               course_type: @course_type,
               residence: "away-in-london",
@@ -845,7 +796,7 @@ module SmartAnswer
 
           should "be £2534 for students living away from home outside London" do
             calculator = StudentFinanceCalculator.new(
-              course_start: @course_start,
+              course_start: current_year,
               household_income: @household_income,
               course_type: @course_type,
               residence: "away-outside-london",
@@ -857,7 +808,7 @@ module SmartAnswer
 
           should "be £1902 for students living away from home outside London" do
             calculator = StudentFinanceCalculator.new(
-              course_start: @course_start,
+              course_start: current_year,
               household_income: @household_income,
               course_type: @course_type,
               residence: "at-home",

--- a/test/unit/calculators/student_finance_calculator_test.rb
+++ b/test/unit/calculators/student_finance_calculator_test.rb
@@ -5,14 +5,14 @@ module SmartAnswer
     class StudentFinanceCalculatorTest < ActiveSupport::TestCase
       test "StudentFinanceCalculator is valid and setup properly" do
         calculator = StudentFinanceCalculator.new(
-          course_start: "2020-2021",
+          course_start: "2021-2022",
           household_income: 25_000,
           residence: "at-home",
           course_type: "uk-full-time",
         )
         assert_instance_of StudentFinanceCalculator, calculator
 
-        assert_equal "2020-2021", calculator.course_start
+        assert_equal "2021-2022", calculator.course_start
         assert_equal 25_000, calculator.household_income
         assert_equal "at-home", calculator.residence
         assert_equal "uk-full-time", calculator.course_type
@@ -28,12 +28,12 @@ module SmartAnswer
         assert_nil calculator.residence
         assert_nil calculator.course_type
 
-        calculator.course_start = "2020-2021"
+        calculator.course_start = "2021-2022"
         calculator.household_income = 25_000
         calculator.residence = "at-home"
         calculator.course_type = "uk-full-time"
 
-        assert_equal "2020-2021", calculator.course_start
+        assert_equal "2021-2022", calculator.course_start
         assert_equal 25_000, calculator.household_income
         assert_equal "at-home", calculator.residence
         assert_equal "uk-full-time", calculator.course_type
@@ -64,7 +64,7 @@ module SmartAnswer
 
         should "have high household income and children" do
           calculator = StudentFinanceCalculator.new(
-            household_income: 18_787,
+            household_income: 19_068,
             uk_ft_circumstances: %w[children-under-17],
           )
           assert_not calculator.eligible_for_childcare_grant_one_child?
@@ -96,7 +96,7 @@ module SmartAnswer
 
         should "have high household income and children" do
           calculator = StudentFinanceCalculator.new(
-            household_income: 26_650,
+            household_income: 27_132,
             uk_ft_circumstances: %w[children-under-17],
           )
           assert_not calculator.eligible_for_childcare_grant_more_than_one_child?
@@ -106,7 +106,7 @@ module SmartAnswer
       context "childcare_grant" do
         context "for one child" do
           context "in 2020-2021" do
-            should "be 174.22" do
+            should "be £174.22" do
               calculator = StudentFinanceCalculator.new(
                 course_start: "2020-2021",
                 household_income: 25_000,
@@ -115,16 +115,38 @@ module SmartAnswer
               assert_equal 174.22, calculator.childcare_grant_one_child
             end
           end
+
+          context "in 2021-2022" do
+            should "be £179.62" do
+              calculator = StudentFinanceCalculator.new(
+                course_start: "2021-2022",
+                household_income: 25_000,
+                residence: :unused_variable,
+              )
+              assert_equal 179.62, calculator.childcare_grant_one_child
+            end
+          end
         end
         context "for more than one child" do
           context "in 2020-2021" do
-            should "be 298.69" do
+            should "be £298.69" do
               calculator = StudentFinanceCalculator.new(
                 course_start: "2020-2021",
                 household_income: 25_000,
                 residence: :unused_variable,
               )
               assert_equal 298.69, calculator.childcare_grant_more_than_one_child
+            end
+          end
+
+          context "in 2021-2022" do
+            should "be £307.95" do
+              calculator = StudentFinanceCalculator.new(
+                course_start: "2021-2022",
+                household_income: 25_000,
+                residence: :unused_variable,
+              )
+              assert_equal 307.95, calculator.childcare_grant_more_than_one_child
             end
           end
         end
@@ -155,7 +177,7 @@ module SmartAnswer
 
         should "have high household income and adult dependant" do
           calculator = StudentFinanceCalculator.new(
-            household_income: 18_442,
+            household_income: 18_552,
             uk_ft_circumstances: %w[children-under-17],
           )
           assert_not calculator.eligible_for_parent_learning_allowance?
@@ -163,13 +185,22 @@ module SmartAnswer
       end
 
       context "#parent_learning_allowance" do
-        should "be 1766 in 2018-2019" do
+        should "be £1766 in 2020-2021" do
           calculator = StudentFinanceCalculator.new(
             course_start: "2020-2021",
             household_income: 25_000,
             residence: :unused_variable,
           )
           assert_equal 1766, calculator.parent_learning_allowance
+        end
+
+        should "be £1821 in 2021-2022" do
+          calculator = StudentFinanceCalculator.new(
+            course_start: "2021-2022",
+            household_income: 25_000,
+            residence: :unused_variable,
+          )
+          assert_equal 1821, calculator.parent_learning_allowance
         end
       end
 
@@ -198,7 +229,7 @@ module SmartAnswer
 
         should "have high household income and adult dependant" do
           calculator = StudentFinanceCalculator.new(
-            household_income: 14_934,
+            household_income: 15_126,
             uk_ft_circumstances: %w[dependant-adult],
           )
           assert_not calculator.eligible_for_adult_dependant_allowance?
@@ -206,13 +237,22 @@ module SmartAnswer
       end
 
       context "#adult_dependant_allowance" do
-        should "be 3094 in 2020-2021" do
+        should "be £3094 in 2020-2021" do
           calculator = StudentFinanceCalculator.new(
             course_start: "2020-2021",
             household_income: 25_000,
             residence: :unused_variable,
           )
           assert_equal 3094, calculator.adult_dependant_allowance
+        end
+
+        should "be £3190 in 2020-2021" do
+          calculator = StudentFinanceCalculator.new(
+            course_start: "2021-2022",
+            household_income: 25_000,
+            residence: :unused_variable,
+          )
+          assert_equal 3190, calculator.adult_dependant_allowance
         end
       end
 
@@ -226,11 +266,11 @@ module SmartAnswer
           )
         end
 
-        should "be 9250 for uk or eu full-time student" do
+        should "be £9250 for uk or eu full-time student" do
           assert_equal 9250, @calculator.tuition_fee_maximum
         end
 
-        should "be 6935 for uk or eu part-time student" do
+        should "be £6935 for uk or eu part-time student" do
           @calculator.course_type = "uk-part-time"
           assert_equal 6935, @calculator.tuition_fee_maximum
         end
@@ -238,7 +278,7 @@ module SmartAnswer
 
       context "maximum tuition fee" do
         context "for a full time student" do
-          should "be 9250" do
+          should "be £9250" do
             calculator = StudentFinanceCalculator.new(
               household_income: 25_000,
               residence: :unused_variable,
@@ -248,7 +288,7 @@ module SmartAnswer
           end
         end
         context "for part time student" do
-          should "be 6935" do
+          should "be £6935" do
             calculator = StudentFinanceCalculator.new(
               household_income: 25_000,
               residence: :unused_variable,
@@ -504,15 +544,15 @@ module SmartAnswer
           end
         end
 
-        context "for 2019-2020" do
+        context "for 2020-2021" do
           setup do
-            @course_start = "2019-2020"
+            @course_start = "2020-2021"
             @household_income = 25_000
             @course_type = "uk-full-time"
             @doctor_or_dentist = true
           end
 
-          should "be £3354 for students living away from home in London" do
+          should "be £3451 for students living away from home in London" do
             calculator = StudentFinanceCalculator.new(
               course_start: @course_start,
               household_income: @household_income,
@@ -521,10 +561,10 @@ module SmartAnswer
               doctor_or_dentist: @doctor_or_dentist,
             )
 
-            assert_equal 3354, calculator.reduced_maintenance_loan_for_healthcare
+            assert_equal 3451, calculator.reduced_maintenance_loan_for_healthcare
           end
 
-          should "be £2389 for students living away from home outside London" do
+          should "be £2458 for students living away from home outside London" do
             calculator = StudentFinanceCalculator.new(
               course_start: @course_start,
               household_income: @household_income,
@@ -533,10 +573,10 @@ module SmartAnswer
               doctor_or_dentist: @doctor_or_dentist,
             )
 
-            assert_equal 2389, calculator.reduced_maintenance_loan_for_healthcare
+            assert_equal 2458, calculator.reduced_maintenance_loan_for_healthcare
           end
 
-          should "be £1793 for students living away from home outside London" do
+          should "be £1845 for students living away from home outside London" do
             calculator = StudentFinanceCalculator.new(
               course_start: @course_start,
               household_income: @household_income,
@@ -545,19 +585,298 @@ module SmartAnswer
               doctor_or_dentist: @doctor_or_dentist,
             )
 
-            assert_equal 1793, calculator.reduced_maintenance_loan_for_healthcare
+            assert_equal 1845, calculator.reduced_maintenance_loan_for_healthcare
+          end
+        end
+      end
+
+      context "#maintenance_loan_amount" do
+        context "for students who started 2021-2022 living at home with parents" do
+          setup do
+            @course_start = "2021-2022"
+            @residence = "at-home"
+          end
+
+          should "give the maximum amount of 7987 if household income is £25k or below" do
+            calculator = StudentFinanceCalculator.new(
+              course_start: @course_start,
+              household_income: 25_000,
+              residence: @residence,
+              course_type: "uk-full-time",
+            )
+            assert_equal SmartAnswer::Money.new(7987).to_s, calculator.maintenance_loan_amount.to_s
+          end
+
+          should "reduce the maximum amount (£7987) by £1 for every complete £7.43 of income above £25k" do
+            {
+              30_000 => 7315,
+              35_000 => 6642,
+              40_000 => 5969,
+              42_875 => 5582,
+              45_000 => 5296,
+              50_000 => 4623,
+              55_000 => 3950,
+              58_215 => 3517,
+              60_000 => 3516,
+              65_000 => 3516,
+            }.each do |household_income, loan_amount|
+              calculator = StudentFinanceCalculator.new(
+                course_start: @course_start,
+                household_income: household_income,
+                residence: @residence,
+                course_type: "uk-full-time",
+              )
+              assert_equal SmartAnswer::Money.new(loan_amount).to_s, calculator.maintenance_loan_amount.to_s
+            end
+          end
+
+          should "cap the reductions and give the minimum loan of £3516 for high household income students" do
+            calculator = StudentFinanceCalculator.new(
+              course_start: @course_start,
+              household_income: 500_000,
+              residence: @residence,
+              course_type: "uk-full-time",
+            )
+            assert_equal SmartAnswer::Money.new(3516).to_s, calculator.maintenance_loan_amount.to_s
+          end
+        end
+
+        context "for students who started 2021-2022 living away not in london" do
+          setup do
+            @course_start = "2021-2022"
+            @residence = "away-outside-london"
+          end
+
+          should "give the maximum amount of 9488 if household income is £25k or below" do
+            calculator = StudentFinanceCalculator.new(
+              course_start: @course_start,
+              household_income: 25_000,
+              residence: @residence,
+              course_type: "uk-full-time",
+            )
+            assert_equal SmartAnswer::Money.new(9_488).to_s, calculator.maintenance_loan_amount.to_s
+          end
+
+          should "reduce the maximum amount (£9488) by £1 for every complete £7.36 of income above £25k" do
+            # Samples taken from the document provided
+            {
+              30_000 => 8809,
+              35_000 => 8130,
+              40_000 => 7450,
+              42_875 => 7060,
+              45_000 => 6771,
+              50_000 => 6092,
+              55_000 => 5412,
+              60_000 => 4733,
+              62_215 => 4432,
+              65_000 => 4422,
+              70_000 => 4422,
+            }.each do |household_income, loan_amount|
+              calculator = StudentFinanceCalculator.new(
+                course_start: @course_start,
+                household_income: household_income,
+                residence: @residence,
+                course_type: "uk-full-time",
+              )
+              assert_equal SmartAnswer::Money.new(loan_amount).to_s, calculator.maintenance_loan_amount.to_s
+            end
+          end
+
+          should "cap the reductions and give the minimum loan of £4,422 for high household income students" do
+            calculator = StudentFinanceCalculator.new(
+              course_start: @course_start,
+              household_income: 500_000,
+              residence: @residence,
+              course_type: "uk-full-time",
+            )
+            assert_equal SmartAnswer::Money.new(4422).to_s, calculator.maintenance_loan_amount.to_s
+          end
+        end
+
+        context "for students who started 2021-2022 living away in london" do
+          setup do
+            @course_start = "2021-2022"
+            @residence = "away-in-london"
+          end
+
+          should "give the maximum amount of £12382 if household income is £25k or below" do
+            calculator = StudentFinanceCalculator.new(
+              course_start: @course_start,
+              household_income: 25_000,
+              residence: @residence,
+              course_type: "uk-full-time",
+            )
+            assert_equal SmartAnswer::Money.new(12_382).to_s, calculator.maintenance_loan_amount.to_s
+          end
+
+          should "reduce the maximum amount (£12382) by £1 for every complete £7.24 of income above £25k" do
+            # Samples taken from the document provided
+            {
+              30_000 => 11_692,
+              35_000 => 11_001,
+              40_000 => 10_311,
+              42_875 => 9914,
+              45_000 => 9620,
+              50_000 => 8929,
+              55_000 => 8239,
+              60_000 => 7548,
+              65_000 => 6858,
+              69_860 => 6186,
+              70_000 => 6167,
+              75_000 => 6166,
+            }.each do |household_income, loan_amount|
+              calculator = StudentFinanceCalculator.new(
+                course_start: @course_start,
+                household_income: household_income,
+                residence: @residence,
+                course_type: "uk-full-time",
+              )
+              assert_equal SmartAnswer::Money.new(loan_amount).to_s, calculator.maintenance_loan_amount.to_s
+            end
+          end
+
+          should "cap the reductions and give the minimum loan of £6166 for high household income students" do
+            calculator = StudentFinanceCalculator.new(
+              course_start: @course_start,
+              household_income: 500_000,
+              residence: @residence,
+              course_type: "uk-full-time",
+            )
+            assert_equal SmartAnswer::Money.new(6166).to_s, calculator.maintenance_loan_amount.to_s
+          end
+        end
+
+        context "for 2021-2022 part-time students" do
+          setup do
+            @course_start = "2021-2022"
+            @course_type = "uk-part-time"
+          end
+
+          should "be weighted by course intensity" do
+            full_time_credits = 20
+            {
+              2 => 0.00,
+              6 => 2405.00,
+              7 => 3203.46,
+              10 => 4810.00,
+              14 => 6406.92,
+              15 => 7215.00,
+              20 => 9620.00,
+            }.each do |part_time_credits, loan_amount|
+              calculator = StudentFinanceCalculator.new(
+                course_start: @course_start,
+                household_income: 45_000,
+                residence: "away-in-london",
+                course_type: @course_type,
+                part_time_credits: part_time_credits,
+                full_time_credits: full_time_credits,
+              )
+              assert_equal SmartAnswer::Money.new(loan_amount).to_s, calculator.maintenance_loan_amount.to_s
+            end
+          end
+        end
+      end
+
+      context "#reduced_maintenance_loan_for_healthcare" do
+        context "for 2020-2021" do
+          setup do
+            @course_start = "2020-2021"
+            @household_income = 25_000
+            @course_type = "uk-full-time"
+            @doctor_or_dentist = true
+          end
+
+          should "be £3451 for students living away from home in London" do
+            calculator = StudentFinanceCalculator.new(
+              course_start: @course_start,
+              household_income: @household_income,
+              course_type: @course_type,
+              residence: "away-in-london",
+              doctor_or_dentist: @doctor_or_dentist,
+            )
+
+            assert_equal 3451, calculator.reduced_maintenance_loan_for_healthcare
+          end
+
+          should "be £2458 for students living away from home outside London" do
+            calculator = StudentFinanceCalculator.new(
+              course_start: @course_start,
+              household_income: @household_income,
+              course_type: @course_type,
+              residence: "away-outside-london",
+              doctor_or_dentist: @doctor_or_dentist,
+            )
+
+            assert_equal 2458, calculator.reduced_maintenance_loan_for_healthcare
+          end
+
+          should "be £1845 for students living away from home outside London" do
+            calculator = StudentFinanceCalculator.new(
+              course_start: @course_start,
+              household_income: @household_income,
+              course_type: @course_type,
+              residence: "at-home",
+              doctor_or_dentist: @doctor_or_dentist,
+            )
+
+            assert_equal 1845, calculator.reduced_maintenance_loan_for_healthcare
+          end
+        end
+
+        context "for 2021-2022" do
+          setup do
+            @course_start = "2021-2022"
+            @household_income = 25_000
+            @course_type = "uk-full-time"
+            @doctor_or_dentist = true
+          end
+
+          should "be £3558 for students living away from home in London" do
+            calculator = StudentFinanceCalculator.new(
+              course_start: @course_start,
+              household_income: @household_income,
+              course_type: @course_type,
+              residence: "away-in-london",
+              doctor_or_dentist: @doctor_or_dentist,
+            )
+
+            assert_equal 3558, calculator.reduced_maintenance_loan_for_healthcare
+          end
+
+          should "be £2534 for students living away from home outside London" do
+            calculator = StudentFinanceCalculator.new(
+              course_start: @course_start,
+              household_income: @household_income,
+              course_type: @course_type,
+              residence: "away-outside-london",
+              doctor_or_dentist: @doctor_or_dentist,
+            )
+
+            assert_equal 2534, calculator.reduced_maintenance_loan_for_healthcare
+          end
+
+          should "be £1902 for students living away from home outside London" do
+            calculator = StudentFinanceCalculator.new(
+              course_start: @course_start,
+              household_income: @household_income,
+              course_type: @course_type,
+              residence: "at-home",
+              doctor_or_dentist: @doctor_or_dentist,
+            )
+
+            assert_equal 1902, calculator.reduced_maintenance_loan_for_healthcare
           end
         end
       end
 
       context "#course_start_years" do
         context "for students" do
-          should "be 2020 and 2021" do
+          should "be 2021 and 2022" do
             calculator = StudentFinanceCalculator.new(
-              course_start: "2020-2021",
+              course_start: "2021-2022",
             )
 
-            assert_equal [2020, 2021], calculator.course_start_years
+            assert_equal [2021, 2022], calculator.course_start_years
           end
         end
       end


### PR DESCRIPTION
This is the annual uprating for the Student Finance Calculator.  It removes 2019-2020 and adds 2021-2022 values.

Additionally, this splits the tests into more manageable context blocks (i.e. by year, rather than nesting these within finance types) which should make it easier to update these tests next year (we can simply delete the previous year's context block, copy the current year then update with the new values, rather than having to go through each block and figure out which year it relates to).

Trello card: https://trello.com/c/1qXrq9h6

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️