### PR TITLE
Remove SimpleCov for MiniTests - Enhance report output for RSpec tests 

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,7 +3,10 @@ require "spec_helper"
 ENV["RAILS_ENV"] ||= "test"
 
 require "simplecov"
-SimpleCov.start "rails"
+
+SimpleCov.start "rails" do
+  add_group "Smart Answer Flows", "lib/smart_answer_flows"
+end
 
 require File.expand_path("../config/environment", __dir__)
 # Prevent database truncation if the environment is production

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,20 +6,6 @@ require File.expand_path("../config/environment", __dir__)
 require "simplecov"
 require "simplecov-rcov"
 
-SimpleCov.start "rails" do
-  formatter SimpleCov::Formatter::MultiFormatter.new([
-    SimpleCov::Formatter::RcovFormatter,
-    SimpleCov::Formatter::HTMLFormatter,
-  ])
-
-  add_group "Presenters", "app/presenters"
-  add_group "Services", "app/services"
-  add_group "Smart Answer", "lib/smart_answer"
-  add_group "Smart Answer Flows", "lib/smart_answer_flows"
-
-  SimpleCov.minimum_coverage 92
-end
-
 require "rails/test_help"
 
 require "mocha/minitest"
@@ -54,14 +40,6 @@ class ActiveSupport::TestCase
   include GdsApi::TestHelpers::Worldwide
   include ActionDispatch::Assertions
   parallelize workers: 6
-
-  parallelize_setup do |worker|
-    SimpleCov.command_name "#{SimpleCov.command_name}-#{worker}"
-  end
-
-  parallelize_teardown do |_worker|
-    SimpleCov.result
-  end
 end
 
 require "slimmer/test"


### PR DESCRIPTION
# What

Turn off SimpleCov reporting for MiniTests.

# Why 

Reports from SimpleCov when both MiniTest and RSpec are configured are inaccurate and/or are being incorrectly merged.  MiniTests are in the process of being converted to RSpec - so keep SimpleCov for RSpec only. 

[Trello](https://trello.com/c/du3PaPkW/738-rspec-code-coverage-results-not-reported-correctly)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
