### PR TITLE
Update documentation on question templates

### DIFF
--- a/docs/smart-answers/erb-templates/question-templates.md
+++ b/docs/smart-answers/erb-templates/question-templates.md
@@ -18,11 +18,16 @@ Used as the h1 heading and can only be text. Example:
 
 ### `:hint`
 
-Used as a "hint" paragraph and can only be text. Example:
+Used as a "hint" paragraph and can be text. For money and radio questions you can
+also use govspeak or HTML. Example:
 
 ```erb
-<% text_for :hint do %>
-  The values represent % by weight
+<% govspeak_for :hint do %>
+  Examples of some fruit:
+
+  - apple
+  - orange
+  - banana
 <% end %>
 ```
 


### PR DESCRIPTION
As part of the work in https://github.com/alphagov/smart-answers/pull/4762
we allow the `hint` component to render markdown, so that guidance
that is more than a line of text can be included.

Trello card: https://trello.com/c/zkSrev8n/2325-updates-to-the-child-benefit-tax-calculator-in-smart-answers

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
