### PR TITLE
Make link text and numbers more accessible

### DIFF
--- a/lib/smart_answer_flows/find-coronavirus-support/outcomes/_getting_food.erb
+++ b/lib/smart_answer_flows/find-coronavirus-support/outcomes/_getting_food.erb
@@ -36,7 +36,7 @@
   <% end %>
 
   <% if calculator.needs_help_in?("northern_ireland") %>
-    Call the coronavirus Community Helpline for Northern Ireland on [0808 802 0020](tel:+448088020020), email [covid19@adviceni.net](mailto:covid19@adviceni.net) or text ‘ACTION’ to 81025
+    Call the coronavirus Community Helpline for Northern Ireland on 0808 802 0020, email [covid19@adviceni.net](mailto:covid19@adviceni.net) or text ‘ACTION’ to 81025
   <% end %>
 <% end %>
 

--- a/lib/smart_answer_flows/find-coronavirus-support/outcomes/_somewhere_to_live.erb
+++ b/lib/smart_answer_flows/find-coronavirus-support/outcomes/_somewhere_to_live.erb
@@ -12,7 +12,7 @@
   <% end %>
 
   <% if calculator.needs_help_in?("northern_ireland") %>
-    Call the Northern Ireland Housing Executive on [03448 920 908](tel:+443448920908)
+    Call the Northern Ireland Housing Executive on 03448 920 908
   <% end %>
 
   <% if calculator.needs_help_in?("scotland") %>
@@ -42,7 +42,7 @@
   <% end %>
 
   <% if calculator.needs_help_in?("northern_ireland") %>
-    Call the Northern Ireland Housing Executive on [03448 920 908](tel:+443448920908)
+    Call the Northern Ireland Housing Executive on 03448 920 908
   <% end %>
 
   <% if calculator.needs_help_in?("scotland") %>


### PR DESCRIPTION
An accessibility audit showed that we need to make link text more specific and remove number markdown. This is because the links do not make much sense out of context. 

Number markdown is less good for accessibility, plain text is fine. Devices often show numbers as a link anyway. 

https://trello.com/c/eC65z3Om/187-accessibility-smart-answer-make-link-text-specific-on-find-support-results-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
