### PR TITLE
Allow redirect type and segments_mode in unpublish redirects

### DIFF
--- a/docs/smart-answer-flow-development/retiring-a-smart-answer.md
+++ b/docs/smart-answer-flow-development/retiring-a-smart-answer.md
@@ -39,7 +39,7 @@ To send visitors to the Smart Answer to a new page you can run the
 to a new destination, `/random`, you'd run the following rake tasks:
 
 ```
-bundle exec rake "publishing_api:unpublish_redirect[<start_page_content_id>,<start_page_path>,/random]"
+bundle exec rake "publishing_api:unpublish_redirect[<start_page_content_id>,<start_page_path>,/random,exact]"
 bundle exec rake "publishing_api:unpublish_redirect[<flow_page_content_id>,<flow_page_path>,/random]"
 ```
 
@@ -47,7 +47,7 @@ Applying this to the [Marriage Abroad](../../lib/smart_answer_flows/marriage-abr
 Smart Answer you'd run the following commands:
 
 ```
-bundle exec rake "publishing_api:unpublish_redirect[d0a95767-f6ab-432a-aebc-096e37fb3039,/marriage-abroad,/random]"
+bundle exec rake "publishing_api:unpublish_redirect[d0a95767-f6ab-432a-aebc-096e37fb3039,/marriage-abroad,/random,exact]"
 bundle exec rake "publishing_api:unpublish_redirect[92c0a193-3b3b-4378-ba43-279e7274b7e7,/marriage-abroad/y,/random]"
 ```
 

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -16,12 +16,19 @@ namespace :publishing_api do
   end
 
   desc "Unpublish a content item with a redirect"
-  task :unpublish_redirect, %i[content_id base_path destination] => :environment do |_, args|
+  task :unpublish_redirect, %i[content_id base_path destination type] => :environment do |_, args|
     raise "Missing content_id parameter" if args.content_id.blank?
     raise "Missing base_path parameter" if args.base_path.blank?
     raise "Missing destination parameter" if args.destination.blank?
 
-    redirect = { path: args.base_path, type: "prefix", destination: args.destination }
+    type = args.type || "prefix"
+
+    redirect = {
+      path: args.base_path,
+      segments_mode: "ignore",
+      type: type,
+      destination: args.destination,
+    }
     GdsApi.publishing_api.unpublish(
       args.content_id,
       type: "redirect",

--- a/test/unit/tasks/publishing_api_rake_test.rb
+++ b/test/unit/tasks/publishing_api_rake_test.rb
@@ -38,12 +38,29 @@ class PublishingApiRakeTest < ActiveSupport::TestCase
         "content-id",
         body: { type: "redirect",
                 redirects: [{ path: "/base-path",
+                              segments_mode: "ignore",
                               type: "prefix",
                               destination: "/new-destination" }] },
       )
 
       Rake::Task["publishing_api:unpublish_redirect"]
         .invoke("content-id", "/base-path", "/new-destination")
+      assert_requested unpublish_request
+    end
+
+    should "allow specifying the redirect type as a parameter" do
+      WebMock.reset!
+      unpublish_request = stub_publishing_api_unpublish(
+        "content-id",
+        body: { type: "redirect",
+                redirects: [{ path: "/base-path",
+                              segments_mode: "ignore",
+                              type: "exact",
+                              destination: "/new-destination" }] },
+      )
+
+      Rake::Task["publishing_api:unpublish_redirect"]
+        .invoke("content-id", "/base-path", "/new-destination", "exact")
       assert_requested unpublish_request
     end
   end


### PR DESCRIPTION
Trello: https://trello.com/c/kjtIlrE8/631-bs-smart-answer-set-up-a-prefix-redirect

By default Publishing API redirects will have a segments_mode of
"preserve". This means that, for a prefix route of /item-a, to /item-b
that a request of /item-a/a/b/c will redirect to /item-b/a/b/c. This is
rarely what we want as Smart Answers typically have a lot of potential
segments. To resolve this segments_mode is set to "ignore".

I also noticed that the two routes registered for Smart Answers are
different types, there is an exact route for a start page and a prefix
route for a flow page. To allow these to be accurately redirected I've
added a type parameter and updated the examples to use "exact" for start
pages.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
