### PR TITLE
Fix calculator

### DIFF
--- a/lib/smart_answer/calculators/self_assessment_penalties.rb
+++ b/lib/smart_answer/calculators/self_assessment_penalties.rb
@@ -85,6 +85,8 @@ module SmartAnswer::Calculators
     end
 
     def valid_payment_date?
+      return true if tax_year == "2019-20"
+
       filing_date <= payment_date
     end
 

--- a/lib/smart_answer/calculators/self_assessment_penalties.rb
+++ b/lib/smart_answer/calculators/self_assessment_penalties.rb
@@ -139,12 +139,16 @@ module SmartAnswer::Calculators
     def interest
       return 0 if overdue_payment_days <= 0
 
-      days_with_penalty_interest = payment_deadline..(payment_date - 2)
+      days_with_penalty_interest = payment_deadline..interest_accrual_start_date_for_year
       interest_charges_per_day = days_with_penalty_interest.map do |date|
         calculate_interest_for_date(date)
       end
 
       SmartAnswer::Money.new(interest_charges_per_day.sum.round(2))
+    end
+
+    def interest_accrual_start_date_for_year
+      tax_year == "2019-20" ? payment_date - 1.day : payment_date - 2.days
     end
 
     def total_owed

--- a/lib/smart_answer/calculators/self_assessment_penalties.rb
+++ b/lib/smart_answer/calculators/self_assessment_penalties.rb
@@ -3,6 +3,7 @@ require "ostruct"
 module SmartAnswer::Calculators
   class SelfAssessmentPenalties < OpenStruct
     ONLINE_FILING_DEADLINE_YEAR = SmartAnswer::YearRange.resetting_on("31 January").freeze
+    ONLINE_FILING_DEADLINE_YEAR_FEB = SmartAnswer::YearRange.resetting_on("28 February").freeze
     OFFLINE_FILING_DEADLINE_YEAR = SmartAnswer::YearRange.resetting_on("31 October").freeze
     PAYMENT_DEADLINE_YEAR = SmartAnswer::YearRange.resetting_on("31 January").freeze
     PENALTY_YEAR = SmartAnswer::YearRange.resetting_on("1 February").freeze
@@ -15,7 +16,7 @@ module SmartAnswer::Calculators
         "2016-17": ONLINE_FILING_DEADLINE_YEAR.starting_in(2018).begins_on,
         "2017-18": ONLINE_FILING_DEADLINE_YEAR.starting_in(2019).begins_on,
         "2018-19": ONLINE_FILING_DEADLINE_YEAR.starting_in(2020).begins_on,
-        "2019-20": ONLINE_FILING_DEADLINE_YEAR.starting_in(2021).begins_on,
+        "2019-20": ONLINE_FILING_DEADLINE_YEAR_FEB.starting_in(2021).begins_on,
       },
       offline_filing_deadline: {
         "2013-14": OFFLINE_FILING_DEADLINE_YEAR.starting_in(2014).begins_on,

--- a/lib/smart_answer_flows/estimate-self-assessment-penalties/estimate_self_assessment_penalties.erb
+++ b/lib/smart_answer_flows/estimate-self-assessment-penalties/estimate_self_assessment_penalties.erb
@@ -26,8 +26,4 @@
   If your 2018 to 2019 tax return is more than 3 months late, your calculation may be wrong. This is because daily penalties are not being charged for the 2018 to 2019 tax year, because of coronavirus (COVID-19).
 
   You’ll still be charged £100 for missing the deadline, as well as further penalties if your tax return is more than 6 months late.
-
-  $CTA
-  This calculator is out of date for 2019 to 2020 tax returns. It will be updated soon.
-  $CTA
 <% end %>

--- a/test/unit/calculators/self_assessment_penalties_test.rb
+++ b/test/unit/calculators/self_assessment_penalties_test.rb
@@ -126,7 +126,7 @@ module SmartAnswer::Calculators
       end
 
       should "be invalid if filing date is before start of next tax year" do
-        @calculator.filing_date = @calculator.start_of_next_tax_year - 1
+        @calculator.filing_date = @calculator.start_of_next_tax_year - 1.day
         assert_not @calculator.valid_filing_date?
       end
     end
@@ -134,7 +134,7 @@ module SmartAnswer::Calculators
     context "valid_payment_date?" do
       should "be valid if payment date is before filing date for tax year 2019-20" do
         @calculator.tax_year = "2019-20"
-        @calculator.payment_date = @calculator.filing_date - 1
+        @calculator.payment_date = @calculator.filing_date - 1.day
         assert @calculator.valid_payment_date?
       end
 
@@ -144,7 +144,7 @@ module SmartAnswer::Calculators
       end
 
       should "be invalid if filing date is before filing date" do
-        @calculator.payment_date = @calculator.filing_date - 1
+        @calculator.payment_date = @calculator.filing_date - 1.day
         assert_not @calculator.valid_payment_date?
       end
     end

--- a/test/unit/calculators/self_assessment_penalties_test.rb
+++ b/test/unit/calculators/self_assessment_penalties_test.rb
@@ -296,6 +296,14 @@ module SmartAnswer::Calculators
             @calculator.estimated_bill = SmartAnswer::Money.new(1000)
           end
 
+          should "start interest payments on the 1st of Feb for tax year 2019-20" do
+            @calculator.tax_year = "2019-20"
+            @calculator.estimated_bill = SmartAnswer::Money.new(10_000)
+            @calculator.payment_date = Date.parse("2021-02-01")
+
+            assert_equal 0.71, @calculator.interest
+          end
+
           context "deadline and payment dates are before rate change date" do
             should "have values with rate at 3%" do
               @calculator.payment_deadline = Date.parse("2016-01-31")

--- a/test/unit/calculators/self_assessment_penalties_test.rb
+++ b/test/unit/calculators/self_assessment_penalties_test.rb
@@ -132,6 +132,12 @@ module SmartAnswer::Calculators
     end
 
     context "valid_payment_date?" do
+      should "be valid if payment date is before filing date for tax year 2019-20" do
+        @calculator.tax_year = "2019-20"
+        @calculator.payment_date = @calculator.filing_date - 1
+        assert @calculator.valid_payment_date?
+      end
+
       should "be valid if payment date is on or after filing date" do
         @calculator.payment_date = @calculator.filing_date
         assert @calculator.valid_payment_date?


### PR DESCRIPTION
Few changes to the self assessment calculator as requested for tax year 2019-20:

* Filing deadline pushed back until 28th February (late filing fee starting from 1st March)
* Late payment interest rates start on the 1st of Feb rather than 2nd
* Validation removed that ensures payment date is before filing date
* Content removed concerning outdated calculator (as it now should be up to date 😄) 

Trello:
https://trello.com/c/Uff9Ko9M/2339-fix-anomaly-in-estimate-your-penalty-for-late-self-assessment-tax-returns

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
