### PR TITLE
Removed number markdown and improved link text

### DIFF
--- a/lib/smart_answer_flows/find-coronavirus-support/outcomes/_feeling_unsafe.erb
+++ b/lib/smart_answer_flows/find-coronavirus-support/outcomes/_feeling_unsafe.erb
@@ -7,9 +7,9 @@
 
   If you’re in danger and unable to talk on the phone, call 999, then press 55 when prompted.
 
-  Call the National Domestic Abuse Helpline on [0808 2000 247](tel:0808 2000 247), you can get advice in different languages. You can also [get help online](https://www.nationaldahelpline.org.uk/Chat-to-us-online).
+  Call the National Domestic Abuse Helpline on 0808 2000 247, you can get advice in different languages. You can also [get help from the National Domestic Abuse helpline online](https://www.nationaldahelpline.org.uk/Chat-to-us-online).
 
-  If you’re a child or young person call Childline on [0800 1111](tel:0800 1111) or [get help online](https://www.childline.org.uk).
+  If you’re a child or young person call Childline on 0800 1111 or [get help from Childline online](https://www.childline.org.uk).
 
   <% if calculator.needs_help_in?("northern_ireland") %>
     [Get help from Nexus NI](https://nexusni.org/domestic-and-sexual-abuse-24-hour-helpline/).
@@ -27,7 +27,7 @@
 
   [Contact NSPCC if you’re concerned about a child](https://www.nspcc.org.uk/keeping-children-safe/our-services/nspcc-helpline/).
 
-  Call Hourglass, if you're an older person or worried about an older person on [0808 808 8141](tel:0808 808 8141), or [find out what support they offer](https://wearehourglass.org/).
+  Call Hourglass, if you're an older person or worried about an older person on 0808 808 8141, or [find out what support Hourglass offer](https://wearehourglass.org/).
 
   <% if calculator.needs_help_in?("wales") %>
     [Find helplines if you’re an older person (Older People’s Commissioner for Wales)](https://www.olderpeoplewales.com/en/coronavirus.aspx).
@@ -35,13 +35,13 @@
     [Find victim support helplines (this page is in Welsh)](https://www.victimsupport.org.uk/help-and-support/get-help/support-near-you/wales).
   <% end %>
 
-  Call Galop, the LGBT+ helpline on [0800 999 5428](tel:0800 999 5428), or [find out what support they offer](http://www.galop.org.uk/how-we-can-help/).
+  Call Galop, the LGBT+ helpline on 0800 999 5428, or [find out what support Galop offer](http://www.galop.org.uk/how-we-can-help/).
 
-  Call Men’s Advice Line on [0808 8010327](tel:0808 8010327) or [get help online](https://mensadviceline.org.uk/).
+  Call Men’s Advice Line on 0808 801 0327 or [get help from Men’s Advice Line online](https://mensadviceline.org.uk/).
 
-  Call Southall Black Sisters for help for black and minority women, including if you’ve got No Recourse to Public Funds on [0208 571 9595](tel:0208 571 9595). You can get advice in different languages. You can also [find out what support they offer](https://southallblacksisters.org.uk).
+  Call Southall Black Sisters for help for black and minority women, including if you’ve got No Recourse to Public Funds on 0208 571 9595. You can get advice in different languages. You can also [find out what support Southall Black Sisters offer](https://southallblacksisters.org.uk).
 
-  Call [Karma Nirvana](https://karmanirvana.org.uk/help/) for help with honour-based abuse and forced marriage on [0800 5999 247](tel:0800 5999 247).
+  Call [Karma Nirvana](https://karmanirvana.org.uk/help/) for help with honour-based abuse and forced marriage on 0800 5999 247.
 
   [Get specialist support for Deaf people from Signhealth](https://signhealth.org.uk/with-deaf-people/domestic-abuse/domestic-abuse-service).
 


### PR DESCRIPTION
An accessibility audit showed that we need to make link text more specific and remove number markdown. This is because the links do not make much sense out of context.

Number markdown is less good for accessibility, plain text is fine. Devices often show numbers as a link anyway.

https://trello.com/c/eC65z3Om/187-accessibility-smart-answer-make-link-text-specific-on-find-support-results-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
