### PR TITLE
Update marriage abroad booking urls

### DIFF
--- a/lib/smart_answer_flows/marriage-abroad/outcomes/_contact_method.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/_contact_method.erb
@@ -11,47 +11,47 @@
   <% when 'bahrain' %>
     [Make an appointment at the embassy in Manama.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=127&service=10)
   <% when 'belarus' %>
-    [Make an appointment at the embassy in Minsk.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-minsk/oaths-affirmations-and-affidavits/slot_picker)
+    [Make an appointment at the embassy in Minsk.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=130&service=13)
   <% when 'belgium' %>
-    [Make an appointment at the British embassy in Brussels.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
+    [Make an appointment at the British embassy in Brussels.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=19&service=13)
   <% when 'bolivia' %>
     [Make an appointment at the embassy in La Paz.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=124&service=10)
   <% when 'bosnia-and-herzegovina' %>
     [Make an appointment at the embassy in Sarajevo.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=145&service=10)
   <% when 'croatia' %>
-    [Make an appointment at the embassy in Zagreb.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-zagreb/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in Zagreb.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=41&service=10)
   <% when 'cuba' %>
     [Make an appointment at the embassy in Havana.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=117&service=10)
   <% when 'democratic-republic-of-the-congo' %>
-    [Make an appointment at the embassy in Kinshasa.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-kinshasa/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in Kinshasa.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=122&service=10)
   <% when 'estonia' %>
     [Make an appointment at the embassy in Tallinn.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=36&service=10)
   <% when 'georgia' %>
-    [Make an appointment at the embassy in Tblisi.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-tblisi/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in Tblisi.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=148&service=10)
   <% when 'guatemala' %>
-    [Make an appointment at the embassy in Guatamala City.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-guatemala-city/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in Guatamala City.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=114&service=10)
   <% when 'iceland' %>
-    [Make an appointment at the embassy in Reykjavik.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-reykjavik/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in Reykjavik.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=31&service=10)
   <% when 'kazakhstan' %>
-    [Make an appointment at the embassy in Astana.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-astana/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in Astana.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=97&service=10)
   <% when 'kosovo' %>
-    [Make an appointment at the embassy in Pristina.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-pristina/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in Pristina.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=137&service=10)
   <% when 'kyrgyzstan' %>
-    [Make an appointment at the embassy in Bishkek.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bishkek/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in Bishkek.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=103&service=10)
   <% when 'laos' %>
-    [Make an appointment at the embassy in Vientiane.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-vientiane/oaths-affirmations-and-affidavits/slot_picker)
+    [Make an appointment at the embassy in Vientiane.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=155&service=13)
   <% when 'lebanon' %>
-    [Make an appointment at the embassy in Beirut.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beirut/oaths-affirmations-and-affidavits/slot_picker)
+    [Make an appointment at the embassy in Beirut.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=101&service=13)
   <% when 'lithuania' %>
     [Make an appointment at the embassy in Vilnius.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=39&service=10)
   <% when 'luxembourg' %>
-    [Make an appointment at the embassy in Luxembourg.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-luxembourg/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in Luxembourg.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=27&service=10)
   <% when 'macao' %>
-    [Make an appointment at the British Consulate General Hong Kong.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-hong-kong/oaths-affirmations-and-affidavits/slot_picker)
+    [Make an appointment at the British Consulate General Hong Kong.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=65&service=13)
   <% when 'mexico' %>
-    [Make an appointment at the embassy in Mexico City.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-mexico-city/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in Mexico City.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=129&service=10)
   <% when 'mongolia' %>
-    [Make an appointment at the embassy in Ulaanbaatar.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ulaanbaatar/oaths-affirmations-and-affidavits/slot_picker)
+    [Make an appointment at the embassy in Ulaanbaatar.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=154&service=13)
   <% when 'montenegro' %>
     [Make an appointment at the embassy in Podgorica.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-podgorica/notice-of-marriage-or-civil-partnership/slot_picker)
   <% when 'morocco' %>
@@ -101,7 +101,7 @@
   <% when 'albania' %>
     [Make an appointment at the embassy in Tirana.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=151&service=10)
   <% when 'belgium' %>
-    [Make an appointment at the British embassy in Brussels.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
+    [Make an appointment at the British embassy in Brussels.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=19&service=13)
   <% when 'bolivia' %>
     [Make an appointment at the embassy in La Paz.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=124&service=10)
   <% when 'cambodia' %>
@@ -113,7 +113,7 @@
   <% when 'estonia' %>
     [Make an appointment at the embassy in Tallinn.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=36&service=10)
   <% when 'kosovo' %>
-    [Make an appointment at the embassy in Pristina.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-pristina/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in Pristina.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=137&service=10)
   <% when 'lithuania' %>
     [Make an appointment at the embassy in Vilnius.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=39&service=10)
   <% when 'malta' %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/_contact_method.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/_contact_method.erb
@@ -61,7 +61,7 @@
   <% when 'norway' %>
     [Make an appointment at the embassy in Oslo.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker)
   <% when 'oman' %>
-    [Make an appointment at the embassy in Muscat.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-muscat/oaths-affirmations-and-affidavits/slot_picker)
+    [Make an appointment at the embassy in Muscat.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=133&service=13)
   <% when 'panama' %>
     [Make an appointment at the embassy in Panama City.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-panama-city/notice-of-marriage-or-civil-partnership/slot_picker)
   <% when 'peru' %>
@@ -75,7 +75,7 @@
   <% when 'slovenia' %>
     [Make an appointment at the embassy in Ljubljana.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ljubljana/oaths-affirmations-and-affidavits/slot_picker)
   <% when 'south-korea' %>
-    [Make an appointment at the embassy in Seoul.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-seoul/oaths-affirmations-and-affidavits/slot_picker)
+    [Make an appointment at the embassy in Seoul.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=146&service=13)
   <% when 'sudan' %>
     [Make an appointment at the embassy in Khartoum.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-khartoum/notice-of-marriage-or-civil-partnership/slot_picker)
   <% when 'tajikistan' %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/_contact_method.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/_contact_method.erb
@@ -107,9 +107,9 @@
   <% when 'cambodia' %>
     You must post notice of your marriage at the British embassy in Phnom Penh.
 
-    [Make an appointment at the embassy in Phnom Penh.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-phnom-penh/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in Phnom Penh.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=135&service=10)
   <% when 'peru' %>
-    [Make an appointment at the embassy in Lima.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in Lima.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=125&service=10)
   <% when 'estonia' %>
     [Make an appointment at the embassy in Tallinn.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=36&service=10)
   <% when 'kosovo' %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/_contact_method.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/_contact_method.erb
@@ -53,43 +53,43 @@
   <% when 'mongolia' %>
     [Make an appointment at the embassy in Ulaanbaatar.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=154&service=13)
   <% when 'montenegro' %>
-    [Make an appointment at the embassy in Podgorica.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-podgorica/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in Podgorica.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=136&service=10)
   <% when 'morocco' %>
     [Make an appointment at the embassy in Rabat.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=52&service=13)
   <% when 'nepal' %>
-    [Make an appointment at the embassy in Kathmandu.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-kathmandu/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in Kathmandu.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=120&service=10)
   <% when 'norway' %>
-    [Make an appointment at the embassy in Oslo.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker)
+    [Make an appointment at the embassy in Oslo.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=28&service=13)
   <% when 'oman' %>
     [Make an appointment at the embassy in Muscat.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=133&service=13)
   <% when 'panama' %>
-    [Make an appointment at the embassy in Panama City.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-panama-city/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in Panama City.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=134&service=10)
   <% when 'peru' %>
-    [Make an appointment at the embassy in Lima.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/oaths-affirmations-and-affidavits/slot_picker)
+    [Make an appointment at the embassy in Lima.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=125&service=13)
   <% when 'russia' %>
-    [Make an appointment at the embassy in Moscow.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-moscow/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in Moscow.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=132&service=10)
 
     [Make an appointment at the embassy in St Petersburg.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-st-petersburg/notice-of-marriage-or-civil-partnership/slot_picker)
   <% when 'serbia' %>
-    [Make an appointment at the embassy in Belgrade.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-belgrade/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in Belgrade.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=102&service=10)
   <% when 'slovenia' %>
-    [Make an appointment at the embassy in Ljubljana.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ljubljana/oaths-affirmations-and-affidavits/slot_picker)
+    [Make an appointment at the embassy in Ljubljana.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=26&service=13)
   <% when 'south-korea' %>
     [Make an appointment at the embassy in Seoul.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=146&service=13)
   <% when 'sudan' %>
-    [Make an appointment at the embassy in Khartoum.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-khartoum/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in Khartoum.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=121&service=10)
   <% when 'tajikistan' %>
-    [Make an appointment at the embassy in Dushanbe.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-dushanbe/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in Dushanbe.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=113&service=10)
   <% when 'turkmenistan' %>
-    [Make an appointment at the embassy in Ashgabat.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ashgabat/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in Ashgabat.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=95&service=10)
   <% when 'united-arab-emirates' %>
-    [Make an appointment at the embassy in Dubai.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-dubai/oaths-affirmations-and-affidavits/slot_picker)
+    [Make an appointment at the embassy in Dubai.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=112&service=13)
 
-    [Make an appointment at the embassy in Abu Dhabi.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-abu-dhabi/oaths-affirmations-and-affidavits/slot_picker)
+    [Make an appointment at the embassy in Abu Dhabi.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=89&service=13)
   <% when 'uzbekistan' %>
-    [Make an appointment at the embassy in Tashkent.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tashkent/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in Tashkent.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=147&service=10)
   <% when 'venezuela' %>
-    [Make an appointment at the embassy in Caracas.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-caracas/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in Caracas.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=108&service=10)
   <% else %>
     <%= render partial: 'shared/overseas_passports_embassies',
                locals: {
@@ -119,13 +119,13 @@
   <% when 'malta' %>
     [Make an appointment at the embassy in Valletta.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=42&service=10)
   <% when 'dominican-republic' %>
-    [Make an appointment at the embassy in Santo Domingo.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-santo-domingo/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in Santo Domingo.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=144&service=10)
   <% when 'montenegro' %>
-    [Make an appointment at the embassy in Podgorica.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-podgorica/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in Podgorica.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=136&service=10)
   <% when 'norway' %>
-    [Make an appointment at the embassy in Oslo.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker)
+    [Make an appointment at the embassy in Oslo.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=28&service=13)
   <% when 'serbia' %>
-    [Make an appointment at the embassy in Belgrade.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-belgrade/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in Belgrade.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=102&service=10)
   <% else %>
     <% if defined?(contact_message) %>
       <%= contact_message %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/_contact_method.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/_contact_method.erb
@@ -21,7 +21,7 @@
   <% when 'croatia' %>
     [Make an appointment at the embassy in Zagreb.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-zagreb/notice-of-marriage-or-civil-partnership/slot_picker)
   <% when 'cuba' %>
-    [Make an appointment at the embassy in Havana.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-havana/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in Havana.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=117&service=10)
   <% when 'democratic-republic-of-the-congo' %>
     [Make an appointment at the embassy in Kinshasa.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-kinshasa/notice-of-marriage-or-civil-partnership/slot_picker)
   <% when 'estonia' %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/_contact_method.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/_contact_method.erb
@@ -7,7 +7,7 @@
   <% when 'armenia' %>
     [Make an appointment at the embassy in Yerevan.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-yerevan/notice-of-marriage-or-civil-partnership/slot_picker)
   <% when 'austria' %>
-    [Make an appointment at the embassy in Vienna.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-vienna/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in Vienna.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=38&service=10)
   <% when 'bahrain' %>
     [Make an appointment at the embassy in Manama.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-manama/notice-of-marriage-or-civil-partnership/slot_picker)
   <% when 'belarus' %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/_contact_method.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/_contact_method.erb
@@ -25,7 +25,7 @@
   <% when 'democratic-republic-of-the-congo' %>
     [Make an appointment at the embassy in Kinshasa.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-kinshasa/notice-of-marriage-or-civil-partnership/slot_picker)
   <% when 'estonia' %>
-    [Make an appointment at the embassy in Tallinn.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-tallinn/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in Tallinn.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=36&service=10)
   <% when 'georgia' %>
     [Make an appointment at the embassy in Tblisi.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-tblisi/notice-of-marriage-or-civil-partnership/slot_picker)
   <% when 'guatemala' %>
@@ -111,7 +111,7 @@
   <% when 'peru' %>
     [Make an appointment at the embassy in Lima.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/notice-of-marriage-or-civil-partnership/slot_picker)
   <% when 'estonia' %>
-    [Make an appointment at the embassy in Tallinn.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-tallinn/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in Tallinn.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=36&service=10)
   <% when 'kosovo' %>
     [Make an appointment at the embassy in Pristina.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-pristina/notice-of-marriage-or-civil-partnership/slot_picker)
   <% when 'lithuania' %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/_contact_method.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/_contact_method.erb
@@ -1,7 +1,7 @@
 <% if calculator.partner_is_opposite_sex? %>
   <% case calculator.ceremony_country %>
   <% when 'albania' %>
-    [Make an appointment at the embassy in Tirana.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in Tirana.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=151&service=10)
   <% when 'angola' %>
     [Make an appointment at the embassy in Luanda.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-luanda/notice-of-marriage-or-civil-partnership/slot_picker)
   <% when 'armenia' %>
@@ -43,7 +43,7 @@
   <% when 'lebanon' %>
     [Make an appointment at the embassy in Beirut.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beirut/oaths-affirmations-and-affidavits/slot_picker)
   <% when 'lithuania' %>
-    [Make an appointment at the embassy in Vilnius.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-vilnius/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in Vilnius.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=39&service=10)
   <% when 'luxembourg' %>
     [Make an appointment at the embassy in Luxembourg.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-luxembourg/notice-of-marriage-or-civil-partnership/slot_picker)
   <% when 'macao' %>
@@ -99,7 +99,7 @@
 <% elsif calculator.partner_is_same_sex? %>
   <% case calculator.ceremony_country %>
   <% when 'albania' %>
-    [Make an appointment at the embassy in Tirana.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in Tirana.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=151&service=10)
   <% when 'belgium' %>
     [Make an appointment at the British embassy in Brussels.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
   <% when 'bolivia' %>
@@ -115,9 +115,9 @@
   <% when 'kosovo' %>
     [Make an appointment at the embassy in Pristina.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-pristina/notice-of-marriage-or-civil-partnership/slot_picker)
   <% when 'lithuania' %>
-    [Make an appointment at the embassy in Vilnius.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-vilnius/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in Vilnius.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=39&service=10)
   <% when 'malta' %>
-    [Make an appointment at the embassy in Valletta.](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-valletta/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in Valletta.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=42&service=10)
   <% when 'dominican-republic' %>
     [Make an appointment at the embassy in Santo Domingo.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-santo-domingo/notice-of-marriage-or-civil-partnership/slot_picker)
   <% when 'montenegro' %>

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/_contact_method.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/_contact_method.erb
@@ -3,21 +3,21 @@
   <% when 'albania' %>
     [Make an appointment at the embassy in Tirana.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=151&service=10)
   <% when 'angola' %>
-    [Make an appointment at the embassy in Luanda.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-luanda/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in Luanda.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=126&service=10)
   <% when 'armenia' %>
-    [Make an appointment at the embassy in Yerevan.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-yerevan/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in Yerevan.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=157&service=10)
   <% when 'austria' %>
     [Make an appointment at the embassy in Vienna.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=38&service=10)
   <% when 'bahrain' %>
-    [Make an appointment at the embassy in Manama.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-manama/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in Manama.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=127&service=10)
   <% when 'belarus' %>
     [Make an appointment at the embassy in Minsk.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-minsk/oaths-affirmations-and-affidavits/slot_picker)
   <% when 'belgium' %>
     [Make an appointment at the British embassy in Brussels.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
   <% when 'bolivia' %>
-    [Make an appointment at the embassy in La Paz.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-la-paz/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in La Paz.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=124&service=10)
   <% when 'bosnia-and-herzegovina' %>
-    [Make an appointment at the embassy in Sarajevo.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-sarajevo/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in Sarajevo.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=145&service=10)
   <% when 'croatia' %>
     [Make an appointment at the embassy in Zagreb.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-zagreb/notice-of-marriage-or-civil-partnership/slot_picker)
   <% when 'cuba' %>
@@ -103,7 +103,7 @@
   <% when 'belgium' %>
     [Make an appointment at the British embassy in Brussels.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brussels/oaths-affirmations-and-affidavits/slot_picker)
   <% when 'bolivia' %>
-    [Make an appointment at the embassy in La Paz.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-la-paz/notice-of-marriage-or-civil-partnership/slot_picker)
+    [Make an appointment at the embassy in La Paz.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=124&service=10)
   <% when 'cambodia' %>
     You must post notice of your marriage at the British embassy in Phnom Penh.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/albania/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/albania/ceremony_country/partner_british/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Albania. You can
 
 You’ll need to have been living in Albania for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Tirana.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tirana.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=151&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/albania/ceremony_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/albania/ceremony_country/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to register a civil partnership or get married at the British embassy or consulate in Albania.
 
-[Make an appointment at the embassy in Tirana.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tirana.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=151&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/albania/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/albania/ceremony_country/partner_local/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Albania. You can
 
 You’ll need to have been living in Albania for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Tirana.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tirana.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=151&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/albania/ceremony_country/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/albania/ceremony_country/partner_local/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to register a civil partnership or get married at the British embassy or consulate in Albania.
 
-[Make an appointment at the embassy in Tirana.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tirana.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=151&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/albania/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/albania/ceremony_country/partner_other/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Albania. You can
 
 You’ll need to have been living in Albania for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Tirana.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tirana.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=151&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/albania/ceremony_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/albania/ceremony_country/partner_other/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to register a civil partnership or get married at the British embassy or consulate in Albania.
 
-[Make an appointment at the embassy in Tirana.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tirana.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=151&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/albania/third_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/albania/third_country/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to register a civil partnership or get married at the British embassy or consulate in Albania.
 
-[Make an appointment at the embassy in Tirana.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tirana.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=151&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/albania/third_country/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/albania/third_country/partner_local/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to register a civil partnership or get married at the British embassy or consulate in Albania.
 
-[Make an appointment at the embassy in Tirana.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tirana.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=151&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/albania/third_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/albania/third_country/partner_other/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to register a civil partnership or get married at the British embassy or consulate in Albania.
 
-[Make an appointment at the embassy in Tirana.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tirana.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=151&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/albania/uk/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/albania/uk/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to register a civil partnership or get married at the British embassy or consulate in Albania.
 
-[Make an appointment at the embassy in Tirana.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tirana.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=151&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/albania/uk/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/albania/uk/partner_local/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to register a civil partnership or get married at the British embassy or consulate in Albania.
 
-[Make an appointment at the embassy in Tirana.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tirana.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=151&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/albania/uk/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/albania/uk/partner_other/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to register a civil partnership or get married at the British embassy or consulate in Albania.
 
-[Make an appointment at the embassy in Tirana.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tirana/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tirana.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=151&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/algeria/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/algeria/ceremony_country/partner_british/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Algeria. You can
 
 You’ll need to have been living in Algeria for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Algeria.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-algeria/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Algeria.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=91&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/algeria/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/algeria/ceremony_country/partner_local/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Algeria. You can
 
 You’ll need to have been living in Algeria for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Algeria.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-algeria/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Algeria.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=91&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/algeria/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/algeria/ceremony_country/partner_other/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Algeria. You can
 
 You’ll need to have been living in Algeria for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Algeria.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-algeria/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Algeria.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=91&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/algeria/uk/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/algeria/uk/partner_british/_opposite_sex.erb
@@ -12,7 +12,7 @@ You can normally get a CNI by giving a notice of marriage at your local register
 
 You’ll need to exchange your UK-issued CNI for one that’s valid in Algeria at the nearest British embassy to where you’re getting married.
 
-[Make an appointment at the British Embassy in Algiers](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-algeria/exchange-a-certificate-of-no-impediment/slot_picker).
+[Make an appointment at the British Embassy in Algiers](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=91&service=4).
 
 %The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/algeria/uk/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/algeria/uk/partner_local/_opposite_sex.erb
@@ -12,7 +12,7 @@ You can normally get a CNI by giving a notice of marriage at your local register
 
 You’ll need to exchange your UK-issued CNI for one that’s valid in Algeria at the nearest British embassy to where you’re getting married.
 
-[Make an appointment at the British Embassy in Algiers](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-algeria/exchange-a-certificate-of-no-impediment/slot_picker).
+[Make an appointment at the British Embassy in Algiers](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=91&service=4).
 
 %The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/algeria/uk/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/algeria/uk/partner_other/_opposite_sex.erb
@@ -12,7 +12,7 @@ You can normally get a CNI by giving a notice of marriage at your local register
 
 You’ll need to exchange your UK-issued CNI for one that’s valid in Algeria at the nearest British embassy to where you’re getting married.
 
-[Make an appointment at the British Embassy in Algiers](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-algeria/exchange-a-certificate-of-no-impediment/slot_picker).
+[Make an appointment at the British Embassy in Algiers](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=91&service=4).
 
 %The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example marriage certificate or deed poll).%
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/angola/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/angola/ceremony_country/partner_british/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Angola. You can 
 
 You’ll need to have been living in Angola for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Luanda.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-luanda/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Luanda.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=126&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/angola/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/angola/ceremony_country/partner_local/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Angola. You can 
 
 You’ll need to have been living in Angola for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Luanda.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-luanda/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Luanda.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=126&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/angola/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/angola/ceremony_country/partner_other/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Angola. You can 
 
 You’ll need to have been living in Angola for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Luanda.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-luanda/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Luanda.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=126&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/armenia/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/armenia/ceremony_country/partner_british/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Armenia. You can
 
 You’ll need to have been living in Armenia for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Yerevan.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-yerevan/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Yerevan.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=157&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/armenia/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/armenia/ceremony_country/partner_local/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Armenia. You can
 
 You’ll need to have been living in Armenia for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Yerevan.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-yerevan/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Yerevan.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=157&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/armenia/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/armenia/ceremony_country/partner_other/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Armenia. You can
 
 You’ll need to have been living in Armenia for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Yerevan.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-yerevan/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Yerevan.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=157&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/ceremony_country/partner_british/_opposite_sex.erb
@@ -16,7 +16,7 @@ To get a CNI, you must post notice of your intention to get married or enter int
 
 You’ll need to have been living in Austria for at least 3 full days before you can post notice. For example, if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Vienna.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-vienna/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Vienna.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=38&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/ceremony_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/ceremony_country/partner_british/_same_sex.erb
@@ -12,7 +12,7 @@ To get a CNI, you must post notice of your intended marriage or civil partnershi
 
 You’ll need to have been living in Austria for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Vienna](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-vienna/notice-of-marriage-or-civil-partnership/slot_picker).
+[Make an appointment at the embassy in Vienna](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=38&service=10).
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/ceremony_country/partner_local/_opposite_sex.erb
@@ -16,7 +16,7 @@ To get a CNI, you must post notice of your intention to get married or enter int
 
 You’ll need to have been living in Austria for at least 3 full days before you can post notice. For example, if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Vienna.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-vienna/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Vienna.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=38&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/ceremony_country/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/ceremony_country/partner_local/_same_sex.erb
@@ -12,7 +12,7 @@ To get a CNI, you must post notice of your intended marriage or civil partnershi
 
 You’ll need to have been living in Austria for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Vienna](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-vienna/notice-of-marriage-or-civil-partnership/slot_picker).
+[Make an appointment at the embassy in Vienna](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=38&service=10).
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/ceremony_country/partner_other/_opposite_sex.erb
@@ -16,7 +16,7 @@ To get a CNI, you must post notice of your intention to get married or enter int
 
 You’ll need to have been living in Austria for at least 3 full days before you can post notice. For example, if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Vienna.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-vienna/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Vienna.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=38&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/ceremony_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/austria/ceremony_country/partner_other/_same_sex.erb
@@ -12,7 +12,7 @@ To get a CNI, you must post notice of your intended marriage or civil partnershi
 
 You’ll need to have been living in Austria for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Vienna](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-vienna/notice-of-marriage-or-civil-partnership/slot_picker).
+[Make an appointment at the embassy in Vienna](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=38&service=10).
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/azerbaijan/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/azerbaijan/ceremony_country/partner_british/_opposite_sex.erb
@@ -12,7 +12,7 @@ You need to:
 
 s1. Download an [affirmation](/government/publications/azerbaijan-affirmation-of-marital-status).
 s2. Print it out but don’t sign it.
-s3. [Make an appointment at the embassy in Baku](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-baku/notice-of-marriage-or-civil-partnership/slot_picker) to sign it.
+s3. [Make an appointment at the embassy in Baku](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=99&service=10) to sign it.
 
 
 It costs £50 per person. You can pay in the [local currency](/government/publications/azerbaijan-consular-fees) in cash or with a credit card or debit card.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/azerbaijan/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/azerbaijan/ceremony_country/partner_local/_opposite_sex.erb
@@ -12,7 +12,7 @@ You need to:
 
 s1. Download an [affirmation](/government/publications/azerbaijan-affirmation-of-marital-status).
 s2. Print it out but don’t sign it.
-s3. [Make an appointment at the embassy in Baku](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-baku/notice-of-marriage-or-civil-partnership/slot_picker) to sign it.
+s3. [Make an appointment at the embassy in Baku](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=99&service=10) to sign it.
 
 
 It costs £50 per person. You can pay in the [local currency](/government/publications/azerbaijan-consular-fees) in cash or with a credit card or debit card.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/azerbaijan/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/azerbaijan/ceremony_country/partner_other/_opposite_sex.erb
@@ -12,7 +12,7 @@ You need to:
 
 s1. Download an [affirmation](/government/publications/azerbaijan-affirmation-of-marital-status).
 s2. Print it out but don’t sign it.
-s3. [Make an appointment at the embassy in Baku](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-baku/notice-of-marriage-or-civil-partnership/slot_picker) to sign it.
+s3. [Make an appointment at the embassy in Baku](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=99&service=10) to sign it.
 
 
 It costs £50 per person. You can pay in the [local currency](/government/publications/azerbaijan-consular-fees) in cash or with a credit card or debit card.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/azerbaijan/third_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/azerbaijan/third_country/partner_british/_opposite_sex.erb
@@ -12,7 +12,7 @@ You need to:
 
 s1. Download an [affirmation](/government/publications/azerbaijan-affirmation-of-marital-status).
 s2. Print it out but don’t sign it.
-s3. [Make an appointment at the embassy in Baku](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-baku/notice-of-marriage-or-civil-partnership/slot_picker) to sign it.
+s3. [Make an appointment at the embassy in Baku](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=99&service=10) to sign it.
 
 
 It costs £50 per person. You can pay in the [local currency](/government/publications/azerbaijan-consular-fees) in cash or with a credit card or debit card.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/azerbaijan/third_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/azerbaijan/third_country/partner_local/_opposite_sex.erb
@@ -12,7 +12,7 @@ You need to:
 
 s1. Download an [affirmation](/government/publications/azerbaijan-affirmation-of-marital-status).
 s2. Print it out but don’t sign it.
-s3. [Make an appointment at the embassy in Baku](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-baku/notice-of-marriage-or-civil-partnership/slot_picker) to sign it.
+s3. [Make an appointment at the embassy in Baku](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=99&service=10) to sign it.
 
 
 It costs £50 per person. You can pay in the [local currency](/government/publications/azerbaijan-consular-fees) in cash or with a credit card or debit card.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/azerbaijan/third_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/azerbaijan/third_country/partner_other/_opposite_sex.erb
@@ -12,7 +12,7 @@ You need to:
 
 s1. Download an [affirmation](/government/publications/azerbaijan-affirmation-of-marital-status).
 s2. Print it out but don’t sign it.
-s3. [Make an appointment at the embassy in Baku](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-baku/notice-of-marriage-or-civil-partnership/slot_picker) to sign it.
+s3. [Make an appointment at the embassy in Baku](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=99&service=10) to sign it.
 
 
 It costs £50 per person. You can pay in the [local currency](/government/publications/azerbaijan-consular-fees) in cash or with a credit card or debit card.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/azerbaijan/uk/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/azerbaijan/uk/partner_british/_opposite_sex.erb
@@ -13,7 +13,7 @@ You need to:
 
 s1. Download an [affirmation](/government/publications/azerbaijan-affirmation-of-marital-status).
 s2. Print it out but don’t sign it.
-s3. [Make an appointment at the embassy in Baku](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-baku/notice-of-marriage-or-civil-partnership/slot_picker) to sign it.
+s3. [Make an appointment at the embassy in Baku](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=99&service=10) to sign it.
 
 
 It costs £50 per person. You can pay in the [local currency](/government/publications/azerbaijan-consular-fees) in cash or with a credit card or debit card.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/azerbaijan/uk/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/azerbaijan/uk/partner_local/_opposite_sex.erb
@@ -13,7 +13,7 @@ You need to:
 
 s1. Download an [affirmation](/government/publications/azerbaijan-affirmation-of-marital-status).
 s2. Print it out but don’t sign it.
-s3. [Make an appointment at the embassy in Baku](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-baku/notice-of-marriage-or-civil-partnership/slot_picker) to sign it.
+s3. [Make an appointment at the embassy in Baku](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=99&service=10) to sign it.
 
 
 It costs £50 per person. You can pay in the [local currency](/government/publications/azerbaijan-consular-fees) in cash or with a credit card or debit card.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/azerbaijan/uk/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/azerbaijan/uk/partner_other/_opposite_sex.erb
@@ -12,7 +12,7 @@ You need to:
 
 s1. Download an [affirmation](/government/publications/azerbaijan-affirmation-of-marital-status).
 s2. Print it out but don’t sign it.
-s3. [Make an appointment at the embassy in Baku](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-baku/notice-of-marriage-or-civil-partnership/slot_picker) to sign it.
+s3. [Make an appointment at the embassy in Baku](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=99&service=10) to sign it.
 
 
 It costs £50 per person. You can pay in the [local currency](/government/publications/azerbaijan-consular-fees) in cash or with a credit card or debit card.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bahrain/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bahrain/ceremony_country/partner_british/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Bahrain. You can
 
 You’ll need to have been living in Bahrain for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Manama.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-manama/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Manama.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=127&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bahrain/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bahrain/ceremony_country/partner_local/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Bahrain. You can
 
 You’ll need to have been living in Bahrain for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Manama.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-manama/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Manama.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=127&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bahrain/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bahrain/ceremony_country/partner_other/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Bahrain. You can
 
 You’ll need to have been living in Bahrain for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Manama.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-manama/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Manama.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=127&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belarus/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belarus/ceremony_country/partner_british/_opposite_sex.erb
@@ -8,7 +8,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 
 Make an appointment at the British embassy or consulate in Belarus to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your and your partner’s passport and pay a fee.
 
-[Make an appointment at the embassy in Minsk.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-minsk/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Minsk.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=130&service=13)
 
 ###Legalisation and translation
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belarus/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belarus/ceremony_country/partner_local/_opposite_sex.erb
@@ -8,7 +8,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 
 Make an appointment at the British embassy or consulate in Belarus to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your and your partner’s passport and pay a fee.
 
-[Make an appointment at the embassy in Minsk.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-minsk/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Minsk.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=130&service=13)
 
 ###Legalisation and translation
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belarus/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belarus/ceremony_country/partner_other/_opposite_sex.erb
@@ -8,7 +8,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 
 Make an appointment at the British embassy or consulate in Belarus to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your and your partner’s passport and pay a fee.
 
-[Make an appointment at the embassy in Minsk.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-minsk/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Minsk.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=130&service=13)
 
 ###Legalisation and translation
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belarus/third_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belarus/third_country/partner_british/_opposite_sex.erb
@@ -8,7 +8,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 
 Make an appointment at the British embassy or consulate in Belarus to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your and your partner’s passport and pay a fee.
 
-[Make an appointment at the embassy in Minsk.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-minsk/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Minsk.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=130&service=13)
 
 ###Legalisation and translation
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belarus/third_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belarus/third_country/partner_local/_opposite_sex.erb
@@ -8,7 +8,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 
 Make an appointment at the British embassy or consulate in Belarus to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your and your partner’s passport and pay a fee.
 
-[Make an appointment at the embassy in Minsk.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-minsk/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Minsk.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=130&service=13)
 
 ###Legalisation and translation
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belarus/third_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belarus/third_country/partner_other/_opposite_sex.erb
@@ -8,7 +8,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 
 Make an appointment at the British embassy or consulate in Belarus to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your and your partner’s passport and pay a fee.
 
-[Make an appointment at the embassy in Minsk.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-minsk/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Minsk.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=130&service=13)
 
 ###Legalisation and translation
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belarus/uk/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belarus/uk/partner_british/_opposite_sex.erb
@@ -8,7 +8,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 
 Make an appointment at the British embassy or consulate in Belarus to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your and your partner’s passport and pay a fee.
 
-[Make an appointment at the embassy in Minsk.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-minsk/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Minsk.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=130&service=13)
 
 ###Legalisation and translation
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belarus/uk/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belarus/uk/partner_local/_opposite_sex.erb
@@ -8,7 +8,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 
 Make an appointment at the British embassy or consulate in Belarus to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your and your partner’s passport and pay a fee.
 
-[Make an appointment at the embassy in Minsk.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-minsk/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Minsk.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=130&service=13)
 
 ###Legalisation and translation
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belarus/uk/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/belarus/uk/partner_other/_opposite_sex.erb
@@ -8,7 +8,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 
 Make an appointment at the British embassy or consulate in Belarus to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your and your partner’s passport and pay a fee.
 
-[Make an appointment at the embassy in Minsk.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-minsk/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Minsk.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=130&service=13)
 
 ###Legalisation and translation
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bolivia/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bolivia/ceremony_country/partner_british/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Bolivia. You can
 
 You’ll need to have been living in Bolivia for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in La Paz.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-la-paz/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in La Paz.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=124&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bolivia/ceremony_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bolivia/ceremony_country/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Bolivia.
 
-[Make an appointment at the embassy in La Paz.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-la-paz/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in La Paz.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=124&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bolivia/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bolivia/ceremony_country/partner_local/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Bolivia. You can
 
 You’ll need to have been living in Bolivia for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in La Paz.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-la-paz/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in La Paz.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=124&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bolivia/ceremony_country/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bolivia/ceremony_country/partner_local/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Bolivia.
 
-[Make an appointment at the embassy in La Paz.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-la-paz/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in La Paz.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=124&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bolivia/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bolivia/ceremony_country/partner_other/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Bolivia. You can
 
 You’ll need to have been living in Bolivia for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in La Paz.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-la-paz/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in La Paz.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=124&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bolivia/ceremony_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bolivia/ceremony_country/partner_other/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Bolivia.
 
-[Make an appointment at the embassy in La Paz.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-la-paz/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in La Paz.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=124&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bolivia/third_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bolivia/third_country/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Bolivia.
 
-[Make an appointment at the embassy in La Paz.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-la-paz/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in La Paz.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=124&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bolivia/third_country/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bolivia/third_country/partner_local/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Bolivia.
 
-[Make an appointment at the embassy in La Paz.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-la-paz/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in La Paz.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=124&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bolivia/third_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bolivia/third_country/partner_other/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Bolivia.
 
-[Make an appointment at the embassy in La Paz.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-la-paz/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in La Paz.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=124&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bolivia/uk/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bolivia/uk/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Bolivia.
 
-[Make an appointment at the embassy in La Paz.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-la-paz/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in La Paz.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=124&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bolivia/uk/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bolivia/uk/partner_local/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Bolivia.
 
-[Make an appointment at the embassy in La Paz.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-la-paz/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in La Paz.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=124&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bolivia/uk/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bolivia/uk/partner_other/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Bolivia.
 
-[Make an appointment at the embassy in La Paz.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-la-paz/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in La Paz.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=124&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bosnia-and-herzegovina/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bosnia-and-herzegovina/ceremony_country/partner_british/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Bosnia and Herze
 
 You’ll need to have been living in Bosnia and Herzegovina for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Sarajevo.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-sarajevo/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Sarajevo.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=145&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bosnia-and-herzegovina/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bosnia-and-herzegovina/ceremony_country/partner_local/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Bosnia and Herze
 
 You’ll need to have been living in Bosnia and Herzegovina for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Sarajevo.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-sarajevo/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Sarajevo.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=145&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bosnia-and-herzegovina/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bosnia-and-herzegovina/ceremony_country/partner_other/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Bosnia and Herze
 
 You’ll need to have been living in Bosnia and Herzegovina for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Sarajevo.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-sarajevo/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Sarajevo.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=145&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/brazil/uk/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/brazil/uk/partner_british/_opposite_sex.erb
@@ -29,7 +29,7 @@ If you live in the UK but are currently in Brazil, you can make an affirmation o
 
 Book an appointment to administer an oath, affirmation or affidavit at the:
 
-* [British Embassy Brasilia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brasilia/oaths-affirmations-and-affidavits/slot_picker)
+* [British Embassy Brasilia](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=105&service=13)
 * [British Consulate-General Sao Paulo](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-sao-paulo/oaths-affirmations-and-affidavits/slot_picker)
 * [British Consulate-General Rio de Janeiro](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-rio-de-janeiro/oaths-affirmations-and-affidavits/slot_picker)
 * [British Consulate-General Recife](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-recife/oaths-affirmations-and-affidavits/slot_picker)

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/brazil/uk/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/brazil/uk/partner_british/_opposite_sex.erb
@@ -30,9 +30,9 @@ If you live in the UK but are currently in Brazil, you can make an affirmation o
 Book an appointment to administer an oath, affirmation or affidavit at the:
 
 * [British Embassy Brasilia](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=105&service=13)
-* [British Consulate-General Sao Paulo](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-sao-paulo/oaths-affirmations-and-affidavits/slot_picker)
-* [British Consulate-General Rio de Janeiro](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-rio-de-janeiro/oaths-affirmations-and-affidavits/slot_picker)
-* [British Consulate-General Recife](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-recife/oaths-affirmations-and-affidavits/slot_picker)
+* [British Consulate-General Sao Paulo](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=76&service=13)
+* [British Consulate-General Rio de Janeiro](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=59&service=13)
+* [British Consulate-General Recife](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=74&service=13)
 
 ###What you need to bring to your appointment
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/brazil/uk/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/brazil/uk/partner_british/_same_sex.erb
@@ -30,7 +30,7 @@ If you live in the UK but are currently in Brazil, you can make an affirmation o
 
 Book an appointment to administer an oath, affirmation or affidavit at the:
 
-* [British Embassy Brasilia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brasilia/oaths-affirmations-and-affidavits/slot_picker)
+* [British Embassy Brasilia](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=105&service=13)
 * [British Consulate-General Sao Paulo](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-sao-paulo/oaths-affirmations-and-affidavits/slot_picker)
 * [British Consulate-General Rio de Janeiro](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-rio-de-janeiro/oaths-affirmations-and-affidavits/slot_picker)
 * [British Consulate-General Recife](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-recife/oaths-affirmations-and-affidavits/slot_picker)

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/brazil/uk/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/brazil/uk/partner_british/_same_sex.erb
@@ -31,9 +31,9 @@ If you live in the UK but are currently in Brazil, you can make an affirmation o
 Book an appointment to administer an oath, affirmation or affidavit at the:
 
 * [British Embassy Brasilia](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=105&service=13)
-* [British Consulate-General Sao Paulo](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-sao-paulo/oaths-affirmations-and-affidavits/slot_picker)
-* [British Consulate-General Rio de Janeiro](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-rio-de-janeiro/oaths-affirmations-and-affidavits/slot_picker)
-* [British Consulate-General Recife](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-recife/oaths-affirmations-and-affidavits/slot_picker)
+* [British Consulate-General Sao Paulo](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=76&service=13)
+* [British Consulate-General Rio de Janeiro](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=59&service=13)
+* [British Consulate-General Recife](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=74&service=13)
 
 ###What you need to bring to your appointment
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/brazil/uk/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/brazil/uk/partner_local/_opposite_sex.erb
@@ -29,7 +29,7 @@ If you live in the UK but are currently in Brazil, you can make an affirmation o
 
 Book an appointment to administer an oath, affirmation or affidavit at the:
 
-* [British Embassy Brasilia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brasilia/oaths-affirmations-and-affidavits/slot_picker)
+* [British Embassy Brasilia](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=105&service=13)
 * [British Consulate-General Sao Paulo](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-sao-paulo/oaths-affirmations-and-affidavits/slot_picker)
 * [British Consulate-General Rio de Janeiro](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-rio-de-janeiro/oaths-affirmations-and-affidavits/slot_picker)
 * [British Consulate-General Recife](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-recife/oaths-affirmations-and-affidavits/slot_picker)

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/brazil/uk/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/brazil/uk/partner_local/_opposite_sex.erb
@@ -30,9 +30,9 @@ If you live in the UK but are currently in Brazil, you can make an affirmation o
 Book an appointment to administer an oath, affirmation or affidavit at the:
 
 * [British Embassy Brasilia](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=105&service=13)
-* [British Consulate-General Sao Paulo](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-sao-paulo/oaths-affirmations-and-affidavits/slot_picker)
-* [British Consulate-General Rio de Janeiro](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-rio-de-janeiro/oaths-affirmations-and-affidavits/slot_picker)
-* [British Consulate-General Recife](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-recife/oaths-affirmations-and-affidavits/slot_picker)
+* [British Consulate-General Sao Paulo](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=76&service=13)
+* [British Consulate-General Rio de Janeiro](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=59&service=13)
+* [British Consulate-General Recife](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=74&service=13)
 
 ###What you need to bring to your appointment
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/brazil/uk/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/brazil/uk/partner_local/_same_sex.erb
@@ -30,7 +30,7 @@ If you live in the UK but are currently in Brazil, you can make an affirmation o
 
 Book an appointment to administer an oath, affirmation or affidavit at the:
 
-* [British Embassy Brasilia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brasilia/oaths-affirmations-and-affidavits/slot_picker)
+* [British Embassy Brasilia](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=105&service=13)
 * [British Consulate-General Sao Paulo](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-sao-paulo/oaths-affirmations-and-affidavits/slot_picker)
 * [British Consulate-General Rio de Janeiro](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-rio-de-janeiro/oaths-affirmations-and-affidavits/slot_picker)
 * [British Consulate-General Recife](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-recife/oaths-affirmations-and-affidavits/slot_picker)

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/brazil/uk/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/brazil/uk/partner_local/_same_sex.erb
@@ -31,9 +31,9 @@ If you live in the UK but are currently in Brazil, you can make an affirmation o
 Book an appointment to administer an oath, affirmation or affidavit at the:
 
 * [British Embassy Brasilia](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=105&service=13)
-* [British Consulate-General Sao Paulo](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-sao-paulo/oaths-affirmations-and-affidavits/slot_picker)
-* [British Consulate-General Rio de Janeiro](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-rio-de-janeiro/oaths-affirmations-and-affidavits/slot_picker)
-* [British Consulate-General Recife](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-recife/oaths-affirmations-and-affidavits/slot_picker)
+* [British Consulate-General Sao Paulo](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=76&service=13)
+* [British Consulate-General Rio de Janeiro](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=59&service=13)
+* [British Consulate-General Recife](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=74&service=13)
 
 ###What you need to bring to your appointment
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/brazil/uk/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/brazil/uk/partner_other/_opposite_sex.erb
@@ -29,7 +29,7 @@ If you live in the UK but are currently in Brazil, you can make an affirmation o
 
 Book an appointment to administer an oath, affirmation or affidavit at the:
 
-* [British Embassy Brasilia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brasilia/oaths-affirmations-and-affidavits/slot_picker)
+* [British Embassy Brasilia](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=105&service=13)
 * [British Consulate-General Sao Paulo](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-sao-paulo/oaths-affirmations-and-affidavits/slot_picker)
 * [British Consulate-General Rio de Janeiro](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-rio-de-janeiro/oaths-affirmations-and-affidavits/slot_picker)
 * [British Consulate-General Recife](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-recife/oaths-affirmations-and-affidavits/slot_picker)

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/brazil/uk/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/brazil/uk/partner_other/_opposite_sex.erb
@@ -30,9 +30,9 @@ If you live in the UK but are currently in Brazil, you can make an affirmation o
 Book an appointment to administer an oath, affirmation or affidavit at the:
 
 * [British Embassy Brasilia](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=105&service=13)
-* [British Consulate-General Sao Paulo](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-sao-paulo/oaths-affirmations-and-affidavits/slot_picker)
-* [British Consulate-General Rio de Janeiro](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-rio-de-janeiro/oaths-affirmations-and-affidavits/slot_picker)
-* [British Consulate-General Recife](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-recife/oaths-affirmations-and-affidavits/slot_picker)
+* [British Consulate-General Sao Paulo](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=76&service=13)
+* [British Consulate-General Rio de Janeiro](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=59&service=13)
+* [British Consulate-General Recife](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=74&service=13)
 
 ###What you need to bring to your appointment
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/brazil/uk/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/brazil/uk/partner_other/_same_sex.erb
@@ -30,7 +30,7 @@ If you live in the UK but are currently in Brazil, you can make an affirmation o
 
 Book an appointment to administer an oath, affirmation or affidavit at the:
 
-* [British Embassy Brasilia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-brasilia/oaths-affirmations-and-affidavits/slot_picker)
+* [British Embassy Brasilia](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=105&service=13)
 * [British Consulate-General Sao Paulo](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-sao-paulo/oaths-affirmations-and-affidavits/slot_picker)
 * [British Consulate-General Rio de Janeiro](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-rio-de-janeiro/oaths-affirmations-and-affidavits/slot_picker)
 * [British Consulate-General Recife](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-recife/oaths-affirmations-and-affidavits/slot_picker)

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/brazil/uk/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/brazil/uk/partner_other/_same_sex.erb
@@ -31,9 +31,9 @@ If you live in the UK but are currently in Brazil, you can make an affirmation o
 Book an appointment to administer an oath, affirmation or affidavit at the:
 
 * [British Embassy Brasilia](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=105&service=13)
-* [British Consulate-General Sao Paulo](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-sao-paulo/oaths-affirmations-and-affidavits/slot_picker)
-* [British Consulate-General Rio de Janeiro](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-rio-de-janeiro/oaths-affirmations-and-affidavits/slot_picker)
-* [British Consulate-General Recife](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-recife/oaths-affirmations-and-affidavits/slot_picker)
+* [British Consulate-General Sao Paulo](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=76&service=13)
+* [British Consulate-General Rio de Janeiro](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=59&service=13)
+* [British Consulate-General Recife](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=74&service=13)
 
 ###What you need to bring to your appointment
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bulgaria/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bulgaria/ceremony_country/partner_british/_opposite_sex.erb
@@ -61,7 +61,7 @@ The consulate will display your notice of marriage publicly for 7 days before is
 
 You can collect the CNI from the embassy or ask for it to be sent by courier to an address in Bulgaria. You’ll need to pay any courier fees.
 
-[Make an appointment to collect your CNI at the embassy in Sofia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-sofia/certificate-of-no-impediment/slot_picker)
+[Make an appointment to collect your CNI at the embassy in Sofia](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=34&service=4)
 
 ^You don't need to stay in the country while your notice is posted.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bulgaria/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bulgaria/ceremony_country/partner_british/_opposite_sex.erb
@@ -29,7 +29,7 @@ $A
 
 ## Get your documents witnessed at the embassy
 
-[Make an appointment at the embassy in Sofia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-sofia/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Sofia](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=34&service=10)
 
 You’ll need to complete a [‘Notice of marriage’](/government/publications/notice-of-marriage-form--2) form and an [‘Affidavit for marriage’](/government/publications/affirmationaffidavit-of-marital-status-form) form.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bulgaria/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bulgaria/ceremony_country/partner_local/_opposite_sex.erb
@@ -59,7 +59,7 @@ The consulate will display your notice of marriage publicly for 7 days before is
 
 You can collect the CNI from the embassy or ask for it to be sent by courier to an address in Bulgaria. You’ll need to pay any courier fees.
 
-[Make an appointment to collect your CNI at the embassy in Sofia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-sofia/certificate-of-no-impediment/slot_picker)
+[Make an appointment to collect your CNI at the embassy in Sofia](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=34&service=4)
 
 ^You don't need to stay in the country while your notice is posted.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bulgaria/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bulgaria/ceremony_country/partner_local/_opposite_sex.erb
@@ -29,7 +29,7 @@ $A
 
 ## Get your documents witnessed at the embassy
 
-[Make an appointment at the embassy in Sofia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-sofia/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Sofia](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=34&service=10)
 
 You’ll need to complete a [‘Notice of marriage’](/government/publications/notice-of-marriage-form--2) form and an [‘Affidavit for marriage’](/government/publications/affirmationaffidavit-of-marital-status-form) form.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bulgaria/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bulgaria/ceremony_country/partner_other/_opposite_sex.erb
@@ -59,7 +59,7 @@ The consulate will display your notice of marriage publicly for 7 days before is
 
 You can collect the CNI from the embassy or ask for it to be sent by courier to an address in Bulgaria. You’ll need to pay any courier fees.
 
-[Make an appointment to collect your CNI at the embassy in Sofia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-sofia/certificate-of-no-impediment/slot_picker)
+[Make an appointment to collect your CNI at the embassy in Sofia](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=34&service=4)
 
 ^You don't need to stay in the country while your notice is posted.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bulgaria/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bulgaria/ceremony_country/partner_other/_opposite_sex.erb
@@ -29,7 +29,7 @@ $A
 
 ## Get your documents witnessed at the embassy
 
-[Make an appointment at the embassy in Sofia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-sofia/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Sofia](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=34&service=10)
 
 You’ll need to complete a [‘Notice of marriage’](/government/publications/notice-of-marriage-form--2) form and an [‘Affidavit for marriage’](/government/publications/affirmationaffidavit-of-marital-status-form) form.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bulgaria/third_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bulgaria/third_country/partner_british/_opposite_sex.erb
@@ -61,7 +61,7 @@ The consulate will display your notice of marriage publicly for 7 days before is
 
 You can collect the CNI from the embassy or ask for it to be sent by courier to an address in Bulgaria. You’ll need to pay any courier fees.
 
-[Make an appointment to collect your CNI at the embassy in Sofia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-sofia/certificate-of-no-impediment/slot_picker)
+[Make an appointment to collect your CNI at the embassy in Sofia](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=34&service=4)
 
 ^You don't need to stay in the country while your notice is posted.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bulgaria/third_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bulgaria/third_country/partner_british/_opposite_sex.erb
@@ -29,7 +29,7 @@ $A
 
 ## Get your documents witnessed at the embassy
 
-[Make an appointment at the embassy in Sofia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-sofia/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Sofia](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=34&service=10)
 
 You’ll need to complete a [‘Notice of marriage’](/government/publications/notice-of-marriage-form--2) form and an [‘Affidavit for marriage’](/government/publications/affirmationaffidavit-of-marital-status-form) form.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bulgaria/third_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bulgaria/third_country/partner_local/_opposite_sex.erb
@@ -59,7 +59,7 @@ The consulate will display your notice of marriage publicly for 7 days before is
 
 You can collect the CNI from the embassy or ask for it to be sent by courier to an address in Bulgaria. You’ll need to pay any courier fees.
 
-[Make an appointment to collect your CNI at the embassy in Sofia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-sofia/certificate-of-no-impediment/slot_picker)
+[Make an appointment to collect your CNI at the embassy in Sofia](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=34&service=4)
 
 ^You don't need to stay in the country while your notice is posted.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bulgaria/third_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bulgaria/third_country/partner_local/_opposite_sex.erb
@@ -29,7 +29,7 @@ $A
 
 ## Get your documents witnessed at the embassy
 
-[Make an appointment at the embassy in Sofia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-sofia/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Sofia](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=34&service=10)
 
 You’ll need to complete a [‘Notice of marriage’](/government/publications/notice-of-marriage-form--2) form and an [‘Affidavit for marriage’](/government/publications/affirmationaffidavit-of-marital-status-form) form.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bulgaria/third_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bulgaria/third_country/partner_other/_opposite_sex.erb
@@ -59,7 +59,7 @@ The consulate will display your notice of marriage publicly for 7 days before is
 
 You can collect the CNI from the embassy or ask for it to be sent by courier to an address in Bulgaria. You’ll need to pay any courier fees.
 
-[Make an appointment to collect your CNI at the embassy in Sofia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-sofia/certificate-of-no-impediment/slot_picker)
+[Make an appointment to collect your CNI at the embassy in Sofia](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=34&service=4)
 
 ^You don't need to stay in the country while your notice is posted.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bulgaria/third_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bulgaria/third_country/partner_other/_opposite_sex.erb
@@ -29,7 +29,7 @@ $A
 
 ## Get your documents witnessed at the embassy
 
-[Make an appointment at the embassy in Sofia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-sofia/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Sofia](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=34&service=10)
 
 You’ll need to complete a [‘Notice of marriage’](/government/publications/notice-of-marriage-form--2) form and an [‘Affidavit for marriage’](/government/publications/affirmationaffidavit-of-marital-status-form) form.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bulgaria/uk/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bulgaria/uk/partner_british/_opposite_sex.erb
@@ -18,7 +18,7 @@ You can normally get a CNI by giving a notice of marriage at your local register
 
 You must make an appointment at the British embassy in Sofia to to exchange your UK-issued CNI for a locally-issued one.
 
-[Make an appointment at the embassy in Sofia.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-sofia/certificate-of-no-impediment/slot_picker)
+[Make an appointment at the embassy in Sofia.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=34&service=4)
 
 ### Legalisation and translation
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bulgaria/uk/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bulgaria/uk/partner_local/_opposite_sex.erb
@@ -18,7 +18,7 @@ You can normally get a CNI by giving a notice of marriage at your local register
 
 You must make an appointment at the British embassy in Sofia to to exchange your UK-issued CNI for a locally-issued one.
 
-[Make an appointment at the embassy in Sofia.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-sofia/certificate-of-no-impediment/slot_picker)
+[Make an appointment at the embassy in Sofia.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=34&service=4)
 
 ### Legalisation and translation
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bulgaria/uk/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/bulgaria/uk/partner_other/_opposite_sex.erb
@@ -18,7 +18,7 @@ You can normally get a CNI by giving a notice of marriage at your local register
 
 You must make an appointment at the British embassy in Sofia to to exchange your UK-issued CNI for a locally-issued one.
 
-[Make an appointment at the embassy in Sofia.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-sofia/certificate-of-no-impediment/slot_picker)
+[Make an appointment at the embassy in Sofia.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=34&service=4)
 
 ### Legalisation and translation
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/cambodia/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/cambodia/ceremony_country/partner_british/_opposite_sex.erb
@@ -8,7 +8,7 @@ If the local authorities say you can get married, you’ll be asked to provide a
 
 Make an appointment at the British embassy or consulate in Cambodia to swear an affidavit (written statement of facts) that you’re free to marry.
 
-[Make an appointment at the embassy in Phnom Penh.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-phnom-penh/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Phnom Penh.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=135&service=13)
 
 You’ll need to bring your passport, your partner’s passport (or Cambodian ID card) and pay a fee.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/cambodia/ceremony_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/cambodia/ceremony_country/partner_british/_same_sex.erb
@@ -2,7 +2,7 @@ You may be able to register a civil partnership or get married at the British em
 
 You must post notice of your marriage at the British embassy in Phnom Penh.
 
-[Make an appointment at the embassy in Phnom Penh.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-phnom-penh/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Phnom Penh.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=135&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/cambodia/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/cambodia/ceremony_country/partner_local/_opposite_sex.erb
@@ -6,7 +6,7 @@ If the local authorities say you can get married, you’ll be asked to provide a
 
 Make an appointment at the British embassy or consulate in Cambodia to swear an affidavit (written statement of facts) that you’re free to marry.
 
-[Make an appointment at the embassy in Phnom Penh.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-phnom-penh/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Phnom Penh.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=135&service=13)
 
 You’ll need to bring your passport, your partner’s passport (or Cambodian ID card) and pay a fee.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/cambodia/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/cambodia/ceremony_country/partner_other/_opposite_sex.erb
@@ -8,7 +8,7 @@ If the local authorities say you can get married, you’ll be asked to provide a
 
 Make an appointment at the British embassy or consulate in Cambodia to swear an affidavit (written statement of facts) that you’re free to marry.
 
-[Make an appointment at the embassy in Phnom Penh.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-phnom-penh/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Phnom Penh.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=135&service=13)
 
 You’ll need to bring your passport, your partner’s passport (or Cambodian ID card) and pay a fee.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/cambodia/ceremony_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/cambodia/ceremony_country/partner_other/_same_sex.erb
@@ -2,7 +2,7 @@ You may be able to register a civil partnership or get married at the British em
 
 You must post notice of your marriage at the British embassy in Phnom Penh.
 
-[Make an appointment at the embassy in Phnom Penh.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-phnom-penh/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Phnom Penh.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=135&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/cambodia/third_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/cambodia/third_country/partner_british/_opposite_sex.erb
@@ -8,7 +8,7 @@ If the local authorities say you can get married, you’ll be asked to provide a
 
 Make an appointment at the British embassy or consulate in Cambodia to swear an affidavit (written statement of facts) that you’re free to marry.
 
-[Make an appointment at the embassy in Phnom Penh.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-phnom-penh/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Phnom Penh.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=135&service=13)
 
 You’ll need to bring your passport, your partner’s passport (or Cambodian ID card) and pay a fee.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/cambodia/third_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/cambodia/third_country/partner_british/_same_sex.erb
@@ -2,7 +2,7 @@ You may be able to register a civil partnership or get married at the British em
 
 You must post notice of your marriage at the British embassy in Phnom Penh.
 
-[Make an appointment at the embassy in Phnom Penh.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-phnom-penh/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Phnom Penh.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=135&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/cambodia/third_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/cambodia/third_country/partner_local/_opposite_sex.erb
@@ -6,7 +6,7 @@ If the local authorities say you can get married, you’ll be asked to provide a
 
 Make an appointment at the British embassy or consulate in Cambodia to swear an affidavit (written statement of facts) that you’re free to marry.
 
-[Make an appointment at the embassy in Phnom Penh.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-phnom-penh/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Phnom Penh.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=135&service=13)
 
 You’ll need to bring your passport, your partner’s passport (or Cambodian ID card) and pay a fee.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/cambodia/third_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/cambodia/third_country/partner_other/_opposite_sex.erb
@@ -8,7 +8,7 @@ If the local authorities say you can get married, you’ll be asked to provide a
 
 Make an appointment at the British embassy or consulate in Cambodia to swear an affidavit (written statement of facts) that you’re free to marry.
 
-[Make an appointment at the embassy in Phnom Penh.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-phnom-penh/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Phnom Penh.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=135&service=13)
 
 You’ll need to bring your passport, your partner’s passport (or Cambodian ID card) and pay a fee.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/cambodia/third_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/cambodia/third_country/partner_other/_same_sex.erb
@@ -2,7 +2,7 @@ You may be able to register a civil partnership or get married at the British em
 
 You must post notice of your marriage at the British embassy in Phnom Penh.
 
-[Make an appointment at the embassy in Phnom Penh.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-phnom-penh/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Phnom Penh.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=135&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/cambodia/uk/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/cambodia/uk/partner_british/_opposite_sex.erb
@@ -8,7 +8,7 @@ If the local authorities say you can get married, you’ll be asked to provide a
 
 Make an appointment at the British embassy or consulate in Cambodia to swear an affidavit (written statement of facts) that you’re free to marry.
 
-[Make an appointment at the embassy in Phnom Penh.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-phnom-penh/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Phnom Penh.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=135&service=13)
 
 You’ll need to bring your passport, your partner’s passport (or Cambodian ID card) and pay a fee.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/cambodia/uk/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/cambodia/uk/partner_british/_same_sex.erb
@@ -2,7 +2,7 @@ You may be able to register a civil partnership or get married at the British em
 
 You must post notice of your marriage at the British embassy in Phnom Penh.
 
-[Make an appointment at the embassy in Phnom Penh.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-phnom-penh/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Phnom Penh.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=135&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/cambodia/uk/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/cambodia/uk/partner_local/_opposite_sex.erb
@@ -6,7 +6,7 @@ If the local authorities say you can get married, you’ll be asked to provide a
 
 Make an appointment at the British embassy or consulate in Cambodia to swear an affidavit (written statement of facts) that you’re free to marry.
 
-[Make an appointment at the embassy in Phnom Penh.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-phnom-penh/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Phnom Penh.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=135&service=13)
 
 You’ll need to bring your passport, your partner’s passport (or Cambodian ID card) and pay a fee.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/cambodia/uk/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/cambodia/uk/partner_other/_opposite_sex.erb
@@ -8,7 +8,7 @@ If the local authorities say you can get married, you’ll be asked to provide a
 
 Make an appointment at the British embassy or consulate in Cambodia to swear an affidavit (written statement of facts) that you’re free to marry.
 
-[Make an appointment at the embassy in Phnom Penh.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-phnom-penh/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Phnom Penh.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=135&service=13)
 
 You’ll need to bring your passport, your partner’s passport (or Cambodian ID card) and pay a fee.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/cambodia/uk/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/cambodia/uk/partner_other/_same_sex.erb
@@ -2,7 +2,7 @@ You may be able to register a civil partnership or get married at the British em
 
 You must post notice of your marriage at the British embassy in Phnom Penh.
 
-[Make an appointment at the embassy in Phnom Penh.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-phnom-penh/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Phnom Penh.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=135&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/chile/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/chile/ceremony_country/partner_british/_opposite_sex.erb
@@ -12,7 +12,7 @@ To get a CNI, you must post notice of your intended marriage in Chile. You can d
 
 You’ll need to have been living in Chile for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Santiago.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-santiago/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Santiago.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=143&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/chile/ceremony_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/chile/ceremony_country/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Chile.
 
-[Make an appointment at the embassy in Santiago.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-santiago/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Santiago.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=143&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/chile/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/chile/ceremony_country/partner_local/_opposite_sex.erb
@@ -12,7 +12,7 @@ To get a CNI, you must post notice of your intended marriage in Chile. You can d
 
 You’ll need to have been living in Chile for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Santiago.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-santiago/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Santiago.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=143&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/chile/ceremony_country/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/chile/ceremony_country/partner_local/_same_sex.erb
@@ -1,5 +1,5 @@
 You may be able to get married at the British embassy or consulate in Chile.
-[Make an appointment at the embassy in Santiago.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-santiago/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Santiago.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=143&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/chile/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/chile/ceremony_country/partner_other/_opposite_sex.erb
@@ -12,7 +12,7 @@ To get a CNI, you must post notice of your intended marriage in Chile. You can d
 
 You’ll need to have been living in Chile for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Santiago.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-santiago/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Santiago.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=143&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/chile/ceremony_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/chile/ceremony_country/partner_other/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Chile.
 
-[Make an appointment at the embassy in Santiago.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-santiago/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Santiago.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=143&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/chile/third_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/chile/third_country/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Chile.
 
-[Make an appointment at the embassy in Santiago.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-santiago/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Santiago.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=143&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/chile/third_country/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/chile/third_country/partner_local/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Chile.
 
-[Make an appointment at the embassy in Santiago.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-santiago/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Santiago.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=143&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/chile/third_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/chile/third_country/partner_other/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Chile.
 
-[Make an appointment at the embassy in Santiago.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-santiago/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Santiago.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=143&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/chile/uk/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/chile/uk/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Chile.
 
-[Make an appointment at the embassy in Santiago.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-santiago/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Santiago.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=143&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/chile/uk/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/chile/uk/partner_local/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Chile.
 
-[Make an appointment at the embassy in Santiago.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-santiago/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Santiago.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=143&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/chile/uk/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/chile/uk/partner_other/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Chile.
 
-[Make an appointment at the embassy in Santiago.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-santiago/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Santiago.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=143&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/china/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/china/_opposite_sex.erb
@@ -19,7 +19,7 @@ An affidavit is a religious document. If you do not want to swear a religious oa
 
 s1. Download an [affirmation](/government/publications/affirmation-form-china) or [affidavit](/government/publications/affidavit-form-china).
 s2. Fill it in on your computer - it won't be accepted if it's handwritten.
-s3. Make an appointment to swear your affirmation or affidavit at [the embassy in Beijing](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beijing/oaths-affirmations-and-affidavits/slot_picker) or the consulate in [Shanghai](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-shanghai/oaths-affirmations-and-affidavits/slot_picker) or [Guangzhou](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=63&service=13).
+s3. Make an appointment to swear your affirmation or affidavit at [the embassy in Beijing](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=100&service=13) or the consulate in [Shanghai](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=77&service=13) or [Guangzhou](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=63&service=13).
 
 
 You’ll need to bring:

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/china/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/china/_opposite_sex.erb
@@ -19,7 +19,7 @@ An affidavit is a religious document. If you do not want to swear a religious oa
 
 s1. Download an [affirmation](/government/publications/affirmation-form-china) or [affidavit](/government/publications/affidavit-form-china).
 s2. Fill it in on your computer - it won't be accepted if it's handwritten.
-s3. Make an appointment to swear your affirmation or affidavit at [the embassy in Beijing](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beijing/oaths-affirmations-and-affidavits/slot_picker) or the consulate in [Shanghai](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-shanghai/oaths-affirmations-and-affidavits/slot_picker) or [Guangzhou](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-guangzhou/oaths-affirmations-and-affidavits/slot_picker).
+s3. Make an appointment to swear your affirmation or affidavit at [the embassy in Beijing](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beijing/oaths-affirmations-and-affidavits/slot_picker) or the consulate in [Shanghai](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-shanghai/oaths-affirmations-and-affidavits/slot_picker) or [Guangzhou](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=63&service=13).
 
 
 You’ll need to bring:

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/china/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/china/_same_sex.erb
@@ -14,7 +14,7 @@ You both need to sign a declaration that you’re free to marry.
 
 Make an appointment to give notice of your marriage at:
 
-- [the embassy in Beijing](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beijing/notice-of-marriage-or-civil-partnership/slot_picker)
+- [the embassy in Beijing](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=100&service=10)
 - [the consulate in Guangzhou](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-guangzhou/notice-of-marriage-or-civil-partnership/slot_picker)
 - [the consulate in Shanghai](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=77&service=10)
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/china/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/china/_same_sex.erb
@@ -16,7 +16,7 @@ Make an appointment to give notice of your marriage at:
 
 - [the embassy in Beijing](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beijing/notice-of-marriage-or-civil-partnership/slot_picker)
 - [the consulate in Guangzhou](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-guangzhou/notice-of-marriage-or-civil-partnership/slot_picker)
-- [the consulate in Shanghai](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-shanghai/notice-of-marriage-or-civil-partnership/slot_picker)
+- [the consulate in Shanghai](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=77&service=10)
 
 It costs <%= format_money calculator.consular_fee(:receiving_notice_of_marriage) %> to give notice. You can pay in the [local currency](/government/publications/china-consular-fees) with cash or credit card.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/china/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/china/_same_sex.erb
@@ -15,7 +15,7 @@ You both need to sign a declaration that you’re free to marry.
 Make an appointment to give notice of your marriage at:
 
 - [the embassy in Beijing](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=100&service=10)
-- [the consulate in Guangzhou](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-guangzhou/notice-of-marriage-or-civil-partnership/slot_picker)
+- [the consulate in Guangzhou](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=63&service=10)
 - [the consulate in Shanghai](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=77&service=10)
 
 It costs <%= format_money calculator.consular_fee(:receiving_notice_of_marriage) %> to give notice. You can pay in the [local currency](/government/publications/china-consular-fees) with cash or credit card.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/colombia/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/colombia/ceremony_country/partner_british/_opposite_sex.erb
@@ -11,7 +11,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy in Bogota to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Bogota.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Bogota.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=104&service=13)
 
 ## Fees
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/colombia/ceremony_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/colombia/ceremony_country/partner_british/_same_sex.erb
@@ -8,7 +8,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
  
 Make an appointment at the British embassy in Bogota to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
  
-[Make an appointment at the embassy in Bogota.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Bogota.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=104&service=13)
  
 ## Fees
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/colombia/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/colombia/ceremony_country/partner_local/_opposite_sex.erb
@@ -10,7 +10,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy in Bogota to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Bogota.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Bogota.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=104&service=13)
 
 ## Fees
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/colombia/ceremony_country/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/colombia/ceremony_country/partner_local/_same_sex.erb
@@ -8,7 +8,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
  
 Make an appointment at the British embassy in Bogota to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
  
-[Make an appointment at the embassy in Bogota.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Bogota.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=104&service=13)
  
 ## Fees
  

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/colombia/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/colombia/ceremony_country/partner_other/_opposite_sex.erb
@@ -10,7 +10,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy in Bogota to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Bogota.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Bogota.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=104&service=13)
 
 ## Fees
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/colombia/ceremony_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/colombia/ceremony_country/partner_other/_same_sex.erb
@@ -8,7 +8,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
  
 Make an appointment at the British embassy in Bogota to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
  
-[Make an appointment at the embassy in Bogota.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Bogota.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=104&service=13)
  
 ## Fees
  

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/colombia/third_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/colombia/third_country/partner_british/_opposite_sex.erb
@@ -11,7 +11,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy in Bogota to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Bogota.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Bogota.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=104&service=13)
 
 ## Fees
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/colombia/third_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/colombia/third_country/partner_british/_same_sex.erb
@@ -8,7 +8,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
  
 Make an appointment at the British embassy in Bogota to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
  
-[Make an appointment at the embassy in Bogota.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Bogota.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=104&service=13)
  
 ## Fees
  

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/colombia/third_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/colombia/third_country/partner_local/_opposite_sex.erb
@@ -11,7 +11,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy in Bogota to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Bogota.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Bogota.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=104&service=13)
 
 ## Fees
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/colombia/third_country/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/colombia/third_country/partner_local/_same_sex.erb
@@ -8,7 +8,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
  
 Make an appointment at the British embassy in Bogota to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
  
-[Make an appointment at the embassy in Bogota.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Bogota.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=104&service=13)
  
 ## Fees
  

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/colombia/third_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/colombia/third_country/partner_other/_opposite_sex.erb
@@ -11,7 +11,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy in Bogota to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Bogota.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Bogota.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=104&service=13)
 
 ## Fees
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/colombia/third_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/colombia/third_country/partner_other/_same_sex.erb
@@ -8,7 +8,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
  
 Make an appointment at the British embassy in Bogota to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
  
-[Make an appointment at the embassy in Bogota.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Bogota.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=104&service=13)
  
 ## Fees
  

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/colombia/uk/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/colombia/uk/partner_british/_opposite_sex.erb
@@ -11,7 +11,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy in Bogota to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Bogota.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Bogota.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=104&service=13)
 
 ## Fees
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/colombia/uk/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/colombia/uk/partner_british/_same_sex.erb
@@ -8,7 +8,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
  
 Make an appointment at the British embassy in Bogota to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
  
-[Make an appointment at the embassy in Bogota.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Bogota.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=104&service=13)
  
 ## Fees
  

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/colombia/uk/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/colombia/uk/partner_local/_opposite_sex.erb
@@ -11,7 +11,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy in Bogota to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Bogota.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Bogota.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=104&service=13)
 
 ## Fees
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/colombia/uk/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/colombia/uk/partner_local/_same_sex.erb
@@ -8,7 +8,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
  
 Make an appointment at the British embassy in Bogota to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
  
-[Make an appointment at the embassy in Bogota.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Bogota.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=104&service=13)
  
 ## Fees
  

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/colombia/uk/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/colombia/uk/partner_other/_opposite_sex.erb
@@ -11,7 +11,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy in Bogota to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Bogota.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Bogota.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=104&service=13)
 
 ## Fees
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/colombia/uk/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/colombia/uk/partner_other/_same_sex.erb
@@ -8,7 +8,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
  
 Make an appointment at the British embassy in Bogota to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
  
-[Make an appointment at the embassy in Bogota.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bogot%25C3%25A1/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Bogota.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=104&service=13)
  
 ## Fees
  

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/congo/ceremony_country/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/congo/ceremony_country/_opposite_sex.erb
@@ -16,7 +16,7 @@ You need to prove you’re legally allowed to get married or register a civil pa
 
 To get a CNI, you’ll need to travel to the Democratic Republic of the Congo and give notice of your marriage at the British embassy in Kinshasa.
 
-s1.  Make an appointment at the [British embassy in Kinshasa](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-kinshasa/notice-of-marriage-or-civil-partnership/slot_picker). You need to be in the Democratic Republic of the Congo for 3 full days before your appointment.
+s1.  Make an appointment at the [British embassy in Kinshasa](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=122&service=10). You need to be in the Democratic Republic of the Congo for 3 full days before your appointment.
 s2. Download and complete a [‘notice of marriage’](/government/publications/notice-of-marriage-form--2) and [‘affidavit for marriage’](/government/publications/affirmationaffidavit-of-marital-status-form). Do not sign them before your appointment.
 
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/croatia/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/croatia/_opposite_sex.erb
@@ -3,12 +3,12 @@ Contact the relevant local authorities in Croatia to find out about local marria
 
 ##What you need to do
 You’ll be asked to provide a certificate of no impediment (CNI) to prove you’re free to marry.
-The local registrar may also need a certificate of custom law, which confirms that the marriage would be valid in the UK. This costs £50 from the [British Embassy in Zagreb](/guidance/notarial-and-documentary-services-guide-for-croatia).  
+The local registrar may also need a certificate of custom law, which confirms that the marriage would be valid in the UK. This costs £50 from the [British Embassy in Zagreb](/guidance/notarial-and-documentary-services-guide-for-croatia).
 
 ##Prove you’re free to get married
 You need to prove you’re legally allowed to get married by getting a:
 
-- certificate of no impediment (CNI) 
+- certificate of no impediment (CNI)
 - certificate of custom law - if the registrar has asked for it
 
 If your partner is British they’ll need to apply for their own CNI and certificate of custom law.
@@ -20,13 +20,13 @@ You’ll need to get a CNI if you’re in the UK.
 
 To get a CNI, make an appointment at your [local register office](/register-offices) to give notice of your marriage. A CNI costs £35.
 
-Contact your local register office to find out what you need to do if you live in [Scotland](https://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](https://www.nidirect.gov.uk/contacts/district-registrars-northern-ireland), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages/), [Jersey](https://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).  
+Contact your local register office to find out what you need to do if you live in [Scotland](https://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](https://www.nidirect.gov.uk/contacts/district-registrars-northern-ireland), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages/), [Jersey](https://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
 You’ll need to bring [certain documents](/marriages-civil-partnerships/documents-to-take-to-the-register-office) with you to your appointment.
 
 Your notice will be publicly displayed in the register office for 28 days. You can collect your CNI after this if nobody registers an objection. A CNI is valid for 3 months under Croatian law.
 
-You can exchange your UK-issued CNI for one in Croatian and get a certificate of custom law (if you need to) from the [British Embassy in Croatia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-zagreb/certificate-of-no-impediment/slot_picker).
+You can exchange your UK-issued CNI for one in Croatian and get a certificate of custom law (if you need to) from the [British Embassy in Croatia](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=41&service=4).
 
 Download and fill in the section on certificate of custom and law in the [CNI application pack](/government/publications/croatia-marriage-pack) before your appointment. You’ll need to take your passport and UK-issued CNI to your appointment.
 
@@ -36,16 +36,16 @@ You’ll need to have been living in Croatia for at least 3 full days before you
 
 You can then book an appointment at the embassy to give notice of your marriage. It costs <%= format_money calculator.consular_fee(:receiving_notice_of_marriage) %>. You can only pay by card.
 
-[Make an appointment at the embassy in Zagreb](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-zagreb/certificate-of-no-impediment/slot_picker).
+[Make an appointment at the embassy in Zagreb](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=41&service=4).
 
 Download and fill in the [CNI application](/government/publications/croatia-marriage-pack) pack before your appointment.  It contains a list of the documents you’ll need.  Fill in the notice of marriage and affidavit for marriage in the application pack. Don’t sign it unless you’re posting it.
 
 You must take the forms with you to your appointment.
 
-You can also apply for marriage documents by post. 
+You can also apply for marriage documents by post.
 
 The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the marriage to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example, a marriage certificate or deed poll).
- 
+
 ##What happens next
 
 The consulate will display your notice of marriage publicly for 7 days.
@@ -56,7 +56,7 @@ You should check if your CNI needs to be legalised (certified as genuine) by the
 
 ##Get married
 
-You’ll need to give your CNI and certificate of custom law to the registrar or priest who’ll be marrying you.  
+You’ll need to give your CNI and certificate of custom law to the registrar or priest who’ll be marrying you.
 
 ##After you get married
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/croatia/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/croatia/_same_sex.erb
@@ -1,6 +1,6 @@
 Contact the:
 
-- [Ministry for Administration](https://uprava.gov.hr/o-ministarstvu/ustrojstvo/uprava-za-opcu-upravu/sklapanje-zivotnog-partnerstva/12954) to find out about local civil partnership laws and what documents you’ll need 
+- [Ministry for Administration](https://uprava.gov.hr/o-ministarstvu/ustrojstvo/uprava-za-opcu-upravu/sklapanje-zivotnog-partnerstva/12954) to find out about local civil partnership laws and what documents you’ll need
 - [local registrar](https://uprava.gov.hr/maticni-uredi-u-rh/1603) where you want to have your civil partnership
 
 ^ You should get [legal advice](/government/collections/list-of-lawyers) and check the [travel advice for Croatia](/foreign-travel-advice/croatia) before making any plans.
@@ -19,13 +19,13 @@ You’ll need to get a CNI if you’re in the UK.
 
 To get a CNI, make an appointment at your [local register office](/register-offices) to give notice of your civil partnership. A CNI costs £35.
 
-Contact your local register office to find out what you need to do if you live in [Scotland](https://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](https://www.nidirect.gov.uk/contacts/district-registrars-northern-ireland), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages/), [Jersey](https://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).  
+Contact your local register office to find out what you need to do if you live in [Scotland](https://www.nrscotland.gov.uk/files/registration/reglist.pdf), [Northern Ireland](https://www.nidirect.gov.uk/contacts/district-registrars-northern-ireland), [Isle of Man](https://www.gov.im/categories/births-deaths-and-marriages/), [Jersey](https://www.gov.je/pages/contacts.aspx?contactId=71) or [Guernsey](http://www.guernseyroyalcourt.gg/article/1663/Contact-Us).
 
 You’ll need to bring [certain documents](/marriages-civil-partnerships/documents-to-take-to-the-register-office) with you to your appointment.
 
 Your notice will be publicly displayed in the register office for 28 days. You can collect your CNI after this if nobody registers an objection. A CNI is valid for 3 months under Croatian law.
 
-You can exchange your UK-issued CNI for one in Croatian and get a certificate of custom law (if you need to) from the [British Embassy in Croatia](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-zagreb/certificate-of-no-impediment/slot_picker).
+You can exchange your UK-issued CNI for one in Croatian and get a certificate of custom law (if you need to) from the [British Embassy in Croatia](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=41&service=4).
 
 Download and fill in the section on certificate of custom and law in the [CNI application pack](/government/publications/croatia-civil-partnership-pack) before your appointment. You’ll need to take your passport and UK-issued CNI to your appointment.
 
@@ -35,7 +35,7 @@ You’ll need to have been living in Croatia for at least 3 full days before you
 
 You can then book an appointment at the embassy to give notice of your civil partnership. It costs <%= format_money calculator.consular_fee(:receiving_notice_of_marriage) %>. You can only pay by card.
 
-[Make an appointment at the embassy in Zagreb](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-zagreb/certificate-of-no-impediment/slot_picker).
+[Make an appointment at the embassy in Zagreb](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=41&service=4).
 
 You and your partner need to bring:
 
@@ -47,12 +47,12 @@ You’ll need to complete and bring a [notice for civil partnership form and a c
 Download and fill in (but not sign) the forms in advance.
 
 The names on all documents you provide must appear exactly as they do on your passports - if not, the authorities may refuse to allow the civil partnership to go ahead. You may need to provide evidence if the name on your passport is different to your birth certificate (for example, a marriage certificate or deed poll).
- 
+
 ##What happens next
 
 The consulate will display your notice of civil partnership publicly for 7 full days.
 
-The British embassy will then issue your CNI (as long as nobody has registered an objection) after 8 days. This costs <%= format_money calculator.consular_fee(:issuing_cni_or_nulla_osta) %>. 
+The British embassy will then issue your CNI (as long as nobody has registered an objection) after 8 days. This costs <%= format_money calculator.consular_fee(:issuing_cni_or_nulla_osta) %>.
 
 You should check if your CNI needs to be legalised (certified as genuine) by the local authorities in Croatia.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/cuba/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/cuba/ceremony_country/partner_british/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Cuba. You can do
 
 You’ll need to have been living in Cuba for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Havana.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-havana/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Havana.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=117&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/cuba/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/cuba/ceremony_country/partner_local/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Cuba. You can do
 
 You’ll need to have been living in Cuba for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Havana.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-havana/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Havana.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=117&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/cuba/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/cuba/ceremony_country/partner_other/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Cuba. You can do
 
 You’ll need to have been living in Cuba for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Havana.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-havana/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Havana.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=117&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/cyprus/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/cyprus/_same_sex.erb
@@ -18,7 +18,7 @@ notice until the following Tuesday.
 ### Give notice of your civil partnership
 
 [Make an appointment at the high commission](
-https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-nicosia/notice-of-marriage-or-civil-partnership/slot_picker
+https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=43&service=10
 ) to give notice of your civil partnership and set a date for your
 ceremony.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/democratic-republic-of-the-congo/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/democratic-republic-of-the-congo/ceremony_country/partner_british/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in the Democratic R
 
 You’ll need to have been living in the Democratic Republic of the Congo for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Kinshasa.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-kinshasa/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Kinshasa.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=122&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/democratic-republic-of-the-congo/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/democratic-republic-of-the-congo/ceremony_country/partner_local/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in the Democratic R
 
 You’ll need to have been living in the Democratic Republic of the Congo for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Kinshasa.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-kinshasa/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Kinshasa.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=122&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/democratic-republic-of-the-congo/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/democratic-republic-of-the-congo/ceremony_country/partner_other/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in the Democratic R
 
 You’ll need to have been living in the Democratic Republic of the Congo for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Kinshasa.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-kinshasa/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Kinshasa.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=122&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/denmark/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/denmark/ceremony_country/partner_british/_opposite_sex.erb
@@ -29,7 +29,7 @@ To get a CNI, you must post notice of your intended marriage in Denmark. You can
 
 You’ll need to have been living in Denmark for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Copenhagen.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-copenhagen/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Copenhagen.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=22&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/denmark/ceremony_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/denmark/ceremony_country/partner_british/_same_sex.erb
@@ -31,7 +31,7 @@ To get a CNI, you must post notice of your intended marriage in Denmark. You can
 
 You’ll need to have been living in Denmark for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Copenhagen.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-copenhagen/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Copenhagen.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=22&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/denmark/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/denmark/ceremony_country/partner_local/_opposite_sex.erb
@@ -29,7 +29,7 @@ To get a CNI, you must post notice of your intended marriage in Denmark. You can
 
 You’ll need to have been living in Denmark for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Copenhagen.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-copenhagen/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Copenhagen.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=22&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/denmark/ceremony_country/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/denmark/ceremony_country/partner_local/_same_sex.erb
@@ -31,7 +31,7 @@ To get a CNI, you must post notice of your intended marriage in Denmark. You can
 
 You’ll need to have been living in Denmark for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Copenhagen.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-copenhagen/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Copenhagen.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=22&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/denmark/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/denmark/ceremony_country/partner_other/_opposite_sex.erb
@@ -29,7 +29,7 @@ To get a CNI, you must post notice of your intended marriage in Denmark. You can
 
 You’ll need to have been living in Denmark for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Copenhagen.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-copenhagen/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Copenhagen.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=22&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/denmark/ceremony_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/denmark/ceremony_country/partner_other/_same_sex.erb
@@ -31,7 +31,7 @@ To get a CNI, you must post notice of your intended marriage in Denmark. You can
 
 You’ll need to have been living in Denmark for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Copenhagen.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-copenhagen/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Copenhagen.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=22&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/dominican-republic/ceremony_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/dominican-republic/ceremony_country/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in the Dominican Republic.
 
-[Make an appointment at the embassy in Santo Domingo.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-santo-domingo/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Santo Domingo.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=144&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/dominican-republic/ceremony_country/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/dominican-republic/ceremony_country/partner_local/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in the Dominican Republic.
 
-[Make an appointment at the embassy in Santo Domingo.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-santo-domingo/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Santo Domingo.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=144&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/dominican-republic/ceremony_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/dominican-republic/ceremony_country/partner_other/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in the Dominican Republic.
 
-[Make an appointment at the embassy in Santo Domingo.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-santo-domingo/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Santo Domingo.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=144&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/dominican-republic/third_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/dominican-republic/third_country/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in the Dominican Republic.
 
-[Make an appointment at the embassy in Santo Domingo.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-santo-domingo/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Santo Domingo.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=144&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/dominican-republic/third_country/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/dominican-republic/third_country/partner_local/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in the Dominican Republic.
 
-[Make an appointment at the embassy in Santo Domingo.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-santo-domingo/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Santo Domingo.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=144&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/dominican-republic/third_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/dominican-republic/third_country/partner_other/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in the Dominican Republic.
 
-[Make an appointment at the embassy in Santo Domingo.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-santo-domingo/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Santo Domingo.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=144&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/dominican-republic/uk/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/dominican-republic/uk/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in the Dominican Republic.
 
-[Make an appointment at the embassy in Santo Domingo.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-santo-domingo/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Santo Domingo.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=144&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/dominican-republic/uk/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/dominican-republic/uk/partner_local/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in the Dominican Republic.
 
-[Make an appointment at the embassy in Santo Domingo.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-santo-domingo/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Santo Domingo.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=144&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/dominican-republic/uk/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/dominican-republic/uk/partner_other/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in the Dominican Republic.
 
-[Make an appointment at the embassy in Santo Domingo.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-santo-domingo/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Santo Domingo.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=144&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/ceremony_country/partner_british/_opposite_sex.erb
@@ -7,7 +7,7 @@ You might be able to form an opposite sex civil partnership. Check the local rul
 
 You’ll be asked for an affirmation or affidavit document to prove you’re allowed to marry.
 
-To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-quito/oaths-affirmations-and-affidavits/slot_picker).
+To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=138&service=13).
 
 You’ll need to bring your passport and pay a fee.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/ceremony_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/ceremony_country/partner_british/_same_sex.erb
@@ -4,7 +4,7 @@ Contact the relevant local authorities in Ecuador to find out about local laws, 
 
 You’ll be asked for an affirmation or affidavit document to prove that you’re allowed to marry.
 
-To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-quito/oaths-affirmations-and-affidavits/slot_picker).
+To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=138&service=13).
 
 You’ll need to bring your passport and pay a fee.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/ceremony_country/partner_local/_opposite_sex.erb
@@ -7,7 +7,7 @@ You might be able to form an opposite sex civil partnership. Check the local rul
 
 You’ll be asked for an affirmation or affidavit document to prove you’re allowed to marry.
 
-To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-quito/oaths-affirmations-and-affidavits/slot_picker).
+To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=138&service=13).
 
 You’ll need to bring your passport and pay a fee.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/ceremony_country/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/ceremony_country/partner_local/_same_sex.erb
@@ -4,7 +4,7 @@ Contact the relevant local authorities in Ecuador to find out about local laws, 
 
 You’ll be asked for an affirmation or affidavit document to prove that you’re allowed to marry.
 
-To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-quito/oaths-affirmations-and-affidavits/slot_picker).
+To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=138&service=13).
 
 You’ll need to bring your passport and pay a fee.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/ceremony_country/partner_other/_opposite_sex.erb
@@ -7,7 +7,7 @@ You might be able to form an opposite sex civil partnership. Check the local rul
 
 You’ll be asked for an affirmation or affidavit document to prove you’re allowed to marry.
 
-To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-quito/oaths-affirmations-and-affidavits/slot_picker).
+To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=138&service=13).
 
 You’ll need to bring your passport and pay a fee.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/ceremony_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/ceremony_country/partner_other/_same_sex.erb
@@ -4,7 +4,7 @@ Contact the relevant local authorities in Ecuador to find out about local laws, 
 
 You’ll be asked for an affirmation or affidavit document to prove that you’re allowed to marry.
 
-To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-quito/oaths-affirmations-and-affidavits/slot_picker).
+To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=138&service=13).
 
 You’ll need to bring your passport and pay a fee.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/third_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/third_country/partner_british/_opposite_sex.erb
@@ -7,7 +7,7 @@ You might be able to form an opposite sex civil partnership. Check the local rul
 
 You’ll be asked for an affirmation or affidavit document to prove you’re allowed to marry.
 
-To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-quito/oaths-affirmations-and-affidavits/slot_picker).
+To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=138&service=13).
 
 You’ll need to bring your passport and pay a fee.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/third_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/third_country/partner_british/_same_sex.erb
@@ -6,7 +6,7 @@ You should also check the [travel advice for Ecuador](/foreign-travel-advice/ecu
 
 You’ll be asked for an affirmation or affidavit document to prove that you’re allowed to marry.
 
-To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-quito/oaths-affirmations-and-affidavits/slot_picker).
+To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=138&service=13).
 
 You’ll need to bring your passport and pay a fee.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/third_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/third_country/partner_local/_opposite_sex.erb
@@ -7,7 +7,7 @@ You might be able to form an opposite sex civil partnership. Check the local rul
 
 You’ll be asked for an affirmation or affidavit document to prove you’re allowed to marry.
 
-To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-quito/oaths-affirmations-and-affidavits/slot_picker).
+To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=138&service=13).
 
 You’ll need to bring your passport and pay a fee.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/third_country/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/third_country/partner_local/_same_sex.erb
@@ -6,7 +6,7 @@ You should also check the [travel advice for Ecuador](/foreign-travel-advice/ecu
 
 You’ll be asked for an affirmation or affidavit document to prove that you’re allowed to marry.
 
-To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-quito/oaths-affirmations-and-affidavits/slot_picker).
+To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=138&service=13).
 
 You’ll need to bring your passport and pay a fee.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/third_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/third_country/partner_other/_opposite_sex.erb
@@ -7,7 +7,7 @@ You might be able to form an opposite sex civil partnership. Check the local rul
 
 You’ll be asked for an affirmation or affidavit document to prove you’re allowed to marry.
 
-To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-quito/oaths-affirmations-and-affidavits/slot_picker).
+To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=138&service=13).
 
 You’ll need to bring your passport and pay a fee.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/third_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/third_country/partner_other/_same_sex.erb
@@ -6,7 +6,7 @@ You should also check the [travel advice for Ecuador](/foreign-travel-advice/ecu
 
 You’ll be asked for an affirmation or affidavit document to prove that you’re allowed to marry.
 
-To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-quito/oaths-affirmations-and-affidavits/slot_picker).
+To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=138&service=13).
 
 You’ll need to bring your passport and pay a fee.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/uk/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/uk/partner_british/_opposite_sex.erb
@@ -7,7 +7,7 @@ You might be able to form an opposite sex civil partnership. Check the local rul
 
 You’ll be asked for an affirmation or affidavit document to prove you’re allowed to marry.
 
-To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-quito/oaths-affirmations-and-affidavits/slot_picker).
+To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=138&service=13).
 
 You’ll need to bring your passport and pay a fee.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/uk/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/uk/partner_british/_same_sex.erb
@@ -6,7 +6,7 @@ You should also check the [travel advice for Ecuador](/foreign-travel-advice/ecu
 
 You’ll be asked for an affirmation or affidavit document to prove that you’re allowed to marry.
 
-To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-quito/oaths-affirmations-and-affidavits/slot_picker).
+To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=138&service=13).
 
 You’ll need to bring your passport and pay a fee.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/uk/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/uk/partner_local/_opposite_sex.erb
@@ -7,7 +7,7 @@ You might be able to form an opposite sex civil partnership. Check the local rul
 
 You’ll be asked for an affirmation or affidavit document to prove you’re allowed to marry.
 
-To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-quito/oaths-affirmations-and-affidavits/slot_picker).
+To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=138&service=13).
 
 You’ll need to bring your passport and pay a fee.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/uk/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/uk/partner_local/_same_sex.erb
@@ -6,7 +6,7 @@ You should also check the [travel advice for Ecuador](/foreign-travel-advice/ecu
 
 You’ll be asked for an affirmation or affidavit document to prove that you’re allowed to marry.
 
-To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-quito/oaths-affirmations-and-affidavits/slot_picker).
+To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=138&service=13).
 
 You’ll need to bring your passport and pay a fee.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/uk/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/uk/partner_other/_opposite_sex.erb
@@ -7,7 +7,7 @@ You might be able to form an opposite sex civil partnership. Check the local rul
 
 You’ll be asked for an affirmation or affidavit document to prove you’re allowed to marry.
 
-To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-quito/oaths-affirmations-and-affidavits/slot_picker).
+To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=138&service=13).
 
 You’ll need to bring your passport and pay a fee.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/uk/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/ecuador/uk/partner_other/_same_sex.erb
@@ -6,7 +6,7 @@ You should also check the [travel advice for Ecuador](/foreign-travel-advice/ecu
 
 You’ll be asked for an affirmation or affidavit document to prove that you’re allowed to marry.
 
-To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-quito/oaths-affirmations-and-affidavits/slot_picker).
+To swear an affirmation or affidavit, [make an appointment at the British Embassy Quito](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=138&service=13).
 
 You’ll need to bring your passport and pay a fee.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/egypt/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/egypt/_opposite_sex.erb
@@ -14,7 +14,7 @@ This costs <%= format_money calculator.consular_fee(:affidavit_or_affirmation_fo
 
 Download, fill in and print an [affirmation form](/government/uploads/system/uploads/attachment_data/file/686639/Marriage_Affirmation_Template.ods).
 
-[Make an appointment at the embassy in Cairo](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-cairo/oaths-affirmations-and-affidavits/slot_picker) to swear your affirmation.
+[Make an appointment at the embassy in Cairo](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=107&service=13) to swear your affirmation.
 
 You’ll need to bring supporting documents to your appointment, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/estonia/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/estonia/ceremony_country/partner_british/_opposite_sex.erb
@@ -14,7 +14,7 @@ You’ll need to have been living in Estonia for at least 3 full days before you
 
 ^You may be able to get married without a CNI if you have a permanent address in Estonia and have a 6 month residence permit - contact the local authorities to find out.^
 
-[Make an appointment at the embassy in Tallinn.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-tallinn/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tallinn.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=36&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/estonia/ceremony_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/estonia/ceremony_country/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Estonia.
 
-[Make an appointment at the embassy in Tallinn.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-tallinn/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tallinn.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=36&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/estonia/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/estonia/ceremony_country/partner_local/_opposite_sex.erb
@@ -14,7 +14,7 @@ You’ll need to have been living in Estonia for at least 3 full days before you
 
 ^You may be able to get married without a CNI if you have a permanent address in Estonia and have a 6 month residence permit - contact the local authorities to find out.^
 
-[Make an appointment at the embassy in Tallinn.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-tallinn/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tallinn.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=36&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/estonia/ceremony_country/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/estonia/ceremony_country/partner_local/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Estonia.
 
-[Make an appointment at the embassy in Tallinn.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-tallinn/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tallinn.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=36&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/estonia/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/estonia/ceremony_country/partner_other/_opposite_sex.erb
@@ -14,7 +14,7 @@ You’ll need to have been living in Estonia for at least 3 full days before you
 
 ^You may be able to get married without a CNI if you have a permanent address in Estonia and have a 6 month residence permit - contact the local authorities to find out.^
 
-[Make an appointment at the embassy in Tallinn.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-tallinn/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tallinn.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=36&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/estonia/ceremony_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/estonia/ceremony_country/partner_other/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Estonia.
 
-[Make an appointment at the embassy in Tallinn.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-tallinn/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tallinn.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=36&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/estonia/third_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/estonia/third_country/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Estonia.
 
-[Make an appointment at the embassy in Tallinn.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-tallinn/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tallinn.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=36&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/estonia/third_country/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/estonia/third_country/partner_local/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Estonia.
 
-[Make an appointment at the embassy in Tallinn.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-tallinn/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tallinn.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=36&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/estonia/third_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/estonia/third_country/partner_other/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Estonia.
 
-[Make an appointment at the embassy in Tallinn.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-tallinn/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tallinn.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=36&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/estonia/uk/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/estonia/uk/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Estonia.
 
-[Make an appointment at the embassy in Tallinn.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-tallinn/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tallinn.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=36&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/estonia/uk/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/estonia/uk/partner_local/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Estonia.
 
-[Make an appointment at the embassy in Tallinn.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-tallinn/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tallinn.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=36&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/estonia/uk/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/estonia/uk/partner_other/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Estonia.
 
-[Make an appointment at the embassy in Tallinn.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-tallinn/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tallinn.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=36&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/finland/_ceremony_country.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/finland/_ceremony_country.erb
@@ -10,7 +10,7 @@ You need to swear an affidavit or make an affirmation that says you’re legally
 
 This costs <%= format_money calculator.consular_fee(:affidavit_or_affirmation_for_marriage) %> per person. You can pay in the [local currency](/government/publications/finland-consular-fees) with cash or card (not Visa Electron).
 
-s1. [Make an appointment at the embassy in Finland](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-helsinki/oaths-affirmations-and-affidavits/slot_picker) to swear your affidavit or make your affirmation.
+s1. [Make an appointment at the embassy in Finland](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=24&service=13) to swear your affidavit or make your affirmation.
 s2. Download and fill in the [questionnaire](/government/publications/civil-status-questionnaire-finland) to bring to your appointment.
 s3. The embassy will contact you to confirm your appointment and any other information you need to bring.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/finland/_third_country.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/finland/_third_country.erb
@@ -10,7 +10,7 @@ You need to swear an affidavit or make an affirmation that says you’re legally
 
 This costs <%= format_money calculator.consular_fee(:affidavit_or_affirmation_for_marriage) %> per person. You can pay in the [local currency](/government/publications/finland-consular-fees) with cash or card (not Visa Electron).
 
-s1. [Make an appointment at the embassy in Finland](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-helsinki/oaths-affirmations-and-affidavits/slot_picker) to swear your affidavit or make your affirmation.
+s1. [Make an appointment at the embassy in Finland](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=24&service=13) to swear your affidavit or make your affirmation.
 s2. Download and fill in the [questionnaire](/government/publications/civil-status-questionnaire-finland) to bring to your appointment.
 s3. The embassy will contact you to confirm your appointment and any other information you need to bring.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/greece/ceremony_country/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/greece/ceremony_country/_opposite_sex.erb
@@ -12,7 +12,7 @@ If your partner is British, they’ll need to follow the same process to get the
 
 ### Get a CNI
 
-To get a CNI, either [make an appointment at the British Embassy in Athens](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-athens/notice-of-marriage/slot_picker) or your nearest local vice-consulate in [Crete](https://www.consular-appointments.service.gov.uk/fco/#!/british-vice-consulate-crete/notice-of-marriage/slot_picker), [Corfu](https://www.consular-appointments.service.gov.uk/fco/#!/british-vice-consulate-corfu/notice-of-marriage/slot_picker), [Rhodes](https://www.consular-appointments.service.gov.uk/fco/#!/british-vice-consulate-rhodes/notice-of-marriage/slot_picker) or [Zakynthos](https://www.consular-appointments.service.gov.uk/fco/#!/british-vice-consulate-zakynthos/notice-of-marriage/slot_picker).
+To get a CNI, either [make an appointment at the British Embassy in Athens](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-athens/notice-of-marriage/slot_picker) or your nearest local vice-consulate in [Crete](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=46&service=11), [Corfu](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=45&service=11), [Rhodes](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=48&service=11) or [Zakynthos](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=49&service=11).
 
 You need to be in Greece for 3 full days before you can give notice. This means if you arrive on Monday you can’t give notice until Friday.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/greece/ceremony_country/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/greece/ceremony_country/_opposite_sex.erb
@@ -12,7 +12,7 @@ If your partner is British, they’ll need to follow the same process to get the
 
 ### Get a CNI
 
-To get a CNI, either [make an appointment at the British Embassy in Athens](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-athens/notice-of-marriage/slot_picker) or your nearest local vice-consulate in [Crete](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=46&service=11), [Corfu](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=45&service=11), [Rhodes](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=48&service=11) or [Zakynthos](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=49&service=11).
+To get a CNI, either [make an appointment at the British Embassy in Athens](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=15&service=11) or your nearest local vice-consulate in [Crete](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=46&service=11), [Corfu](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=45&service=11), [Rhodes](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=48&service=11) or [Zakynthos](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=49&service=11).
 
 You need to be in Greece for 3 full days before you can give notice. This means if you arrive on Monday you can’t give notice until Friday.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/guatemala/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/guatemala/ceremony_country/partner_british/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Guatemala. You c
 
 You’ll need to have been living in Guatemala for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Guatamala City.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-guatemala-city/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Guatamala City.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=114&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/guatemala/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/guatemala/ceremony_country/partner_local/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Guatemala. You c
 
 You’ll need to have been living in Guatemala for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Guatamala City.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-guatemala-city/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Guatamala City.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=114&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/guatemala/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/guatemala/ceremony_country/partner_other/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Guatemala. You c
 
 You’ll need to have been living in Guatemala for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Guatamala City.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-guatemala-city/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Guatamala City.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=114&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/hungary/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/hungary/ceremony_country/partner_british/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Hungary. You can
 
 You’ll need to have been living in Hungary for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Budapest.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-budapest/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Budapest.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=21&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/hungary/ceremony_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/hungary/ceremony_country/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Hungary.
 
-[Make an appointment at the embassy in Budapest.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-budapest/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Budapest.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=21&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/hungary/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/hungary/ceremony_country/partner_local/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Hungary. You can
 
 You’ll need to have been living in Hungary for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Budapest.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-budapest/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Budapest.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=21&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/hungary/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/hungary/ceremony_country/partner_other/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Hungary. You can
 
 You’ll need to have been living in Hungary for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Budapest.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-budapest/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Budapest.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=21&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/hungary/third_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/hungary/third_country/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Hungary.
 
-[Make an appointment at the embassy in Budapest.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-budapest/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Budapest.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=21&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/hungary/uk/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/hungary/uk/partner_british/_opposite_sex.erb
@@ -14,7 +14,7 @@ You can normally get a CNI by giving a notice of marriage at your local register
 
 You’ll need to exchange your UK-issued CNI for one that’s valid in Hungary at the British embassy in Budapest.
 
-[Make an appointment to exchange your CNI at the British Embassy Budapest](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-budapest/exchange-a-certificate-of-no-impediment/slot_picker).
+[Make an appointment to exchange your CNI at the British Embassy Budapest](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=21&service=4).
 
 You should also check if it needs to be:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/hungary/uk/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/hungary/uk/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Hungary.
 
-[Make an appointment at the embassy in Budapest.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-budapest/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Budapest.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=21&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/hungary/uk/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/hungary/uk/partner_local/_opposite_sex.erb
@@ -14,7 +14,7 @@ You can normally get a CNI by giving a notice of marriage at your local register
 
 You’ll need to exchange your UK-issued CNI for one that’s valid in Hungary at the British embassy in Budapest.
 
-[Make an appointment to exchange your CNI at the British Embassy Budapest](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-budapest/exchange-a-certificate-of-no-impediment/slot_picker).
+[Make an appointment to exchange your CNI at the British Embassy Budapest](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=21&service=4).
 
 You should also check if it needs to be:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/hungary/uk/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/hungary/uk/partner_other/_opposite_sex.erb
@@ -14,7 +14,7 @@ You can normally get a CNI by giving a notice of marriage at your local register
 
 You’ll need to exchange your UK-issued CNI for one that’s valid in Hungary at the British embassy in Budapest.
 
-[Make an appointment to exchange your CNI at the British Embassy Budapest](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-budapest/exchange-a-certificate-of-no-impediment/slot_picker).
+[Make an appointment to exchange your CNI at the British Embassy Budapest](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=21&service=4).
 
 You should also check if it needs to be:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/iceland/_ceremony_country.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/iceland/_ceremony_country.erb
@@ -14,7 +14,7 @@ You need to be in Iceland for 3 full days before you can give notice. This means
 
 It costs £50 to give notice and £50 for the CNI. You can pay by credit card or in cash in Iceland and payment must be in the local currency.
 
-[Make an appointment at the embassy in Reykjavik to get a CNI](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-reykjavik/certificate-of-no-impediment/slot_picker).
+[Make an appointment at the embassy in Reykjavik to get a CNI](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=31&service=4).
 
 You’ll need to bring:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/iceland/_uk.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/iceland/_uk.erb
@@ -32,7 +32,7 @@ You should check with the District Commissioner whether they will accept the UK-
 
 If the District Commissioner accepts a UK-issued CNI you should check with the District Commissioner whether it needs to be [legalised](/get-document-legalised).
 
-You can [make an appointment to exchange your UK issued CNI for a local one](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-reykjavik/exchange-a-certificate-of-no-impediment/slot_picker) if the District Commissioner asks you to get one from the British Embassy in Reykjavik. This costs £50.  You can pay by credit card or in cash in Iceland and payment must be in the local currency.
+You can [make an appointment to exchange your UK issued CNI for a local one](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=31&service=4) if the District Commissioner asks you to get one from the British Embassy in Reykjavik. This costs £50.  You can pay by credit card or in cash in Iceland and payment must be in the local currency.
 
 You should check with the local authorities in Iceland to find out if you need to provide legalised and translated copies of other documents.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/indonesia/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/indonesia/ceremony_country/partner_british/_opposite_sex.erb
@@ -2,7 +2,7 @@
 
 You need to swear an affirmation or affidavit that says you’re legally allowed to get married.
 
-Make an appointment to swear your affirmation or affidavit at the [embassy in Jakarta](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-jakarta/oaths-affirmations-and-affidavits/slot_picker) or the [consulate in Bali](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-bali/oaths-affirmations-and-affidavits/slot_picker).
+Make an appointment to swear your affirmation or affidavit at the [embassy in Jakarta](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=118&service=13) or the [consulate in Bali](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=55&service=13).
 
 This costs £50 per person.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/indonesia/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/indonesia/ceremony_country/partner_local/_opposite_sex.erb
@@ -2,7 +2,7 @@
 
 You need to swear an affirmation or affidavit that says you’re legally allowed to get married.
 
-Make an appointment to swear your affirmation or affidavit at the [embassy in Jakarta](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-jakarta/oaths-affirmations-and-affidavits/slot_picker) or the [consulate in Bali](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-bali/oaths-affirmations-and-affidavits/slot_picker).
+Make an appointment to swear your affirmation or affidavit at the [embassy in Jakarta](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=118&service=13) or the [consulate in Bali](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=55&service=13).
 
 This costs £50 per person.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/indonesia/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/indonesia/ceremony_country/partner_other/_opposite_sex.erb
@@ -2,7 +2,7 @@
 
 You need to swear an affirmation or affidavit that says you’re legally allowed to get married.
 
-Make an appointment to swear your affirmation or affidavit at the [embassy in Jakarta](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-jakarta/oaths-affirmations-and-affidavits/slot_picker) or the [consulate in Bali](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-bali/oaths-affirmations-and-affidavits/slot_picker).
+Make an appointment to swear your affirmation or affidavit at the [embassy in Jakarta](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=118&service=13) or the [consulate in Bali](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=55&service=13).
 
 This costs £50 per person.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/indonesia/third_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/indonesia/third_country/partner_british/_opposite_sex.erb
@@ -2,7 +2,7 @@
 
 You need to swear an affirmation or affidavit that says you’re legally allowed to get married.
 
-Make an appointment to swear your affirmation or affidavit at the [embassy in Jakarta](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-jakarta/oaths-affirmations-and-affidavits/slot_picker) or the [consulate in Bali](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-bali/oaths-affirmations-and-affidavits/slot_picker).
+Make an appointment to swear your affirmation or affidavit at the [embassy in Jakarta](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=118&service=13) or the [consulate in Bali](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=55&service=13).
 
 This costs £50 per person.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/indonesia/third_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/indonesia/third_country/partner_local/_opposite_sex.erb
@@ -2,7 +2,7 @@
 
 You need to swear an affirmation or affidavit that says you’re legally allowed to get married.
 
-Make an appointment to swear your affirmation or affidavit at the [embassy in Jakarta](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-jakarta/oaths-affirmations-and-affidavits/slot_picker) or the [consulate in Bali](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-bali/oaths-affirmations-and-affidavits/slot_picker).
+Make an appointment to swear your affirmation or affidavit at the [embassy in Jakarta](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=118&service=13) or the [consulate in Bali](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=55&service=13).
 
 This costs £50 per person.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/indonesia/third_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/indonesia/third_country/partner_other/_opposite_sex.erb
@@ -2,7 +2,7 @@
 
 You need to swear an affirmation or affidavit that says you’re legally allowed to get married.
 
-Make an appointment to swear your affirmation or affidavit at the [embassy in Jakarta](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-jakarta/oaths-affirmations-and-affidavits/slot_picker) or the [consulate in Bali](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-bali/oaths-affirmations-and-affidavits/slot_picker).
+Make an appointment to swear your affirmation or affidavit at the [embassy in Jakarta](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=118&service=13) or the [consulate in Bali](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=55&service=13).
 
 This costs £50 per person.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/indonesia/uk/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/indonesia/uk/partner_british/_opposite_sex.erb
@@ -2,7 +2,7 @@
 
 You need to swear an affirmation or affidavit that says you’re legally allowed to get married.
 
-Make an appointment to swear your affirmation or affidavit at the [embassy in Jakarta](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-jakarta/oaths-affirmations-and-affidavits/slot_picker) or the [consulate in Bali](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-bali/oaths-affirmations-and-affidavits/slot_picker).
+Make an appointment to swear your affirmation or affidavit at the [embassy in Jakarta](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=118&service=13) or the [consulate in Bali](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=55&service=13).
 
 This costs £50 per person.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/indonesia/uk/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/indonesia/uk/partner_local/_opposite_sex.erb
@@ -2,7 +2,7 @@
 
 You need to swear an affirmation or affidavit that says you’re legally allowed to get married.
 
-Make an appointment to swear your affirmation or affidavit at the [embassy in Jakarta](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-jakarta/oaths-affirmations-and-affidavits/slot_picker) or the [consulate in Bali](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-bali/oaths-affirmations-and-affidavits/slot_picker).
+Make an appointment to swear your affirmation or affidavit at the [embassy in Jakarta](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=118&service=13) or the [consulate in Bali](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=55&service=13).
 
 This costs £50 per person.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/indonesia/uk/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/indonesia/uk/partner_other/_opposite_sex.erb
@@ -2,7 +2,7 @@
 
 You need to swear an affirmation or affidavit that says you’re legally allowed to get married.
 
-Make an appointment to swear your affirmation or affidavit at the [embassy in Jakarta](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-jakarta/oaths-affirmations-and-affidavits/slot_picker) or the [consulate in Bali](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-bali/oaths-affirmations-and-affidavits/slot_picker).
+Make an appointment to swear your affirmation or affidavit at the [embassy in Jakarta](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=118&service=13) or the [consulate in Bali](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=55&service=13).
 
 This costs £50 per person.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/iran/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/iran/ceremony_country/partner_british/_opposite_sex.erb
@@ -12,7 +12,7 @@ You’ll need to have been living in Iran for at least 3 full days before you ca
 
 You and your partner must be over the age of 16. If your partner is a female Iranian national and this is her first marriage, you’ll need to get parental permission from her father. You don’t need to get parental permission for second marriages. 
 
-[Make an appointment at the embassy in Tehran.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tehran/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tehran.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=149&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/iran/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/iran/ceremony_country/partner_local/_opposite_sex.erb
@@ -12,7 +12,7 @@ You’ll need to have been living in Iran for at least 3 full days before you ca
 
 You and your partner must be over the age of 16. If your partner is a female Iranian national and this is her first marriage, you’ll need to get parental permission from her father. You don’t need to get parental permission for second marriages. 
 
-[Make an appointment at the embassy in Tehran.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tehran/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tehran.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=149&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/iran/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/iran/ceremony_country/partner_other/_opposite_sex.erb
@@ -12,7 +12,7 @@ You’ll need to have been living in Iran for at least 3 full days before you ca
 
 You and your partner must be over the age of 16. If your partner is a female Iranian national and this is her first marriage, you’ll need to get parental permission from her father. You don’t need to get parental permission for second marriages. 
 
-[Make an appointment at the embassy in Tehran.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tehran/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tehran.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=149&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/iran/uk/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/iran/uk/partner_british/_opposite_sex.erb
@@ -14,7 +14,7 @@ You can normally get a CNI by giving a notice of marriage at your local register
 
 You might need to exchange your UK-issued CNI for one that’s valid in Iran at the nearest embassy or consulate to where you’re getting married.
 
-[Make an appointment with the Embassy in Tehran](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tehran/certificate-of-no-impediment/slot_picker) to exchange your UK CNI. It costs £50 to exchange your CNI.
+[Make an appointment with the Embassy in Tehran](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=149&service=4) to exchange your UK CNI. It costs £50 to exchange your CNI.
 
 You should also check if it needs to be:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/iran/uk/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/iran/uk/partner_local/_opposite_sex.erb
@@ -14,7 +14,7 @@ You can normally get a CNI by giving a notice of marriage at your local register
 
 You might need to exchange your UK-issued CNI for one that’s valid in Iran at the nearest embassy or consulate to where you’re getting married.
 
-[Make an appointment with the Embassy in Tehran](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tehran/certificate-of-no-impediment/slot_picker) to exchange your UK CNI. It costs £50 to exchange your CNI.
+[Make an appointment with the Embassy in Tehran](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=149&service=4) to exchange your UK CNI. It costs £50 to exchange your CNI.
 
 You should also check if it needs to be:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/iran/uk/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/iran/uk/partner_other/_opposite_sex.erb
@@ -14,7 +14,7 @@ You can normally get a CNI by giving a notice of marriage at your local register
 
 You might need to exchange your UK-issued CNI for one that’s valid in Iran at the nearest embassy or consulate to where you’re getting married.
 
-[Make an appointment with the Embassy in Tehran](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tehran/certificate-of-no-impediment/slot_picker) to exchange your UK CNI. It costs £50 to exchange your CNI.
+[Make an appointment with the Embassy in Tehran](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=149&service=4) to exchange your UK CNI. It costs £50 to exchange your CNI.
 
 You should also check if it needs to be:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/italy/ceremony_country/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/italy/ceremony_country/_opposite_sex.erb
@@ -14,7 +14,7 @@ You need to prove you’re legally allowed to get married by getting a ‘Nulla 
 
 You’ll need to get a Nulla Osta if you’re in Italy.
 
-To get a Nulla Osta, [make an appointment at the British Embassy in Rome](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rome/notice-of-marriage-or-civil-partnership/slot_picker) to give notice of your marriage. Your partner doesn’t have to come with you if they are not a British citizen applying for their own
+To get a Nulla Osta, [make an appointment at the British Embassy in Rome](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=33&service=10) to give notice of your marriage. Your partner doesn’t have to come with you if they are not a British citizen applying for their own
 Nulla Osta.
 
 If you can’t get to the embassy, download the [Nulla Osta application pack](/government/publications/nulla-osta-application-pack-for-marriages-in-italy), fill in the affirmation and notice of marriage and sign them in front of an [Italian notary](https://notaries-directory.eu/). You’ll have to pay a fee. Send the signed documents and supporting documents to the embassy.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/italy/ceremony_country/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/italy/ceremony_country/_same_sex.erb
@@ -12,7 +12,7 @@ You need to prove you’re legally allowed to register a civil partnership by ge
 
 You’ll need to get a Nulla Osta if you’re in Italy.
 
-To get a Nulla Osta, [make an appointment at the British Embassy in Rome](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-rome/notice-of-marriage-or-civil-partnership/slot_picker) to give notice of your civil partnership. Your partner doesn’t have to come with you.
+To get a Nulla Osta, [make an appointment at the British Embassy in Rome](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=33&service=10) to give notice of your civil partnership. Your partner doesn’t have to come with you.
 
 If you can’t get to the embassy, download the [Nulla Osta application pack](/government/publications/nulla-osta-application-pack-for-marriages-in-italy), fill in the declaration and registration form and sign them in front of an [Italian notary](https://notaries-directory.eu/). You’ll have to pay a fee. Send the signed documents and supporting documents to the embassy.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/japan/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/japan/_opposite_sex.erb
@@ -14,7 +14,7 @@ This costs <%= format_money calculator.consular_fee(:affidavit_or_affirmation_fo
 
 ###Swearing an affirmation or affidavit
 
-s1. [Make an appointment at the embassy in Tokyo](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tokyo/oaths-affirmations-and-affidavits/service_list) to swear your affirmation or affidavit.
+s1. [Make an appointment at the embassy in Tokyo](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=152&service=13) to swear your affirmation or affidavit.
 s2. Download the [affirmation or affidavit](/government/publications/affidavitaffirmation-of-marital-status-japan).
 s3. Print it double-sided - it won’t be accepted otherwise.
 s4. Fill it in (in English) but don’t sign it - you need to sign it at the embassy.

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/japan/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/japan/_same_sex.erb
@@ -14,7 +14,7 @@ You both need to sign a declaration that you’re free to marry and that you hav
 
 ### Give notice of your marriage
 
-[Make an appointment to give notice of your marriage](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tokyo/notice-of-marriage-or-civil-partnership/slot_picker) at the embassy in Tokyo.
+[Make an appointment to give notice of your marriage](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=152&service=10) at the embassy in Tokyo.
 
 It costs <%= format_money calculator.consular_fee(:receiving_notice_of_marriage) %> to give notice. You can pay in the [local currency](/government/publications/japan-consular-fees) with cash or card (Visa or Mastercard).
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/ceremony_country/partner_british/_opposite_sex.erb
@@ -10,7 +10,7 @@ Contact the relevant local authorities in Jordan to find out about local marriag
 
 If you’re getting married at the Sharia Court, you’ll need to provide a single declaration document to prove you’re allowed to marry or a single divorced declaration document if you’re divorced.
 
-[Make an appointment at the embassy in Amman](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-amman/administer-a-single-declaration-for-an-islamic-marriage/slot_picker) to get a copy of the single declaration.
+[Make an appointment at the embassy in Amman](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=92&service=29) to get a copy of the single declaration.
 
 You’ll need to pay a fee and bring your passport and your partner’s passport.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/ceremony_country/partner_british/_opposite_sex.erb
@@ -22,7 +22,7 @@ For non-Islamic marriages, you’ll be asked to swear an oath before you get mar
 
 You can download and fill in (but not sign) the [affidavit form](https://www.gov.uk/government/publications/affidavit-of-marital-status-jordan) in advance.
 
-[Make an appointment at the embassy in Amman](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-amman/administer-a-marital-affidavit-for-a-christian-marriage/slot_picker).
+[Make an appointment at the embassy in Amman](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=92&service=30).
 
 You need to bring:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/ceremony_country/partner_local/_opposite_sex.erb
@@ -10,7 +10,7 @@ Contact the relevant local authorities in Jordan to find out about local marriag
 
 If you’re getting married at the Sharia Court, you’ll need to provide a single declaration document to prove you’re allowed to marry or a single divorced declaration document if you’re divorced.
 
-[Make an appointment at the embassy in Amman](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-amman/administer-a-single-declaration-for-an-islamic-marriage/slot_picker) to get a copy of the single declaration.
+[Make an appointment at the embassy in Amman](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=92&service=29) to get a copy of the single declaration.
 
 You’ll need to pay a fee and bring your passport and your partner’s passport.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/ceremony_country/partner_local/_opposite_sex.erb
@@ -22,7 +22,7 @@ For non-Islamic marriages, you’ll be asked to swear an oath before you get mar
 
 You can download and fill in (but not sign) the [affidavit form](https://www.gov.uk/government/publications/affidavit-of-marital-status-jordan) in advance.
 
-[Make an appointment at the embassy in Amman](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-amman/administer-a-marital-affidavit-for-a-christian-marriage/slot_picker).
+[Make an appointment at the embassy in Amman](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=92&service=30).
 
 You need to bring:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/ceremony_country/partner_other/_opposite_sex.erb
@@ -10,7 +10,7 @@ Contact the relevant local authorities in Jordan to find out about local marriag
 
 If you’re getting married at the Sharia Court, you’ll need to provide a single declaration document to prove you’re allowed to marry or a single divorced declaration document if you’re divorced.
 
-[Make an appointment at the embassy in Amman](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-amman/administer-a-single-declaration-for-an-islamic-marriage/slot_picker) to get a copy of the single declaration.
+[Make an appointment at the embassy in Amman](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=92&service=29) to get a copy of the single declaration.
 
 You’ll need to pay a fee and bring your passport and your partner’s passport.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/ceremony_country/partner_other/_opposite_sex.erb
@@ -22,7 +22,7 @@ For non-Islamic marriages, you’ll be asked to swear an oath before you get mar
 
 You can download and fill in (but not sign) the [affidavit form](https://www.gov.uk/government/publications/affidavit-of-marital-status-jordan) in advance.
 
-[Make an appointment at the embassy in Amman](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-amman/administer-a-marital-affidavit-for-a-christian-marriage/slot_picker).
+[Make an appointment at the embassy in Amman](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=92&service=30).
 
 You need to bring:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/third_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/third_country/partner_british/_opposite_sex.erb
@@ -10,7 +10,7 @@ Contact the relevant local authorities in Jordan to find out about local marriag
 
 If you’re getting married at the Sharia Court, you’ll need to provide a single declaration document to prove you’re allowed to marry or a single divorced declaration document if you’re divorced.
 
-[Make an appointment at the embassy in Amman](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-amman/administer-a-single-declaration-for-an-islamic-marriage/slot_picker) to get a copy of the single declaration.
+[Make an appointment at the embassy in Amman](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=92&service=29) to get a copy of the single declaration.
 
 You’ll need to pay a fee and bring your passport and your partner’s passport.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/third_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/third_country/partner_british/_opposite_sex.erb
@@ -22,7 +22,7 @@ For non-Islamic marriages, you’ll be asked to swear an oath before you get mar
 
 You can download and fill in (but not sign) the [affidavit form](https://www.gov.uk/government/publications/affidavit-of-marital-status-jordan) in advance.
 
-[Make an appointment at the embassy in Amman](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-amman/administer-a-marital-affidavit-for-a-christian-marriage/slot_picker).
+[Make an appointment at the embassy in Amman](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=92&service=30).
 
 You need to bring:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/third_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/third_country/partner_local/_opposite_sex.erb
@@ -10,7 +10,7 @@ Contact the relevant local authorities in Jordan to find out about local marriag
 
 If you’re getting married at the Sharia Court, you’ll need to provide a single declaration document to prove you’re allowed to marry or a single divorced declaration document if you’re divorced.
 
-[Make an appointment at the embassy in Amman](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-amman/administer-a-single-declaration-for-an-islamic-marriage/slot_picker) to get a copy of the single declaration.
+[Make an appointment at the embassy in Amman](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=92&service=29) to get a copy of the single declaration.
 
 You’ll need to pay a fee and bring your passport and your partner’s passport.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/third_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/third_country/partner_local/_opposite_sex.erb
@@ -22,7 +22,7 @@ For non-Islamic marriages, you’ll be asked to swear an oath before you get mar
 
 You can download and fill in (but not sign) the [affidavit form](https://www.gov.uk/government/publications/affidavit-of-marital-status-jordan) in advance.
 
-[Make an appointment at the embassy in Amman](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-amman/administer-a-marital-affidavit-for-a-christian-marriage/slot_picker).
+[Make an appointment at the embassy in Amman](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=92&service=30).
 
 You need to bring:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/third_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/third_country/partner_other/_opposite_sex.erb
@@ -10,7 +10,7 @@ Contact the relevant local authorities in Jordan to find out about local marriag
 
 If you’re getting married at the Sharia Court, you’ll need to provide a single declaration document to prove you’re allowed to marry or a single divorced declaration document if you’re divorced.
 
-[Make an appointment at the embassy in Amman](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-amman/administer-a-single-declaration-for-an-islamic-marriage/slot_picker) to get a copy of the single declaration.
+[Make an appointment at the embassy in Amman](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=92&service=29) to get a copy of the single declaration.
 
 You’ll need to pay a fee and bring your passport and your partner’s passport.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/third_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/third_country/partner_other/_opposite_sex.erb
@@ -22,7 +22,7 @@ For non-Islamic marriages, you’ll be asked to swear an oath before you get mar
 
 You can download and fill in (but not sign) the [affidavit form](https://www.gov.uk/government/publications/affidavit-of-marital-status-jordan) in advance.
 
-[Make an appointment at the embassy in Amman](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-amman/administer-a-marital-affidavit-for-a-christian-marriage/slot_picker).
+[Make an appointment at the embassy in Amman](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=92&service=30).
 
 You need to bring:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/uk/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/uk/partner_british/_opposite_sex.erb
@@ -10,7 +10,7 @@ Contact the [Embassy of Jordan](/government/publications/foreign-embassies-in-th
 
 If you’re getting married at the Sharia Court, you’ll need to provide a single declaration document to prove you’re allowed to marry or a single divorced declaration document if you’re divorced.
 
-[Make an appointment at the embassy in Amman](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-amman/administer-a-single-declaration-for-an-islamic-marriage/slot_picker) to get a copy of the single declaration.
+[Make an appointment at the embassy in Amman](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=92&service=29) to get a copy of the single declaration.
 
 You’ll need to pay a fee and bring your passport and your partner’s passport.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/uk/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/uk/partner_british/_opposite_sex.erb
@@ -22,7 +22,7 @@ For non-Islamic marriages, you’ll be asked to swear an oath before you get mar
 
 You can download and fill in (but not sign) the [affidavit form](https://www.gov.uk/government/publications/affidavit-of-marital-status-jordan) in advance.
 
-[Make an appointment at the embassy in Amman](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-amman/administer-a-marital-affidavit-for-a-christian-marriage/slot_picker).
+[Make an appointment at the embassy in Amman](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=92&service=30).
 
 You need to bring:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/uk/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/uk/partner_local/_opposite_sex.erb
@@ -10,7 +10,7 @@ Contact the [Embassy of Jordan](/government/publications/foreign-embassies-in-th
 
 If you’re getting married at the Sharia Court, you’ll need to provide a single declaration document to prove you’re allowed to marry or a single divorced declaration document if you’re divorced.
 
-[Make an appointment at the embassy in Amman](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-amman/administer-a-single-declaration-for-an-islamic-marriage/slot_picker) to get a copy of the single declaration.
+[Make an appointment at the embassy in Amman](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=92&service=29) to get a copy of the single declaration.
 
 You’ll need to pay a fee and bring your passport and your partner’s passport.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/uk/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/uk/partner_local/_opposite_sex.erb
@@ -22,7 +22,7 @@ For non-Islamic marriages, you’ll be asked to swear an oath before you get mar
 
 You can download and fill in (but not sign) the [affidavit form](https://www.gov.uk/government/publications/affidavit-of-marital-status-jordan) in advance.
 
-[Make an appointment at the embassy in Amman](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-amman/administer-a-marital-affidavit-for-a-christian-marriage/slot_picker).
+[Make an appointment at the embassy in Amman](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=92&service=30).
 
 You need to bring:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/uk/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/uk/partner_other/_opposite_sex.erb
@@ -10,7 +10,7 @@ Contact the [Embassy of Jordan](/government/publications/foreign-embassies-in-th
 
 If you’re getting married at the Sharia Court, you’ll need to provide a single declaration document to prove you’re allowed to marry or a single divorced declaration document if you’re divorced.
 
-[Make an appointment at the embassy in Amman](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-amman/administer-a-single-declaration-for-an-islamic-marriage/slot_picker) to get a copy of the single declaration.
+[Make an appointment at the embassy in Amman](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=92&service=29) to get a copy of the single declaration.
 
 You’ll need to pay a fee and bring your passport and your partner’s passport.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/uk/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/jordan/uk/partner_other/_opposite_sex.erb
@@ -22,7 +22,7 @@ For non-Islamic marriages, you’ll be asked to swear an oath before you get mar
 
 You can download and fill in (but not sign) the [affidavit form](https://www.gov.uk/government/publications/affidavit-of-marital-status-jordan) in advance.
 
-[Make an appointment at the embassy in Amman](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-amman/administer-a-marital-affidavit-for-a-christian-marriage/slot_picker).
+[Make an appointment at the embassy in Amman](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=92&service=30).
 
 You need to bring:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/kazakhstan/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/kazakhstan/ceremony_country/partner_british/_opposite_sex.erb
@@ -10,7 +10,7 @@ You’ll need to have been living in Kazakhstan for at least 3 full days before 
 
 If you need a CNI, you’ll first need to give notice of your intended marriage (banns) at the British Embassy Office in Nur-Sultan.
 
-[Make an appointment at the embassy in Nur-Sultan](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-nursultan/notice-of-marriage-or-civil-partnership/slot_picker). 
+[Make an appointment at the embassy in Nur-Sultan](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=97&service=10). 
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/kazakhstan/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/kazakhstan/ceremony_country/partner_local/_opposite_sex.erb
@@ -10,7 +10,7 @@ You’ll need to have been living in Kazakhstan for at least 3 full days before 
 
 If you need a CNI, you’ll first need to give notice of your intended marriage (banns) at the British Embassy Office in Nur-Sultan.
 
-[Make an appointment at the embassy in Nur-Sultan](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-nursultan/notice-of-marriage-or-civil-partnership/slot_picker). 
+[Make an appointment at the embassy in Nur-Sultan](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=97&service=10). 
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/kazakhstan/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/kazakhstan/ceremony_country/partner_other/_opposite_sex.erb
@@ -10,7 +10,7 @@ You’ll need to have been living in Kazakhstan for at least 3 full days before 
 
 If you need a CNI, you’ll first need to give notice of your intended marriage (banns) at the British Embassy Office in Nur-Sultan.
 
-[Make an appointment at the embassy in Nur-Sultan](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-nursultan/notice-of-marriage-or-civil-partnership/slot_picker). 
+[Make an appointment at the embassy in Nur-Sultan](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=97&service=10). 
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/kosovo/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/kosovo/ceremony_country/partner_british/_opposite_sex.erb
@@ -8,7 +8,7 @@ You’ll be asked to provide a certificate of no impediment (CNI) to prove you�
 
 To get a CNI, you must post notice of your intended marriage in Kosovo. You can do this at the British embassy or in front of a notary public.
 
-[Make an appointment at the embassy in Pristina](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-pristina/notice-of-marriage-or-civil-partnership/slot_picker).
+[Make an appointment at the embassy in Pristina](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=137&service=10).
 
 You’ll need to have been living in Kosovo for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/kosovo/ceremony_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/kosovo/ceremony_country/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Kosovo.
 
-[Make an appointment at the embassy in Pristina.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-pristina/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Pristina.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=137&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/kosovo/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/kosovo/ceremony_country/partner_local/_opposite_sex.erb
@@ -8,7 +8,7 @@ You’ll be asked to provide a certificate of no impediment (CNI) to prove you�
 
 To get a CNI, you must post notice of your intended marriage in Kosovo. You can do this at the British embassy or in front of a notary public.
 
-[Make an appointment at the embassy in Pristina](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-pristina/notice-of-marriage-or-civil-partnership/slot_picker).
+[Make an appointment at the embassy in Pristina](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=137&service=10).
 
 You’ll need to have been living in Kosovo for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/kosovo/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/kosovo/ceremony_country/partner_other/_opposite_sex.erb
@@ -8,7 +8,7 @@ You’ll be asked to provide a certificate of no impediment (CNI) to prove you�
 
 To get a CNI, you must post notice of your intended marriage in Kosovo. You can do this at the British embassy or in front of a notary public.
 
-[Make an appointment at the embassy in Pristina](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-pristina/notice-of-marriage-or-civil-partnership/slot_picker).
+[Make an appointment at the embassy in Pristina](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=137&service=10).
 
 You’ll need to have been living in Kosovo for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/kosovo/ceremony_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/kosovo/ceremony_country/partner_other/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Kosovo.
 
-[Make an appointment at the embassy in Pristina.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-pristina/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Pristina.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=137&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/kosovo/third_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/kosovo/third_country/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Kosovo.
 
-[Make an appointment at the embassy in Pristina.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-pristina/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Pristina.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=137&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/kosovo/third_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/kosovo/third_country/partner_other/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Kosovo.
 
-[Make an appointment at the embassy in Pristina.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-pristina/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Pristina.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=137&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/kosovo/uk/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/kosovo/uk/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Kosovo.
 
-[Make an appointment at the embassy in Pristina.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-pristina/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Pristina.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=137&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/kosovo/uk/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/kosovo/uk/partner_other/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Kosovo.
 
-[Make an appointment at the embassy in Pristina.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-pristina/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Pristina.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=137&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/kyrgyzstan/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/kyrgyzstan/ceremony_country/partner_british/_opposite_sex.erb
@@ -12,7 +12,7 @@ You’ll need to have been living in Kyrgyzstan for at least 3 full days before 
 
 If you need a CNI, you’ll first need to give notice of your intended marriage (banns) at the British Embassy Office in Bishkek.
 
-[Make an appointment at the embassy in Bishkek.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bishkek/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Bishkek.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=103&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/kyrgyzstan/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/kyrgyzstan/ceremony_country/partner_local/_opposite_sex.erb
@@ -12,7 +12,7 @@ You’ll need to have been living in Kyrgyzstan for at least 3 full days before 
 
 If you need a CNI, you’ll first need to give notice of your intended marriage (banns) at the British Embassy Office in Bishkek.
 
-[Make an appointment at the embassy in Bishkek.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bishkek/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Bishkek.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=103&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/kyrgyzstan/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/kyrgyzstan/ceremony_country/partner_other/_opposite_sex.erb
@@ -12,7 +12,7 @@ You’ll need to have been living in Kyrgyzstan for at least 3 full days before 
 
 If you need a CNI, you’ll first need to give notice of your intended marriage (banns) at the British Embassy Office in Bishkek.
 
-[Make an appointment at the embassy in Bishkek.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bishkek/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Bishkek.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=103&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/laos/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/laos/ceremony_country/partner_local/_opposite_sex.erb
@@ -8,7 +8,7 @@ You may be asked to provide an [affirmation of freedom to marry document](/gover
 
 Make an appointment at the British Embassy in Vientiane to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, your partner’s ID and pay a fee.
 
-[Make an appointment at the embassy in Vientiane.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-vientiane/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Vientiane.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=155&service=13)
 
 You’ll need to pay a fee and bring the following to your appointment:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/laos/third_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/laos/third_country/partner_local/_opposite_sex.erb
@@ -8,7 +8,7 @@ You may be asked to provide an [affirmation of freedom to marry document](/gover
 
 Make an appointment at the British Embassy in Vientiane to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, your partner’s ID and pay a fee.
 
-[Make an appointment at the embassy in Vientiane.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-vientiane/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Vientiane.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=155&service=13)
 
 You’ll need to pay a fee and bring the following to your appointment:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/laos/uk/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/laos/uk/partner_local/_opposite_sex.erb
@@ -8,7 +8,7 @@ You may be asked to provide an [affirmation of freedom to marry document](/gover
 
 Make an appointment at the British Embassy in Vientiane to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, your partner’s ID and pay a fee.
 
-[Make an appointment at the embassy in Vientiane.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-vientiane/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Vientiane.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=155&service=13)
 
 You’ll need to pay a fee and bring the following to your appointment:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/latvia/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/latvia/ceremony_country/partner_british/_opposite_sex.erb
@@ -8,7 +8,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 
 Make an appointment at the British embassy or consulate in Latvia to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your and your partner’s passport and pay a fee.
 
-[Make an appointment at the embassy in Riga.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-riga/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Riga.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=32&service=13)
 
 If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/latvia/ceremony_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/latvia/ceremony_country/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Latvia.
 
-[Make an appointment at the embassy in Riga.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-riga/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Riga.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=32&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/latvia/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/latvia/ceremony_country/partner_local/_opposite_sex.erb
@@ -8,7 +8,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 
 Make an appointment at the British embassy or consulate in Latvia to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your and your partner’s passport and pay a fee.
 
-[Make an appointment at the embassy in Riga.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-riga/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Riga.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=32&service=13)
 
 If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/latvia/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/latvia/ceremony_country/partner_other/_opposite_sex.erb
@@ -8,7 +8,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 
 Make an appointment at the British embassy or consulate in Latvia to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your and your partner’s passport and pay a fee.
 
-[Make an appointment at the embassy in Riga.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-riga/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Riga.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=32&service=13)
 
 If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/latvia/ceremony_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/latvia/ceremony_country/partner_other/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Latvia.
 
-[Make an appointment at the embassy in Riga.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-riga/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Riga.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=32&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/latvia/third_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/latvia/third_country/partner_british/_opposite_sex.erb
@@ -8,7 +8,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 
 Make an appointment at the British embassy or consulate in Latvia to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your and your partner’s passport and pay a fee.
 
-[Make an appointment at the embassy in Riga.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-riga/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Riga.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=32&service=13)
 
 If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/latvia/third_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/latvia/third_country/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Latvia.
 
-[Make an appointment at the embassy in Riga.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-riga/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Riga.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=32&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/latvia/third_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/latvia/third_country/partner_local/_opposite_sex.erb
@@ -8,7 +8,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 
 Make an appointment at the British embassy or consulate in Latvia to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your and your partner’s passport and pay a fee.
 
-[Make an appointment at the embassy in Riga.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-riga/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Riga.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=32&service=13)
 
 If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/latvia/third_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/latvia/third_country/partner_other/_opposite_sex.erb
@@ -8,7 +8,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 
 Make an appointment at the British embassy or consulate in Latvia to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your and your partner’s passport and pay a fee.
 
-[Make an appointment at the embassy in Riga.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-riga/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Riga.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=32&service=13)
 
 If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/latvia/third_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/latvia/third_country/partner_other/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Latvia.
 
-[Make an appointment at the embassy in Riga.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-riga/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Riga.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=32&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/latvia/uk/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/latvia/uk/partner_british/_opposite_sex.erb
@@ -8,7 +8,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 
 Make an appointment at the British embassy or consulate in Latvia to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your and your partner’s passport and pay a fee.
 
-[Make an appointment at the embassy in Riga.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-riga/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Riga.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=32&service=13)
 
 If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/latvia/uk/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/latvia/uk/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Latvia.
 
-[Make an appointment at the embassy in Riga.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-riga/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Riga.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=32&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/latvia/uk/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/latvia/uk/partner_local/_opposite_sex.erb
@@ -8,7 +8,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 
 Make an appointment at the British embassy or consulate in Latvia to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your and your partner’s passport and pay a fee.
 
-[Make an appointment at the embassy in Riga.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-riga/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Riga.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=32&service=13)
 
 If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/latvia/uk/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/latvia/uk/partner_other/_opposite_sex.erb
@@ -8,7 +8,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 
 Make an appointment at the British embassy or consulate in Latvia to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your and your partner’s passport and pay a fee.
 
-[Make an appointment at the embassy in Riga.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-riga/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Riga.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=32&service=13)
 
 If you or your partner have been divorced, widowed or previously in a civil partnership, you’ll also need whichever of the following documents is appropriate:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/latvia/uk/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/latvia/uk/partner_other/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Latvia.
 
-[Make an appointment at the embassy in Riga.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-riga/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Riga.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=32&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/lebanon/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/lebanon/ceremony_country/partner_british/_opposite_sex.erb
@@ -9,7 +9,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Lebanon to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Beirut.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beirut/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Beirut.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=101&service=13)
 
 ###Legalisation and translation
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/lebanon/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/lebanon/ceremony_country/partner_local/_opposite_sex.erb
@@ -9,7 +9,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Lebanon to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Beirut.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beirut/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Beirut.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=101&service=13)
 
 ###Legalisation and translation
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/lebanon/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/lebanon/ceremony_country/partner_other/_opposite_sex.erb
@@ -9,7 +9,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Lebanon to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Beirut.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beirut/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Beirut.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=101&service=13)
 
 ###Legalisation and translation
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/lebanon/third_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/lebanon/third_country/partner_british/_opposite_sex.erb
@@ -9,7 +9,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Lebanon to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Beirut.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beirut/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Beirut.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=101&service=13)
 
 ###Legalisation and translation
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/lebanon/third_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/lebanon/third_country/partner_local/_opposite_sex.erb
@@ -9,7 +9,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Lebanon to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Beirut.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beirut/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Beirut.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=101&service=13)
 
 ###Legalisation and translation
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/lebanon/third_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/lebanon/third_country/partner_other/_opposite_sex.erb
@@ -9,7 +9,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Lebanon to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Beirut.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beirut/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Beirut.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=101&service=13)
 
 ###Legalisation and translation
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/lebanon/uk/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/lebanon/uk/partner_british/_opposite_sex.erb
@@ -9,7 +9,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Lebanon to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Beirut.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beirut/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Beirut.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=101&service=13)
 
 ###Legalisation and translation
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/lebanon/uk/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/lebanon/uk/partner_local/_opposite_sex.erb
@@ -9,7 +9,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Lebanon to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Beirut.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beirut/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Beirut.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=101&service=13)
 
 ###Legalisation and translation
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/lebanon/uk/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/lebanon/uk/partner_other/_opposite_sex.erb
@@ -9,7 +9,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Lebanon to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Beirut.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-beirut/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Beirut.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=101&service=13)
 
 ###Legalisation and translation
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/lithuania/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/lithuania/ceremony_country/partner_british/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Lithuania. You c
 
 You’ll need to have been living in Lithuania for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Vilnius.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-vilnius/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Vilnius.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=39&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/lithuania/ceremony_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/lithuania/ceremony_country/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Lithuania.
 
-[Make an appointment at the embassy in Vilnius.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-vilnius/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Vilnius.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=39&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/lithuania/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/lithuania/ceremony_country/partner_local/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Lithuania. You c
 
 You’ll need to have been living in Lithuania for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Vilnius.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-vilnius/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Vilnius.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=39&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/lithuania/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/lithuania/ceremony_country/partner_other/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Lithuania. You c
 
 You’ll need to have been living in Lithuania for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Vilnius.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-vilnius/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Vilnius.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=39&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/lithuania/third_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/lithuania/third_country/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Lithuania.
 
-[Make an appointment at the embassy in Vilnius.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-vilnius/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Vilnius.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=39&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/lithuania/uk/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/lithuania/uk/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Lithuania.
 
-[Make an appointment at the embassy in Vilnius.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-vilnius/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Vilnius.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=39&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/luxembourg/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/luxembourg/_opposite_sex.erb
@@ -14,7 +14,7 @@ This costs <%= format_money calculator.consular_fee(:affidavit_or_affirmation_fo
 
 ### Swearing an affirmation or affidavit
 
-s1. [Make an appointment at the embassy in Luxembourg](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-luxembourg/oaths-affirmations-and-affidavits/slot_picker) to swear your affirmation or affidavit.
+s1. [Make an appointment at the embassy in Luxembourg](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=27&service=13) to swear your affirmation or affidavit.
 s2. Download the [affirmation or affidavit](/government/publications/luxembourg-affirmationaffidavit-of-marital-status-forms).
 s3. Print it out but don't sign it - you need to sign it at the embassy.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/luxembourg/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/luxembourg/_same_sex.erb
@@ -14,7 +14,7 @@ This costs <%= format_money calculator.consular_fee(:affidavit_or_affirmation_fo
 
 ### Swearing an affirmation or affidavit
 
-s1. [Make an appointment at the embassy in Luxembourg](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-luxembourg/oaths-affirmations-and-affidavits/slot_picker) to swear your affirmation or affidavit.
+s1. [Make an appointment at the embassy in Luxembourg](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=27&service=13) to swear your affirmation or affidavit.
 s2. Download the [affirmation or affidavit](/government/publications/luxembourg-affirmationaffidavit-of-marital-status-forms).
 s3. Print it out but don't sign it - you need to sign it at the embassy.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/macao/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/macao/ceremony_country/partner_british/_opposite_sex.erb
@@ -9,7 +9,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British Consulate General Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the British Consulate General Hong Kong.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-hong-kong/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British Consulate General Hong Kong.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=65&service=13)
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/macao/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/macao/ceremony_country/partner_local/_opposite_sex.erb
@@ -9,7 +9,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British Consulate General Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the British Consulate General Hong Kong.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-hong-kong/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British Consulate General Hong Kong.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=65&service=13)
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/macao/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/macao/ceremony_country/partner_other/_opposite_sex.erb
@@ -9,7 +9,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British Consulate General Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the British Consulate General Hong Kong.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-hong-kong/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British Consulate General Hong Kong.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=65&service=13)
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/macao/third_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/macao/third_country/partner_british/_opposite_sex.erb
@@ -10,7 +10,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British Consulate General Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the British Consulate General Hong Kong.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-hong-kong/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British Consulate General Hong Kong.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=65&service=13)
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/macao/third_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/macao/third_country/partner_local/_opposite_sex.erb
@@ -10,7 +10,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British Consulate General Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the British Consulate General Hong Kong.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-hong-kong/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British Consulate General Hong Kong.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=65&service=13)
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/macao/third_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/macao/third_country/partner_other/_opposite_sex.erb
@@ -10,7 +10,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British Consulate General Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the British Consulate General Hong Kong.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-hong-kong/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British Consulate General Hong Kong.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=65&service=13)
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/macao/uk/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/macao/uk/partner_british/_opposite_sex.erb
@@ -10,7 +10,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British Consulate General Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the British Consulate General Hong Kong.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-hong-kong/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British Consulate General Hong Kong.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=65&service=13)
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/macao/uk/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/macao/uk/partner_local/_opposite_sex.erb
@@ -10,7 +10,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British Consulate General Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the British Consulate General Hong Kong.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-hong-kong/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British Consulate General Hong Kong.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=65&service=13)
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/macao/uk/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/macao/uk/partner_other/_opposite_sex.erb
@@ -10,7 +10,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British Consulate General Hong Kong to swear an affirmation/affadavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the British Consulate General Hong Kong.](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-hong-kong/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the British Consulate General Hong Kong.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=65&service=13)
 
 You’ll need to complete an ‘Affirmation for marriage’ (non-religious) form or an ‘Affidavit for marriage’ (religious) form in English.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/malaysia/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/malaysia/ceremony_country/partner_british/_opposite_sex.erb
@@ -7,7 +7,7 @@ The UK does not issue certificates of no impediment (CNI) for marriages in Commo
 
 The British High Commission in Malaysia can provide you with a letter explaining this position for a charge - see [consular fees for Malaysia](/government/publications/malaysia-consular-fees).
 
-[Make an appointment at the High Commission in Kuala Lumpur](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-kuala-lumpur/providing-an-informative-note/slot_picker) to get your letter.
+[Make an appointment at the High Commission in Kuala Lumpur](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=176&service=19) to get your letter.
 
 You’ll need to provide the following documents:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/malaysia/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/malaysia/ceremony_country/partner_local/_opposite_sex.erb
@@ -7,7 +7,7 @@ The UK does not issue certificates of no impediment (CNI) for marriages in Commo
 
 The British High Commission in Malaysia can provide you with a letter explaining this position for a charge - see [consular fees for Malaysia](/government/publications/malaysia-consular-fees).
 
-[Make an appointment at the High Commission in Kuala Lumpur](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-kuala-lumpur/providing-an-informative-note/slot_picker) to get your letter.
+[Make an appointment at the High Commission in Kuala Lumpur](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=176&service=19) to get your letter.
 
 You’ll need to provide the following documents:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/malaysia/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/malaysia/ceremony_country/partner_other/_opposite_sex.erb
@@ -7,7 +7,7 @@ The UK does not issue certificates of no impediment (CNI) for marriages in Commo
 
 The British High Commission in Malaysia can provide you with a letter explaining this position for a charge - see [consular fees for Malaysia](/government/publications/malaysia-consular-fees).
 
-[Make an appointment at the High Commission in Kuala Lumpur](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-kuala-lumpur/providing-an-informative-note/slot_picker) to get your letter.
+[Make an appointment at the High Commission in Kuala Lumpur](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=176&service=19) to get your letter.
 
 You’ll need to provide the following documents:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/malaysia/third_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/malaysia/third_country/partner_british/_opposite_sex.erb
@@ -7,7 +7,7 @@ The UK does not issue certificates of no impediment (CNI) for marriages in Commo
 
 The British High Commission in Malaysia can provide you with a letter explaining this position for a charge - see [consular fees for Malaysia](/government/publications/malaysia-consular-fees).
 
-[Make an appointment at the High Commission in Kuala Lumpur](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-kuala-lumpur/providing-an-informative-note/slot_picker) to get your letter.
+[Make an appointment at the High Commission in Kuala Lumpur](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=176&service=19) to get your letter.
 
 You’ll need to provide the following documents:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/malaysia/third_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/malaysia/third_country/partner_local/_opposite_sex.erb
@@ -7,7 +7,7 @@ The UK does not issue certificates of no impediment (CNI) for marriages in Commo
 
 The British High Commission in Malaysia can provide you with a letter explaining this position for a charge - see [consular fees for Malaysia](/government/publications/malaysia-consular-fees).
 
-[Make an appointment at the High Commission in Kuala Lumpur](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-kuala-lumpur/providing-an-informative-note/slot_picker) to get your letter.
+[Make an appointment at the High Commission in Kuala Lumpur](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=176&service=19) to get your letter.
 
 You’ll need to provide the following documents:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/malaysia/third_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/malaysia/third_country/partner_other/_opposite_sex.erb
@@ -7,7 +7,7 @@ The UK does not issue certificates of no impediment (CNI) for marriages in Commo
 
 The British High Commission in Malaysia can provide you with a letter explaining this position for a charge - see [consular fees for Malaysia](/government/publications/malaysia-consular-fees).
 
-[Make an appointment at the High Commission in Kuala Lumpur](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-kuala-lumpur/providing-an-informative-note/slot_picker) to get your letter.
+[Make an appointment at the High Commission in Kuala Lumpur](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=176&service=19) to get your letter.
 
 You’ll need to provide the following documents:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/malaysia/uk/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/malaysia/uk/partner_british/_opposite_sex.erb
@@ -7,7 +7,7 @@ The UK does not issue certificates of no impediment (CNI) for marriages in Commo
 
 The British High Commission in Malaysia can provide you with a letter explaining this position for a charge - see [consular fees for Malaysia](/government/publications/malaysia-consular-fees).
 
-[Make an appointment at the High Commission in Kuala Lumpur](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-kuala-lumpur/providing-an-informative-note/slot_picker) to get your letter.
+[Make an appointment at the High Commission in Kuala Lumpur](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=176&service=19) to get your letter.
 
 You’ll need to provide the following documents:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/malaysia/uk/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/malaysia/uk/partner_local/_opposite_sex.erb
@@ -7,7 +7,7 @@ The UK does not issue certificates of no impediment (CNI) for marriages in Commo
 
 The British High Commission in Malaysia can provide you with a letter explaining this position for a charge - see [consular fees for Malaysia](/government/publications/malaysia-consular-fees).
 
-[Make an appointment at the High Commission in Kuala Lumpur](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-kuala-lumpur/providing-an-informative-note/slot_picker) to get your letter.
+[Make an appointment at the High Commission in Kuala Lumpur](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=176&service=19) to get your letter.
 
 You’ll need to provide the following documents:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/malaysia/uk/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/malaysia/uk/partner_other/_opposite_sex.erb
@@ -7,7 +7,7 @@ The UK does not issue certificates of no impediment (CNI) for marriages in Commo
 
 The British High Commission in Malaysia can provide you with a letter explaining this position for a charge - see [consular fees for Malaysia](/government/publications/malaysia-consular-fees).
 
-[Make an appointment at the High Commission in Kuala Lumpur](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-kuala-lumpur/providing-an-informative-note/slot_picker) to get your letter.
+[Make an appointment at the High Commission in Kuala Lumpur](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=176&service=19) to get your letter.
 
 You’ll need to provide the following documents:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/malta/ceremony_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/malta/ceremony_country/partner_british/_same_sex.erb
@@ -2,7 +2,7 @@ You may be able to register a civil partnership or get married at the High Commi
 
 Contact them to make an appointment:
 
-[Make an appointment at the embassy in Valletta.](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-valletta/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Valletta.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=42&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/malta/ceremony_country/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/malta/ceremony_country/partner_local/_same_sex.erb
@@ -2,7 +2,7 @@ You may be able to register a civil partnership or get married at the High Commi
 
 Contact them to make an appointment:
 
-[Make an appointment at the embassy in Valletta.](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-valletta/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Valletta.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=42&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/malta/ceremony_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/malta/ceremony_country/partner_other/_same_sex.erb
@@ -2,7 +2,7 @@ You may be able to register a civil partnership or get married at the High Commi
 
 Contact them to make an appointment:
 
-[Make an appointment at the embassy in Valletta.](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-valletta/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Valletta.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=42&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/malta/third_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/malta/third_country/partner_british/_same_sex.erb
@@ -2,7 +2,7 @@ You may be able to register a civil partnership or get married at the High Commi
 
 Contact them to make an appointment:
 
-[Make an appointment at the embassy in Valletta.](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-valletta/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Valletta.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=42&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/malta/third_country/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/malta/third_country/partner_local/_same_sex.erb
@@ -2,7 +2,7 @@ You may be able to register a civil partnership or get married at the High Commi
 
 Contact them to make an appointment:
 
-[Make an appointment at the embassy in Valletta.](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-valletta/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Valletta.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=42&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/malta/third_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/malta/third_country/partner_other/_same_sex.erb
@@ -2,7 +2,7 @@ You may be able to register a civil partnership or get married at the High Commi
 
 Contact them to make an appointment:
 
-[Make an appointment at the embassy in Valletta.](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-valletta/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Valletta.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=42&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/malta/uk/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/malta/uk/partner_british/_same_sex.erb
@@ -2,7 +2,7 @@ You may be able to register a civil partnership or get married at the High Commi
 
 Contact them to make an appointment:
 
-[Make an appointment at the embassy in Valletta.](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-valletta/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Valletta.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=42&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/malta/uk/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/malta/uk/partner_local/_same_sex.erb
@@ -2,7 +2,7 @@ You may be able to register a civil partnership or get married at the High Commi
 
 Contact them to make an appointment:
 
-[Make an appointment at the embassy in Valletta.](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-valletta/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Valletta.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=42&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/malta/uk/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/malta/uk/partner_other/_same_sex.erb
@@ -2,7 +2,7 @@ You may be able to register a civil partnership or get married at the High Commi
 
 Contact them to make an appointment:
 
-[Make an appointment at the embassy in Valletta.](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-valletta/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Valletta.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=42&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/mexico/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/mexico/ceremony_country/partner_british/_opposite_sex.erb
@@ -12,7 +12,7 @@ To get a CNI, you must post notice of your intended marriage in Mexico. You can 
 
 You’ll need to have been living in Mexico for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Mexico City.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-mexico-city/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Mexico City.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=129&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/mexico/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/mexico/ceremony_country/partner_local/_opposite_sex.erb
@@ -12,7 +12,7 @@ To get a CNI, you must post notice of your intended marriage in Mexico. You can 
 
 You’ll need to have been living in Mexico for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Mexico City.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-mexico-city/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Mexico City.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=129&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/mexico/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/mexico/ceremony_country/partner_other/_opposite_sex.erb
@@ -12,7 +12,7 @@ To get a CNI, you must post notice of your intended marriage in Mexico. You can 
 
 You’ll need to have been living in Mexico for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Mexico City.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-mexico-city/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Mexico City.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=129&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/moldova/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/moldova/ceremony_country/partner_british/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Moldova. You can
 
 You’ll need to have been living in Moldova for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Chisinau](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-chisinau/notice-of-marriage-or-civil-partnership/slot_picker). 
+[Make an appointment at the embassy in Chisinau](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=109&service=10). 
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/moldova/ceremony_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/moldova/ceremony_country/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to register a civil partnership at the British embassy or consulate in Moldova.
 
-[Make an appointment at the embassy in Chisinau](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-chisinau/notice-of-marriage-or-civil-partnership/slot_picker). 
+[Make an appointment at the embassy in Chisinau](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=109&service=10). 
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/moldova/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/moldova/ceremony_country/partner_local/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Moldova. You can
 
 You’ll need to have been living in Moldova for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Chisinau](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-chisinau/notice-of-marriage-or-civil-partnership/slot_picker). 
+[Make an appointment at the embassy in Chisinau](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=109&service=10). 
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/moldova/ceremony_country/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/moldova/ceremony_country/partner_local/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to register a civil partnership at the British embassy or consulate in Moldova.
 
-[Make an appointment at the embassy in Chisinau](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-chisinau/notice-of-marriage-or-civil-partnership/slot_picker). 
+[Make an appointment at the embassy in Chisinau](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=109&service=10). 
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/moldova/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/moldova/ceremony_country/partner_other/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Moldova. You can
 
 You’ll need to have been living in Moldova for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Chisinau](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-chisinau/notice-of-marriage-or-civil-partnership/slot_picker). 
+[Make an appointment at the embassy in Chisinau](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=109&service=10). 
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/moldova/ceremony_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/moldova/ceremony_country/partner_other/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to register a civil partnership at the British embassy or consulate in Moldova.
 
-[Make an appointment at the embassy in Chisinau](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-chisinau/notice-of-marriage-or-civil-partnership/slot_picker). 
+[Make an appointment at the embassy in Chisinau](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=109&service=10). 
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/moldova/third_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/moldova/third_country/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to register a civil partnership at the British embassy or consulate in Moldova.
 
-[Make an appointment at the embassy in Chisinau](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-chisinau/notice-of-marriage-or-civil-partnership/slot_picker).
+[Make an appointment at the embassy in Chisinau](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=109&service=10).
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/moldova/third_country/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/moldova/third_country/partner_local/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to register a civil partnership at the British embassy or consulate in Moldova.
 
-[Make an appointment at the embassy in Chisinau](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-chisinau/notice-of-marriage-or-civil-partnership/slot_picker).
+[Make an appointment at the embassy in Chisinau](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=109&service=10).
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/moldova/third_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/moldova/third_country/partner_other/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to register a civil partnership at the British embassy or consulate in Moldova.
 
-[Make an appointment at the embassy in Chisinau](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-chisinau/notice-of-marriage-or-civil-partnership/slot_picker).
+[Make an appointment at the embassy in Chisinau](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=109&service=10).
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/moldova/uk/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/moldova/uk/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to register a civil partnership at the British embassy or consulate in Moldova.
 
-[Make an appointment at the embassy in Chisinau](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-chisinau/notice-of-marriage-or-civil-partnership/slot_picker). 
+[Make an appointment at the embassy in Chisinau](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=109&service=10). 
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/moldova/uk/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/moldova/uk/partner_local/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to register a civil partnership at the British embassy or consulate in Moldova.
 
-[Make an appointment at the embassy in Chisinau](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-chisinau/notice-of-marriage-or-civil-partnership/slot_picker). 
+[Make an appointment at the embassy in Chisinau](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=109&service=10). 
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/moldova/uk/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/moldova/uk/partner_other/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to register a civil partnership at the British embassy or consulate in Moldova.
 
-[Make an appointment at the embassy in Chisinau](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-chisinau/notice-of-marriage-or-civil-partnership/slot_picker). 
+[Make an appointment at the embassy in Chisinau](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=109&service=10). 
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/mongolia/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/mongolia/ceremony_country/partner_british/_opposite_sex.erb
@@ -9,7 +9,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Mongolia to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Ulaanbaatar.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ulaanbaatar/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Ulaanbaatar.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=154&service=13)
 
 ###Legalisation and translation
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/mongolia/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/mongolia/ceremony_country/partner_local/_opposite_sex.erb
@@ -9,7 +9,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Mongolia to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Ulaanbaatar.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ulaanbaatar/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Ulaanbaatar.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=154&service=13)
 
 ###Legalisation and translation
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/mongolia/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/mongolia/ceremony_country/partner_other/_opposite_sex.erb
@@ -9,7 +9,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Mongolia to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Ulaanbaatar.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ulaanbaatar/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Ulaanbaatar.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=154&service=13)
 
 ###Legalisation and translation
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/mongolia/third_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/mongolia/third_country/partner_british/_opposite_sex.erb
@@ -9,7 +9,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Mongolia to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Ulaanbaatar.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ulaanbaatar/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Ulaanbaatar.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=154&service=13)
 
 ###Legalisation and translation
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/mongolia/third_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/mongolia/third_country/partner_local/_opposite_sex.erb
@@ -9,7 +9,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Mongolia to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Ulaanbaatar.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ulaanbaatar/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Ulaanbaatar.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=154&service=13)
 
 ###Legalisation and translation
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/mongolia/third_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/mongolia/third_country/partner_other/_opposite_sex.erb
@@ -9,7 +9,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Mongolia to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Ulaanbaatar.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ulaanbaatar/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Ulaanbaatar.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=154&service=13)
 
 ###Legalisation and translation
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/mongolia/uk/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/mongolia/uk/partner_british/_opposite_sex.erb
@@ -9,7 +9,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Mongolia to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Ulaanbaatar.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ulaanbaatar/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Ulaanbaatar.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=154&service=13)
 
 ###Legalisation and translation
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/mongolia/uk/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/mongolia/uk/partner_local/_opposite_sex.erb
@@ -9,7 +9,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Mongolia to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Ulaanbaatar.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ulaanbaatar/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Ulaanbaatar.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=154&service=13)
 
 ###Legalisation and translation
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/mongolia/uk/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/mongolia/uk/partner_other/_opposite_sex.erb
@@ -9,7 +9,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Mongolia to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Ulaanbaatar.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ulaanbaatar/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Ulaanbaatar.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=154&service=13)
 
 ###Legalisation and translation
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/montenegro/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/montenegro/ceremony_country/partner_british/_opposite_sex.erb
@@ -13,7 +13,7 @@ To get a CNI, you must post notice of your intended marriage in Montenegro. You 
 
 You’ll need to have been living in Montenegro for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Podgorica](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-podgorica/notice-of-marriage-or-civil-partnership/slot_picker) to post notice and make an affirmation.
+[Make an appointment at the embassy in Podgorica](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=136&service=10) to post notice and make an affirmation.
 
 You can make your affirmation that you are free to marry at your appointment to post notice.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/montenegro/ceremony_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/montenegro/ceremony_country/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Montenegro.
 
-[Make an appointment at the embassy in Podgorica.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-podgorica/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Podgorica.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=136&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/montenegro/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/montenegro/ceremony_country/partner_local/_opposite_sex.erb
@@ -12,7 +12,7 @@ To get a CNI, you must post notice of your intended marriage in Montenegro. You 
 
 You’ll need to have been living in Montenegro for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Podgorica](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-podgorica/notice-of-marriage-or-civil-partnership/slot_picker) to post notice and make an affirmation.
+[Make an appointment at the embassy in Podgorica](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=136&service=10) to post notice and make an affirmation.
 
 You can make your affirmation that you are free to marry at your appointment to post notice.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/montenegro/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/montenegro/ceremony_country/partner_other/_opposite_sex.erb
@@ -12,7 +12,7 @@ To get a CNI, you must post notice of your intended marriage in Montenegro. You 
 
 You’ll need to have been living in Montenegro for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Podgorica](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-podgorica/notice-of-marriage-or-civil-partnership/slot_picker) to post notice and make an affirmation.
+[Make an appointment at the embassy in Podgorica](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=136&service=10) to post notice and make an affirmation.
 
 You can make your affirmation that you are free to marry at your appointment to post notice.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/montenegro/third_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/montenegro/third_country/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Montenegro.
 
-[Make an appointment at the embassy in Podgorica.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-podgorica/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Podgorica.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=136&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/montenegro/uk/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/montenegro/uk/partner_british/_opposite_sex.erb
@@ -16,7 +16,7 @@ You can normally get a CNI by giving a notice of marriage at your local register
 
 You need to exchange your UK-issued CNI for one that’s valid in Montenegro at the British Embassy in Podgorica. You also need to make an affirmation at the British embassy that says you’re legally allowed to get married. It costs <%= format_money calculator.consular_fee(:issuing_civil_partnership_certificate) %> for a CNI issued by the British embassy and <%= format_money calculator.consular_fee(:affidavit_or_affirmation_for_marriage) %> for an affirmation made at the British embassy.
 
-[Make an appointment at the British embassy in Podgorica](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-podgorica/exchange-a-certificate-of-no-impediment/slot_picker) to exchange your CNI.
+[Make an appointment at the British embassy in Podgorica](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=136&service=4) to exchange your CNI.
 
 You can make your affirmation at your appointment to exchange your CNI. You’ll need to complete an [affirmation form](/government/publications/montenegro-affirmation-affidavit-of-marital-status-form). You can download and fill in (but not sign) the affirmation in advance.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/montenegro/uk/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/montenegro/uk/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Montenegro.
 
-[Make an appointment at the embassy in Podgorica.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-podgorica/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Podgorica.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=136&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/montenegro/uk/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/montenegro/uk/partner_local/_opposite_sex.erb
@@ -17,7 +17,7 @@ You can normally get a CNI by giving a notice of marriage at your local register
 
 You need to exchange your UK-issued CNI for one that’s valid in Montenegro at the British Embassy in Podgorica. You also need to make an affirmation at the British embassy that says you’re legally allowed to get married. It costs <%= format_money calculator.consular_fee(:issuing_civil_partnership_certificate) %> for a CNI issued by the British embassy and <%= format_money calculator.consular_fee(:affidavit_or_affirmation_for_marriage) %> for an affirmation made at the British embassy.
 
-[Make an appointment at the British embassy in Podgorica](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-podgorica/exchange-a-certificate-of-no-impediment/slot_picker) to exchange your CNI.
+[Make an appointment at the British embassy in Podgorica](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=136&service=4) to exchange your CNI.
 
 You can make your affirmation at your appointment to exchange your CNI. You’ll need to complete an [affirmation form](/government/publications/montenegro-affirmation-affidavit-of-marital-status-form). You can download and fill in (but not sign) the affirmation in advance.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/montenegro/uk/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/montenegro/uk/partner_other/_opposite_sex.erb
@@ -17,7 +17,7 @@ You can normally get a CNI by giving a notice of marriage at your local register
 
 You need to exchange your UK-issued CNI for one that’s valid in Montenegro at the British Embassy in Podgorica. You also need to make an affirmation at the British embassy that says you’re legally allowed to get married. It costs <%= format_money calculator.consular_fee(:issuing_civil_partnership_certificate) %> for a CNI issued by the British embassy and <%= format_money calculator.consular_fee(:affidavit_or_affirmation_for_marriage) %> for an affirmation made at the British embassy.
 
-[Make an appointment at the British embassy in Podgorica](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-podgorica/exchange-a-certificate-of-no-impediment/slot_picker) to exchange your CNI.
+[Make an appointment at the British embassy in Podgorica](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=136&service=4) to exchange your CNI.
 
 You can make your affirmation at your appointment to exchange your CNI. You’ll need to complete an [affirmation form](/government/publications/montenegro-affirmation-affidavit-of-marital-status-form). You can download and fill in (but not sign) the affirmation in advance.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/mozambique/ceremony_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/mozambique/ceremony_country/partner_other/_same_sex.erb
@@ -2,7 +2,7 @@ You may be able to get married at the British High Commission in Maputo.
 
 ^Same sex marriage must be permitted under the law of your non-British partner’s country. Your partner will need to provide evidence of this from their country’s authorities or a lawyer qualified in the law of that country.^
 
-[Make an appointment at the high commission in Maputo.](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-maputo/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the high commission in Maputo.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=179&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/mozambique/third_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/mozambique/third_country/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British High Commission in Maputo.
 
-[Make an appointment at the high commission in Maputo.](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-maputo/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the high commission in Maputo.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=179&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/mozambique/third_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/mozambique/third_country/partner_other/_same_sex.erb
@@ -2,7 +2,7 @@ You may be able to get married at the British High Commission in Maputo.
 
 ^Same sex marriage must be permitted under the law of your non-British partner’s country. Your partner will need to provide evidence of this from their country’s authorities or a lawyer qualified in the law of that country.^
 
-[Make an appointment at the high commission in Maputo.](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-maputo/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the high commission in Maputo.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=179&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/mozambique/uk/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/mozambique/uk/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British High Commission in Maputo.
 
-[Make an appointment at the high commission in Maputo.](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-maputo/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the high commission in Maputo.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=179&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/mozambique/uk/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/mozambique/uk/partner_other/_same_sex.erb
@@ -2,7 +2,7 @@ You may be able to get married at the British High Commission in Maputo.
 
 ^Same sex marriage must be permitted under the law of your non-British partner’s country. Your partner will need to provide evidence of this from their country’s authorities or a lawyer qualified in the law of that country.^
 
-[Make an appointment at the high commission in Maputo.](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-maputo/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the high commission in Maputo.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=179&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/nepal/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/nepal/ceremony_country/partner_british/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Nepal. You can d
 
 You’ll need to have been living in Nepal for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Kathmandu.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-kathmandu/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Kathmandu.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=120&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/nepal/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/nepal/ceremony_country/partner_local/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Nepal. You can d
 
 You’ll need to have been living in Nepal for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Kathmandu.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-kathmandu/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Kathmandu.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=120&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/nepal/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/nepal/ceremony_country/partner_other/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Nepal. You can d
 
 You’ll need to have been living in Nepal for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Kathmandu.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-kathmandu/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Kathmandu.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=120&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/norway/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/norway/ceremony_country/partner_british/_opposite_sex.erb
@@ -9,7 +9,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy in Oslo to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, a copy of your partner’s passport and pay a fee.
 
-[Make an appointment at the embassy in Oslo.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Oslo.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=28&service=13)
 
 ###Legalisation and translation
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/norway/ceremony_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/norway/ceremony_country/partner_british/_same_sex.erb
@@ -13,7 +13,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy in Oslo to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, a copy of your partner’s passport and pay a fee.
 
-[Make an appointment at the embassy in Oslo.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Oslo.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=28&service=13)
 
 ^Your partner will need to get an affirmation as well.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/norway/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/norway/ceremony_country/partner_local/_opposite_sex.erb
@@ -9,7 +9,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy in Oslo to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, a copy of your partner’s passport and pay a fee.
 
-[Make an appointment at the embassy in Oslo.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Oslo.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=28&service=13)
 
 ###Legalisation and translation
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/norway/ceremony_country/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/norway/ceremony_country/partner_local/_same_sex.erb
@@ -13,7 +13,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy in Oslo to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, a copy of your partner’s passport and pay a fee.
 
-[Make an appointment at the embassy in Oslo.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Oslo.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=28&service=13)
 
 ^Your partner will need to get an affirmation as well.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/norway/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/norway/ceremony_country/partner_other/_opposite_sex.erb
@@ -9,7 +9,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy in Oslo to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, a copy of your partner’s passport and pay a fee.
 
-[Make an appointment at the embassy in Oslo.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Oslo.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=28&service=13)
 
 ###Legalisation and translation
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/norway/ceremony_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/norway/ceremony_country/partner_other/_same_sex.erb
@@ -13,7 +13,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy in Oslo to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, a copy of your partner’s passport and pay a fee.
 
-[Make an appointment at the embassy in Oslo.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Oslo.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=28&service=13)
 
 ^Your partner will need to get an affirmation as well.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/norway/third_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/norway/third_country/partner_british/_same_sex.erb
@@ -13,7 +13,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy in Oslo to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, a copy of your partner’s passport and pay a fee.
 
-[Make an appointment at the embassy in Oslo.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Oslo.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=28&service=13)
 
 ^Your partner will need to get an affirmation as well.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/norway/third_country/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/norway/third_country/partner_local/_same_sex.erb
@@ -13,7 +13,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy in Oslo to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, a copy of your partner’s passport and pay a fee.
 
-[Make an appointment at the embassy in Oslo.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Oslo.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=28&service=13)
 
 ^Your partner will need to get an affirmation as well.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/norway/third_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/norway/third_country/partner_other/_same_sex.erb
@@ -13,7 +13,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy in Oslo to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, a copy of your partner’s passport and pay a fee.
 
-[Make an appointment at the embassy in Oslo.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Oslo.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=28&service=13)
 
 ^Your partner will need to get an affirmation as well.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/norway/uk/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/norway/uk/partner_british/_same_sex.erb
@@ -13,7 +13,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy in Oslo to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, a copy of your partner’s passport and pay a fee.
 
-[Make an appointment at the embassy in Oslo.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Oslo.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=28&service=13)
 
 ^Your partner will need to get an affirmation as well.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/norway/uk/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/norway/uk/partner_local/_same_sex.erb
@@ -13,7 +13,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy in Oslo to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, a copy of your partner’s passport and pay a fee.
 
-[Make an appointment at the embassy in Oslo.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Oslo.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=28&service=13)
 
 ^Your partner will need to get an affirmation as well.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/norway/uk/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/norway/uk/partner_other/_same_sex.erb
@@ -13,7 +13,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy in Oslo to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, a copy of your partner’s passport and pay a fee.
 
-[Make an appointment at the embassy in Oslo.](https://www.consular-appointments.service.gov.uk/fco#!/british-embassy-oslo/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Oslo.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=28&service=13)
 
 ^Your partner will need to get an affirmation as well.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/oman/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/oman/ceremony_country/partner_british/_opposite_sex.erb
@@ -8,7 +8,7 @@ Contact the relevant local authorities in Oman (the local church, mosque or temp
 
 You may be asked to swear an oath or affidavit (written statement of facts) before you get married. You must do this at a British embassy in Oman.
 
-[Make an appointment at the embassy in Muscat.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-muscat/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Muscat.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=133&service=13)
 
 You’ll need to complete an [affidavit form](/government/publications/affidavit-form-oman) to prove you’re allowed to marry.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/oman/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/oman/ceremony_country/partner_local/_opposite_sex.erb
@@ -8,7 +8,7 @@ Contact the relevant local authorities in Oman (the local church, mosque or temp
 
 You may be asked to swear an oath or affidavit (written statement of facts) before you get married. You must do this at a British embassy in Oman.
 
-[Make an appointment at the embassy in Muscat.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-muscat/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Muscat.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=133&service=13)
 
 You’ll need to complete an [affidavit form](/government/publications/affidavit-form-oman) to prove you’re allowed to marry.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/oman/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/oman/ceremony_country/partner_other/_opposite_sex.erb
@@ -8,7 +8,7 @@ Contact the relevant local authorities in Oman (the local church, mosque or temp
 
 You may be asked to swear an oath or affidavit (written statement of facts) before you get married. You must do this at a British embassy in Oman.
 
-[Make an appointment at the embassy in Muscat.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-muscat/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Muscat.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=133&service=13)
 
 You’ll need to complete an [affidavit form](/government/publications/affidavit-form-oman) to prove you’re allowed to marry.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/oman/third_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/oman/third_country/partner_british/_opposite_sex.erb
@@ -8,7 +8,7 @@ Contact the relevant local authorities in Oman (the local church, mosque or temp
 
 You may be asked to swear an oath or affidavit (written statement of facts) before you get married. You must do this at a British embassy in Oman.
 
-[Make an appointment at the embassy in Muscat.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-muscat/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Muscat.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=133&service=13)
 
 You’ll need to complete an [affidavit form](/government/publications/affidavit-form-oman) to prove you’re allowed to marry.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/oman/third_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/oman/third_country/partner_local/_opposite_sex.erb
@@ -8,7 +8,7 @@ Contact the relevant local authorities in Oman (the local church, mosque or temp
 
 You may be asked to swear an oath or affidavit (written statement of facts) before you get married. You must do this at a British embassy in Oman.
 
-[Make an appointment at the embassy in Muscat.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-muscat/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Muscat.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=133&service=13)
 
 You’ll need to complete an [affidavit form](/government/publications/affidavit-form-oman) to prove you’re allowed to marry.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/oman/third_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/oman/third_country/partner_other/_opposite_sex.erb
@@ -8,7 +8,7 @@ Contact the relevant local authorities in Oman (the local church, mosque or temp
 
 You may be asked to swear an oath or affidavit (written statement of facts) before you get married. You must do this at a British embassy in Oman.
 
-[Make an appointment at the embassy in Muscat.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-muscat/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Muscat.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=133&service=13)
 
 You’ll need to complete an [affidavit form](/government/publications/affidavit-form-oman) to prove you’re allowed to marry.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/oman/uk/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/oman/uk/partner_british/_opposite_sex.erb
@@ -8,7 +8,7 @@ Contact the relevant local authorities in Oman (the local church, mosque or temp
 
 You may be asked to swear an oath or affidavit (written statement of facts) before you get married. You must do this at a British embassy in Oman.
 
-[Make an appointment at the embassy in Muscat.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-muscat/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Muscat.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=133&service=13)
 
 You’ll need to complete an [affidavit form](/government/publications/affidavit-form-oman) to prove you’re allowed to marry.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/oman/uk/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/oman/uk/partner_local/_opposite_sex.erb
@@ -8,7 +8,7 @@ Contact the relevant local authorities in Oman (the local church, mosque or temp
 
 You may be asked to swear an oath or affidavit (written statement of facts) before you get married. You must do this at a British embassy in Oman.
 
-[Make an appointment at the embassy in Muscat.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-muscat/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Muscat.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=133&service=13)
 
 You’ll need to complete an [affidavit form](/government/publications/affidavit-form-oman) to prove you’re allowed to marry.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/oman/uk/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/oman/uk/partner_other/_opposite_sex.erb
@@ -8,7 +8,7 @@ Contact the relevant local authorities in Oman (the local church, mosque or temp
 
 You may be asked to swear an oath or affidavit (written statement of facts) before you get married. You must do this at a British embassy in Oman.
 
-[Make an appointment at the embassy in Muscat.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-muscat/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Muscat.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=133&service=13)
 
 You’ll need to complete an [affidavit form](/government/publications/affidavit-form-oman) to prove you’re allowed to marry.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/panama/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/panama/ceremony_country/partner_british/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Panama. You can 
 
 You’ll need to have been living in Panama for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Panama City.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-panama-city/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Panama City.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=134&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/panama/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/panama/ceremony_country/partner_local/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Panama. You can 
 
 You’ll need to have been living in Panama for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Panama City.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-panama-city/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Panama City.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=134&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/panama/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/panama/ceremony_country/partner_other/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Panama. You can 
 
 You’ll need to have been living in Panama for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Panama City.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-panama-city/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Panama City.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=134&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/peru/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/peru/ceremony_country/partner_british/_opposite_sex.erb
@@ -9,7 +9,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Peru to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Lima.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Lima.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=125&service=13)
 
 You’ll need to complete an [affidavit form](/government/publications/affidavit-marriage-in-peru-spanish-only) to prove you’re allowed to marry.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/peru/ceremony_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/peru/ceremony_country/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to register a civil partnership or get married at the British embassy or consulate in Peru.
 
-[Make an appointment at the embassy in Lima.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Lima.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=125&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/peru/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/peru/ceremony_country/partner_local/_opposite_sex.erb
@@ -9,7 +9,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Peru to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Lima.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Lima.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=125&service=13)
 
 You’ll need to complete an [affidavit form](/government/publications/affidavit-marriage-in-peru-spanish-only) to prove you’re allowed to marry.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/peru/ceremony_country/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/peru/ceremony_country/partner_local/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to register a civil partnership or get married at the British embassy or consulate in Peru.
 
-[Make an appointment at the embassy in Lima.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Lima.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=125&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/peru/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/peru/ceremony_country/partner_other/_opposite_sex.erb
@@ -9,7 +9,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Peru to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Lima.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Lima.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=125&service=13)
 
 You’ll need to complete an [affidavit form](/government/publications/affidavit-marriage-in-peru-spanish-only) to prove you’re allowed to marry.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/peru/ceremony_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/peru/ceremony_country/partner_other/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to register a civil partnership or get married at the British embassy or consulate in Peru.
 
-[Make an appointment at the embassy in Lima.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Lima.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=125&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/peru/third_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/peru/third_country/partner_british/_opposite_sex.erb
@@ -9,7 +9,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Peru to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Lima.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Lima.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=125&service=13)
 
 You’ll need to complete an [affidavit form](/government/publications/affidavit-marriage-in-peru-spanish-only) to prove you’re allowed to marry.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/peru/third_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/peru/third_country/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to register a civil partnership or get married at the British embassy or consulate in Peru.
 
-[Make an appointment at the embassy in Lima.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Lima.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=125&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/peru/third_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/peru/third_country/partner_local/_opposite_sex.erb
@@ -9,7 +9,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Peru to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Lima.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Lima.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=125&service=13)
 
 You’ll need to complete an [affidavit form](/government/publications/affidavit-marriage-in-peru-spanish-only) to prove you’re allowed to marry.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/peru/third_country/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/peru/third_country/partner_local/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to register a civil partnership or get married at the British embassy or consulate in Peru.
 
-[Make an appointment at the embassy in Lima.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Lima.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=125&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/peru/third_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/peru/third_country/partner_other/_opposite_sex.erb
@@ -9,7 +9,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Peru to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Lima.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Lima.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=125&service=13)
 
 You’ll need to complete an [affidavit form](/government/publications/affidavit-marriage-in-peru-spanish-only) to prove you’re allowed to marry.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/peru/third_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/peru/third_country/partner_other/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to register a civil partnership or get married at the British embassy or consulate in Peru.
 
-[Make an appointment at the embassy in Lima.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Lima.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=125&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/peru/uk/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/peru/uk/partner_british/_opposite_sex.erb
@@ -9,7 +9,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Peru to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Lima.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Lima.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=125&service=13)
 
 You’ll need to complete an [affidavit form](/government/publications/affidavit-marriage-in-peru-spanish-only) to prove you’re allowed to marry.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/peru/uk/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/peru/uk/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to register a civil partnership or get married at the British embassy or consulate in Peru.
 
-[Make an appointment at the embassy in Lima.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Lima.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=125&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/peru/uk/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/peru/uk/partner_local/_opposite_sex.erb
@@ -9,7 +9,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Peru to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Lima.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Lima.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=125&service=13)
 
 You’ll need to complete an [affidavit form](/government/publications/affidavit-marriage-in-peru-spanish-only) to prove you’re allowed to marry.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/peru/uk/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/peru/uk/partner_local/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to register a civil partnership or get married at the British embassy or consulate in Peru.
 
-[Make an appointment at the embassy in Lima.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Lima.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=125&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/peru/uk/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/peru/uk/partner_other/_opposite_sex.erb
@@ -9,7 +9,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in Peru to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Lima.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Lima.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=125&service=13)
 
 You’ll need to complete an [affidavit form](/government/publications/affidavit-marriage-in-peru-spanish-only) to prove you’re allowed to marry.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/peru/uk/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/peru/uk/partner_other/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to register a civil partnership or get married at the British embassy or consulate in Peru.
 
-[Make an appointment at the embassy in Lima.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-lima/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Lima.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=125&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/philippines/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/philippines/_opposite_sex.erb
@@ -17,7 +17,7 @@ s1. Download an [affirmation or affidavit](/government/publications/marriage-in-
 s2. Fill it in on your computer on one side of A4 - the embassy won’t accept it if it’s handwritten.
 s3. Print it out but don’t sign it - you’ll need to sign it at the embassy.
 
-[Make an appointment at the embassy in Manila](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-manila/oaths-affirmations-and-affidavits/slot_picker) to swear your affirmation or affidavit.
+[Make an appointment at the embassy in Manila](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=128&service=13) to swear your affirmation or affidavit.
 
 ^Your partner will also need to swear an affirmation or affidavit if they’re British. If they’re not, they might need an equivalent document.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/philippines/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/philippines/_same_sex.erb
@@ -10,7 +10,7 @@ You and your partner need to give notice of your marriage and sign a declaration
 You need to have been in the Philippines for at least 7 full days before you can give notice. This means if you arrived on Monday, you can’t give notice until the following Tuesday.
 
 ### Give notice of your marriage
-[Make an appointment at the British embassy in Manila](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-manila/notice-of-marriage-or-civil-partnership/slot_picker) to give notice of your marriage and set a date for your wedding.
+[Make an appointment at the British embassy in Manila](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=128&service=10) to give notice of your marriage and set a date for your wedding.
 
 It costs <%= format_money calculator.consular_fee(:receiving_notice_of_marriage) %> to give notice. You can pay:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/poland/ceremony_country/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/poland/ceremony_country/_opposite_sex.erb
@@ -16,7 +16,7 @@ If your partner is British, they’ll need to follow the same process to get the
 
 To get a CNI, [make an appointment at the British Embassy in Warsaw](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=40&service=10) to give notice of your marriage.
 
-The British embassy will display your notice of marriage publicly for 7 full days. This means if the embassy gets your notice on Monday (in person or by post), it will be displayed until the following Tuesday. If nobody registers an objection, you can [book an appointment to collect your CNI from the embassy in Warsaw](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-warsaw/certificate-of-no-impediment/slot_picker) or ask for it it to be posted to an address in Poland.
+The British embassy will display your notice of marriage publicly for 7 full days. This means if the embassy gets your notice on Monday (in person or by post), it will be displayed until the following Tuesday. If nobody registers an objection, you can [book an appointment to collect your CNI from the embassy in Warsaw](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=40&service=4) or ask for it it to be posted to an address in Poland.
 
 You’ll need to bring:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/poland/ceremony_country/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/poland/ceremony_country/_opposite_sex.erb
@@ -14,7 +14,7 @@ If your partner is British, they’ll need to follow the same process to get the
 
 ### Get a CNI at the Embassy in Warsaw
 
-To get a CNI, [make an appointment at the British Embassy in Warsaw](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-warsaw/notice-of-marriage-or-civil-partnership/slot_picker) to give notice of your marriage.
+To get a CNI, [make an appointment at the British Embassy in Warsaw](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=40&service=10) to give notice of your marriage.
 
 The British embassy will display your notice of marriage publicly for 7 full days. This means if the embassy gets your notice on Monday (in person or by post), it will be displayed until the following Tuesday. If nobody registers an objection, you can [book an appointment to collect your CNI from the embassy in Warsaw](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-warsaw/certificate-of-no-impediment/slot_picker) or ask for it it to be posted to an address in Poland.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/poland/uk/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/poland/uk/_opposite_sex.erb
@@ -24,7 +24,7 @@ You’ll need to get your CNI [legalised](/get-document-legalised) (certified as
  
 You’ll also need to get a certified translation of your CNI. Use an [approved translator](/government/publications/poland-list-of-translators-and-interpreters).
  
-If the register office in Poland doesn’t accept UK-issued CNIs, [make an appointment at the British embassy in Warsaw](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-warsaw/certificate-of-no-impediment/slot_picker) to exchange it for a Poland-issued one. This costs <%= format_money calculator.consular_fee(:issuing_cni_or_nulla_osta) %>.
+If the register office in Poland doesn’t accept UK-issued CNIs, [make an appointment at the British embassy in Warsaw](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=40&service=4) to exchange it for a Poland-issued one. This costs <%= format_money calculator.consular_fee(:issuing_cni_or_nulla_osta) %>.
 
 ### If you’ve changed your name
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/qatar/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/qatar/ceremony_country/partner_british/_opposite_sex.erb
@@ -10,7 +10,7 @@ You may be able to get married at the British Embassy if you’re both resident 
 
 You’ll be asked to provide an affirmation or affidavit document to prove you’re allowed to marry. This is called a marital status document.
 
-[Make an appointment at the British embassy or consulate in Qatar](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-doha/marital-status-document/slot_picker) to get a marital status document. You’ll need:
+[Make an appointment at the British embassy or consulate in Qatar](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=111&service=32) to get a marital status document. You’ll need:
 
 - your passport
 - a copy of your partner’s passport

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/qatar/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/qatar/ceremony_country/partner_local/_opposite_sex.erb
@@ -10,7 +10,7 @@ You may be able to get married at the British Embassy if you’re both resident 
 
 You’ll be asked to provide an affirmation or affidavit document to prove you’re allowed to marry. This is called a marital status document.
 
-[Make an appointment at the British embassy or consulate in Qatar](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-doha/marital-status-document/slot_picker) to get a marital status document. You’ll need:
+[Make an appointment at the British embassy or consulate in Qatar](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=111&service=32) to get a marital status document. You’ll need:
 
 - your passport
 - a copy of your partner’s passport

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/qatar/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/qatar/ceremony_country/partner_other/_opposite_sex.erb
@@ -10,7 +10,7 @@ You may be able to get married at the British Embassy if you’re both resident 
 
 You’ll be asked to provide an affirmation or affidavit document to prove you’re allowed to marry. This is called a marital status document.
 
-[Make an appointment at the British embassy or consulate in Qatar](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-doha/marital-status-document/slot_picker) to get a marital status document. You’ll need:
+[Make an appointment at the British embassy or consulate in Qatar](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=111&service=32) to get a marital status document. You’ll need:
 
 - your passport
 - a copy of your partner’s passport

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/qatar/third_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/qatar/third_country/partner_british/_opposite_sex.erb
@@ -10,7 +10,7 @@ You may be able to get married at the British Embassy if you’re both resident 
 
 You’ll be asked to provide an affirmation or affidavit document to prove you’re allowed to marry. This is called a marital status document.
 
-[Make an appointment at the British embassy or consulate in Qatar](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-doha/marital-status-document/slot_picker) to get a marital status document. You’ll need:
+[Make an appointment at the British embassy or consulate in Qatar](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=111&service=32) to get a marital status document. You’ll need:
 
 - your passport
 - a copy of your partner’s passport

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/qatar/third_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/qatar/third_country/partner_local/_opposite_sex.erb
@@ -10,7 +10,7 @@ You may be able to get married at the British Embassy if you’re both resident 
 
 You’ll be asked to provide an affirmation or affidavit document to prove you’re allowed to marry. This is called a marital status document.
 
-[Make an appointment at the British embassy or consulate in Qatar](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-doha/marital-status-document/slot_picker) to get a marital status document. You’ll need:
+[Make an appointment at the British embassy or consulate in Qatar](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=111&service=32) to get a marital status document. You’ll need:
 
 - your passport
 - a copy of your partner’s passport

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/qatar/third_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/qatar/third_country/partner_other/_opposite_sex.erb
@@ -10,7 +10,7 @@ You may be able to get married at the British Embassy if you’re both resident 
 
 You’ll be asked to provide an affirmation or affidavit document to prove you’re allowed to marry. This is called a marital status document.
 
-[Make an appointment at the British embassy or consulate in Qatar](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-doha/marital-status-document/slot_picker) to get a marital status document. You’ll need:
+[Make an appointment at the British embassy or consulate in Qatar](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=111&service=32) to get a marital status document. You’ll need:
 
 - your passport
 - a copy of your partner’s passport

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/qatar/uk/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/qatar/uk/partner_british/_opposite_sex.erb
@@ -6,7 +6,7 @@ Contact the [Embassy of Qatar](/government/publications/foreign-embassies-in-the
 
 You’ll be asked to provide an affirmation or affidavit document to prove you’re allowed to marry. This is called a marital status document.
 
-[Make an appointment at the British embassy or consulate in Qatar](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-doha/marital-status-document/slot_picker) to get a marital status document. You’ll need:
+[Make an appointment at the British embassy or consulate in Qatar](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=111&service=32) to get a marital status document. You’ll need:
 
 - your passport
 - a copy of your partner’s passport

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/qatar/uk/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/qatar/uk/partner_local/_opposite_sex.erb
@@ -6,7 +6,7 @@ Contact the [Embassy of Qatar](/government/publications/foreign-embassies-in-the
 
 You’ll be asked to provide an affirmation or affidavit document to prove you’re allowed to marry. This is called a marital status document.
 
-[Make an appointment at the British embassy or consulate in Qatar](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-doha/marital-status-document/slot_picker) to get a marital status document. You’ll need:
+[Make an appointment at the British embassy or consulate in Qatar](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=111&service=32) to get a marital status document. You’ll need:
 
 - your passport
 - a copy of your partner’s passport

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/qatar/uk/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/qatar/uk/partner_other/_opposite_sex.erb
@@ -6,7 +6,7 @@ Contact the [Embassy of Qatar](/government/publications/foreign-embassies-in-the
 
 You’ll be asked to provide an affirmation or affidavit document to prove you’re allowed to marry. This is called a marital status document.
 
-[Make an appointment at the British embassy or consulate in Qatar](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-doha/marital-status-document/slot_picker) to get a marital status document. You’ll need:
+[Make an appointment at the British embassy or consulate in Qatar](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=111&service=32) to get a marital status document. You’ll need:
 
 - your passport
 - a copy of your partner’s passport

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/romania/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/romania/ceremony_country/partner_british/_opposite_sex.erb
@@ -22,7 +22,7 @@ If you or your partner have been divorced, widowed or previously in a civil part
 
 ###Post notice at the British Embassy
 
-[Make an appointment at the embassy in Bucharest.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bucharest/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Bucharest.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=20&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/romania/ceremony_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/romania/ceremony_country/partner_british/_same_sex.erb
@@ -1,7 +1,7 @@
 
 You may be able to get married at the British embassy or consulate in Romania.
 
-[Make an appointment at the embassy in Bucharest.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bucharest/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Bucharest.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=20&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/romania/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/romania/ceremony_country/partner_local/_opposite_sex.erb
@@ -22,7 +22,7 @@ If you or your partner have been divorced, widowed or previously in a civil part
 
 ###Post notice at the British Embassy
 
-[Make an appointment at the embassy in Bucharest.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bucharest/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Bucharest.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=20&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/romania/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/romania/ceremony_country/partner_other/_opposite_sex.erb
@@ -22,7 +22,7 @@ If you or your partner have been divorced, widowed or previously in a civil part
 
 ###Post notice at the British Embassy
 
-[Make an appointment at the embassy in Bucharest.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bucharest/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Bucharest.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=20&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/romania/ceremony_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/romania/ceremony_country/partner_other/_same_sex.erb
@@ -1,7 +1,7 @@
 
 You may be able to get married at the British embassy or consulate in Romania.
 
-[Make an appointment at the embassy in Bucharest.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bucharest/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Bucharest.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=20&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/romania/third_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/romania/third_country/partner_british/_same_sex.erb
@@ -1,7 +1,7 @@
 
 You may be able to get married at the British embassy or consulate in Romania.
 
-[Make an appointment at the embassy in Bucharest.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bucharest/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Bucharest.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=20&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/romania/third_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/romania/third_country/partner_other/_same_sex.erb
@@ -1,7 +1,7 @@
 
 You may be able to get married at the British embassy or consulate in Romania.
 
-[Make an appointment at the embassy in Bucharest.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bucharest/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Bucharest.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=20&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/romania/uk/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/romania/uk/partner_british/_same_sex.erb
@@ -1,7 +1,7 @@
 
 You may be able to get married at the British embassy or consulate in Romania.
 
-[Make an appointment at the embassy in Bucharest.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bucharest/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Bucharest.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=20&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/romania/uk/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/romania/uk/partner_other/_same_sex.erb
@@ -1,7 +1,7 @@
 
 You may be able to get married at the British embassy or consulate in Romania.
 
-[Make an appointment at the embassy in Bucharest.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-bucharest/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Bucharest.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=20&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/russia/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/russia/ceremony_country/partner_british/_opposite_sex.erb
@@ -14,7 +14,7 @@ You’ll need to have been living in the Russian Federation for at least 3 full 
 
 You can then book an appointment at the embassy to give notice of your marriage.
 
-[Make an appointment at the embassy in Moscow.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-moscow/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Moscow.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=132&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/russia/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/russia/ceremony_country/partner_local/_opposite_sex.erb
@@ -14,7 +14,7 @@ You’ll need to have been living in the Russian Federation for at least 3 full 
 
 You can then book an appointment at the embassy to give notice of your marriage.
 
-[Make an appointment at the embassy in Moscow.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-moscow/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Moscow.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=132&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/russia/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/russia/ceremony_country/partner_other/_opposite_sex.erb
@@ -14,7 +14,7 @@ You’ll need to have been living in the Russian Federation for at least 3 full 
 
 You can then book an appointment at the embassy to give notice of your marriage.
 
-[Make an appointment at the embassy in Moscow.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-moscow/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Moscow.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=132&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/russia/uk/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/russia/uk/partner_british/_opposite_sex.erb
@@ -15,7 +15,7 @@ You can normally get a CNI by giving a notice of marriage at your local register
 To get married in Russia with a UK-issued CNI, you need to either:
 
 - get your CNI [legalised](/get-document-legalised) (certified as genuine) and translated - [find a translator abroad](/government/collections/list-of-lawyers), or in the UK through the [Institute of Linguists](http://www.ciol.org.uk)
-- [exchange your CNI for one that’s valid in Russia at the British embassy](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-moscow/certificate-of-no-impediment/slot_picker) and then get the embassy-issued document certified by the [Russian Ministry of Foreign Affairs Legalisation Department](https://www.kdmid.ru/consr.aspx?lst=cnslfunkrf&it=/%D0%9B%D0%B5%D0%B3%D0%B0%D0%BB%D0%B8%D0%B7%D0%B0%D1%86%D0%B8%D1%8F%20%D0%B4%D0%BE%D0%BA%D1%83%D0%BC%D0%B5%D0%BD%D1%82%D0%BE%D0%B2%20-%20%D0%98%D0%BD%D1%84%D0%BE%D1%80%D0%BC%D0%B0%D1%86%D0%B8%D1%8F%20%D0%BE%D0%B1%20%D1%83%D1%81%D0%BB%D1%83%D0%B3%D0%B5.aspx)
+- [exchange your CNI for one that’s valid in Russia at the British embassy](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=132&service=4) and then get the embassy-issued document certified by the [Russian Ministry of Foreign Affairs Legalisation Department](https://www.kdmid.ru/consr.aspx?lst=cnslfunkrf&it=/%D0%9B%D0%B5%D0%B3%D0%B0%D0%BB%D0%B8%D0%B7%D0%B0%D1%86%D0%B8%D1%8F%20%D0%B4%D0%BE%D0%BA%D1%83%D0%BC%D0%B5%D0%BD%D1%82%D0%BE%D0%B2%20-%20%D0%98%D0%BD%D1%84%D0%BE%D1%80%D0%BC%D0%B0%D1%86%D0%B8%D1%8F%20%D0%BE%D0%B1%20%D1%83%D1%81%D0%BB%D1%83%D0%B3%D0%B5.aspx)
 
 You should also check with the Russian marriage registrar to find out if you need to provide legalised and translated copies of any other documents.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/russia/uk/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/russia/uk/partner_local/_opposite_sex.erb
@@ -15,7 +15,7 @@ You can normally get a CNI by giving a notice of marriage at your local register
 To get married in Russia with a UK-issued CNI, you need to either:
 
 - get your CNI [legalised](/get-document-legalised) (certified as genuine) and translated - [find a translator abroad](/government/collections/list-of-lawyers), or in the UK through the [Institute of Linguists](http://www.ciol.org.uk)
-- [exchange your CNI for one that’s valid in Russia at the British embassy](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-moscow/certificate-of-no-impediment/slot_picker) and then get the embassy-issued document certified by the [Russian Ministry of Foreign Affairs Legalisation Department](https://www.kdmid.ru/consr.aspx?lst=cnslfunkrf&it=/%D0%9B%D0%B5%D0%B3%D0%B0%D0%BB%D0%B8%D0%B7%D0%B0%D1%86%D0%B8%D1%8F%20%D0%B4%D0%BE%D0%BA%D1%83%D0%BC%D0%B5%D0%BD%D1%82%D0%BE%D0%B2%20-%20%D0%98%D0%BD%D1%84%D0%BE%D1%80%D0%BC%D0%B0%D1%86%D0%B8%D1%8F%20%D0%BE%D0%B1%20%D1%83%D1%81%D0%BB%D1%83%D0%B3%D0%B5.aspx)
+- [exchange your CNI for one that’s valid in Russia at the British embassy](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=132&service=4) and then get the embassy-issued document certified by the [Russian Ministry of Foreign Affairs Legalisation Department](https://www.kdmid.ru/consr.aspx?lst=cnslfunkrf&it=/%D0%9B%D0%B5%D0%B3%D0%B0%D0%BB%D0%B8%D0%B7%D0%B0%D1%86%D0%B8%D1%8F%20%D0%B4%D0%BE%D0%BA%D1%83%D0%BC%D0%B5%D0%BD%D1%82%D0%BE%D0%B2%20-%20%D0%98%D0%BD%D1%84%D0%BE%D1%80%D0%BC%D0%B0%D1%86%D0%B8%D1%8F%20%D0%BE%D0%B1%20%D1%83%D1%81%D0%BB%D1%83%D0%B3%D0%B5.aspx)
 
 You should also check with the Russian marriage registrar to find out if you need to provide legalised and translated copies of any other documents.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/russia/uk/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/russia/uk/partner_other/_opposite_sex.erb
@@ -15,7 +15,7 @@ You can normally get a CNI by giving a notice of marriage at your local register
 To get married in Russia with a UK-issued CNI, you need to either:
 
 - get your CNI [legalised](/get-document-legalised) (certified as genuine) and translated - [find a translator abroad](/government/collections/list-of-lawyers), or in the UK through the [Institute of Linguists](http://www.ciol.org.uk)
-- [exchange your CNI for one that’s valid in Russia at the British embassy](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-moscow/certificate-of-no-impediment/slot_picker) and then get the embassy-issued document certified by the [Russian Ministry of Foreign Affairs Legalisation Department](https://www.kdmid.ru/consr.aspx?lst=cnslfunkrf&it=/%D0%9B%D0%B5%D0%B3%D0%B0%D0%BB%D0%B8%D0%B7%D0%B0%D1%86%D0%B8%D1%8F%20%D0%B4%D0%BE%D0%BA%D1%83%D0%BC%D0%B5%D0%BD%D1%82%D0%BE%D0%B2%20-%20%D0%98%D0%BD%D1%84%D0%BE%D1%80%D0%BC%D0%B0%D1%86%D0%B8%D1%8F%20%D0%BE%D0%B1%20%D1%83%D1%81%D0%BB%D1%83%D0%B3%D0%B5.aspx)
+- [exchange your CNI for one that’s valid in Russia at the British embassy](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=132&service=4) and then get the embassy-issued document certified by the [Russian Ministry of Foreign Affairs Legalisation Department](https://www.kdmid.ru/consr.aspx?lst=cnslfunkrf&it=/%D0%9B%D0%B5%D0%B3%D0%B0%D0%BB%D0%B8%D0%B7%D0%B0%D1%86%D0%B8%D1%8F%20%D0%B4%D0%BE%D0%BA%D1%83%D0%BC%D0%B5%D0%BD%D1%82%D0%BE%D0%B2%20-%20%D0%98%D0%BD%D1%84%D0%BE%D1%80%D0%BC%D0%B0%D1%86%D0%B8%D1%8F%20%D0%BE%D0%B1%20%D1%83%D1%81%D0%BB%D1%83%D0%B3%D0%B5.aspx)
 
 You should also check with the Russian marriage registrar to find out if you need to provide legalised and translated copies of any other documents.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/saudi-arabia/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/saudi-arabia/ceremony_country/partner_british/_opposite_sex.erb
@@ -4,7 +4,7 @@ One of you must be a Muslim to get married under local laws in Saudi Arabia. Con
 
 ^ You can only apply to get married at the British Embassy in Riyadh if you’re resident in Saudi Arabia and neither of you is a Muslim.^
 
-[Book an appointment at the British Embassy in Riyadh.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-riyadh/notice-of-marriage-or-civil-partnership/slot_picker)
+[Book an appointment at the British Embassy in Riyadh.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=140&service=10)
 
 You’ll need to provide:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/saudi-arabia/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/saudi-arabia/ceremony_country/partner_local/_opposite_sex.erb
@@ -4,7 +4,7 @@ One of you must be a Muslim to get married under local laws in Saudi Arabia. Con
 
 ^ You can only apply to get married at the British Embassy in Riyadh if you’re resident in Saudi Arabia and neither of you is a Muslim.^
 
-[Book an appointment at the British Embassy in Riyadh.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-riyadh/notice-of-marriage-or-civil-partnership/slot_picker)
+[Book an appointment at the British Embassy in Riyadh.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=140&service=10)
 
 You’ll need to provide:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/saudi-arabia/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/saudi-arabia/ceremony_country/partner_other/_opposite_sex.erb
@@ -4,7 +4,7 @@ One of you must be a Muslim to get married under local laws in Saudi Arabia. Con
 
 ^ You can only apply to get married at the British Embassy in Riyadh if you’re resident in Saudi Arabia and neither of you is a Muslim.^
 
-[Book an appointment at the British Embassy in Riyadh.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-riyadh/notice-of-marriage-or-civil-partnership/slot_picker)
+[Book an appointment at the British Embassy in Riyadh.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=140&service=10)
 
 You’ll need to provide:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/serbia/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/serbia/ceremony_country/partner_british/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Serbia. You can 
 
 You’ll need to have been living in Serbia for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Belgrade.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-belgrade/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Belgrade.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=102&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/serbia/ceremony_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/serbia/ceremony_country/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Serbia.
 
-[Make an appointment at the embassy in Belgrade.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-belgrade/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Belgrade.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=102&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/serbia/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/serbia/ceremony_country/partner_local/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Serbia. You can 
 
 You’ll need to have been living in Serbia for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Belgrade.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-belgrade/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Belgrade.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=102&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/serbia/ceremony_country/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/serbia/ceremony_country/partner_local/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Serbia.
 
-[Make an appointment at the embassy in Belgrade.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-belgrade/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Belgrade.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=102&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/serbia/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/serbia/ceremony_country/partner_other/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Serbia. You can 
 
 You’ll need to have been living in Serbia for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Belgrade.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-belgrade/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Belgrade.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=102&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/serbia/ceremony_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/serbia/ceremony_country/partner_other/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Serbia.
 
-[Make an appointment at the embassy in Belgrade.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-belgrade/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Belgrade.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=102&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/serbia/third_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/serbia/third_country/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Serbia.
 
-[Make an appointment at the embassy in Belgrade.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-belgrade/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Belgrade.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=102&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/serbia/third_country/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/serbia/third_country/partner_local/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Serbia.
 
-[Make an appointment at the embassy in Belgrade.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-belgrade/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Belgrade.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=102&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/serbia/third_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/serbia/third_country/partner_other/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Serbia.
 
-[Make an appointment at the embassy in Belgrade.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-belgrade/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Belgrade.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=102&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/serbia/uk/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/serbia/uk/partner_british/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Serbia.
 
-[Make an appointment at the embassy in Belgrade.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-belgrade/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Belgrade.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=102&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/serbia/uk/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/serbia/uk/partner_local/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Serbia.
 
-[Make an appointment at the embassy in Belgrade.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-belgrade/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Belgrade.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=102&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/serbia/uk/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/serbia/uk/partner_other/_same_sex.erb
@@ -1,6 +1,6 @@
 You may be able to get married at the British embassy or consulate in Serbia.
 
-[Make an appointment at the embassy in Belgrade.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-belgrade/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Belgrade.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=102&service=10)
 
 ##What documents you’ll need
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/slovenia/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/slovenia/ceremony_country/partner_british/_opposite_sex.erb
@@ -8,7 +8,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 
 Make an appointment at the British embassy or consulate in Slovenia to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Ljubljana.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ljubljana/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Ljubljana.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=26&service=13)
 
 You’ll need to complete an [affidavit form](/government/publications/affidavit-form-slovenia) to prove you’re allowed to marry.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/slovenia/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/slovenia/ceremony_country/partner_local/_opposite_sex.erb
@@ -8,7 +8,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 
 Make an appointment at the British embassy or consulate in Slovenia to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Ljubljana.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ljubljana/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Ljubljana.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=26&service=13)
 
 You’ll need to complete an [affidavit form](/government/publications/affidavit-form-slovenia) to prove you’re allowed to marry.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/slovenia/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/slovenia/ceremony_country/partner_other/_opposite_sex.erb
@@ -8,7 +8,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 
 Make an appointment at the British embassy or consulate in Slovenia to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Ljubljana.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ljubljana/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Ljubljana.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=26&service=13)
 
 You’ll need to complete an [affidavit form](/government/publications/affidavit-form-slovenia) to prove you’re allowed to marry.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/slovenia/uk/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/slovenia/uk/partner_british/_opposite_sex.erb
@@ -8,7 +8,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 
 Make an appointment at the British embassy or consulate in Slovenia to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Ljubljana.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ljubljana/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Ljubljana.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=26&service=13)
 
 You’ll need to complete an [affidavit form](/government/publications/affidavit-form-slovenia) to prove you’re allowed to marry.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/slovenia/uk/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/slovenia/uk/partner_local/_opposite_sex.erb
@@ -8,7 +8,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 
 Make an appointment at the British embassy or consulate in Slovenia to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Ljubljana.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ljubljana/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Ljubljana.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=26&service=13)
 
 You’ll need to complete an [affidavit form](/government/publications/affidavit-form-slovenia) to prove you’re allowed to marry.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/slovenia/uk/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/slovenia/uk/partner_other/_opposite_sex.erb
@@ -8,7 +8,7 @@ You may be asked to provide an ‘affirmation for marriage’ document to prove 
 
 Make an appointment at the British embassy or consulate in Slovenia to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Ljubljana.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ljubljana/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Ljubljana.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=26&service=13)
 
 You’ll need to complete an [affidavit form](/government/publications/affidavit-form-slovenia) to prove you’re allowed to marry.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/_opposite_sex.erb
@@ -12,7 +12,7 @@ The UK doesn’t issue certificates of no impediment (CNI) for marriages in Comm
 
 You can get a letter to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
 
-Book an appointment to collect the letter at the [British Consulate General in Cape Town](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-cape-town/providing-an-informative-note/slot_picker) or the [British High Commission in Pretoria](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-pretoria/providing-an-informative-note/slot_picker). The letter is free. If you can’t go to an appointment, you can ask a friend or family member to make an appointment and collect it for you.
+Book an appointment to collect the letter at the [British Consulate General in Cape Town](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=61&service=19) or the [British High Commission in Pretoria](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=186&service=19). The letter is free. If you can’t go to an appointment, you can ask a friend or family member to make an appointment and collect it for you.
 
 ##After you get married
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-africa/_same_sex.erb
@@ -10,7 +10,7 @@ The UK doesn’t issue certificates of no impediment (CNI) for marriages in Comm
 
 You can get a letter to explain this if you’re asked to provide a CNI or a similar document to prove you’re allowed to marry.
 
-Book an appointment to collect the letter at the [British Consulate General in Cape Town](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-cape-town/providing-an-informative-note/slot_picker) or the [British High Commission in Pretoria](https://www.consular-appointments.service.gov.uk/fco/#!/british-high-commission-pretoria/providing-an-informative-note/slot_picker). The letter is free. If you can’t go to an appointment, you can ask a friend or family member to make an appointment and collect it for you.
+Book an appointment to collect the letter at the [British Consulate General in Cape Town](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=61&service=19) or the [British High Commission in Pretoria](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=186&service=19). The letter is free. If you can’t go to an appointment, you can ask a friend or family member to make an appointment and collect it for you.
 
 ##After you get married
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-korea/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-korea/_opposite_sex.erb
@@ -8,7 +8,7 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy in South Korea to swear an affidavit (written statement of facts) that you’re free to marry. You’ll need to bring your passport, your partner’s passport and pay a fee.
 
-[Make an appointment at the embassy in Seoul](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-seoul/oaths-affirmations-and-affidavits/slot_picker).
+[Make an appointment at the embassy in Seoul](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=146&service=13).
 
 You’ll need to fill in an [‘Affidavit for Marriage’](/government/publications/south-korea-affidavit-of-eligibility-for-marriage-form) form stating that you’re free to marry. You can download and fill in (but not sign) the form in advance. You’ll need to take the form with you to your appointment.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-korea/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/south-korea/_same_sex.erb
@@ -12,7 +12,7 @@ You both need to sign a declaration that you’re free to marry.
 
 ###Give notice of your marriage
 
-Make an appointment to give notice of your marriage [at the embassy in Seoul](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-seoul/consular-marriage-or-civil-partnership/slot_picker).
+Make an appointment to give notice of your marriage [at the embassy in Seoul](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=146&service=5).
 
 It costs £50 to give notice. You can pay in the [local currency](/government/publications/south-korea-consular-fees) with cash or credit card, but not by personal cheque.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/sweden/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/sweden/ceremony_country/partner_british/_opposite_sex.erb
@@ -18,7 +18,7 @@ You can download and fill in (but not sign) the forms in advance.
 
 ###Posting notice at the embassy
 
-[Book an appointment for a CNI in Stockholm](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-stockholm/certificate-of-no-impediment/slot_picker).
+[Book an appointment for a CNI in Stockholm](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=35&service=4).
 
 To give notice of intended marriage at the embassy, you can swear or affirm an oath. If you would like to swear an oath on a holy book (religious), you’ll need to bring your own holy book.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/sweden/ceremony_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/sweden/ceremony_country/partner_british/_same_sex.erb
@@ -23,7 +23,7 @@ You can download and fill in (but not sign) the forms in advance.
 
 ###Posting notice at the embassy
 
-[Book an appointment for a CNI in Stockholm](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-stockholm/certificate-of-no-impediment/slot_picker).
+[Book an appointment for a CNI in Stockholm](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=35&service=4).
 
 To give notice of intended marriage at the embassy, you can swear or affirm an oath. If you would like to swear an oath on a holy book (religious), you’ll need to bring your own holy book.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/sweden/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/sweden/ceremony_country/partner_local/_opposite_sex.erb
@@ -18,7 +18,7 @@ You can download and fill in (but not sign) the forms in advance.
 
 ###Posting notice at the embassy
 
-[Book an appointment for a CNI in Stockholm](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-stockholm/certificate-of-no-impediment/slot_picker).
+[Book an appointment for a CNI in Stockholm](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=35&service=4).
 
 To give notice of intended marriage at the embassy, you can swear or affirm an oath. If you would like to swear an oath on a holy book (religious), you’ll need to bring your own holy book.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/sweden/ceremony_country/partner_local/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/sweden/ceremony_country/partner_local/_same_sex.erb
@@ -23,7 +23,7 @@ You can download and fill in (but not sign) the forms in advance.
 
 ###Posting notice at the embassy
 
-[Book an appointment for a CNI in Stockholm](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-stockholm/certificate-of-no-impediment/slot_picker).
+[Book an appointment for a CNI in Stockholm](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=35&service=4).
 
 To give notice of intended marriage at the embassy, you can swear or affirm an oath. If you would like to swear an oath on a holy book (religious), you’ll need to bring your own holy book.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/sweden/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/sweden/ceremony_country/partner_other/_opposite_sex.erb
@@ -18,7 +18,7 @@ You can download and fill in (but not sign) the forms in advance.
 
 ###Posting notice at the embassy
 
-[Book an appointment for a CNI in Stockholm](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-stockholm/certificate-of-no-impediment/slot_picker).
+[Book an appointment for a CNI in Stockholm](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=35&service=4).
 
 To give notice of intended marriage at the embassy, you can swear or affirm an oath. If you would like to swear an oath on a holy book (religious), you’ll need to bring your own holy book.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/sweden/ceremony_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/sweden/ceremony_country/partner_other/_same_sex.erb
@@ -23,7 +23,7 @@ You can download and fill in (but not sign) the forms in advance.
 
 ###Posting notice at the embassy
 
-[Book an appointment for a CNI in Stockholm](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-stockholm/certificate-of-no-impediment/slot_picker).
+[Book an appointment for a CNI in Stockholm](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=35&service=4).
 
 To give notice of intended marriage at the embassy, you can swear or affirm an oath. If you would like to swear an oath on a holy book (religious), you’ll need to bring your own holy book.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tajikistan/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tajikistan/ceremony_country/partner_british/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Tajikistan. You 
 
 You’ll need to have been living in Tajikistan for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Dushanbe.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-dushanbe/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Dushanbe.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=113&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tajikistan/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tajikistan/ceremony_country/partner_local/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Tajikistan. You 
 
 You’ll need to have been living in Tajikistan for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Dushanbe.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-dushanbe/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Dushanbe.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=113&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tajikistan/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tajikistan/ceremony_country/partner_other/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Tajikistan. You 
 
 You’ll need to have been living in Tajikistan for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Dushanbe.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-dushanbe/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Dushanbe.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=113&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/ceremony_country/partner_british/_opposite_sex.erb
@@ -11,7 +11,7 @@ This costs <%= format_money calculator.consular_fee(:affidavit_or_affirmation_fo
 - in British pounds by Visa or Mastercard
 - in the [local currency](/government/publications/tunisia-consular-fees) in cash
 
-[Make an appointment at the embassy in Tunis](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/oaths-affirmations-and-affidavits/slot_picker) to swear your affirmation or affidavit.
+[Make an appointment at the embassy in Tunis](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=153&service=13) to swear your affirmation or affidavit.
 
 You need to bring your: 
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/ceremony_country/partner_local/_opposite_sex.erb
@@ -11,7 +11,7 @@ This costs <%= format_money calculator.consular_fee(:affidavit_or_affirmation_fo
 - in British pounds by Visa or Mastercard
 - in the [local currency](/government/publications/tunisia-consular-fees) in cash
 
-[Make an appointment at the embassy in Tunis](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/oaths-affirmations-and-affidavits/slot_picker) to swear your affirmation or affidavit.
+[Make an appointment at the embassy in Tunis](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=153&service=13) to swear your affirmation or affidavit.
 
 You need to bring your: 
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/ceremony_country/partner_other/_opposite_sex.erb
@@ -11,7 +11,7 @@ This costs <%= format_money calculator.consular_fee(:affidavit_or_affirmation_fo
 - in British pounds by Visa or Mastercard
 - in the [local currency](/government/publications/tunisia-consular-fees) in cash
 
-[Make an appointment at the embassy in Tunis](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/oaths-affirmations-and-affidavits/slot_picker) to swear your affirmation or affidavit.
+[Make an appointment at the embassy in Tunis](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=153&service=13) to swear your affirmation or affidavit.
 
 You need to bring your: 
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/third_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/third_country/partner_british/_opposite_sex.erb
@@ -11,7 +11,7 @@ This costs <%= format_money calculator.consular_fee(:affidavit_or_affirmation_fo
 - in British pounds by Visa or Mastercard
 - in the [local currency](/government/publications/tunisia-consular-fees) in cash
 
-[Make an appointment at the embassy in Tunis](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/oaths-affirmations-and-affidavits/slot_picker) to swear your affirmation or affidavit.
+[Make an appointment at the embassy in Tunis](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=153&service=13) to swear your affirmation or affidavit.
 
 You need to bring your: 
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/third_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/third_country/partner_local/_opposite_sex.erb
@@ -11,7 +11,7 @@ This costs <%= format_money calculator.consular_fee(:affidavit_or_affirmation_fo
 - in British pounds by Visa or Mastercard
 - in the [local currency](/government/publications/tunisia-consular-fees) in cash
 
-[Make an appointment at the embassy in Tunis](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/oaths-affirmations-and-affidavits/slot_picker) to swear your affirmation or affidavit.
+[Make an appointment at the embassy in Tunis](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=153&service=13) to swear your affirmation or affidavit.
 
 You need to bring your: 
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/third_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/third_country/partner_other/_opposite_sex.erb
@@ -11,7 +11,7 @@ This costs <%= format_money calculator.consular_fee(:affidavit_or_affirmation_fo
 - in British pounds by Visa or Mastercard
 - in the [local currency](/government/publications/tunisia-consular-fees) in cash
 
-[Make an appointment at the embassy in Tunis](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/oaths-affirmations-and-affidavits/slot_picker) to swear your affirmation or affidavit.
+[Make an appointment at the embassy in Tunis](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=153&service=13) to swear your affirmation or affidavit.
 
 You need to bring your: 
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/uk/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/uk/partner_british/_opposite_sex.erb
@@ -11,7 +11,7 @@ This costs <%= format_money calculator.consular_fee(:affidavit_or_affirmation_fo
 - in British pounds by Visa or Mastercard
 - in the [local currency](/government/publications/tunisia-consular-fees) in cash
 
-[Make an appointment at the embassy in Tunis](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/oaths-affirmations-and-affidavits/slot_picker) to swear your affirmation or affidavit.
+[Make an appointment at the embassy in Tunis](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=153&service=13) to swear your affirmation or affidavit.
 
 You need to bring your: 
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/uk/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/uk/partner_local/_opposite_sex.erb
@@ -11,7 +11,7 @@ This costs <%= format_money calculator.consular_fee(:affidavit_or_affirmation_fo
 - in British pounds by Visa or Mastercard
 - in the [local currency](/government/publications/tunisia-consular-fees) in cash
 
-[Make an appointment at the embassy in Tunis](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/oaths-affirmations-and-affidavits/slot_picker) to swear your affirmation or affidavit.
+[Make an appointment at the embassy in Tunis](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=153&service=13) to swear your affirmation or affidavit.
 
 You need to bring your: 
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/uk/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/tunisia/uk/partner_other/_opposite_sex.erb
@@ -11,7 +11,7 @@ This costs <%= format_money calculator.consular_fee(:affidavit_or_affirmation_fo
 - in British pounds by Visa or Mastercard
 - in the [local currency](/government/publications/tunisia-consular-fees) in cash
 
-[Make an appointment at the embassy in Tunis](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tunis/oaths-affirmations-and-affidavits/slot_picker) to swear your affirmation or affidavit.
+[Make an appointment at the embassy in Tunis](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=153&service=13) to swear your affirmation or affidavit.
 
 You need to bring your: 
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/turkey/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/turkey/_opposite_sex.erb
@@ -26,7 +26,7 @@ You’ll need to get your affirmation [‘legalised’](/get-document-legalised)
 
 Make an appointment to swear your affirmation at:
 
-- [the British Consulate General in Istanbul](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-istanbul/oaths-affirmations-and-affidavits/slot_picker)
+- [the British Consulate General in Istanbul](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=67&service=13)
 - [the embassy in Ankara](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ankara/oaths-affirmations-and-affidavits/slot_picker)
 - [the consulate in Izmir](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-izmir/oaths-affirmations-and-affidavits/slot_picker)
 - [the consulate in Antalya](https://www.consular-appointments.service.gov.uk/fco/#!/british-vice-consulate-antalya/oaths-affirmations-and-affidavits/slot_picker)

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/turkey/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/turkey/_opposite_sex.erb
@@ -27,9 +27,9 @@ You’ll need to get your affirmation [‘legalised’](/get-document-legalised)
 Make an appointment to swear your affirmation at:
 
 - [the British Consulate General in Istanbul](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=67&service=13)
-- [the embassy in Ankara](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ankara/oaths-affirmations-and-affidavits/slot_picker)
-- [the consulate in Izmir](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-izmir/oaths-affirmations-and-affidavits/slot_picker)
-- [the consulate in Antalya](https://www.consular-appointments.service.gov.uk/fco/#!/british-vice-consulate-antalya/oaths-affirmations-and-affidavits/slot_picker)
+- [the embassy in Ankara](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=93&service=13)
+- [the consulate in Izmir](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=81&service=13)
+- [the consulate in Antalya](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=196&service=13)
 
 It costs <%= format_money calculator.consular_fee(:affidavit_or_affirmation_for_marriage) %> per person to swear an affirmation. You can pay in the [local currency](/government/publications/turkey-consular-fees) in cash or with a credit card or UK debit card.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/turkey/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/turkey/_same_sex.erb
@@ -14,7 +14,7 @@ You need to have been in Turkey for at least 7 full days before you can give not
 
 ### Give notice of your marriage
 
-[Make an appointment at the British Consulate General in Istanbul](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-istanbul/notice-of-marriage-or-civil-partnership/slot_picker) to give notice of your marriage and set a date for your wedding.
+[Make an appointment at the British Consulate General in Istanbul](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=67&service=10) to give notice of your marriage and set a date for your wedding.
 
 It costs <%= format_money calculator.consular_fee(:receiving_notice_of_marriage) %> to give notice. You can pay in the [local currency](/government/publications/turkey-consular-fees) in cash or with a credit card or UK debit card.
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/turkmenistan/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/turkmenistan/ceremony_country/partner_british/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Turkmenistan. Yo
 
 You’ll need to have been living in Turkmenistan for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Ashgabat.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ashgabat/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Ashgabat.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=95&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/turkmenistan/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/turkmenistan/ceremony_country/partner_local/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Turkmenistan. Yo
 
 You’ll need to have been living in Turkmenistan for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Ashgabat.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ashgabat/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Ashgabat.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=95&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/turkmenistan/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/turkmenistan/ceremony_country/partner_other/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Turkmenistan. Yo
 
 You’ll need to have been living in Turkmenistan for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Ashgabat.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-ashgabat/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Ashgabat.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=95&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/united-arab-emirates/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/united-arab-emirates/ceremony_country/partner_british/_opposite_sex.erb
@@ -13,9 +13,9 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in the United Arab Emirates to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Dubai.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-dubai/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Dubai.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=112&service=13)
 
-[Make an appointment at the embassy in Abu Dhabi.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-abu-dhabi/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Abu Dhabi.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=89&service=13)
 
 ^If you have dual nationality and you entered the United Arab Emirates on a non-British passport, you must contact the embassy of that country to get your affirmation or affidavit.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/united-arab-emirates/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/united-arab-emirates/ceremony_country/partner_local/_opposite_sex.erb
@@ -13,9 +13,9 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in the United Arab Emirates to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Dubai.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-dubai/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Dubai.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=112&service=13)
 
-[Make an appointment at the embassy in Abu Dhabi.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-abu-dhabi/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Abu Dhabi.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=89&service=13)
 
 ^If you have dual nationality and you entered the United Arab Emirates on a non-British passport, you must contact the embassy of that country to get your affirmation or affidavit.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/united-arab-emirates/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/united-arab-emirates/ceremony_country/partner_other/_opposite_sex.erb
@@ -13,9 +13,9 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in the United Arab Emirates to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Dubai.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-dubai/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Dubai.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=112&service=13)
 
-[Make an appointment at the embassy in Abu Dhabi.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-abu-dhabi/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Abu Dhabi.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=89&service=13)
 
 ^If you have dual nationality and you entered the United Arab Emirates on a non-British passport, you must contact the embassy of that country to get your affirmation or affidavit.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/united-arab-emirates/third_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/united-arab-emirates/third_country/partner_british/_opposite_sex.erb
@@ -13,9 +13,9 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in the United Arab Emirates to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Dubai.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-dubai/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Dubai.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=112&service=13)
 
-[Make an appointment at the embassy in Abu Dhabi.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-abu-dhabi/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Abu Dhabi.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=89&service=13)
 
 ^If you have dual nationality and you entered the United Arab Emirates on a non-British passport, you must contact the embassy of that country to get your affirmation or affidavit.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/united-arab-emirates/third_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/united-arab-emirates/third_country/partner_local/_opposite_sex.erb
@@ -13,9 +13,9 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in the United Arab Emirates to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Dubai.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-dubai/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Dubai.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=112&service=13)
 
-[Make an appointment at the embassy in Abu Dhabi.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-abu-dhabi/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Abu Dhabi.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=89&service=13)
 
 ^If you have dual nationality and you entered the United Arab Emirates on a non-British passport, you must contact the embassy of that country to get your affirmation or affidavit.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/united-arab-emirates/third_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/united-arab-emirates/third_country/partner_other/_opposite_sex.erb
@@ -13,9 +13,9 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in the United Arab Emirates to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Dubai.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-dubai/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Dubai.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=112&service=13)
 
-[Make an appointment at the embassy in Abu Dhabi.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-abu-dhabi/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Abu Dhabi.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=89&service=13)
 
 ^If you have dual nationality and you entered the United Arab Emirates on a non-British passport, you must contact the embassy of that country to get your affirmation or affidavit.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/united-arab-emirates/uk/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/united-arab-emirates/uk/partner_british/_opposite_sex.erb
@@ -13,9 +13,9 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in the United Arab Emirates to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Dubai.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-dubai/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Dubai.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=112&service=13)
 
-[Make an appointment at the embassy in Abu Dhabi.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-abu-dhabi/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Abu Dhabi.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=89&service=13)
 
 ^If you have dual nationality and you entered the United Arab Emirates on a non-British passport, you must contact the embassy of that country to get your affirmation or affidavit.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/united-arab-emirates/uk/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/united-arab-emirates/uk/partner_local/_opposite_sex.erb
@@ -13,9 +13,9 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in the United Arab Emirates to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Dubai.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-dubai/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Dubai.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=112&service=13)
 
-[Make an appointment at the embassy in Abu Dhabi.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-abu-dhabi/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Abu Dhabi.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=89&service=13)
 
 ^If you have dual nationality and you entered the United Arab Emirates on a non-British passport, you must contact the embassy of that country to get your affirmation or affidavit.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/united-arab-emirates/uk/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/united-arab-emirates/uk/partner_other/_opposite_sex.erb
@@ -13,9 +13,9 @@ You’ll be asked to provide an affirmation or affidavit document to prove you�
 
 Make an appointment at the British embassy or consulate in the United Arab Emirates to swear an affirmation or affidavit that you’re free to marry. You’ll need to bring your passport and pay a fee.
 
-[Make an appointment at the embassy in Dubai.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-dubai/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Dubai.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=112&service=13)
 
-[Make an appointment at the embassy in Abu Dhabi.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-abu-dhabi/oaths-affirmations-and-affidavits/slot_picker)
+[Make an appointment at the embassy in Abu Dhabi.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=89&service=13)
 
 ^If you have dual nationality and you entered the United Arab Emirates on a non-British passport, you must contact the embassy of that country to get your affirmation or affidavit.^
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/uzbekistan/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/uzbekistan/ceremony_country/partner_british/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Uzbekistan. You 
 
 You’ll need to have been living in Uzbekistan for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Tashkent.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tashkent/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tashkent.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=147&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/uzbekistan/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/uzbekistan/ceremony_country/partner_local/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Uzbekistan. You 
 
 You’ll need to have been living in Uzbekistan for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Tashkent.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tashkent/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tashkent.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=147&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/uzbekistan/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/uzbekistan/ceremony_country/partner_other/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Uzbekistan. You 
 
 You’ll need to have been living in Uzbekistan for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Tashkent.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-tashkent/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Tashkent.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=147&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/venezuela/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/venezuela/ceremony_country/partner_british/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Venezuela. You c
 
 You’ll need to have been living in Venezuela for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Caracas.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-caracas/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Caracas.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=108&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/venezuela/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/venezuela/ceremony_country/partner_local/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Venezuela. You c
 
 You’ll need to have been living in Venezuela for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Caracas.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-caracas/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Caracas.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=108&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/venezuela/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/venezuela/ceremony_country/partner_other/_opposite_sex.erb
@@ -10,7 +10,7 @@ To get a CNI, you must post notice of your intended marriage in Venezuela. You c
 
 You’ll need to have been living in Venezuela for at least 3 full days before you can post notice, for example if you arrive in the country on Thursday, the earliest you can post notice is the following Monday.
 
-[Make an appointment at the embassy in Caracas.](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-caracas/notice-of-marriage-or-civil-partnership/slot_picker)
+[Make an appointment at the embassy in Caracas.](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=108&service=10)
 
 You’ll need to provide supporting documents, including:
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/vietnam/ceremony_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/vietnam/ceremony_country/partner_british/_opposite_sex.erb
@@ -9,8 +9,8 @@ You'll be asked to provide an affirmation or affidavit document to prove you're 
 
 Make an appointment at the British embassy in Hanoi or the British Consulate General in Ho Chi Minh City to swear an affidavit (written statement of facts) that you're free to marry:
 
-- [make an appointment at the British Embassy in Hanoi](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-hanoi/oaths-affirmations-and-affidavits/slot_picker)
-- [make an appointment at the Consulate General in Ho Chi Minh City](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-ho-chi-minh-city/oaths-affirmations-and-affidavits/slot_picker)
+- [make an appointment at the British Embassy in Hanoi](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=115&service=13)
+- [make an appointment at the Consulate General in Ho Chi Minh City](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=64&service=13)
 
 At your appointment, you'll complete and sign an [affirmation or affidavit](/government/publications/affirmation-affidavit-of-marital-status-vietnam) of marital status in front of a consular officer. You can fill in (but not sign) the form before your appointment. 
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/vietnam/ceremony_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/vietnam/ceremony_country/partner_british/_same_sex.erb
@@ -2,8 +2,8 @@ You may be able to get married at the British embassy in Hanoi.
 
 Make an appointment at the embassy or consulate to give notice of your intention to marry:  
 
-- [make an appointment at the British Embassy in Hanoi](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-hanoi/notice-of-marriage-or-civil-partnership/slot_picker)
-- [make an appointment at the Consulate General in Ho Chi Minh City](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-ho-chi-minh-city/notice-of-marriage-or-civil-partnership/slot_picker)
+- [make an appointment at the British Embassy in Hanoi](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=115&service=10)
+- [make an appointment at the Consulate General in Ho Chi Minh City](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=64&service=10)
 
 ^You can only register your marriage at the British Embassy in Hanoi.^ 
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/vietnam/ceremony_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/vietnam/ceremony_country/partner_local/_opposite_sex.erb
@@ -9,8 +9,8 @@ Youâ€™ll be asked to provide an affirmation or affidavit document to prove youâ€
 
 Make an appointment at the British embassy in Hanoi or the British Consulate General in Ho Chi Minh City to swear an affidavit (written statement of facts) that you're free to marry:
 
-- [Make an appointment at the British Embassy in Hanoi](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-hanoi/oaths-affirmations-and-affidavits/slot_picker)
-- [Make an appointment at the Consulate General in Ho Chi Minh City](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-ho-chi-minh-city/oaths-affirmations-and-affidavits/slot_picker)
+- [Make an appointment at the British Embassy in Hanoi](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=115&service=13)
+- [Make an appointment at the Consulate General in Ho Chi Minh City](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=64&service=13)
 
 At your appointment, you'll complete and sign an [affirmation or affidavit](/government/publications/affirmation-affidavit-of-marital-status-vietnam) of marital status in front of a consular officer. You can fill in (but not sign) the form before your appointment.  
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/vietnam/ceremony_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/vietnam/ceremony_country/partner_other/_opposite_sex.erb
@@ -9,8 +9,8 @@ Youâ€™ll be asked to provide an affirmation or affidavit document to prove youâ€
 
 Make an appointment at the British embassy in Hanoi or the British Consulate General in Ho Chi Minh City to swear an affidavit (written statement of facts) that you're free to marry:
 
-- [Make an appointment at the British Embassy in Hanoi](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-hanoi/oaths-affirmations-and-affidavits/slot_picker)
-- [Make an appointment at the Consulate General in Ho Chi Minh City](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-ho-chi-minh-city/oaths-affirmations-and-affidavits/slot_picker)
+- [Make an appointment at the British Embassy in Hanoi](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=115&service=13)
+- [Make an appointment at the Consulate General in Ho Chi Minh City](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=64&service=13)
 
 
 At your appointment, you'll complete and sign an [affirmation or affidavit](/government/publications/affirmation-affidavit-of-marital-status-vietnam) of marital status in front of a consular officer. You can fill in (but not sign) the form before your appointment. 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/vietnam/ceremony_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/vietnam/ceremony_country/partner_other/_same_sex.erb
@@ -2,8 +2,8 @@ You may be able to get married at the British embassy in Hanoi.
 
 Make an appointment at the embassy or consulate to give notice of your intention to marry:  
 
-- [make an appointment at the British Embassy in Hanoi](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-hanoi/notice-of-marriage-or-civil-partnership/slot_picker)
-- [make an appointment at the Consulate General in Ho Chi Minh City](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-ho-chi-minh-city/notice-of-marriage-or-civil-partnership/slot_picker)
+- [make an appointment at the British Embassy in Hanoi](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=115&service=10)
+- [make an appointment at the Consulate General in Ho Chi Minh City](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=64&service=10)
 
 ^You can only register your marriage at the British Embassy in Hanoi.^ 
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/vietnam/third_country/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/vietnam/third_country/partner_british/_opposite_sex.erb
@@ -9,8 +9,8 @@ Youâ€™ll be asked to provide an affirmation or affidavit document to prove youâ€
 
 Make an appointment at the British embassy in Hanoi or the British Consulate General in Ho Chi Minh City to swear an affidavit (written statement of facts) that you're free to marry:
 
-- [Make an appointment at the British Embassy in Hanoi](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-hanoi/oaths-affirmations-and-affidavits/slot_picker)
-- [Make an appointment at the Consulate General in Ho Chi Minh City](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-ho-chi-minh-city/oaths-affirmations-and-affidavits/slot_picker)
+- [Make an appointment at the British Embassy in Hanoi](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=115&service=13)
+- [Make an appointment at the Consulate General in Ho Chi Minh City](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=64&service=13)
 
 
 At your appointment, you'll complete and sign an [affirmation or affidavit](/government/publications/affirmation-affidavit-of-marital-status-vietnam) of marital status in front of a consular officer. You can fill in (but not sign) the form before your appointment. 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/vietnam/third_country/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/vietnam/third_country/partner_british/_same_sex.erb
@@ -2,8 +2,8 @@ You may be able to get married at the British embassy in Hanoi.
 
 Make an appointment at the embassy or consulate to give notice of your intention to marry:  
 
-- [make an appointment at the British Embassy in Hanoi](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-hanoi/notice-of-marriage-or-civil-partnership/slot_picker)
-- [make an appointment at the Consulate General in Ho Chi Minh City](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-ho-chi-minh-city/notice-of-marriage-or-civil-partnership/slot_picker)
+- [make an appointment at the British Embassy in Hanoi](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=115&service=10)
+- [make an appointment at the Consulate General in Ho Chi Minh City](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=64&service=10)
 
 ^You can only register your marriage at the British Embassy in Hanoi.^ 
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/vietnam/third_country/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/vietnam/third_country/partner_local/_opposite_sex.erb
@@ -9,8 +9,8 @@ Youâ€™ll be asked to provide an affirmation or affidavit document to prove youâ€
 
 Make an appointment at the British embassy in Hanoi or the British Consulate General in Ho Chi Minh City to swear an affidavit (written statement of facts) that you're free to marry:
 
-- [Make an appointment at the British Embassy in Hanoi](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-hanoi/oaths-affirmations-and-affidavits/slot_picker)
-- [Make an appointment at the Consulate General in Ho Chi Minh City](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-ho-chi-minh-city/oaths-affirmations-and-affidavits/slot_picker)
+- [Make an appointment at the British Embassy in Hanoi](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=115&service=13)
+- [Make an appointment at the Consulate General in Ho Chi Minh City](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=64&service=13)
 
 
 At your appointment, you'll complete and sign an [affirmation or affidavit](/government/publications/affirmation-affidavit-of-marital-status-vietnam) of marital status in front of a consular officer. You can fill in (but not sign) the form before your appointment. 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/vietnam/third_country/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/vietnam/third_country/partner_other/_opposite_sex.erb
@@ -9,8 +9,8 @@ Youâ€™ll be asked to provide an affirmation or affidavit document to prove youâ€
 
 Make an appointment at the British embassy in Hanoi or the British Consulate General in Ho Chi Minh City to swear an affidavit (written statement of facts) that you're free to marry:
 
-- [Make an appointment at the British Embassy in Hanoi](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-hanoi/oaths-affirmations-and-affidavits/slot_picker)
-- [Make an appointment at the Consulate General in Ho Chi Minh City](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-ho-chi-minh-city/oaths-affirmations-and-affidavits/slot_picker)
+- [Make an appointment at the British Embassy in Hanoi](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=115&service=13)
+- [Make an appointment at the Consulate General in Ho Chi Minh City](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=64&service=13)
 
 
 At your appointment, you'll complete and sign an [affirmation or affidavit](/government/publications/affirmation-affidavit-of-marital-status-vietnam) of marital status in front of a consular officer. You can fill in (but not sign) the form before your appointment. 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/vietnam/third_country/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/vietnam/third_country/partner_other/_same_sex.erb
@@ -2,8 +2,8 @@ You may be able to get married at the British embassy in Hanoi.
 
 Make an appointment at the embassy or consulate to give notice of your intention to marry:  
 
-- [make an appointment at the British Embassy in Hanoi](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-hanoi/notice-of-marriage-or-civil-partnership/slot_picker)
-- [make an appointment at the Consulate General in Ho Chi Minh City](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-ho-chi-minh-city/notice-of-marriage-or-civil-partnership/slot_picker)
+- [make an appointment at the British Embassy in Hanoi](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=115&service=10)
+- [make an appointment at the Consulate General in Ho Chi Minh City](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=64&service=10)
 
 ^You can only register your marriage at the British Embassy in Hanoi.^ 
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/vietnam/uk/partner_british/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/vietnam/uk/partner_british/_opposite_sex.erb
@@ -20,8 +20,8 @@ Youâ€™ll be asked to provide an affirmation or affidavit document to prove youâ€
 
 Make an appointment at the British embassy in Hanoi or the British Consulate General in Ho Chi Minh City to swear an affidavit (written statement of facts) that you're free to marry:
 
-- [Make an appointment at the British Embassy in Hanoi](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-hanoi/oaths-affirmations-and-affidavits/slot_picker)
-- [Make an appointment at the Consulate General in Ho Chi Minh City](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-ho-chi-minh-city/oaths-affirmations-and-affidavits/slot_picker)
+- [Make an appointment at the British Embassy in Hanoi](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=115&service=13)
+- [Make an appointment at the Consulate General in Ho Chi Minh City](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=64&service=13)
 
 
 At your appointment, you'll complete and sign an [affirmation or affidavit](/government/publications/affirmation-affidavit-of-marital-status-vietnam) of marital status in front of a consular officer. You can fill in (but not sign) the form before your appointment. 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/vietnam/uk/partner_british/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/vietnam/uk/partner_british/_same_sex.erb
@@ -2,8 +2,8 @@ You may be able to get married at the British embassy in Hanoi.
 
 Make an appointment at the embassy or consulate to give notice of your intention to marry:  
 
-- [make an appointment at the British Embassy in Hanoi](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-hanoi/notice-of-marriage-or-civil-partnership/slot_picker)
-- [make an appointment at the Consulate General in Ho Chi Minh City](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-ho-chi-minh-city/notice-of-marriage-or-civil-partnership/slot_picker)
+- [make an appointment at the British Embassy in Hanoi](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=115&service=10)
+- [make an appointment at the Consulate General in Ho Chi Minh City](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=64&service=10)
 
 ^You can only register your marriage at the British Embassy in Hanoi.^ 
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/vietnam/uk/partner_local/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/vietnam/uk/partner_local/_opposite_sex.erb
@@ -20,8 +20,8 @@ Youâ€™ll be asked to provide an affirmation or affidavit document to prove youâ€
 
 Make an appointment at the British embassy in Hanoi or the British Consulate General in Ho Chi Minh City to swear an affidavit (written statement of facts) that you're free to marry:
 
-- [Make an appointment at the British Embassy in Hanoi](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-hanoi/oaths-affirmations-and-affidavits/slot_picker)
-- [Make an appointment at the Consulate General in Ho Chi Minh City](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-ho-chi-minh-city/oaths-affirmations-and-affidavits/slot_picker)
+- [Make an appointment at the British Embassy in Hanoi](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=115&service=13)
+- [Make an appointment at the Consulate General in Ho Chi Minh City](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=64&service=13)
 
 
 At your appointment, you'll complete and sign an [affirmation or affidavit](/government/publications/affirmation-affidavit-of-marital-status-vietnam) of marital status in front of a consular officer. You can fill in (but not sign) the form before your appointment.  

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/vietnam/uk/partner_other/_opposite_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/vietnam/uk/partner_other/_opposite_sex.erb
@@ -9,8 +9,8 @@ Youâ€™ll be asked to provide an affirmation or affidavit document to prove youâ€
 
 Make an appointment at the British embassy in Hanoi or the British Consulate General in Ho Chi Minh City to swear an affidavit (written statement of facts) that you're free to marry:
 
-- [Make an appointment at the British Embassy in Hanoi](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-hanoi/oaths-affirmations-and-affidavits/slot_picker)
-- [Make an appointment at the Consulate General in Ho Chi Minh City](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-ho-chi-minh-city/oaths-affirmations-and-affidavits/slot_picker)
+- [Make an appointment at the British Embassy in Hanoi](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=115&service=13)
+- [Make an appointment at the Consulate General in Ho Chi Minh City](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=64&service=13)
 
 At your appointment, you'll complete and sign an [affirmation or affidavit](/government/publications/affirmation-affidavit-of-marital-status-vietnam) of marital status in front of a consular officer. You can fill in (but not sign) the form before your appointment. 
 

--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/vietnam/uk/partner_other/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/vietnam/uk/partner_other/_same_sex.erb
@@ -2,8 +2,8 @@ You may be able to get married at the British embassy in Hanoi.
 
 Make an appointment at the embassy or consulate to give notice of your intention to marry:  
 
-- [make an appointment at the British Embassy in Hanoi](https://www.consular-appointments.service.gov.uk/fco/#!/british-embassy-hanoi/notice-of-marriage-or-civil-partnership/slot_picker)
-- [make an appointment at the Consulate General in Ho Chi Minh City](https://www.consular-appointments.service.gov.uk/fco/#!/british-consulate-general-ho-chi-minh-city/notice-of-marriage-or-civil-partnership/slot_picker)
+- [make an appointment at the British Embassy in Hanoi](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=115&service=10)
+- [make an appointment at the Consulate General in Ho Chi Minh City](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=64&service=10)
 
 ^You can only register your marriage at the British Embassy in Hanoi.^ 
 


### PR DESCRIPTION
This is part of the work to update some links to the embassy/consulate booking service for Marriage Abroad smart answer outcomes.

FCDO are changing the supplier they use for these bookings so URLs are changing.

[Trello](https://trello.com/c/qqqoFVII/2314-3-change-remaining-urls-in-marriage-abroad-smart-answer)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
