### PR TITLE
Reset the GitHub Actions cache for bundler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: vendor/bundle
-          key: bundle-${{ hashFiles('**/Gemfile.lock') }}
+          key: bundle-${{ hashFiles('**/Gemfile.lock') }}-v2
           restore-keys: bundle
 
       - name: Install Ruby dependencies


### PR DESCRIPTION
We seem to have got some invalid state in our cache, and there is no way
to manually clear the cache.  We can only wait for it to expire (takes 7
days), or change the key.

Trying to build this commit with the current cache gives:

    LoadError: libffi.so.6: cannot open shared object file: No such file
    or directory -
    /home/runner/work/govuk-account-manager-prototype/govuk-account-manager-prototype/tmp/bundle/ruby/2.7.0/gems/ffi-1.14.2/lib/ffi_c.so

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
