### PR TITLE
Fix incorrect text in question hint

### DIFF
--- a/lib/smart_answer_flows/child-benefit-tax-calculator/questions/allowable_deductions.erb
+++ b/lib/smart_answer_flows/child-benefit-tax-calculator/questions/allowable_deductions.erb
@@ -9,7 +9,7 @@
   - pension contributions not paid from your salary (the amount you actually paid, not the grossed-up amount)
   - gift aid donations
 
-  Do not include deductions from cycle scheme or Gift Aid donations.
+  Do not include deductions from cycle scheme or retirement annuity contracts.
 
   If you are not sure whether something is an allowable deduction, [contact the Income Tax Helpline](/government/organisations/hm-revenue-customs/contact/income-tax-enquiries-for-individuals-pensioners-and-employees).
 <% end %>


### PR DESCRIPTION
Deductions in the child benefit tax calculator need to be spilt based on 
whether they are grossed up or not. 

We accidently stated that gift aid should not be included in a question 
where it should be included. This fixes the text to state that 
retirement annuities should be excluded rather than gift aid.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
