### PR TITLE
Rename SessionAnswersController to FlowController

### DIFF
--- a/app/controllers/flow_controller.rb
+++ b/app/controllers/flow_controller.rb
@@ -1,9 +1,9 @@
-class SessionAnswersController < ApplicationController
+class FlowController < ApplicationController
   before_action :set_cache_headers
 
   def start
     session_store.clear
-    redirect_to session_flow_path(id: params[:id], node_slug: next_node_slug)
+    redirect_to flow_path(id: params[:id], node_slug: next_node_slug)
   end
 
   def show
@@ -13,13 +13,13 @@ class SessionAnswersController < ApplicationController
     if params[:node_slug] == presenter.node_slug
       render "smart_answers/#{page_type}", formats: [:html]
     else
-      redirect_to session_flow_path(id: params[:id], node_slug: presenter.node_slug)
+      redirect_to flow_path(id: params[:id], node_slug: presenter.node_slug)
     end
   end
 
   def update
     session_store.add_response(params[:response])
-    redirect_to session_flow_path(id: params[:id], node_slug: next_node_slug)
+    redirect_to flow_path(id: params[:id], node_slug: next_node_slug)
   end
 
   def destroy

--- a/app/helpers/current_question_helper.rb
+++ b/app/helpers/current_question_helper.rb
@@ -1,7 +1,7 @@
 module CurrentQuestionHelper
   def current_question_path(presenter)
     if presenter.use_session?
-      session_answers_question_path(presenter)
+      flow_question_path(presenter)
     else
       smart_answers_question_path(presenter)
     end
@@ -13,14 +13,14 @@ module CurrentQuestionHelper
     smart_answer_path(attrs)
   end
 
-  def session_answers_question_path(presenter)
+  def flow_question_path(presenter)
     node_name = presenter.current_state.current_node.to_s
-    update_session_flow_path(id: params[:id], node_slug: node_name.dasherize)
+    update_flow_path(id: params[:id], node_slug: node_name.dasherize)
   end
 
   def restart_flow_path(presenter)
     if presenter.use_session?
-      destroy_session_flow_path(presenter.name)
+      destroy_flow_path(presenter.name)
     else
       smart_answer_path(presenter.name)
     end

--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -96,7 +96,7 @@ class FlowPresenter
 
   def change_collapsed_question_link(question_number, question)
     if use_session?
-      session_flow_path(params[:id], node_slug: question.node_slug)
+      flow_path(params[:id], node_slug: question.node_slug)
     else
       smart_answer_path(
         id: @params[:id],
@@ -140,7 +140,7 @@ class FlowPresenter
 
   def start_page_link
     if use_session?
-      start_session_flow_path(name)
+      start_flow_path(name)
     else
       smart_answer_path(name, started: "y")
     end

--- a/app/views/smart_answers/shared/_escape-link.html.erb
+++ b/app/views/smart_answers/shared/_escape-link.html.erb
@@ -3,7 +3,7 @@
   data_attributes[:module] = 'app-escape-link'
 %>
 <%= link_to("Hide this page",
-  destroy_session_flow_path(ext_r: "true"),
+  destroy_flow_path(ext_r: "true"),
   class: "app-c-escape-link govuk-link",
   rel: "nofollow noreferrer noopener",
   target: "_blank",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,8 +15,8 @@ Rails.application.routes.draw do
         format: false
   end
 
-  get "/:id/s/destroy_session", to: "session_answers#destroy", as: :destroy_session_flow
-  get "/:id/s", to: "session_answers#start", as: :start_session_flow
-  get "/:id/s/:node_slug", to: "session_answers#show", as: :session_flow
-  get "/:id/s/:node_slug/next", to: "session_answers#update", as: :update_session_flow
+  get "/:id/s/destroy_session", to: "flow#destroy", as: :destroy_flow
+  get "/:id/s", to: "flow#start", as: :start_flow
+  get "/:id/s/:node_slug", to: "flow#show", as: :flow
+  get "/:id/s/:node_slug/next", to: "flow#update", as: :update_flow
 end

--- a/test/controllers/flow_controller_test.rb
+++ b/test/controllers/flow_controller_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class SessionAnswersControllerTest < ActionDispatch::IntegrationTest
+class FlowControllerTest < ActionDispatch::IntegrationTest
   def flow_name
     :find_coronavirus_support
   end
@@ -22,17 +22,17 @@ class SessionAnswersControllerTest < ActionDispatch::IntegrationTest
 
   context "GET /:id/s" do
     setup do
-      get start_session_flow_path(flow_name)
+      get start_flow_path(flow_name)
     end
 
     should "redirect to show first node" do
-      assert_redirected_to(session_flow_path(id: flow_name, node_slug: nodes[0]))
+      assert_redirected_to(flow_path(id: flow_name, node_slug: nodes[0]))
     end
   end
 
   context "GET /:id/s/:node_slug" do
     setup do
-      get session_flow_path(id: flow_name, node_slug: nodes[0])
+      get flow_path(id: flow_name, node_slug: nodes[0])
     end
 
     should "be successful" do
@@ -51,11 +51,11 @@ class SessionAnswersControllerTest < ActionDispatch::IntegrationTest
 
   context "GET /:id/s/:node_slug with later slug" do
     setup do
-      get session_flow_path(id: flow_name, node_slug: nodes[1])
+      get flow_path(id: flow_name, node_slug: nodes[1])
     end
 
     should "redirect later node to earlier node if session data not present" do
-      assert_redirected_to(session_flow_path(id: flow_name, node_slug: nodes[0]))
+      assert_redirected_to(flow_path(id: flow_name, node_slug: nodes[0]))
     end
   end
 
@@ -65,23 +65,23 @@ class SessionAnswersControllerTest < ActionDispatch::IntegrationTest
 
   context "GET /:id/s/:node_slug/next" do
     should "redirect to next node" do
-      get update_session_flow_path(id: flow_name, node_slug: nodes[0]), params: params
-      assert_redirected_to(session_flow_path(id: flow_name, node_slug: nodes[1]))
+      get update_flow_path(id: flow_name, node_slug: nodes[0]), params: params
+      assert_redirected_to(flow_path(id: flow_name, node_slug: nodes[1]))
     end
 
     should "updates session" do
       session_store.expects(:add_response).with(params["response"])
-      get update_session_flow_path(id: flow_name, node_slug: nodes[0]), params: params
+      get update_flow_path(id: flow_name, node_slug: nodes[0]), params: params
     end
   end
 
   context "GET /:id/s/:node_slug/next with error submission" do
     setup do
-      get update_session_flow_path(id: flow_name, node_slug: nodes[0]), params: { "response" => [], "next" => "1" }
+      get update_flow_path(id: flow_name, node_slug: nodes[0]), params: { "response" => [], "next" => "1" }
     end
 
     should "redirect back to show" do
-      assert_redirected_to(session_flow_path(id: flow_name, node_slug: nodes[0]))
+      assert_redirected_to(flow_path(id: flow_name, node_slug: nodes[0]))
     end
 
     should "display error" do
@@ -92,32 +92,32 @@ class SessionAnswersControllerTest < ActionDispatch::IntegrationTest
 
   context "GET /:id/s/destroy_session" do
     setup do
-      get update_session_flow_path(id: flow_name, node_slug: nodes[0]), params: params
+      get update_flow_path(id: flow_name, node_slug: nodes[0]), params: params
     end
 
     should "redirect to external sitewhen the ext_r option is present and true" do
-      get destroy_session_flow_path(id: flow_name, ext_r: "true")
+      get destroy_flow_path(id: flow_name, ext_r: "true")
       assert_redirected_to "https://www.bbc.co.uk/weather"
     end
 
     should "remove the session data for the flow when escaping" do
       session_store.expects(:clear)
-      get destroy_session_flow_path(id: flow_name, ext_r: "true")
+      get destroy_flow_path(id: flow_name, ext_r: "true")
     end
 
     should "redirect to external sitewhen the ext_r option is present and false" do
-      get destroy_session_flow_path(id: flow_name, ext_r: "false")
+      get destroy_flow_path(id: flow_name, ext_r: "false")
       assert_redirected_to "/#{flow_name}"
     end
 
     should "redirect to external sitewhen the ext_r option is not present" do
-      get destroy_session_flow_path(id: flow_name)
+      get destroy_flow_path(id: flow_name)
       assert_redirected_to "/#{flow_name}"
     end
 
     should "remove the session data for the flow when not escaping" do
       session_store.expects(:clear)
-      get destroy_session_flow_path(id: flow_name)
+      get destroy_flow_path(id: flow_name)
     end
   end
 end

--- a/test/helpers/current_question_helper_test.rb
+++ b/test/helpers/current_question_helper_test.rb
@@ -7,7 +7,7 @@ class CurrentQuestionHelperTest < ActionView::TestCase
     end
 
     should "return link to session answer when flow uses sessions" do
-      assert_equal update_session_flow_path(flow_name, node_name.dasherize), current_question_path(session_presenter)
+      assert_equal update_flow_path(flow_name, node_name.dasherize), current_question_path(session_presenter)
     end
   end
 
@@ -17,7 +17,7 @@ class CurrentQuestionHelperTest < ActionView::TestCase
     end
 
     should "return root smart answer path for session answer" do
-      assert_equal destroy_session_flow_path(flow_name), restart_flow_path(session_presenter)
+      assert_equal destroy_flow_path(flow_name), restart_flow_path(session_presenter)
     end
   end
 

--- a/test/integration/revisit_page_test.rb
+++ b/test/integration/revisit_page_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 GovukTest.configure
 
-class SessionAnswersTest < ActionDispatch::SystemTestCase
+class RevisitPageTest < ActionDispatch::SystemTestCase
   setup do
     Capybara.current_driver = :headless_chrome
   end

--- a/test/unit/flow_presenter_test.rb
+++ b/test/unit/flow_presenter_test.rb
@@ -125,7 +125,7 @@ class FlowPresenterTest < ActiveSupport::TestCase
       flow_presenter = FlowPresenter.new(params, flow)
       question = OpenStruct.new(node_slug: "foo")
       assert_equal(
-        flow_presenter.session_flow_path(name, question.node_slug),
+        flow_presenter.flow_path(name, question.node_slug),
         flow_presenter.change_collapsed_question_link(1, question),
       )
     end


### PR DESCRIPTION
The naming "SessionAnswers" is somewhat confusing as it's used uniquely here and isn't defined anywhere. It originally was named this to represent a SmartAnswer that used session for handling user responses. However this controller will in future not only support sessions, but also query string. This generalises the name and uses terminology we have defined.

[Trello card](https://trello.com/c/42XuYGir)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
