### PR TITLE
Add a link to "Tell Us Once" service for deaths in EEA or Switzerland

### DIFF
--- a/lib/smart_answer/calculators/register_a_death_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_death_calculator.rb
@@ -22,6 +22,10 @@ module SmartAnswer::Calculators
       %w[england_wales scotland northern_ireland].include?(location_of_death)
     end
 
+    def died_in_eea_or_switzerland?
+      @reg_data_query.eea_country_or_switzerland?(country_of_death)
+    end
+
     def died_at_home_or_in_hospital?
       death_location_type == "at_home_hospital"
     end

--- a/lib/smart_answer/calculators/registrations_data_query.rb
+++ b/lib/smart_answer/calculators/registrations_data_query.rb
@@ -20,6 +20,39 @@ module SmartAnswer::Calculators
       turks-and-caicos-islands
     ].freeze
 
+    EEA_COUNTRIES = %w[
+      austria
+      belgium
+      bulgaria
+      croatia
+      cyprus
+      czech-republic
+      denmark
+      estonia
+      finland
+      france
+      germany
+      greece
+      hungary
+      iceland
+      ireland
+      italy
+      latvia
+      liechtenstein
+      lithuania
+      luxembourg
+      malta
+      netherlands
+      norway
+      poland
+      portugal
+      romania
+      slovakia
+      slovenia
+      spain
+      sweden
+    ].freeze
+
     COUNTRIES_WITH_CONSULATES = %w[
       china
       colombia
@@ -166,6 +199,14 @@ module SmartAnswer::Calculators
 
     def commonwealth_country?(country_slug)
       COMMONWEALTH_COUNTRIES.include?(country_slug)
+    end
+
+    def eea_country?(country_slug)
+      EEA_COUNTRIES.include?(country_slug)
+    end
+
+    def eea_country_or_switzerland?(country_slug)
+      eea_country?(country_slug) || country_slug == "switzerland"
     end
 
     def has_consulate?(country_slug)

--- a/lib/smart_answer_flows/register-a-death/outcomes/oru_result.erb
+++ b/lib/smart_answer_flows/register-a-death/outcomes/oru_result.erb
@@ -58,8 +58,8 @@
   <%= render partial: 'shared/births_and_deaths_registration/document_return_fees', locals: { document_return_fees: calculator.document_return_fees } %>
   <%= render partial: 'shared/births_and_deaths_registration/button', locals: { button_data: { text: "Pay now", url: "https://pay-register-death-abroad.service.gov.uk/start" } } %>
 
-  The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register. 
-      
+  The registration fee does not include any copies of the certificate, but you can order them at the same time. Cheaper copies will be available from the General Register Office in the UK, but only from November the year after you register.
+
   If you need a copy sooner, email the name of the registered person, the registration date and reference number to <deathregistrationapplications@fcdo.gov.uk>. You’ll get a reply telling you how to get your copy and the cost - usually £50 plus courier fees.
 
   ###4. Send your registration

--- a/lib/smart_answer_flows/register-a-death/outcomes/oru_result.erb
+++ b/lib/smart_answer_flows/register-a-death/outcomes/oru_result.erb
@@ -3,6 +3,10 @@
 
   This local death certificate will be accepted in the UK. It may need to be a [certified translation](/certifying-a-document) of the document if it’s not in English.
 
+  <% if calculator.died_in_eea_or_switzerland? %>
+    You can [report the death to most UK government organisations](/after-a-death/death-abroad) in one go using the Tell Us Once service.
+  <% end %>
+
   ##Register the death with the UK authorities
 
   You can also apply to register the death with the UK authorities. You do not have to do this, but it means:

--- a/test/integration/smart_answer_flows/register_a_death_test.rb
+++ b/test/integration/smart_answer_flows/register_a_death_test.rb
@@ -413,5 +413,13 @@ class RegisterADeathTest < ActiveSupport::TestCase
         assert_equal "/government/publications/democratic-republic-of-congo-list-of-lawyers", current_state.calculator.translator_link_url
       end
     end
+
+    context "death in EEA" do
+      should "includes a link to Tell Us Once" do
+        add_response "france"
+        add_response "in_the_uk"
+        assert_match("Tell Us Once", outcome_body)
+      end
+    end
   end # Overseas
 end


### PR DESCRIPTION
This adds a paragraph containing a link to the "Tell Us Once" service for deaths that happen in [European Economic Area (EEA) countries](https://www.gov.uk/eu-eea) or Switzerland.

Example:
![Screenshot 2021-02-03 at 15 24 15](https://user-images.githubusercontent.com/6329861/106768540-e9fd7800-6633-11eb-92d8-a989f83e7819.png)

Trello card: https://trello.com/c/OK8in2Ud

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️