### PR TITLE
Updated link for translators in Spain

### DIFF
--- a/config/smart_answers/translators.yml
+++ b/config/smart_answers/translators.yml
@@ -60,7 +60,7 @@ san-marino: /government/publications/italy-list-of-lawyers
 serbia: /government/publications/list-of-translators-and-interpreters-in-serbia
 slovakia: /government/publications/slovakia-list-of-lawyers
 slovenia: /government/publications/slovenia-list-of-lawyers
-spain: http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx
+spain: /government/publications/spain-list-of-translators-and-interpreters
 switzerland: /government/publications/switzerland-list-of-lawyers
 the-occupied-palestinian-territories: /government/publications/the-occupied-palestinian-territories-list-of-lawyers
 united-arab-emirates: /government/publications/united-arab-emirates-list-of-lawyers

--- a/test/integration/smart_answer_flows/register_a_birth_test.rb
+++ b/test/integration/smart_answer_flows/register_a_birth_test.rb
@@ -136,7 +136,7 @@ class RegisterABirthTest < ActiveSupport::TestCase
             add_response "in_the_uk"
             assert_equal "spain", current_state.calculator.registration_country
             assert_current_node :oru_result
-            assert_equal "http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx", current_state.calculator.translator_link_url
+            assert_equal "/government/publications/spain-list-of-translators-and-interpreters", current_state.calculator.translator_link_url
           end
         end
       end # married

--- a/test/integration/smart_answer_flows/register_a_death_test.rb
+++ b/test/integration/smart_answer_flows/register_a_death_test.rb
@@ -132,7 +132,7 @@ class RegisterADeathTest < ActiveSupport::TestCase
         end
         should "give the embassy result and be done" do
           assert_current_node :oru_result
-          assert_equal "http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx", current_state.calculator.translator_link_url
+          assert_equal "/government/publications/spain-list-of-translators-and-interpreters", current_state.calculator.translator_link_url
           assert current_state.calculator.document_return_fees.present?
         end
       end # Answer embassy
@@ -142,7 +142,7 @@ class RegisterADeathTest < ActiveSupport::TestCase
         end
         should "give the ORU result and be done" do
           assert_current_node :oru_result
-          assert_equal "http://www.exteriores.gob.es/Portal/en/ServiciosAlCiudadano/Paginas/Traductoresas---Int%C3%A9rpretes-Juradosas.aspx", current_state.calculator.translator_link_url
+          assert_equal "/government/publications/spain-list-of-translators-and-interpreters", current_state.calculator.translator_link_url
         end
       end # Answer ORU
     end # Answer Spain


### PR DESCRIPTION
https://trello.com/c/77MoHCwB/3466-broken-link-on-registering-a-death-smart-tool-for-spain

I've fixed the broken link for translators in Spain.
