### PR TITLE
Update statutory_sick_pay.yml

### DIFF
--- a/config/smart_answers/rates/statutory_sick_pay.yml
+++ b/config/smart_answers/rates/statutory_sick_pay.yml
@@ -53,5 +53,3 @@
   end_date: 2022-04-05
   lower_earning_limit_rate: 120
   ssp_weekly_rate: 96.35
-  
-

--- a/config/smart_answers/rates/statutory_sick_pay.yml
+++ b/config/smart_answers/rates/statutory_sick_pay.yml
@@ -48,4 +48,10 @@
   end_date: 2021-04-05
   lower_earning_limit_rate: 120
   ssp_weekly_rate: 95.85
+  
+  - start_date: 2021-04-06
+  end_date: 2022-04-05
+  lower_earning_limit_rate: 120
+  ssp_weekly_rate: 96.35
+  
 


### PR DESCRIPTION
Weekly rate for 2021 uprated to 96.35

https://trello.com/c/IwVsNDWa/2043-stat-sick-uprating-content-requests

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
