### PR TITLE
Update README links: doc  => docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Read more in [Lisa Scott's GDS blog post](https://gds.blog.gov.uk/2012/02/16/sma
 
 ## Screenshots
 
-![Student Finance Forms screenshot](./doc/assets/govuk-student-finance-forms.png)
+![Student Finance Forms screenshot](./docs/assets/govuk-student-finance-forms.png)
 
 ## Live examples
 
@@ -46,37 +46,37 @@ This is a Ruby on Rails application that contains:
 
 ### Smart Answers
 
-* [File structure](doc/smart-answers/file-structure.md)
-* [Flow definition](doc/smart-answers/flow-definition.md)
-* [Question types](doc/smart-answers/question-types.md)
-* [Next node rules](doc/smart-answers/next-node-rules.md)
-* [Storing data](doc/smart-answers/storing-data.md)
-* [ERB templates](doc/smart-answers/erb-templates.md)
-  * [Landing page template](doc/smart-answers/erb-templates/landing-page-template.md)
-  * [Question templates](doc/smart-answers/erb-templates/question-templates.md)
-  * [Outcome templates](doc/smart-answers/erb-templates/outcome-templates.md)
+* [File structure](docs/smart-answers/file-structure.md)
+* [Flow definition](docs/smart-answers/flow-definition.md)
+* [Question types](docs/smart-answers/question-types.md)
+* [Next node rules](docs/smart-answers/next-node-rules.md)
+* [Storing data](docs/smart-answers/storing-data.md)
+* [ERB templates](docs/smart-answers/erb-templates.md)
+  * [Landing page template](docs/smart-answers/erb-templates/landing-page-template.md)
+  * [Question templates](docs/smart-answers/erb-templates/question-templates.md)
+  * [Outcome templates](docs/smart-answers/erb-templates/outcome-templates.md)
 
 ### Smart Answer flow development
 
-* [Development principles](doc/smart-answer-flow-development/development-principles.md)
-* [Deploying changes for fact-check](doc/smart-answer-flow-development/fact-check.md)
-* [Flattening outcomes](doc/smart-answer-flow-development/flattening-outcomes.md)
-* [Refactoring existing Smart Answers](doc/smart-answer-flow-development/refactoring.md)
-* [Creating a new Smart Answer](doc/smart-answer-flow-development/creating-a-new-smart-answer.md)
-* [Publishing a Smart Answer](doc/smart-answer-flow-development/publishing.md)
-* [Retiring a Smart Answer](doc/smart-answer-flow-development/retiring-a-smart-answer.md)
-* [Updating worldwide fixture data](doc/smart-answer-flow-development/updating-worldwide-fixture-data.md)
+* [Development principles](docs/smart-answer-flow-development/development-principles.md)
+* [Deploying changes for fact-check](docs/smart-answer-flow-development/fact-check.md)
+* [Flattening outcomes](docs/smart-answer-flow-development/flattening-outcomes.md)
+* [Refactoring existing Smart Answers](docs/smart-answer-flow-development/refactoring.md)
+* [Creating a new Smart Answer](docs/smart-answer-flow-development/creating-a-new-smart-answer.md)
+* [Publishing a Smart Answer](docs/smart-answer-flow-development/publishing.md)
+* [Retiring a Smart Answer](docs/smart-answer-flow-development/retiring-a-smart-answer.md)
+* [Updating worldwide fixture data](docs/smart-answer-flow-development/updating-worldwide-fixture-data.md)
 
 ### Smart Answers app development
 
-* [Testing](doc/smart-answers-app-development/testing.md)
+* [Testing](docs/smart-answers-app-development/testing.md)
 
 ### Debugging
 
-* [Custom Google Analytics accounts and Tracking IDs](doc/debugging/custom-google-analytics-tracking-id.md)
-* [Viewing landing pages and outcomes as Govspeak](doc/debugging/viewing-templates-as-govspeak.md)
-* [Viewing state of a Smart Answer](doc/debugging/viewing-state.md)
-* [Visualising flows](doc/debugging/visualising-flows.md)
+* [Custom Google Analytics accounts and Tracking IDs](docs/debugging/custom-google-analytics-tracking-id.md)
+* [Viewing landing pages and outcomes as Govspeak](docs/debugging/viewing-templates-as-govspeak.md)
+* [Viewing state of a Smart Answer](docs/debugging/viewing-state.md)
+* [Visualising flows](docs/debugging/visualising-flows.md)
 
 ### Registering on GOV.UK
 

--- a/docs/smart-answer-flow-development/creating-a-new-smart-answer.md
+++ b/docs/smart-answer-flow-development/creating-a-new-smart-answer.md
@@ -94,7 +94,7 @@ Open the new landing page template your editor and copy/paste the following cont
 
 Refresh the Smart Answer in your browser to see this new content.
 
-Read more about [landing page templates](/doc/smart-answers/erb-templates/landing-page-template.md).
+Read more about [landing page templates](/docs/smart-answers/erb-templates/landing-page-template.md).
 
 Click "Start now" to visit the first question. You should see an error message indicating that we're now missing an ERB template for our question.
 
@@ -125,7 +125,7 @@ Open the new question page template in your editor and copy/paste the following 
 
 Refresh the Smart Answer in your browser to see this new content.
 
-Read more about [question page templates](/doc/smart-answers/erb-templates/question-templates.md).
+Read more about [question page templates](/docs/smart-answers/erb-templates/question-templates.md).
 
 Enter any value in the text field and click "Continue". You should see an error message indicating that we're now missing an ERB template for the outcome.
 
@@ -156,7 +156,7 @@ Open the new outcome page template in your editor and copy/paste the following c
 
 Refresh the Smart Answer in your browser to see this new content.
 
-Read more about [outcome page templates](/doc/smart-answers/erb-templates/outcome-templates.md).
+Read more about [outcome page templates](/docs/smart-answers/erb-templates/outcome-templates.md).
 
 And that's all there is to an incredibly simple Smart Answer.
 

--- a/docs/smart-answers/flow-definition.md
+++ b/docs/smart-answers/flow-definition.md
@@ -81,7 +81,7 @@ Some flows (e.g. [register-a-birth][local-variable-in-flow-definition]) define l
 
 Every flow has an implicit start node which represents the "landing page" i.e. the page which displays the "Start" button. There is no representation of this start node in the flow definition. Clicking the "Start" button on the "landing page" takes you to the page for the first question node (see below).
 
-Also see the documentation for [landing page templates](/doc/smart-answers/erb-templates/landing-page-template.md).
+Also see the documentation for [landing page templates](/docs/smart-answers/erb-templates/landing-page-template.md).
 
 ### Question nodes
 
@@ -264,7 +264,7 @@ Each of these block types and the point at which they are executed is explained 
   1. A `SmartAnswer::InvalidResponse` exception is raised with the `message_key` set as the exception message.
   2. This exception is handled within the app and prevents the transition to the next node.
   3. The `message_key` from the exception message is set on the built-in state variable, `error`.
-  4. When the question template is re-rendered, the `error` state variable is used to lookup the appropriate validation error message in the [question template](/doc/smart-answers/erb-templates/question-templates.md#error_messagemessage).
+  4. When the question template is re-rendered, the `error` state variable is used to lookup the appropriate validation error message in the [question template](/docs/smart-answers/erb-templates/question-templates.md#error_messagemessage).
 
 > The use of these blocks is encouraged. However, they should call `valid_xxx?` methods on the `calculator` state variable and not rely on the `response` argument passed into the block.
 
@@ -296,7 +296,7 @@ See the [documentation on storing data](storing-data.md).
 
 #### Templates
 
-See the [documentation for question templates](/doc/smart-answers/erb-templates/question-templates.md).
+See the [documentation for question templates](/docs/smart-answers/erb-templates/question-templates.md).
 
 ### Outcome nodes
 
@@ -308,7 +308,7 @@ If any attempt is made to process a response when the current node is an outcome
 
 #### Templates
 
-See the [documentation for outcome templates](/doc/smart-answers/erb-templates/outcome-templates.md).
+See the [documentation for outcome templates](/docs/smart-answers/erb-templates/outcome-templates.md).
 
 [instance-eval]: http://ruby-doc.org/core-2.6.1/BasicObject.html#method-i-instance_eval
 [instance-exec]: http://ruby-doc.org/core-2.6.1/BasicObject.html#method-i-instance_exec


### PR DESCRIPTION
[`\doc` was recently changed to `\docs`](https://github.com/alphagov/smart-answers/commit/5608a0ed738f0399d969fb8b80f04fa6e245d62e). 

This updates internal links to the new folder name.