### PR TITLE
Remove Future Fund scheme

### DIFF
--- a/lib/smart_answer/calculators/business_coronavirus_support_finder_calculator.rb
+++ b/lib/smart_answer/calculators/business_coronavirus_support_finder_calculator.rb
@@ -48,9 +48,6 @@ module SmartAnswer::Calculators
       bounce_back_loan: lambda { |calculator|
         %w[under_85k 85k_to_45m].include?(calculator.annual_turnover)
       },
-      future_fund: lambda { |calculator|
-        calculator.annual_turnover == "pre_revenue"
-      },
       kickstart_scheme: lambda { |calculator|
         calculator.business_based != "northern_ireland"
       },

--- a/lib/smart_answer_flows/business-coronavirus-support-finder.rb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder.rb
@@ -36,7 +36,6 @@ module SmartAnswer
       end
 
       radio :annual_turnover? do
-        option :pre_revenue
         option :under_85k
         option :"85k_to_45m"
         option :"45m_to_500m"

--- a/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.erb
@@ -189,26 +189,6 @@
     $CTA
   <% end %>
 
-  <% if calculator.show?(:future_fund) %>
-    $CTA
-    ### Future Fund
-
-    The Future Fund scheme gives convertible loans from £125,000 to £5 million to companies facing financing difficulties because of coronavirus. The loan must be matched by funding from a private investor.
-
-    Your business is eligible if:
-
-    - it’s UK incorporated - if your business is part of a corporate group, only the parent company is eligible
-    - it’s raised at least £250,000 in equity investment from third-party investors in the past 5 years
-    - none of its shares are traded on a regulated market, multilateral trading facility or other listing venue
-    - it was incorporated on or before 31 December 2019
-    - half or more of the employees are UK-based, or half or more of the revenue is from UK sales
-
-    The scheme is open until 31 January 2021.
-
-    [Find out how to apply for the Future Fund scheme](/guidance/future-fund)
-    $CTA
-  <% end %>
-
   <% if calculator.show?(:kickstart_scheme) %>
     $CTA
     ### Support to create job placements: Kickstart Scheme

--- a/lib/smart_answer_flows/business-coronavirus-support-finder/questions/annual_turnover.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/questions/annual_turnover.erb
@@ -3,9 +3,8 @@
 <% end %>
 
 <% options(
-  "pre_revenue": "My business is a start-up and is pre-revenue",
   "under_85k": "Under £85,000",
   "85k_to_45m": "£85,000 to £45 million",
   "45m_to_500m": "£45 million to £500 million",
-  "500m_and_over": "£500 million and over", 
+  "500m_and_over": "£500 million and over",
 ) %>

--- a/spec/features/smart_answer/business_coronavirus_support_finder_flow_spec.rb
+++ b/spec/features/smart_answer/business_coronavirus_support_finder_flow_spec.rb
@@ -38,7 +38,7 @@ RSpec.feature "SmartAnswer::BusinessCoronavirusSupportFinderFlow", type: :featur
     click_button "Continue"
     expect(page).to have_selector("h1", text: headings[:annual_turnover])
 
-    choose "My business is a start-up and is pre-revenue"
+    choose "Under £85,000"
     click_button "Continue"
     expect(page).to have_selector("h1", text: headings[:paye_scheme])
 
@@ -79,7 +79,7 @@ RSpec.feature "SmartAnswer::BusinessCoronavirusSupportFinderFlow", type: :featur
     click_button "Continue"
     expect(page).to have_selector("h1", text: headings[:annual_turnover])
 
-    choose "My business is a start-up and is pre-revenue"
+    choose "Under £85,000"
     click_button "Continue"
     expect(page).to have_selector("h1", text: headings[:paye_scheme])
 

--- a/test/unit/calculators/business_coronavirus_support_calculator_test.rb
+++ b/test/unit/calculators/business_coronavirus_support_calculator_test.rb
@@ -187,18 +187,6 @@ module SmartAnswer::Calculators
         end
       end
 
-      context "future_fund" do
-        should "return true when annual turnover is pre-prevenue" do
-          @calculator.annual_turnover = "pre_revenue"
-          assert @calculator.show?(:future_fund)
-        end
-
-        should "return false when annual turnover not pre-prevenue" do
-          @calculator.annual_turnover = "45m_to_500m"
-          assert_not @calculator.show?(:future_fund)
-        end
-      end
-
       context "kickstart_scheme" do
         should "return true when business based not in Northern Ireland" do
           @calculator.business_based = "scotland"


### PR DESCRIPTION
## What

Remove the Future Fund scheme from the Business Coronavirus Support Finder flow

## Why

The Future Fund scheme is no longer valid

[Trello](https://trello.com/c/A8j4DyzP/760-remove-future-fund)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
