### PR TITLE
Add ability to specify custom view template

### DIFF
--- a/app/controllers/flow_controller.rb
+++ b/app/controllers/flow_controller.rb
@@ -11,7 +11,7 @@ class FlowController < ApplicationController
     @content_item = ContentItemRetriever.fetch(name) if presenter.finished?
 
     if params[:node_slug] == presenter.node_slug
-      render "smart_answers/#{page_type}", formats: [:html]
+      render page_type, formats: [:html]
     else
       redirect_to flow_path(id: params[:id], node_slug: presenter.node_slug)
     end
@@ -66,10 +66,9 @@ private
   end
 
   def page_type
-    return :landing if node_name.blank?
-    return :result if presenter.finished?
+    return "smart_answers/landing" if node_name.blank?
 
-    :question
+    presenter.current_node.view_template_path
   end
   helper_method :page_type
 

--- a/app/controllers/flow_controller.rb
+++ b/app/controllers/flow_controller.rb
@@ -11,7 +11,7 @@ class FlowController < ApplicationController
     @content_item = ContentItemRetriever.fetch(name) if presenter.finished?
 
     if params[:node_slug] == presenter.node_slug
-      render page_type, formats: [:html]
+      render presenter.current_node.view_template_path, formats: [:html]
     else
       redirect_to flow_path(id: params[:id], node_slug: presenter.node_slug)
     end
@@ -64,13 +64,6 @@ private
   def node_name
     @node_name ||= params[:node_slug].underscore if params[:node_slug].present?
   end
-
-  def page_type
-    return "smart_answers/landing" if node_name.blank?
-
-    presenter.current_node.view_template_path
-  end
-  helper_method :page_type
 
   def next_node_slug
     presenter.current_state.current_node.to_s.dasherize

--- a/app/presenters/node_presenter.rb
+++ b/app/presenters/node_presenter.rb
@@ -14,4 +14,8 @@ class NodePresenter
   def node_slug
     node_name.to_s.dasherize
   end
+
+  def view_template_path
+    @node.view_template_path
+  end
 end

--- a/app/presenters/outcome_presenter.rb
+++ b/app/presenters/outcome_presenter.rb
@@ -34,4 +34,8 @@ class OutcomePresenter < NodePresenter
   def next_steps
     @renderer.content_for(:next_steps)
   end
+
+  def view_template_path
+    @node.view_template_path || "smart_answers/result"
+  end
 end

--- a/app/presenters/question_presenter.rb
+++ b/app/presenters/question_presenter.rb
@@ -88,4 +88,8 @@ class QuestionPresenter < NodePresenter
   def default_error_message
     "Please answer this question"
   end
+
+  def view_template_path
+    "smart_answers/question"
+  end
 end

--- a/lib/smart_answer/node.rb
+++ b/lib/smart_answer/node.rb
@@ -3,7 +3,7 @@ require "active_support/inflector"
 module SmartAnswer
   class Node
     attr_accessor :flow
-    attr_reader :name
+    attr_reader :name, :view_template_path
 
     def initialize(flow, name, &block)
       @flow = flow
@@ -39,6 +39,10 @@ module SmartAnswer
 
     def flow_name
       @flow.name
+    end
+
+    def view_template(path)
+      @view_template_path = path
     end
   end
 end

--- a/test/unit/node_presenter_test.rb
+++ b/test/unit/node_presenter_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class NodePresenterTest < ActiveSupport::TestCase
   def node
-    OpenStruct.new(name: :foo_bar)
+    OpenStruct.new(name: :foo_bar, view_template_path: "view")
   end
 
   def node_presenter
@@ -18,6 +18,12 @@ class NodePresenterTest < ActiveSupport::TestCase
   context "#node_slug" do
     should "return version of node name for url path" do
       assert_equal "foo-bar", node_presenter.node_slug
+    end
+  end
+
+  context "#view_template_path" do
+    should "return view template name from the node" do
+      assert_equal "view", node_presenter.view_template_path
     end
   end
 end

--- a/test/unit/node_test.rb
+++ b/test/unit/node_test.rb
@@ -29,5 +29,15 @@ module SmartAnswer
       question = Question::Base.new(@flow, :how_much?)
       assert_equal "how_much", question.filesystem_friendly_name
     end
+
+    test "#view_template sets the view template name" do
+      node = Node.new(@flow, "node-name") { view_template "view-name" }
+      assert_equal "view-name", node.view_template_path
+    end
+
+    test "#view_template_path return nil is not set" do
+      node = Node.new(@flow, "node-name")
+      assert_nil node.view_template_path
+    end
   end
 end

--- a/test/unit/outcome_presenter_test.rb
+++ b/test/unit/outcome_presenter_test.rb
@@ -84,5 +84,19 @@ module SmartAnswer
 
       assert_equal "next-steps-html", @presenter.next_steps
     end
+
+    test "#view_template_path returns default when not set on node" do
+      node = stub(view_template_path: nil)
+      presenter = OutcomePresenter.new(node, nil, nil, renderer: @renderer)
+
+      assert_equal "smart_answers/result", presenter.view_template_path
+    end
+
+    test "#view_template_path returns view template set on node" do
+      node = stub(view_template_path: :alt_view)
+      presenter = OutcomePresenter.new(node, nil, nil, renderer: @renderer)
+
+      assert_equal :alt_view, presenter.view_template_path
+    end
   end
 end

--- a/test/unit/question_presenter_test.rb
+++ b/test/unit/question_presenter_test.rb
@@ -132,5 +132,9 @@ module SmartAnswer
 
       assert_equal "caption-text", @presenter.caption
     end
+
+    test "#view_template_path returns the question view template name" do
+      assert_equal "smart_answers/question", @presenter.view_template_path
+    end
   end
 end


### PR DESCRIPTION
This allow the ability to specify a name of an alternative view template to render than the default for an outcome node. This allows the creation of custom results pages beyond the standard render govspeak body. This allow Smart Answer to be used for future pages such as Start a business, that have more dynamic and custom styled results pages.

This is an unnecessary methods as it is only called once within the controller itself. We can remove the logic for rendering the start page, as this is never executed, as start pages always rendered by SmartAnswerController.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
