### PR TITLE
Switch from trackClick to gemTrackClick script

### DIFF
--- a/app/views/smart_answers/_previous_answer.html.erb
+++ b/app/views/smart_answers/_previous_answer.html.erb
@@ -15,7 +15,7 @@
     <%= link_to question_link,
       class: "govuk-link",
       data: {
-        "module": "track-click",
+        "module": "gem-track-click",
         "track-category": "Smart Answer Change Link",
         "track-action":  "Link clicked",
         "track-label": "#{question.title} / #{question.response_label(accepted_response)}"

--- a/app/views/smart_answers/_previous_answers.html.erb
+++ b/app/views/smart_answers/_previous_answers.html.erb
@@ -22,7 +22,7 @@
         restart_flow_path(@presenter),
         :class => "govuk-link",
         :data => {
-          module: "track-click",
+          module: "gem-track-click",
           "track-action": "Start again",
           "track-category": "StartAgain",
           "track-label": @presenter.current_node.title


### PR DESCRIPTION
### What

Switch from using `trackClick` script to `gemTrackClick` script. They are virtually the same, the latter being [copied over from `static` to `govuk_publishing_components`](https://github.com/alphagov/govuk_publishing_components/pull/1751).

### Why

Part of [a bigger piece of work](https://github.com/alphagov/static/pull/2405) to reduce the size of assets served to users and keep our codebase to a minimum.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
