### PR TITLE
Add ability to put Heroku preview app behind basic auth

### DIFF
--- a/app.json
+++ b/app.json
@@ -8,7 +8,13 @@
     "GOVUK_WEBSITE_ROOT": "https://www.gov.uk",
     "PLEK_SERVICE_CONTENT_STORE_URI": "https://www.gov.uk/api" ,
     "PLEK_SERVICE_STATIC_URI": "https://assets.publishing.service.gov.uk/",
-    "RUNNING_ON_HEROKU": "true"
+    "RUNNING_ON_HEROKU": "true",
+    "BASIC_AUTH_USERNAME": {
+      "required": true
+    },
+    "BASIC_AUTH_PASSWORD": {
+      "required": true
+    }
   },
   "image": "heroku/ruby",
   "buildpacks": [ { "url": "heroku/ruby" } ],

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,13 @@ class ApplicationController < ActionController::Base
   rescue_from GdsApi::HTTPForbidden, with: :error_403
   rescue_from ActionController::UnknownFormat, with: :error_404
 
+  if ENV["BASIC_AUTH_USERNAME"] && ENV["BASIC_AUTH_PASSWORD"]
+    http_basic_authenticate_with(
+      name: ENV.fetch("BASIC_AUTH_USERNAME"),
+      password: ENV.fetch("BASIC_AUTH_PASSWORD"),
+    )
+  end
+
   slimmer_template "core_layout"
 
 protected


### PR DESCRIPTION
The username and password are set using environment variables which are configured through the Heroku UI.

This has been lifted from [Collections](https://github.com/alphagov/collections/blob/master/app/controllers/application_controller.rb#L11-L16) and the env variables have been added to smart-answers-preview.herokuapp.com already.

This is to prevent users from accidentally landing on a page in the review app and believing that it's GOV.UK.

[Trello Card](https://trello.com/c/65Fp8KmU/2425-3-set-username-password-for-heroku-previews-of-smart-answers)