### PR TITLE
Update years for start page of student finance calculator

### DIFF
--- a/lib/smart_answer_flows/student-finance-calculator/student_finance_calculator.erb
+++ b/lib/smart_answer_flows/student-finance-calculator/student_finance_calculator.erb
@@ -9,8 +9,8 @@
 <% govspeak_for :body do %>
   This calculator is for students from England or the European Union (EU) starting a new undergraduate course in academic years:
 
-  + 2019 to 2020
   + 2020 to 2021
+  + 2021 to 2022
 
   Use the student finance calculator to estimate:
 


### PR DESCRIPTION
We updated the calculator in https://github.com/alphagov/smart-answers/pull/5119 but didn't update the start page to reflect this change.

Trello card: https://trello.com/c/1qXrq9h6

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
