### PR TITLE
Removed old furlough date

### DIFF
--- a/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/outcomes/results.erb
@@ -21,8 +21,6 @@
 
     You must submit your claim by:
 
-    - 15 February 2021, for eligible employees on furlough in January 2021
-
     - 15 March 2021, for eligible employees on furlough in February 2021
 
     - 14 April 2021, for eligible employees on furlough in March 2021


### PR DESCRIPTION
https://trello.com/c/T4dpfk0W/184-remove-old-furlough-information

Removed 15 Feb date

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
