### PR TITLE
Convert the existing RSpec feature flow tests to use new helper methods

### DIFF
--- a/spec/features/smart_answer/business_coronavirus_support_finder_flow_spec.rb
+++ b/spec/features/smart_answer/business_coronavirus_support_finder_flow_spec.rb
@@ -18,75 +18,44 @@ RSpec.feature "SmartAnswer::BusinessCoronavirusSupportFinderFlow", type: :featur
     }
   end
 
+  let(:answers) do
+    {
+      england: "England",
+      yes: "Yes",
+      no: "No",
+      employees: "0 to 249 employees",
+      turnover: "Under £85,000",
+      property: "Under £51,000",
+      non_adult: "Nurseries",
+      adult: "Nightclub, dancehall, or adult entertainment venue",
+    }
+  end
+
   before do
     stub_content_store_has_item("/business-coronavirus-support-finder")
+    start(the_flow: headings[:flow_title], at: "business-coronavirus-support-finder")
   end
 
   scenario "Answers all questions" do
-    visit "/business-coronavirus-support-finder"
-    expect(page).to have_selector("h1", text: headings[:flow_title])
+    answer(question: headings[:business_based], of_type: :radio, with: answers[:england])
+    answer(question: headings[:business_size], of_type: :radio, with: answers[:employees])
+    answer(question: headings[:annual_turnover], of_type: :radio, with: answers[:turnover])
+    answer(question: headings[:paye_scheme], of_type: :radio, with: answers[:yes])
+    answer(question: headings[:non_domestic_property], of_type: :radio, with: answers[:property])
+    answer(question: headings[:sectors], of_type: :checkbox, with: answers[:non_adult])
+    answer(question: headings[:closed_by_restrictions], of_type: :checkbox, with: answers[:no])
 
-    click_link "Start now"
-    expect(page).to have_selector("h1", text: headings[:business_based])
-
-    choose "England"
-    click_button "Continue"
-    expect(page).to have_selector("h1", text: headings[:business_size])
-
-    choose "0 to 249 employees"
-    click_button "Continue"
-    expect(page).to have_selector("h1", text: headings[:annual_turnover])
-
-    choose "Under £85,000"
-    click_button "Continue"
-    expect(page).to have_selector("h1", text: headings[:paye_scheme])
-
-    choose "Yes"
-    click_button "Continue"
-    expect(page).to have_selector("h1", text: headings[:non_domestic_property])
-
-    choose "Under £51,000"
-    click_button "Continue"
-    expect(page).to have_selector("h1", text: headings[:sectors])
-
-    check "Nurseries"
-    click_button "Continue"
-    expect(page).to have_selector("h1", text: headings[:closed_by_restrictions])
-
-    check "No"
-    click_button "Continue"
-    expect(page).to have_selector("h1", text: headings[:results])
+    ensure_page_has(header: headings[:results])
   end
 
   scenario "Skip last question if business type nightclubs" do
-    visit "/business-coronavirus-support-finder"
-    expect(page).to have_selector("h1", text: headings[:flow_title])
+    answer(question: headings[:business_based], of_type: :radio, with: answers[:england])
+    answer(question: headings[:business_size], of_type: :radio, with: answers[:employees])
+    answer(question: headings[:annual_turnover], of_type: :radio, with: answers[:turnover])
+    answer(question: headings[:paye_scheme], of_type: :radio, with: answers[:yes])
+    answer(question: headings[:non_domestic_property], of_type: :radio, with: answers[:property])
+    answer(question: headings[:sectors], of_type: :checkbox, with: answers[:adult])
 
-    click_link "Start now"
-    expect(page).to have_selector("h1", text: headings[:business_based])
-
-    choose "England"
-    click_button "Continue"
-    expect(page).to have_selector("h1", text: headings[:business_size])
-
-    choose "0 to 249 employees"
-    click_button "Continue"
-    expect(page).to have_selector("h1", text: headings[:annual_turnover])
-
-    choose "Under £85,000"
-    click_button "Continue"
-    expect(page).to have_selector("h1", text: headings[:paye_scheme])
-
-    choose "Yes"
-    click_button "Continue"
-    expect(page).to have_selector("h1", text: headings[:non_domestic_property])
-
-    choose "Under £51,000"
-    click_button "Continue"
-    expect(page).to have_selector("h1", text: headings[:sectors])
-
-    check "Nightclub, dancehall, or adult entertainment venue"
-    click_button "Continue"
-    expect(page).to have_selector("h1", text: headings[:results])
+    ensure_page_has(header: headings[:results])
   end
 end

--- a/spec/features/smart_answer/calculate_your_holiday_entitlement_flow_spec.rb
+++ b/spec/features/smart_answer/calculate_your_holiday_entitlement_flow_spec.rb
@@ -39,94 +39,56 @@ RSpec.feature "CalculateYourHolidayEntitlementFlow", type: :feature do
     }
   end
 
-  def start_the_flow
-    visit "/calculate-your-holiday-entitlement"
-    expect(page).to have_selector("h1", text: headings[:flow_title])
-    click_link "Start now"
-  end
-
   def basis_of_calculation(response)
-    expect(page).to have_selector("h1", text: headings[:basis_of_calculation])
-    choose response
-    click_button "Continue"
+    answer(question: headings[:basis_of_calculation], of_type: :radio, with: response)
   end
 
   def calculation_period(response)
-    expect(page).to have_selector("h1", text: headings[:calculation_period])
-    choose response
-    click_button "Continue"
+    answer(question: headings[:calculation_period], of_type: :radio, with: response)
   end
 
   def calculation_period_shifts(response)
-    expect(page).to have_selector("h1", text: headings[:shift_worker_basis])
-    choose response
-    click_button "Continue"
+    answer(question: headings[:shift_worker_basis], of_type: :radio, with: response)
   end
 
   def how_many_days_per_week(response)
-    expect(page).to have_selector("h1", text: headings[:how_many_days_per_week])
-    fill_in "response", with: response
-    click_button "Continue"
+    answer(question: headings[:how_many_days_per_week], of_type: :value, with: response)
   end
 
-  def what_is_your_starting_date(day, month, year)
-    expect(page).to have_selector("h1", text: headings[:what_is_your_starting_date])
-    fill_in "response[day]", with: day
-    fill_in "response[month]", with: month
-    fill_in "response[year]", with: year
-    click_button "Continue"
+  def what_is_your_starting_date(date_string)
+    answer(question: headings[:what_is_your_starting_date], of_type: :date, with: date_string)
   end
 
-  def what_is_your_leaving_date(day, month, year)
-    expect(page).to have_selector("h1", text: headings[:what_is_your_leaving_date])
-    fill_in "response[day]", with: day
-    fill_in "response[month]", with: month
-    fill_in "response[year]", with: year
-    click_button "Continue"
+  def what_is_your_leaving_date(date_string)
+    answer(question: headings[:what_is_your_leaving_date], of_type: :date, with: date_string)
   end
 
-  def when_does_your_leave_year_start(day, month, year)
-    expect(page).to have_selector("h1", text: headings[:when_does_your_leave_year_start])
-    fill_in "response[day]", with: day
-    fill_in "response[month]", with: month
-    fill_in "response[year]", with: year
-    click_button "Continue"
+  def when_does_your_leave_year_start(date_string)
+    answer(question: headings[:when_does_your_leave_year_start], of_type: :date, with: date_string)
   end
 
   def how_many_hours_per_week(response)
-    expect(page).to have_selector("h1", text: headings[:how_many_hours_per_week])
-    fill_in "response", with: response
-    click_button "Continue"
+    answer(question: headings[:how_many_hours_per_week], of_type: :value, with: response)
   end
 
   def how_many_days_per_week_for_hours(response)
-    expect(page).to have_selector("h1", text: headings[:how_many_days_per_week_for_hours])
-    fill_in "response", with: response
-    click_button "Continue"
+    answer(question: headings[:how_many_days_per_week_for_hours], of_type: :value, with: response)
   end
 
   def shift_worker_basis(response)
-    expect(page).to have_selector("h1", text: headings[:shift_worker_basis])
-    choose response
-    click_button "Continue"
+    answer(question: headings[:shift_worker_basis], of_type: :radio, with: response)
   end
 
   def shift_worker_hours_per_shift(response)
-    expect(page).to have_selector("h1", text: headings[:shift_worker_hours_per_shift])
-    fill_in "response", with: response
-    click_button "Continue"
+    answer(question: headings[:shift_worker_hours_per_shift], of_type: :value, with: response)
   end
 
   def shift_worker_shifts_per_shift_pattern(response)
-    expect(page).to have_selector("h1", text: headings[:shift_worker_shifts_per_shift_pattern])
-    fill_in "response", with: response
-    click_button "Continue"
+    answer(question: headings[:shift_worker_shifts_per_shift_pattern], of_type: :value, with: response)
   end
 
   def shift_worker_days_per_shift_pattern(response)
-    expect(page).to have_selector("h1", text: headings[:shift_worker_days_per_shift_pattern])
-    fill_in "response", with: response
-    click_button "Continue"
+    answer(question: headings[:shift_worker_days_per_shift_pattern], of_type: :value, with: response)
   end
 
   def statutory_entitlement(count, basis = "days")
@@ -147,7 +109,7 @@ RSpec.feature "CalculateYourHolidayEntitlementFlow", type: :feature do
 
   before do
     stub_content_store_has_item("/calculate-your-holiday-entitlement")
-    start_the_flow
+    start(the_flow: headings[:flow_title], at: "calculate-your-holiday-entitlement")
   end
 
   context "days-worked-per-week" do
@@ -158,31 +120,31 @@ RSpec.feature "CalculateYourHolidayEntitlementFlow", type: :feature do
     scenario "full-year" do
       calculation_period calculation_periods[:full_year]
       how_many_days_per_week 5
-      expect(page).to have_selector("p", text: statutory_entitlement(28))
+      ensure_page_has(text: statutory_entitlement(28))
     end
 
     scenario "starting" do
       calculation_period calculation_periods[:starting]
-      what_is_your_starting_date(14, 3, 2020)
-      when_does_your_leave_year_start(2, 3, 2020)
+      what_is_your_starting_date("14/3/2020")
+      when_does_your_leave_year_start("2-3-2020")
       how_many_days_per_week 5
-      expect(page).to have_selector("p", text: statutory_entitlement(28))
+      ensure_page_has(text: statutory_entitlement(28))
     end
 
     scenario "leaving" do
       calculation_period calculation_periods[:leaving]
-      what_is_your_leaving_date(14, 7, 2020)
-      when_does_your_leave_year_start(1, 1, 2020)
+      what_is_your_leaving_date("14-7-2020")
+      when_does_your_leave_year_start("1/1/2020")
       how_many_days_per_week 5
-      expect(page).to have_selector("p", text: statutory_entitlement(15))
+      ensure_page_has(text: statutory_entitlement(15))
     end
 
     scenario "starting-and-leaving" do
       calculation_period calculation_periods[:starting_and_leaving]
-      what_is_your_starting_date(14, 7, 2020)
-      what_is_your_leaving_date(14, 10, 2020)
+      what_is_your_starting_date("14-7-2020")
+      what_is_your_leaving_date("14/10/2020")
       how_many_days_per_week 5
-      expect(page).to have_selector("p", text: statutory_entitlement(7.2))
+      ensure_page_has(text: statutory_entitlement(7.2))
     end
   end # days-worked-per-week
 
@@ -195,34 +157,34 @@ RSpec.feature "CalculateYourHolidayEntitlementFlow", type: :feature do
       calculation_period calculation_periods[:full_year]
       how_many_hours_per_week 40
       how_many_days_per_week_for_hours 5
-      expect(page).to have_selector("p", text: statutory_entitlement_hours(224))
+      ensure_page_has(text: statutory_entitlement_hours(224))
     end
 
     scenario "starting" do
       calculation_period calculation_periods[:starting]
-      what_is_your_starting_date(1, 6, 2020)
-      when_does_your_leave_year_start(1, 1, 2020)
+      what_is_your_starting_date("1/6/2020")
+      when_does_your_leave_year_start("1/1/2020")
       how_many_hours_per_week 40
       how_many_days_per_week_for_hours 5
-      expect(page).to have_selector("p", text: statutory_entitlement_hours(132))
+      ensure_page_has(text: statutory_entitlement_hours(132))
     end
 
     scenario "leaving" do
       calculation_period calculation_periods[:leaving]
-      what_is_your_leaving_date(1, 6, 2020)
-      when_does_your_leave_year_start(1, 1, 2020)
+      what_is_your_leaving_date("01-06-2020")
+      when_does_your_leave_year_start("1/1/2020")
       how_many_hours_per_week 40
       how_many_days_per_week_for_hours 5
-      expect(page).to have_selector("p", text: statutory_entitlement_hours(93.7))
+      ensure_page_has(text: statutory_entitlement_hours(93.7))
     end
 
     scenario "starting-and-leaving" do
       calculation_period calculation_periods[:starting_and_leaving]
-      what_is_your_starting_date(20, 1, 2020)
-      what_is_your_leaving_date(18, 7, 2020)
+      what_is_your_starting_date("20/1/2020")
+      what_is_your_leaving_date("18/07/2020")
       how_many_hours_per_week 40
       how_many_days_per_week_for_hours 5
-      expect(page).to have_selector("p", text: statutory_entitlement_hours(110.8))
+      ensure_page_has(text: statutory_entitlement_hours(110.8))
     end
   end # hours-worked-per-week
 
@@ -233,28 +195,28 @@ RSpec.feature "CalculateYourHolidayEntitlementFlow", type: :feature do
 
     scenario "full-year" do
       calculation_period calculation_periods[:full_year]
-      expect(page).to have_selector("p", text: statutory_entitlement(5.6, "weeks"))
+      ensure_page_has(text: statutory_entitlement(5.6, "weeks"))
     end
 
     scenario "starting" do
       calculation_period calculation_periods[:starting]
-      what_is_your_starting_date 1, 6, 2020
-      when_does_your_leave_year_start 1, 1, 2020
-      expect(page).to have_selector("p", text: statutory_entitlement(3.27, "weeks"))
+      what_is_your_starting_date "1-6-2020"
+      when_does_your_leave_year_start "1-1-2020"
+      ensure_page_has(text: statutory_entitlement(3.27, "weeks"))
     end
 
     scenario "leaving" do
       calculation_period calculation_periods[:leaving]
-      what_is_your_leaving_date 1, 6, 2020
-      when_does_your_leave_year_start 1, 1, 2020
-      expect(page).to have_selector("p", text: statutory_entitlement(2.35, "weeks"))
+      what_is_your_leaving_date "01-06-2020"
+      when_does_your_leave_year_start "1-1-2020"
+      ensure_page_has(text: statutory_entitlement(2.35, "weeks"))
     end
 
     scenario "starting-and-leaving" do
       calculation_period calculation_periods[:starting_and_leaving]
-      what_is_your_starting_date 20, 1, 2020
-      what_is_your_leaving_date 18, 7, 2020
-      expect(page).to have_selector("p", text: statutory_entitlement(2.77, "weeks"))
+      what_is_your_starting_date "20-1-2020"
+      what_is_your_leaving_date "18-07-2020"
+      ensure_page_has(text: statutory_entitlement(2.77, "weeks"))
     end
   end # irregular-hours
 
@@ -265,28 +227,28 @@ RSpec.feature "CalculateYourHolidayEntitlementFlow", type: :feature do
 
     scenario "full-year" do
       calculation_period calculation_periods[:full_year]
-      expect(page).to have_selector("p", text: statutory_entitlement(5.6, "weeks"))
+      ensure_page_has(text: statutory_entitlement(5.6, "weeks"))
     end
 
     scenario "starting" do
       calculation_period calculation_periods[:starting]
-      what_is_your_starting_date 1, 6, 2020
-      when_does_your_leave_year_start 1, 1, 2020
-      expect(page).to have_selector("p", text: statutory_entitlement(3.27, "weeks"))
+      what_is_your_starting_date "1-6-2020"
+      when_does_your_leave_year_start "1-1-2020"
+      ensure_page_has(text: statutory_entitlement(3.27, "weeks"))
     end
 
     scenario "leaving" do
       calculation_period calculation_periods[:leaving]
-      what_is_your_leaving_date 1, 6, 2020
-      when_does_your_leave_year_start 1, 1, 2020
-      expect(page).to have_selector("p", text: statutory_entitlement(2.35, "weeks"))
+      what_is_your_leaving_date "1-6-2020"
+      when_does_your_leave_year_start "1-1-2020"
+      ensure_page_has(text: statutory_entitlement(2.35, "weeks"))
     end
 
     scenario "starting-and-leaving" do
       calculation_period calculation_periods[:starting_and_leaving]
-      what_is_your_starting_date 20, 1, 2020
-      what_is_your_leaving_date 18, 7, 2020
-      expect(page).to have_selector("p", text: statutory_entitlement(2.77, "weeks"))
+      what_is_your_starting_date "20-1-2020"
+      what_is_your_leaving_date "18-7-2020"
+      ensure_page_has(text: statutory_entitlement(2.77, "weeks"))
     end
   end # annualised-hours
 
@@ -299,34 +261,34 @@ RSpec.feature "CalculateYourHolidayEntitlementFlow", type: :feature do
       calculation_period calculation_periods[:full_year]
       how_many_hours_per_week 40
       how_many_days_per_week_for_hours 5
-      expect(page).to have_selector("p", text: statutory_entitlement_compressed(224, 0))
+      ensure_page_has(text: statutory_entitlement_compressed(224, 0))
     end
 
     scenario "starting" do
       calculation_period calculation_periods[:starting]
-      what_is_your_starting_date(1, 6, 2020)
-      when_does_your_leave_year_start(1, 1, 2020)
+      what_is_your_starting_date("1/6/2020")
+      when_does_your_leave_year_start("1/1/2020")
       how_many_hours_per_week 40
       how_many_days_per_week_for_hours 5
-      expect(page).to have_selector("p", text: statutory_entitlement_compressed(132, 0))
+      ensure_page_has(text: statutory_entitlement_compressed(132, 0))
     end
 
     scenario "leaving - non-leap year" do
       calculation_period calculation_periods[:leaving]
-      what_is_your_leaving_date(1, 6, 2019)
-      when_does_your_leave_year_start(1, 1, 2019)
+      what_is_your_leaving_date("1/6/2019")
+      when_does_your_leave_year_start("1/1/2019")
       how_many_hours_per_week 40
       how_many_days_per_week_for_hours 5
-      expect(page).to have_selector("p", text: statutory_entitlement_compressed(93, 18))
+      ensure_page_has(text: statutory_entitlement_compressed(93, 18))
     end
 
     scenario "starting-and-leaving - non-leap year" do
       calculation_period calculation_periods[:starting_and_leaving]
-      what_is_your_starting_date(20, 1, 2019)
-      what_is_your_leaving_date(18, 7, 2019)
+      what_is_your_starting_date("20/1/2019")
+      what_is_your_leaving_date("18/7/2019")
       how_many_hours_per_week 40
       how_many_days_per_week_for_hours 5
-      expect(page).to have_selector("p", text: statutory_entitlement_compressed(110, 30))
+      ensure_page_has(text: statutory_entitlement_compressed(110, 30))
     end
   end # compressed-hours
 
@@ -340,37 +302,37 @@ RSpec.feature "CalculateYourHolidayEntitlementFlow", type: :feature do
       shift_worker_hours_per_shift 6
       shift_worker_shifts_per_shift_pattern 8
       shift_worker_days_per_shift_pattern 14
-      expect(page).to have_selector("p", text: statutory_entitlement_shifts(22.4, 6.0))
+      ensure_page_has(text: statutory_entitlement_shifts(22.4, 6.0))
     end
 
     scenario "starting" do
       calculation_period_shifts calculation_periods[:starting]
-      what_is_your_starting_date 1, 6, 2020
-      when_does_your_leave_year_start 1, 1, 2020
+      what_is_your_starting_date "1/6/2020"
+      when_does_your_leave_year_start "1/1/2020"
       shift_worker_hours_per_shift 6
       shift_worker_shifts_per_shift_pattern 8
       shift_worker_days_per_shift_pattern 14
-      expect(page).to have_selector("p", text: statutory_entitlement_shifts(13.5, 6.0))
+      ensure_page_has(text: statutory_entitlement_shifts(13.5, 6.0))
     end
 
     scenario "leaving" do
       calculation_period_shifts calculation_periods[:leaving]
-      what_is_your_leaving_date 1, 6, 2020
-      when_does_your_leave_year_start 1, 1, 2020
+      what_is_your_leaving_date "1-6-2020"
+      when_does_your_leave_year_start "1-1-2020"
       shift_worker_hours_per_shift 6
       shift_worker_shifts_per_shift_pattern 8
       shift_worker_days_per_shift_pattern 14
-      expect(page).to have_selector("p", text: statutory_entitlement_shifts(9.37, 6.0))
+      ensure_page_has(text: statutory_entitlement_shifts(9.37, 6.0))
     end
 
     scenario "starting-and-leaving" do
       calculation_period_shifts calculation_periods[:starting_and_leaving]
-      what_is_your_starting_date 20, 1, 2020
-      what_is_your_leaving_date 18, 7, 2020
+      what_is_your_starting_date "20-1-2020"
+      what_is_your_leaving_date "18-7-2020"
       shift_worker_hours_per_shift 6
       shift_worker_shifts_per_shift_pattern 8
       shift_worker_days_per_shift_pattern 14
-      expect(page).to have_selector("p", text: statutory_entitlement_shifts(11.08, 6.0))
+      ensure_page_has(text: statutory_entitlement_shifts(11.08, 6.0))
     end
   end # shift-worker
 end

--- a/spec/features/smart_answer/find_coronavirus_support_flow_spec.rb
+++ b/spec/features/smart_answer/find_coronavirus_support_flow_spec.rb
@@ -1,24 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "FindCoronavirusSupportFlow", type: :feature do
-  def start_flow_to_need_help_with
-    visit "/find-coronavirus-support"
-    expect(page).to have_selector("h1", text: headings[:flow_title])
-
-    click_link "Start now"
-    expect(page).to have_selector("h1", text: headings[:need_help_with])
-  end
-
-  def continue_to_results
-    click_button "Continue"
-    expect(page).to have_selector("h1", text: headings[:nation])
-
-    choose "England"
-    click_button "Continue"
-    expect(page).to have_selector("h1", text: headings[:results])
-  end
-
-  let(:headings) do
+  let(:questions) do
     {
       flow_title: "Find out what support you can get if you’re affected by coronavirus",
       need_help_with: "What do you need help with because of coronavirus?",
@@ -38,7 +21,7 @@ RSpec.feature "FindCoronavirusSupportFlow", type: :feature do
     }
   end
 
-  let(:result_subheadings) do
+  let(:results) do
     {
       feeling_unsafe: "Feeling unsafe",
       paying_bills: "Paying your rent, mortgage, or bills",
@@ -48,6 +31,7 @@ RSpec.feature "FindCoronavirusSupportFlow", type: :feature do
       self_isolating: "Self-isolating",
       somewhere_to_live: "Having somewhere to live",
       mental_health: "Mental health and wellbeing",
+      no_results: "Based on your answers, there’s no specific information for you in this service at the moment",
     }
   end
 
@@ -65,197 +49,143 @@ RSpec.feature "FindCoronavirusSupportFlow", type: :feature do
     }
   end
 
+  let(:answers) do
+    {
+      england: "England",
+      yes: "Yes",
+      yes_i_am: "Yes, I am",
+      yes_redundant: "Yes, I’ve been made redundant or I’m out of work, or might be soon",
+      no: "No",
+    }
+  end
+
   before do
     stub_content_store_has_item("/find-coronavirus-support")
+    start(the_flow: questions[:flow_title], at: "find-coronavirus-support")
   end
 
   scenario "feeling unsafe" do
-    start_flow_to_need_help_with
+    answer(question: questions[:need_help_with], of_type: :checkbox, with: need_help_with[:feeling_unsafe])
+    answer(question: questions[:feel_unsafe], of_type: :radio, with: answers[:yes])
+    answer(question: questions[:nation], of_type: :radio, with: answers[:england])
 
-    check need_help_with[:feeling_unsafe]
-    click_button "Continue"
-    expect(page).to have_selector("h1", text: headings[:feel_unsafe])
-
-    choose "Yes"
-    continue_to_results
-    expect(page).to have_selector("h2", text: result_subheadings[:feeling_unsafe])
+    ensure_page_has(header: questions[:results], subheaders: results[:feeling_unsafe])
   end
 
   scenario "paying bills" do
-    start_flow_to_need_help_with
+    answer(question: questions[:need_help_with], of_type: :checkbox, with: need_help_with[:paying_bills])
+    answer(question: questions[:afford_rent_mortgage_bills], of_type: :radio, with: answers[:yes])
+    answer(question: questions[:nation], of_type: :radio, with: answers[:england])
 
-    check need_help_with[:paying_bills]
-    click_button "Continue"
-    expect(page).to have_selector("h1", text: headings[:afford_rent_mortgage_bills])
-
-    choose "Yes"
-    continue_to_results
-    expect(page).to have_selector("h2", text: result_subheadings[:paying_bills])
+    ensure_page_has(header: questions[:results], subheaders: results[:paying_bills])
   end
 
   scenario "getting food" do
-    start_flow_to_need_help_with
+    answer(question: questions[:need_help_with], of_type: :checkbox, with: need_help_with[:getting_food])
+    answer(question: questions[:afford_food], of_type: :radio, with: answers[:yes])
+    answer(question: questions[:get_food], of_type: :radio, with: answers[:yes])
+    answer(question: questions[:nation], of_type: :radio, with: answers[:england])
 
-    check need_help_with[:getting_food]
-    click_button "Continue"
-    expect(page).to have_selector("h1", text: headings[:afford_food])
-
-    choose "Yes"
-    click_button "Continue"
-    expect(page).to have_selector("h1", text: headings[:get_food])
-
-    choose "Yes"
-    continue_to_results
-    expect(page).to have_selector("h2", text: result_subheadings[:getting_food])
+    ensure_page_has(header: questions[:results], subheaders: results[:getting_food])
   end
 
   scenario "being unemployed" do
-    start_flow_to_need_help_with
+    answer(question: questions[:need_help_with], of_type: :checkbox, with: need_help_with[:being_unemployed])
+    answer(question: questions[:self_employed], of_type: :radio, with: answers[:no])
+    answer(question: questions[:have_you_been_made_unemployed], of_type: :radio, with: answers[:yes_redundant])
+    answer(question: questions[:nation], of_type: :radio, with: answers[:england])
 
-    check need_help_with[:being_unemployed]
-    click_button "Continue"
-    expect(page).to have_selector("h1", text: headings[:self_employed])
-
-    choose "No"
-    click_button "Continue"
-    expect(page).to have_selector("h1", text: headings[:have_you_been_made_unemployed])
-
-    choose "Yes, I’ve been made redundant or I’m out of work, or might be soon"
-    continue_to_results
-    expect(page).to have_selector("h2", text: result_subheadings[:being_unemployed])
+    ensure_page_has(header: questions[:results], subheaders: results[:being_unemployed])
   end
 
   scenario "being unemployed - self-employed" do
-    start_flow_to_need_help_with
+    answer(question: questions[:need_help_with], of_type: :checkbox, with: need_help_with[:being_unemployed])
+    answer(question: questions[:self_employed], of_type: :radio, with: answers[:yes])
+    answer(question: questions[:nation], of_type: :radio, with: answers[:england])
 
-    check need_help_with[:being_unemployed]
-    click_button "Continue"
-    expect(page).to have_selector("h1", text: headings[:self_employed])
-
-    choose "Yes"
-    continue_to_results
-    expect(page).to have_selector("h2", text: result_subheadings[:being_unemployed])
+    ensure_page_has(header: questions[:results], subheaders: results[:being_unemployed])
   end
 
   scenario "going to work" do
-    start_flow_to_need_help_with
+    answer(question: questions[:need_help_with], of_type: :checkbox, with: need_help_with[:going_to_work])
+    answer(question: questions[:worried_about_work], of_type: :radio, with: answers[:yes])
+    answer(question: questions[:nation], of_type: :radio, with: answers[:england])
 
-    check need_help_with[:going_to_work]
-    click_button "Continue"
-    expect(page).to have_selector("h1", text: headings[:worried_about_work])
-
-    choose "Yes"
-    continue_to_results
-    expect(page).to have_selector("h2", text: result_subheadings[:going_to_work])
+    ensure_page_has(header: questions[:results], subheaders: results[:going_to_work])
   end
 
   scenario "self isolating" do
-    start_flow_to_need_help_with
+    answer(question: questions[:need_help_with], of_type: :checkbox, with: need_help_with[:self_isolating])
+    answer(question: questions[:worried_about_self_isolating], of_type: :radio, with: answers[:yes])
+    answer(question: questions[:nation], of_type: :radio, with: answers[:england])
 
-    check need_help_with[:self_isolating]
-    click_button "Continue"
-    expect(page).to have_selector("h1", text: headings[:worried_about_self_isolating])
-
-    choose "Yes"
-    continue_to_results
-    expect(page).to have_selector("h2", text: result_subheadings[:self_isolating])
+    ensure_page_has(header: questions[:results], subheaders: results[:self_isolating])
   end
 
   scenario "somewhere to live" do
-    start_flow_to_need_help_with
+    answer(question: questions[:need_help_with], of_type: :checkbox, with: need_help_with[:somewhere_to_live])
+    answer(question: questions[:have_somewhere_to_live], of_type: :radio, with: answers[:yes])
+    answer(question: questions[:have_you_been_evicted], of_type: :radio, with: answers[:yes])
+    answer(question: questions[:nation], of_type: :radio, with: answers[:england])
 
-    check need_help_with[:somewhere_to_live]
-    click_button "Continue"
-    expect(page).to have_selector("h1", text: headings[:have_somewhere_to_live])
-
-    choose "Yes"
-    click_button "Continue"
-    expect(page).to have_selector("h1", text: headings[:have_you_been_evicted])
-
-    choose "Yes"
-    continue_to_results
-    expect(page).to have_selector("h2", text: result_subheadings[:somewhere_to_live])
+    ensure_page_has(header: questions[:results], subheaders: results[:somewhere_to_live])
   end
 
   scenario "mental health" do
-    start_flow_to_need_help_with
+    answer(question: questions[:need_help_with], of_type: :checkbox, with: need_help_with[:mental_health])
+    answer(question: questions[:mental_health_worries], of_type: :radio, with: answers[:yes_i_am])
+    answer(question: questions[:nation], of_type: :radio, with: answers[:england])
 
-    check need_help_with[:mental_health]
-    click_button "Continue"
-    expect(page).to have_selector("h1", text: headings[:mental_health_worries])
-
-    choose "Yes, I am"
-    continue_to_results
-    expect(page).to have_selector("h2", text: result_subheadings[:mental_health])
+    ensure_page_has(header: questions[:results], subheaders: results[:mental_health])
   end
 
   scenario "None of these" do
-    start_flow_to_need_help_with
-    check need_help_with[:none]
-    continue_to_results
-    expect(page).to have_text("Based on your answers, there’s no specific information for you in this service at the moment")
+    answer(question: questions[:need_help_with], of_type: :checkbox, with: need_help_with[:none])
+    answer(question: questions[:nation], of_type: :radio, with: answers[:england])
+
+    ensure_page_has(header: questions[:results], text: results[:no_results])
   end
 
   scenario "all the options" do
-    start_flow_to_need_help_with
+    answer(
+      question: questions[:need_help_with],
+      of_type: :checkbox,
+      with: [
+        need_help_with[:mental_health],
+        need_help_with[:somewhere_to_live],
+        need_help_with[:going_to_work],
+        need_help_with[:self_isolating],
+        need_help_with[:being_unemployed],
+        need_help_with[:getting_food],
+        need_help_with[:paying_bills],
+        need_help_with[:feeling_unsafe],
+      ],
+    )
 
-    check need_help_with[:mental_health]
-    check need_help_with[:somewhere_to_live]
-    check need_help_with[:going_to_work]
-    check need_help_with[:self_isolating]
-    check need_help_with[:being_unemployed]
-    check need_help_with[:getting_food]
-    check need_help_with[:paying_bills]
-    check need_help_with[:feeling_unsafe]
+    answer(question: questions[:feel_unsafe], of_type: :radio, with: answers[:yes])
+    answer(question: questions[:afford_rent_mortgage_bills], of_type: :radio, with: answers[:yes])
+    answer(question: questions[:afford_food], of_type: :radio, with: answers[:yes])
+    answer(question: questions[:get_food], of_type: :radio, with: answers[:yes])
+    answer(question: questions[:self_employed], of_type: :radio, with: answers[:yes])
+    answer(question: questions[:worried_about_work], of_type: :radio, with: answers[:yes])
+    answer(question: questions[:worried_about_self_isolating], of_type: :radio, with: answers[:yes])
+    answer(question: questions[:have_somewhere_to_live], of_type: :radio, with: answers[:yes])
+    answer(question: questions[:have_you_been_evicted], of_type: :radio, with: answers[:yes])
+    answer(question: questions[:mental_health_worries], of_type: :radio, with: answers[:yes_i_am])
+    answer(question: questions[:nation], of_type: :radio, with: answers[:england])
 
-    click_button "Continue"
-    expect(page).to have_selector("h1", text: headings[:feel_unsafe])
-
-    choose "Yes"
-    click_button "Continue"
-    expect(page).to have_selector("h1", text: headings[:afford_rent_mortgage_bills])
-
-    choose "Yes"
-    click_button "Continue"
-    expect(page).to have_selector("h1", text: headings[:afford_food])
-
-    choose "Yes"
-    click_button "Continue"
-    expect(page).to have_selector("h1", text: headings[:get_food])
-
-    choose "Yes"
-    click_button "Continue"
-    expect(page).to have_selector("h1", text: headings[:self_employed])
-
-    choose "Yes"
-    click_button "Continue"
-    expect(page).to have_selector("h1", text: headings[:worried_about_work])
-
-    choose "Yes"
-    click_button "Continue"
-    expect(page).to have_selector("h1", text: headings[:worried_about_self_isolating])
-
-    choose "Yes"
-    click_button "Continue"
-    expect(page).to have_selector("h1", text: headings[:have_somewhere_to_live])
-
-    choose "Yes"
-    click_button "Continue"
-    expect(page).to have_selector("h1", text: headings[:have_you_been_evicted])
-
-    choose "Yes"
-    click_button "Continue"
-    expect(page).to have_selector("h1", text: headings[:mental_health_worries])
-
-    choose "Yes, I am"
-    continue_to_results
-    expect(page).to have_selector("h2", text: result_subheadings[:mental_health])
-    expect(page).to have_selector("h2", text: result_subheadings[:somewhere_to_live])
-    expect(page).to have_selector("h2", text: result_subheadings[:going_to_work])
-    expect(page).to have_selector("h2", text: result_subheadings[:self_isolating])
-    expect(page).to have_selector("h2", text: result_subheadings[:being_unemployed])
-    expect(page).to have_selector("h2", text: result_subheadings[:getting_food])
-    expect(page).to have_selector("h2", text: result_subheadings[:paying_bills])
-    expect(page).to have_selector("h2", text: result_subheadings[:feeling_unsafe])
+    ensure_page_has(
+      header: questions[:results],
+      subheaders: [
+        results[:mental_health],
+        results[:somewhere_to_live],
+        results[:going_to_work],
+        results[:self_isolating],
+        results[:being_unemployed],
+        results[:getting_food],
+        results[:paying_bills],
+        results[:feeling_unsafe],
+      ],
+    )
   end
 end


### PR DESCRIPTION
## What

Convert the existing RSpec feature flow tests to use new helper methods

## Why

We should be using the new helper methods in our RSpec feature tests

[Trello](https://trello.com/c/R9st6UZn/777-convert-existing-rspec-feature-tests-to-use-new-helper-methods)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
