### PR TITLE
Set the unpublish tasks to discard drafts

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -33,6 +33,7 @@ namespace :publishing_api do
       args.content_id,
       type: "redirect",
       redirects: [redirect],
+      discard_drafts: true,
     )
   end
 
@@ -40,14 +41,14 @@ namespace :publishing_api do
   task :unpublish_gone, [:content_id] => :environment do |_, args|
     raise "Missing content_id parameter" unless args.content_id
 
-    GdsApi.publishing_api.unpublish(args.content_id, type: "gone")
+    GdsApi.publishing_api.unpublish(args.content_id, type: "gone", discard_drafts: true)
   end
 
   desc "Unpublish a content item with a type of vanish"
   task :unpublish_vanish, [:content_id] => :environment do |_, args|
     raise "Missing content_id parameter" unless args.content_id
 
-    GdsApi.publishing_api.unpublish(args.content_id, type: "vanish")
+    GdsApi.publishing_api.unpublish(args.content_id, type: "vanish", discard_drafts: true)
   end
 
   desc "Change publishing application"

--- a/test/unit/tasks/publishing_api_rake_test.rb
+++ b/test/unit/tasks/publishing_api_rake_test.rb
@@ -37,6 +37,7 @@ class PublishingApiRakeTest < ActiveSupport::TestCase
       unpublish_request = stub_publishing_api_unpublish(
         "content-id",
         body: { type: "redirect",
+                discard_drafts: true,
                 redirects: [{ path: "/base-path",
                               segments_mode: "ignore",
                               type: "prefix",
@@ -53,6 +54,7 @@ class PublishingApiRakeTest < ActiveSupport::TestCase
       unpublish_request = stub_publishing_api_unpublish(
         "content-id",
         body: { type: "redirect",
+                discard_drafts: true,
                 redirects: [{ path: "/base-path",
                               segments_mode: "ignore",
                               type: "exact",
@@ -81,7 +83,7 @@ class PublishingApiRakeTest < ActiveSupport::TestCase
     should "send an unpublishing of type gone to the Publishing API" do
       unpublish_request = stub_publishing_api_unpublish(
         "content-id",
-        body: { type: "gone" },
+        body: { type: "gone", discard_drafts: true },
       )
 
       Rake::Task["publishing_api:unpublish_gone"].invoke("content-id")
@@ -105,7 +107,7 @@ class PublishingApiRakeTest < ActiveSupport::TestCase
     should "send an unpublishing of type vanish to the Publishing API" do
       unpublish_request = stub_publishing_api_unpublish(
         "content-id",
-        body: { type: "vanish" },
+        body: { type: "vanish", discard_drafts: true },
       )
 
       Rake::Task["publishing_api:unpublish_vanish"].invoke("content-id")


### PR DESCRIPTION
Trello: https://trello.com/c/kjtIlrE8/212-bs-smart-answer-set-up-a-prefix-redirect

By default the Publishing API will refuse to update the unpublishing of
content which has a draft. This can be problematic if we've temporarily
taken a Smart Answer offline and marked it as a draft.

This can be resolved by telling the Publishing API that we don't mind
them discarding the draft. This feature is normally in place so editors
draft work isn't lost, however since the draft is all part of this repo
we don't need to precious about it.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
