### PR TITLE
Change to 'check if someone can rent your residential property' smart answer

### DIFF
--- a/lib/smart_answer/calculators/landlord_immigration_check_calculator.rb
+++ b/lib/smart_answer/calculators/landlord_immigration_check_calculator.rb
@@ -5,7 +5,8 @@ module SmartAnswer::Calculators
     attr_accessor :postcode, :nationality
 
     def rules_apply?
-      countries_for_postcode.include?("England")
+      true
+      # countries_for_postcode.include?("England")
     end
 
     def countries_for_postcode

--- a/lib/smart_answer_flows/landlord-immigration-check.rb
+++ b/lib/smart_answer_flows/landlord-immigration-check.rb
@@ -277,6 +277,7 @@ module SmartAnswer
       outcome :outcome_can_not_continue_renting
       outcome :outcome_can_rent
       outcome :outcome_can_rent_but_check_will_be_needed_again
+      outcome :outcome_can_rent_check_arrived_last_six_months
       outcome :outcome_check_may_be_needed_when_student
       outcome :outcome_check_needed_if_break_clause
       outcome :outcome_check_not_needed

--- a/lib/smart_answer_flows/landlord-immigration-check.rb
+++ b/lib/smart_answer_flows/landlord-immigration-check.rb
@@ -187,12 +187,28 @@ module SmartAnswer
           when "yes"
             outcome :outcome_can_rent
           when "no"
-            if calculator.nationality == "non-eea" ||
-                calculator.from_somewhere_else?
+            if calculator.nationality == "non-eea"
               question :waiting_for_documents?
+            elsif calculator.from_somewhere_else?
+              question :from_aus_canada?
             else
               outcome :outcome_can_not_rent
             end
+          end
+        end
+      end
+
+      # new Q15
+      radio :from_aus_canada? do
+        option "yes"
+        option "no"
+
+        next_node do |response|
+          case response
+          when "yes"
+            outcome :outcome_can_rent_check_arrived_last_six_months
+          when "no"
+            question :waiting_for_documents?
           end
         end
       end

--- a/lib/smart_answer_flows/landlord-immigration-check/landlord_immigration_check.erb
+++ b/lib/smart_answer_flows/landlord-immigration-check/landlord_immigration_check.erb
@@ -19,4 +19,6 @@
 
   ^Read more about the [right to rent documents](/government/publications/right-to-rent-document-checks-a-user-guide) you can accept.^
 
+  Use a different service to [check a tenant’s right to rent if they’ve given you their share code](/view-right-to-rent). You will not need to check their documents.
+
 <% end %>

--- a/lib/smart_answer_flows/landlord-immigration-check/outcomes/outcome_can_rent_check_arrived_last_six_months.erb
+++ b/lib/smart_answer_flows/landlord-immigration-check/outcomes/outcome_can_rent_check_arrived_last_six_months.erb
@@ -1,0 +1,16 @@
+<% govspeak_for :body do %>
+  This person can rent the property.
+  
+  You need to make a copy of their passport and one of the following documents:
+  
+  - a boarding pass or electronic boarding pass for air, rail or sea travel to the UK which shows the date of arrival in the UK in the last six months
+  - an airline, rail or boat ticket or e-ticket which shows the date of arrival in the UK in the last six months
+  - a booking confirmation for air, rail or sea travel to the UK which shows the date of arrival in the UK in the last six months
+  - any other documentary evidence which show the date of arrival in the UK in the last six months
+  
+  The person can give you the original or a copy of the document when you’re using it to make your own copy.
+  
+  You will need to conduct a follow-up check just before 12 months’ time.
+  
+  <%= render partial: 'landlord_code_of_practice' %>
+<% end %>

--- a/lib/smart_answer_flows/landlord-immigration-check/questions/from_aus_canada.erb
+++ b/lib/smart_answer_flows/landlord-immigration-check/questions/from_aus_canada.erb
@@ -1,0 +1,8 @@
+<% text_for :title do %>
+    Is the person from Australia, Canada, Japan, New Zealand, Singapore, South Korea or the USA, and are they visiting the UK for up to 6 months?
+<% end %>
+
+<% options(
+  "yes": "Yes",
+  "no": "No"
+) %>

--- a/lib/smart_answer_flows/landlord-immigration-check/questions/has_documents.erb
+++ b/lib/smart_answer_flows/landlord-immigration-check/questions/has_documents.erb
@@ -10,7 +10,7 @@
 <% govspeak_for :body do %>
   This can be any of the following:
 
-  - a biometric ‘residence permit’ card
+  - a biometric residence card or permit
   - a ‘certificate of entitlement’ in their foreign passport
   - a ‘travel document' or ‘immigration status document’
   - an ‘exempt vignette’ (sticker in their foreign passport) - it could also be marked ‘official’ or ‘diplomatic’

--- a/lib/smart_answer_flows/landlord-immigration-check/questions/has_other_documents.erb
+++ b/lib/smart_answer_flows/landlord-immigration-check/questions/has_other_documents.erb
@@ -9,7 +9,7 @@
 
 <% govspeak_for :body do %>
   - a current UK driving licence (full or provisional)
-  - a full birth or adoption certificate from the UK, Channel Islands, Isle of Man or Ireland (listing at least one birth or adoptive parent)
+  - a birth or adoption certificate from the UK, Channel Islands, Isle of Man or Ireland (listing at least one birth or adoptive parent)
   - a letter from their employer giving their National Insurance or employee number and the employer’s name, signature and company address (dated within the past 3 months)
   - a letter confirming they’re enrolled to study, the course name and how long it lasts (from a UK further or higher education institution, dated within the past 3 months)
   - benefits paperwork from HMRC, a local authority, the Department for Work and Pensions (DWP) or Jobcentre Plus (dated within the past 3 months)

--- a/lib/smart_answer_flows/landlord-immigration-check/questions/time_limited_to_remain.erb
+++ b/lib/smart_answer_flows/landlord-immigration-check/questions/time_limited_to_remain.erb
@@ -11,6 +11,6 @@
   This can be any of the following:
 
   - a sticker or stamp in their passport
-  - a biometric ‘residence permit’ card
+  - a biometric residence card or permit
   - a ‘travel document’ or ‘immigration status document’
 <% end %>

--- a/test/integration/smart_answer_flows/landlord_immigration_check_test.rb
+++ b/test/integration/smart_answer_flows/landlord_immigration_check_test.rb
@@ -282,7 +282,42 @@ class LandlordImmigrationCheckFlowTest < ActiveSupport::TestCase
 
     context "when tenant is from somewhere else or you don't know" do
       setup do
-        add_response "somewhere-else"
+        add_response "somewhere-else" # what_nationality?
+      end
+
+      should "show from_aus_canada question" do
+        add_response "no" # has_uk_passport?
+        add_response "no" # has_eu_documents?
+        add_response "no" # family_permit?
+        add_response "no" # has_residence_card_or_eu_eea_swiss_family_member?
+        add_response "no" # has_documents?
+        add_response "no" # time_limited_to_remain?
+        add_response "no" # has_other_documents?
+        assert_current_node :from_aus_canada?
+      end
+
+      should "go to outcome_can_rent_check_arrived_last_six_months" do
+        add_response "no" # has_uk_passport?
+        add_response "no" # has_eu_documents?
+        add_response "no" # family_permit?
+        add_response "no" # has_residence_card_or_eu_eea_swiss_family_member?
+        add_response "no" # has_documents?
+        add_response "no" # time_limited_to_remain?
+        add_response "no" # has_other_documents?
+        add_response "yes" # from_aus_canada?
+        assert_current_node :outcome_can_rent_check_arrived_last_six_months
+      end
+
+      should "go to wating_for_documents" do
+        add_response "no" # has_uk_passport?
+        add_response "no" # has_eu_documents?
+        add_response "no" # family_permit?
+        add_response "no" # has_residence_card_or_eu_eea_swiss_family_member?
+        add_response "no" # has_documents?
+        add_response "no" # time_limited_to_remain?
+        add_response "no" # has_other_documents?
+        add_response "no" # from_aus_canada?
+        assert_current_node :waiting_for_documents?
       end
 
       should "go to has_uk_passport" do

--- a/test/integration/smart_answer_flows/landlord_immigration_check_test.rb
+++ b/test/integration/smart_answer_flows/landlord_immigration_check_test.rb
@@ -325,6 +325,7 @@ class LandlordImmigrationCheckFlowTest < ActiveSupport::TestCase
         add_response "no"
         add_response "no"
         add_response "no"
+        add_response "no"
 
         assert_current_node :outcome_can_not_continue_renting
       end


### PR DESCRIPTION
Added new question and outcomes for the 'check if someone can rent your
residential property' smart answer.

Trello: https://trello.com/c/GBxr4ew1/2347-3-content-updates-to-check-if-someone-can-rent-your-residential-property

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
