### PR TITLE
Extend HMRC C-19 late payment penalties to 1st Apr

### DIFF
--- a/lib/smart_answer/calculators/self_assessment_penalties.rb
+++ b/lib/smart_answer/calculators/self_assessment_penalties.rb
@@ -153,6 +153,10 @@ module SmartAnswer::Calculators
       tax_year == "2019-20" ? payment_date - 1.day : payment_date - 2.days
     end
 
+    def first_late_payment_days
+      tax_year == "2019-20" ? 60 : 30
+    end
+
     def total_owed
       SmartAnswer::Money.new((estimated_bill.value + interest.to_f + late_payment_penalty.to_f).floor)
     end
@@ -162,7 +166,7 @@ module SmartAnswer::Calculators
     end
 
     def late_payment_penalty
-      if overdue_payment_days <= 30
+      if overdue_payment_days <= first_late_payment_days
         0
       elsif overdue_payment_days <= 181
         SmartAnswer::Money.new(late_payment_penalty_part.round(2))

--- a/test/unit/calculators/self_assessment_penalties_test.rb
+++ b/test/unit/calculators/self_assessment_penalties_test.rb
@@ -3,42 +3,11 @@ require_relative "../../test_helper"
 module SmartAnswer::Calculators
   class SelfAssessmentPenaltiesTest < ActiveSupport::TestCase
     def setup
-      test_calculator_dates = {
-        online_filing_deadline: {
-          "2013-14": Date.new(2015, 1, 31),
-          "2014-15": Date.new(2016, 1, 31),
-          "2015-16": Date.new(2017, 1, 31),
-          "2016-17": Date.new(2018, 1, 31),
-          "2017-18": Date.new(2019, 1, 31),
-          "2018-19": Date.new(2020, 1, 31),
-          "2019-20": Date.new(2021, 2, 28),
-        },
-        offline_filing_deadline: {
-          "2013-14": Date.new(2014, 10, 31),
-          "2014-15": Date.new(2015, 10, 31),
-          "2015-16": Date.new(2016, 10, 31),
-          "2016-17": Date.new(2017, 10, 31),
-          "2017-18": Date.new(2018, 10, 31),
-          "2018-19": Date.new(2019, 10, 31),
-          "2019-20": Date.new(2020, 10, 31),
-        },
-        payment_deadline: {
-          "2013-14": Date.new(2015, 1, 31),
-          "2014-15": Date.new(2016, 1, 31),
-          "2015-16": Date.new(2017, 1, 31),
-          "2016-17": Date.new(2018, 1, 31),
-          "2017-18": Date.new(2019, 1, 31),
-          "2018-19": Date.new(2020, 1, 31),
-          "2019-20": Date.new(2021, 1, 31),
-        },
-      }
-
       @calculator = SelfAssessmentPenalties.new(
         submission_method: "online",
         filing_date: Date.parse("2015-01-10"),
         payment_date: Date.parse("2015-03-10"),
         estimated_bill: SmartAnswer::Money.new(5000),
-        dates: test_calculator_dates,
         tax_year: "2013-14",
       )
     end


### PR DESCRIPTION
## What

Currently, the trigger date for self assessment late payment penalties
for 2019-20 is 2 March. Because of coronavirus, HMRC have decided to
extend it to 1 April. This means we need to change the calculation
formula, so that users inputting a date between 2 March and 1 April
don't have a late payment penalty listed on their outcome.

## Why

If we don't do this there's a risk that some users will think they need
to pay a late penalty payment when they don't. The late payment penalties
are quite a lot of money, so this could cause unnecessary stress for
users at a time when many may already be having financial problems. There's
also a reputational risk to HMRC and GOV.UK, and a risk to our relationship
with HMRC.

[Trello](https://trello.com/c/qcuggKKf/2072-content-change-in-self-assessment-penalty-calculator)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
