### PR TITLE
Simplify the rateable business property question

### DIFF
--- a/lib/smart_answer/calculators/business_coronavirus_support_finder_calculator.rb
+++ b/lib/smart_answer/calculators/business_coronavirus_support_finder_calculator.rb
@@ -26,12 +26,12 @@ module SmartAnswer::Calculators
       },
       retail_hospitality_leisure_business_rates: lambda { |calculator|
         calculator.business_based == "england" &&
-          calculator.non_domestic_property != "none" &&
+          calculator.non_domestic_property != "no" &&
           calculator.sectors.include?("retail_hospitality_or_leisure")
       },
       nursery_support: lambda { |calculator|
         calculator.business_based == "england" &&
-          calculator.non_domestic_property != "none" &&
+          calculator.non_domestic_property != "no" &&
           calculator.sectors.include?("nurseries")
       },
       business_loan_scheme: lambda { |calculator|

--- a/lib/smart_answer_flows/business-coronavirus-support-finder.rb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder.rb
@@ -64,9 +64,9 @@ module SmartAnswer
       end
 
       radio :non_domestic_property? do
-        option :none
-        option :under_51k
-        option :"51k_and_over"
+        option :yes
+        option :no
+        option :not_sure
 
         on_response do |response|
           calculator.non_domestic_property = response

--- a/lib/smart_answer_flows/business-coronavirus-support-finder/questions/non_domestic_property.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/questions/non_domestic_property.erb
@@ -1,5 +1,5 @@
 <% text_for :title do %>
-  What is the rateable value of your business' non-domestic property?
+  Does your business have any rateable non-domestic property?
 <% end %>
 
 <% text_for :hint do %>
@@ -7,7 +7,7 @@
 <% end %>
 
 <% options(
-  "none": "My business does not have any non-domestic property",
-  "under_51k": "Under £51,000",
-  "51k_and_over": "£51,000 and over",
+  "yes": "Yes",
+  "no": "No",
+  "not_sure": "Not sure",
 ) %>

--- a/spec/features/smart_answer/business_coronavirus_support_finder_flow_spec.rb
+++ b/spec/features/smart_answer/business_coronavirus_support_finder_flow_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "SmartAnswer::BusinessCoronavirusSupportFinderFlow", type: :featur
       annual_turnover: "What is your annual turnover?",
       business_based: "Where is your business based?",
       business_size: "How many employees does your business have?",
-      non_domestic_property: "What is the rateable value of your business' non-domestic property?",
+      non_domestic_property: "Does your business have any rateable non-domestic property?",
       paye_scheme: "Are you an employer with a PAYE scheme?",
       sectors: "Select your type of business",
       self_assessment_july_2020: "Are you due to pay a Self Assessment payment on account by 31 July 2020?",
@@ -25,7 +25,7 @@ RSpec.feature "SmartAnswer::BusinessCoronavirusSupportFinderFlow", type: :featur
       no: "No",
       employees: "0 to 249 employees",
       turnover: "Under £85,000",
-      property: "Under £51,000",
+      property: "Yes",
       non_adult: "Nurseries",
       adult: "Nightclub, dancehall, or adult entertainment venue",
     }

--- a/test/unit/calculators/business_coronavirus_support_calculator_test.rb
+++ b/test/unit/calculators/business_coronavirus_support_calculator_test.rb
@@ -64,7 +64,7 @@ module SmartAnswer::Calculators
       context "retail_hospitality_leisure_business_rates" do
         setup do
           @calculator.business_based = "england"
-          @calculator.non_domestic_property = "51k_and_over"
+          @calculator.non_domestic_property = "yes"
           @calculator.sectors = %w[retail_hospitality_or_leisure]
         end
 
@@ -78,7 +78,7 @@ module SmartAnswer::Calculators
         end
 
         should "return false when no non-domestic property" do
-          @calculator.non_domestic_property = "none"
+          @calculator.non_domestic_property = "no"
           assert_not @calculator.show?(:retail_hospitality_leisure_business_rates)
         end
 
@@ -91,7 +91,7 @@ module SmartAnswer::Calculators
       context "nursery_support" do
         setup do
           @calculator.business_based = "england"
-          @calculator.non_domestic_property = "under_51k"
+          @calculator.non_domestic_property = "yes"
           @calculator.sectors = %w[nurseries]
         end
 
@@ -104,8 +104,8 @@ module SmartAnswer::Calculators
           assert_not @calculator.show?(:nursery_support)
         end
 
-        should "return false when no non-domestic property" do
-          @calculator.non_domestic_property = "none"
+        should "return false when not a non-domestic property" do
+          @calculator.non_domestic_property = "no"
           assert_not @calculator.show?(:nursery_support)
         end
 


### PR DESCRIPTION
[Trello](https://trello.com/c/asQsJdKh/182-simplify-the-rateable-business-property-question)

- Simplifies the `What is the rateable value of your business' non-domestic property?` question
to `Does your business have any rateable non-domestic property?`.

- Updates the radio button options to be: "Yes", "No", "Not sure".

- The reason for this is that this question is used to display the `Business rates holiday for retail, hospitality and leisure` and the `Support for nursery businesses that pay business rates` schemes.

- These schemes don't require knowing specifically what the property value is. We previously had a scheme that did, but that has been removed.

- We also found that some users are not familiar with 'rateable non-domestic property value'. Therefore, adding a "not sure" option aims to help them progress and reduce drop off.

### Before

<img width="726" alt="smart-answers-before" src="https://user-images.githubusercontent.com/5963488/109039512-c5da0780-76c4-11eb-8f86-88b4716a914a.png">


### After
<img width="729" alt="smart-answers-after" src="https://user-images.githubusercontent.com/5963488/109039525-ca9ebb80-76c4-11eb-99ae-6d87eb7fbd08.png">



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
