### PR TITLE
Accessibility fix for hide this page

### DIFF
--- a/app/controllers/session_answers_controller.rb
+++ b/app/controllers/session_answers_controller.rb
@@ -26,7 +26,7 @@ class SessionAnswersController < ApplicationController
     session_store.clear
 
     if params[:ext_r] == "true"
-      redirect_to "https://bbc.co.uk/news"
+      redirect_to "https://www.bbc.co.uk/weather"
     else
       redirect_to "/#{params[:id]}"
     end

--- a/app/views/smart_answers/shared/_escape-link.html.erb
+++ b/app/views/smart_answers/shared/_escape-link.html.erb
@@ -2,4 +2,13 @@
   data_attributes ||= {}
   data_attributes[:module] = 'app-escape-link'
 %>
-<%= link_to "Leave this site", destroy_session_flow_path(ext_r: "true"), class: "app-c-escape-link govuk-link", rel: "nofollow noreferrer noopener", target: "_blank", data: data_attributes %>
+<%= link_to("Hide this page",
+  destroy_session_flow_path(ext_r: "true"),
+  class: "app-c-escape-link govuk-link",
+  rel: "nofollow noreferrer noopener",
+  target: "_blank",
+  data: data_attributes,
+  aria: {
+    label: "Hide this page. Quick exit button, it opens BBC Weather in a new tab"
+  }
+) %>

--- a/test/controllers/session_answers_controller_test.rb
+++ b/test/controllers/session_answers_controller_test.rb
@@ -97,7 +97,7 @@ class SessionAnswersControllerTest < ActionDispatch::IntegrationTest
 
     should "redirect to external sitewhen the ext_r option is present and true" do
       get destroy_session_flow_path(id: flow_name, ext_r: "true")
-      assert_redirected_to "https://bbc.co.uk/news"
+      assert_redirected_to "https://www.bbc.co.uk/weather"
     end
 
     should "remove the session data for the flow when escaping" do


### PR DESCRIPTION
## What

The leave this site button does not properly explain what it does, so it could be more accessible for people using screen readers

We need to design the content for what this says, so that we can make sure people get the right idea of what is happening. 

See page 15 of the report - https://drive.google.com/drive/folders/13sklGDeiQv95CFXFglXZ_ka-NpOK5cGL

Also look at the discussion on the component in the design system

## Why

So people with accessibility needs can use the button 

## Standard used

https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA8.html

## Demo

https://smart-answer-accessibil-jeb3no.herokuapp.com/find-coronavirus-support/s/need-help-with

## Tested with Assistive Labs

Reads out:
```
Quick exit button, it opens BBC Weather in a new tab  link
```

## Dev work - Content change

Button content: 

Change from:
Leave this site

To:
Hide this page

Add hidden screen reader text:
Quick exit button, it opens BBC Weather in a new tab

Change link to: 
BBC Weather - https://www.bbc.co.uk/weather

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

 https://trello.com/c/FGFqviB4/180-accessibility-smart-answer-fix-the-leave-this-site-link-purpose