### PR TITLE
Fix date range used to calculate parental pay leave

### DIFF
--- a/lib/smart_answer/calculators/pay_leave_for_parents_calculator.rb
+++ b/lib/smart_answer/calculators/pay_leave_for_parents_calculator.rb
@@ -126,8 +126,8 @@ module SmartAnswer::Calculators
       earnings_employment == "yes" && work_employment == "yes"
     end
 
-    def paid_leave_is_in_tax_year?(year)
-      (paid_leave_period & SmartAnswer::YearRange.tax_year.starting_in(year)).number_of_days.positive?
+    def paid_leave_is_in_year?(year)
+      (paid_leave_period & SmartAnswer::YearRange.new(begins_on: first_day_in_year(year))).number_of_days.positive?
     end
 
     def paid_leave_period

--- a/lib/smart_answer/calculators/pay_leave_for_parents_calculator.rb
+++ b/lib/smart_answer/calculators/pay_leave_for_parents_calculator.rb
@@ -28,6 +28,14 @@ module SmartAnswer::Calculators
       first_day_in_year(year + 1) - 1
     end
 
+    def formatted_first_day_in_year(year)
+      first_day_in_year(year).strftime("%e %B %Y")
+    end
+
+    def formatted_last_day_in_year(year)
+      last_day_in_year(year).strftime("%e %B %Y")
+    end
+
     def two_carers?
       two_carers == "yes"
     end

--- a/lib/smart_answer/calculators/pay_leave_for_parents_calculator.rb
+++ b/lib/smart_answer/calculators/pay_leave_for_parents_calculator.rb
@@ -17,6 +17,17 @@ module SmartAnswer::Calculators
                   :partner_worked_at_least_26_weeks,
                   :partner_earned_at_least_390
 
+    def first_day_in_year(year)
+      date = Date.new(year, 4, 1)
+      offset = (7 - date.wday) % 7
+
+      date + offset
+    end
+
+    def last_day_in_year(year)
+      first_day_in_year(year + 1) - 1
+    end
+
     def two_carers?
       two_carers == "yes"
     end

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_additional_pat_pay.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_additional_pat_pay.erb
@@ -6,48 +6,48 @@ The mother’s partner can get [additional paternity pay](/paternity-pay-leave/p
 
 <% if calculator.paid_leave_is_in_tax_year?(2013) %>
 
-Weekly rate (between 6 April 2013 and 5 April 2014) | £136.78, or 90% of their average weekly earnings (whichever is lower).
+Weekly rate (between <%= calculator.formatted_first_day_in_year(2013) %> and <%= calculator.formatted_last_day_in_year(2013) %>) | £136.78, or 90% of their average weekly earnings (whichever is lower).
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2014) %>
 
-Weekly rate (between 6 April 2014 and 5 April 2015) | £138.18, or 90% of their average weekly earnings (whichever is lower).
+Weekly rate (between <%= calculator.formatted_first_day_in_year(2014) %> and <%= calculator.formatted_last_day_in_year(2014) %>) | £138.18, or 90% of their average weekly earnings (whichever is lower).
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2015) %>
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of their average weekly earnings (whichever is lower).
+Weekly rate (between <%= calculator.formatted_first_day_in_year(2015) %> and <%= calculator.formatted_last_day_in_year(2015) %>) | £139.58, or 90% of their average weekly earnings (whichever is lower).
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2016) %>
 
-Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of their average weekly earnings (whichever is lower).
+Weekly rate (between <%= calculator.formatted_first_day_in_year(2016) %> and <%= calculator.formatted_last_day_in_year(2016) %>) | £139.58, or 90% of their average weekly earnings (whichever is lower).
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2017) %>
 
-Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of their average weekly earnings (whichever is lower).
+Weekly rate (between <%= calculator.formatted_first_day_in_year(2017) %> and <%= calculator.formatted_last_day_in_year(2017) %>) | £140.98, or 90% of their average weekly earnings (whichever is lower).
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2018) %>
 
-Weekly rate (between 6 April 2018 and 5 April 2019) | £145.18, or 90% of their average weekly earnings (whichever is lower).
+Weekly rate (between <%= calculator.formatted_first_day_in_year(2018) %> and <%= calculator.formatted_last_day_in_year(2018) %>) | £145.18, or 90% of their average weekly earnings (whichever is lower).
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2019) %>
 
-Weekly rate (between 6 April 2019 and 5 April 2020) | £148.68, or 90% of their average weekly earnings (whichever is lower).
+Weekly rate (between <%= calculator.formatted_first_day_in_year(2019) %> and <%= calculator.formatted_last_day_in_year(2019) %>) | £148.68, or 90% of their average weekly earnings (whichever is lower).
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2020) %>
 
-Weekly rate (between 6 April 2020 and 5 April 2021) | £151.20, or 90% of their average weekly earnings (whichever is lower).
+Weekly rate (between <%= calculator.formatted_first_day_in_year(2020) %> and <%= calculator.formatted_last_day_in_year(2020) %>) | £151.20, or 90% of their average weekly earnings (whichever is lower).
 
 <% end %>

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_additional_pat_pay.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_additional_pat_pay.erb
@@ -4,49 +4,49 @@ The mother’s partner can get [additional paternity pay](/paternity-pay-leave/p
 
 ###Dates and amounts
 
-<% if calculator.paid_leave_is_in_tax_year?(2013) %>
+<% if calculator.paid_leave_is_in_year?(2013) %>
 
 Weekly rate (between <%= calculator.formatted_first_day_in_year(2013) %> and <%= calculator.formatted_last_day_in_year(2013) %>) | £136.78, or 90% of their average weekly earnings (whichever is lower).
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2014) %>
+<% if calculator.paid_leave_is_in_year?(2014) %>
 
 Weekly rate (between <%= calculator.formatted_first_day_in_year(2014) %> and <%= calculator.formatted_last_day_in_year(2014) %>) | £138.18, or 90% of their average weekly earnings (whichever is lower).
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2015) %>
+<% if calculator.paid_leave_is_in_year?(2015) %>
 
 Weekly rate (between <%= calculator.formatted_first_day_in_year(2015) %> and <%= calculator.formatted_last_day_in_year(2015) %>) | £139.58, or 90% of their average weekly earnings (whichever is lower).
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2016) %>
+<% if calculator.paid_leave_is_in_year?(2016) %>
 
 Weekly rate (between <%= calculator.formatted_first_day_in_year(2016) %> and <%= calculator.formatted_last_day_in_year(2016) %>) | £139.58, or 90% of their average weekly earnings (whichever is lower).
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2017) %>
+<% if calculator.paid_leave_is_in_year?(2017) %>
 
 Weekly rate (between <%= calculator.formatted_first_day_in_year(2017) %> and <%= calculator.formatted_last_day_in_year(2017) %>) | £140.98, or 90% of their average weekly earnings (whichever is lower).
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2018) %>
+<% if calculator.paid_leave_is_in_year?(2018) %>
 
 Weekly rate (between <%= calculator.formatted_first_day_in_year(2018) %> and <%= calculator.formatted_last_day_in_year(2018) %>) | £145.18, or 90% of their average weekly earnings (whichever is lower).
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2019) %>
+<% if calculator.paid_leave_is_in_year?(2019) %>
 
 Weekly rate (between <%= calculator.formatted_first_day_in_year(2019) %> and <%= calculator.formatted_last_day_in_year(2019) %>) | £148.68, or 90% of their average weekly earnings (whichever is lower).
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2020) %>
+<% if calculator.paid_leave_is_in_year?(2020) %>
 
 Weekly rate (between <%= calculator.formatted_first_day_in_year(2020) %> and <%= calculator.formatted_last_day_in_year(2020) %>) | £151.20, or 90% of their average weekly earnings (whichever is lower).
 

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_both_shared_pay.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_both_shared_pay.erb
@@ -4,85 +4,85 @@ The mother and her partner can both get [shared parental pay](/shared-parental-l
 
 ###Amount
 
-<% if calculator.paid_leave_is_in_tax_year?(2014) %>
+<% if calculator.paid_leave_is_in_year?(2014) %>
 
 Mother’s shared parental pay (between <%= calculator.formatted_first_day_in_year(2014) %> and <%= calculator.formatted_last_day_in_year(2014) %>) | £138.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2015) %>
+<% if calculator.paid_leave_is_in_year?(2015) %>
 
 Mother’s shared parental pay (between <%= calculator.formatted_first_day_in_year(2015) %> and <%= calculator.formatted_last_day_in_year(2015) %>) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2016) %>
+<% if calculator.paid_leave_is_in_year?(2016) %>
 
 Mother’s shared parental pay (between <%= calculator.formatted_first_day_in_year(2016) %> and <%= calculator.formatted_last_day_in_year(2016) %>) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2017) %>
+<% if calculator.paid_leave_is_in_year?(2017) %>
 
 Mother’s shared parental pay (between <%= calculator.formatted_first_day_in_year(2017) %> and <%= calculator.formatted_last_day_in_year(2017) %>) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2018) %>
+<% if calculator.paid_leave_is_in_year?(2018) %>
 
 Mother’s shared parental pay (between <%= calculator.formatted_first_day_in_year(2018) %> and <%= calculator.formatted_last_day_in_year(2018) %>) | £145.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2019) %>
+<% if calculator.paid_leave_is_in_year?(2019) %>
 
 Mother’s shared parental pay (between <%= calculator.formatted_first_day_in_year(2019) %> and <%= calculator.formatted_last_day_in_year(2019) %>) | £148.68 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2020) %>
+<% if calculator.paid_leave_is_in_year?(2020) %>
 
 Mother’s shared parental pay (between <%= calculator.formatted_first_day_in_year(2020) %> and <%= calculator.formatted_last_day_in_year(2020) %>) | £151.20 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2014) %>
+<% if calculator.paid_leave_is_in_year?(2014) %>
 
 Partner's shared parental pay (between <%= calculator.formatted_first_day_in_year(2014) %> and <%= calculator.formatted_last_day_in_year(2014) %>) | £138.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2015) %>
+<% if calculator.paid_leave_is_in_year?(2015) %>
 
 Partner's shared parental pay (between <%= calculator.formatted_first_day_in_year(2015) %> and <%= calculator.formatted_last_day_in_year(2015) %>) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2016) %>
+<% if calculator.paid_leave_is_in_year?(2016) %>
 
 Partner's shared parental pay (between <%= calculator.formatted_first_day_in_year(2016) %> and <%= calculator.formatted_last_day_in_year(2016) %>) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2017) %>
+<% if calculator.paid_leave_is_in_year?(2017) %>
 
 Partner's shared parental pay (between <%= calculator.formatted_first_day_in_year(2017) %> and <%= calculator.formatted_last_day_in_year(2017) %>) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2018) %>
+<% if calculator.paid_leave_is_in_year?(2018) %>
 
 Partner's shared parental pay (between <%= calculator.formatted_first_day_in_year(2018) %> and <%= calculator.formatted_last_day_in_year(2018) %>) | £145.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2019) %>
+<% if calculator.paid_leave_is_in_year?(2019) %>
 
 Partner's shared parental pay (between <%= calculator.formatted_first_day_in_year(2019) %> and <%= calculator.formatted_last_day_in_year(2019) %>) | £148.68 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2020) %>
+<% if calculator.paid_leave_is_in_year?(2020) %>
 
 Partner's shared parental pay (between <%= calculator.formatted_first_day_in_year(2020) %> and <%= calculator.formatted_last_day_in_year(2020) %>) | £151.20 per week or 90% of their average weekly earnings (before tax), whichever is lower
 

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_both_shared_pay.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_both_shared_pay.erb
@@ -6,84 +6,84 @@ The mother and her partner can both get [shared parental pay](/shared-parental-l
 
 <% if calculator.paid_leave_is_in_tax_year?(2014) %>
 
-Mother’s shared parental pay (between 6 April 2014 and 5 April 2015) | £138.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Mother’s shared parental pay (between <%= calculator.formatted_first_day_in_year(2014) %> and <%= calculator.formatted_last_day_in_year(2014) %>) | £138.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2015) %>
 
-Mother’s shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Mother’s shared parental pay (between <%= calculator.formatted_first_day_in_year(2015) %> and <%= calculator.formatted_last_day_in_year(2015) %>) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2016) %>
 
-Mother’s shared parental pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Mother’s shared parental pay (between <%= calculator.formatted_first_day_in_year(2016) %> and <%= calculator.formatted_last_day_in_year(2016) %>) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2017) %>
 
-Mother’s shared parental pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Mother’s shared parental pay (between <%= calculator.formatted_first_day_in_year(2017) %> and <%= calculator.formatted_last_day_in_year(2017) %>) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2018) %>
 
-Mother’s shared parental pay (between 6 April 2018 and 5 April 2019) | £145.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Mother’s shared parental pay (between <%= calculator.formatted_first_day_in_year(2018) %> and <%= calculator.formatted_last_day_in_year(2018) %>) | £145.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2019) %>
 
-Mother’s shared parental pay (between 6 April 2019 and 5 April 2020) | £148.68 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Mother’s shared parental pay (between <%= calculator.formatted_first_day_in_year(2019) %> and <%= calculator.formatted_last_day_in_year(2019) %>) | £148.68 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2020) %>
 
-Mother’s shared parental pay (between 6 April 2020 and 5 April 2021) | £151.20 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Mother’s shared parental pay (between <%= calculator.formatted_first_day_in_year(2020) %> and <%= calculator.formatted_last_day_in_year(2020) %>) | £151.20 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2014) %>
 
-Partner's shared parental pay (between 6 April 2014 and 5 April 2015) | £138.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Partner's shared parental pay (between <%= calculator.formatted_first_day_in_year(2014) %> and <%= calculator.formatted_last_day_in_year(2014) %>) | £138.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2015) %>
 
-Partner's shared parental pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Partner's shared parental pay (between <%= calculator.formatted_first_day_in_year(2015) %> and <%= calculator.formatted_last_day_in_year(2015) %>) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2016) %>
 
-Partner's shared parental pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Partner's shared parental pay (between <%= calculator.formatted_first_day_in_year(2016) %> and <%= calculator.formatted_last_day_in_year(2016) %>) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2017) %>
 
-Partner's shared parental pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Partner's shared parental pay (between <%= calculator.formatted_first_day_in_year(2017) %> and <%= calculator.formatted_last_day_in_year(2017) %>) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2018) %>
 
-Partner's shared parental pay (between 6 April 2018 and 5 April 2019) | £145.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Partner's shared parental pay (between <%= calculator.formatted_first_day_in_year(2018) %> and <%= calculator.formatted_last_day_in_year(2018) %>) | £145.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2019) %>
 
-Partner's shared parental pay (between 6 April 2019 and 5 April 2020) | £148.68 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Partner's shared parental pay (between <%= calculator.formatted_first_day_in_year(2019) %> and <%= calculator.formatted_last_day_in_year(2019) %>) | £148.68 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2020) %>
 
-Partner's shared parental pay (between 6 April 2020 and 5 April 2021) | £151.20 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Partner's shared parental pay (between <%= calculator.formatted_first_day_in_year(2020) %> and <%= calculator.formatted_last_day_in_year(2020) %>) | £151.20 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_allowance.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_allowance.erb
@@ -10,49 +10,49 @@ Maternity allowance can start on | <%= format_date(calculator.start_of_maternity
 
 <% if calculator.paid_leave_is_in_tax_year?(2013) %>
 
-Weekly rate (between 6 April 2013 and 5 April 2014) | £136.78, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between <%= calculator.formatted_first_day_in_year(2013) %> and <%= calculator.formatted_last_day_in_year(2013) %>) | £136.78, or 90% of her average weekly earnings (whichever is lower)
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2014) %>
 
-Weekly rate (between 6 April 2014 and 5 April 2015) | £138.18, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between <%= calculator.formatted_first_day_in_year(2014) %> and <%= calculator.formatted_last_day_in_year(2014) %>) | £138.18, or 90% of her average weekly earnings (whichever is lower)
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2015) %>
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between <%= calculator.formatted_first_day_in_year(2015) %> and <%= calculator.formatted_last_day_in_year(2015) %>) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2016) %>
 
-Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between <%= calculator.formatted_first_day_in_year(2016) %> and <%= calculator.formatted_last_day_in_year(2016) %>) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2017) %>
 
-Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between <%= calculator.formatted_first_day_in_year(2017) %> and <%= calculator.formatted_last_day_in_year(2017) %>) | £140.98, or 90% of her average weekly earnings (whichever is lower)
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2018) %>
 
-Weekly rate (between 6 April 2018 and 5 April 2019) | £145.18, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between <%= calculator.formatted_first_day_in_year(2018) %> and <%= calculator.formatted_last_day_in_year(2018) %>) | £145.18, or 90% of her average weekly earnings (whichever is lower)
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2019) %>
 
-Weekly rate (between 6 April 2019 and 5 April 2020) | £148.68, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between <%= calculator.formatted_first_day_in_year(2019) %> and <%= calculator.formatted_last_day_in_year(2019) %>) | £148.68, or 90% of her average weekly earnings (whichever is lower)
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2020) %>
 
-Weekly rate (between 6 April 2020 and 5 April 2021) | £151.20, or 90% of her average weekly earnings (whichever is lower)
+Weekly rate (between <%= calculator.formatted_first_day_in_year(2020) %> and <%= calculator.formatted_last_day_in_year(2020) %>) | £151.20, or 90% of her average weekly earnings (whichever is lower)
 
 <% end %>
 

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_allowance.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_allowance.erb
@@ -8,49 +8,49 @@ The mother can get [maternity allowance](/maternity-allowance) from the governme
 
 Maternity allowance can start on | <%= format_date(calculator.start_of_maternity_allowance) %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2013) %>
+<% if calculator.paid_leave_is_in_year?(2013) %>
 
 Weekly rate (between <%= calculator.formatted_first_day_in_year(2013) %> and <%= calculator.formatted_last_day_in_year(2013) %>) | £136.78, or 90% of her average weekly earnings (whichever is lower)
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2014) %>
+<% if calculator.paid_leave_is_in_year?(2014) %>
 
 Weekly rate (between <%= calculator.formatted_first_day_in_year(2014) %> and <%= calculator.formatted_last_day_in_year(2014) %>) | £138.18, or 90% of her average weekly earnings (whichever is lower)
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2015) %>
+<% if calculator.paid_leave_is_in_year?(2015) %>
 
 Weekly rate (between <%= calculator.formatted_first_day_in_year(2015) %> and <%= calculator.formatted_last_day_in_year(2015) %>) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2016) %>
+<% if calculator.paid_leave_is_in_year?(2016) %>
 
 Weekly rate (between <%= calculator.formatted_first_day_in_year(2016) %> and <%= calculator.formatted_last_day_in_year(2016) %>) | £139.58, or 90% of her average weekly earnings (whichever is lower)
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2017) %>
+<% if calculator.paid_leave_is_in_year?(2017) %>
 
 Weekly rate (between <%= calculator.formatted_first_day_in_year(2017) %> and <%= calculator.formatted_last_day_in_year(2017) %>) | £140.98, or 90% of her average weekly earnings (whichever is lower)
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2018) %>
+<% if calculator.paid_leave_is_in_year?(2018) %>
 
 Weekly rate (between <%= calculator.formatted_first_day_in_year(2018) %> and <%= calculator.formatted_last_day_in_year(2018) %>) | £145.18, or 90% of her average weekly earnings (whichever is lower)
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2019) %>
+<% if calculator.paid_leave_is_in_year?(2019) %>
 
 Weekly rate (between <%= calculator.formatted_first_day_in_year(2019) %> and <%= calculator.formatted_last_day_in_year(2019) %>) | £148.68, or 90% of her average weekly earnings (whichever is lower)
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2020) %>
+<% if calculator.paid_leave_is_in_year?(2020) %>
 
 Weekly rate (between <%= calculator.formatted_first_day_in_year(2020) %> and <%= calculator.formatted_last_day_in_year(2020) %>) | £151.20, or 90% of her average weekly earnings (whichever is lower)
 

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_pay.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_pay.erb
@@ -8,49 +8,49 @@ First 6 weeks | 90% of her average weekly earnings (before tax)
 
 <% if calculator.paid_leave_is_in_tax_year?(2013) %>
 
-Remaining weeks (between 6 April 2013 and 5 April 2014) | £136.78 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks (between <%= calculator.formatted_first_day_in_year(2013) %> and <%= calculator.formatted_last_day_in_year(2013) %>) | £136.78 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2014) %>
 
-Remaining weeks (between 6 April 2014 and 5 April 2015) | £138.18 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks (between <%= calculator.formatted_first_day_in_year(2014) %> and <%= calculator.formatted_last_day_in_year(2014) %>) | £138.18 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2015) %>
 
-Remaining weeks (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks (between <%= calculator.formatted_first_day_in_year(2015) %> and <%= calculator.formatted_last_day_in_year(2015) %>) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2016) %>
 
-Remaining weeks (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks (between <%= calculator.formatted_first_day_in_year(2016) %> and <%= calculator.formatted_last_day_in_year(2016) %>) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2017) %>
 
-Remaining weeks (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks (between <%= calculator.formatted_first_day_in_year(2017) %> and <%= calculator.formatted_last_day_in_year(2017) %>) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2018) %>
 
-Remaining weeks (between 6 April 2018 and 5 April 2019) | £145.18 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks (between <%= calculator.formatted_first_day_in_year(2018) %> and <%= calculator.formatted_last_day_in_year(2018) %>) | £145.18 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2019) %>
 
-Remaining weeks (between 6 April 2019 and 5 April 2020) | £148.68 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks (between <%= calculator.formatted_first_day_in_year(2019) %> and <%= calculator.formatted_last_day_in_year(2019) %>) | £148.68 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2020) %>
 
-Remaining weeks (between 6 April 2020 and 5 April 2021) | £151.20 per week or 90% of her average weekly earnings (before tax), whichever is lower
+Remaining weeks (between <%= calculator.formatted_first_day_in_year(2020) %> and <%= calculator.formatted_last_day_in_year(2020) %>) | £151.20 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 <% end %>
 

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_pay.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_pay.erb
@@ -6,49 +6,49 @@ The mother can get up to 39 weeks of [maternity pay](/maternity-pay-leave/pay).
 
 First 6 weeks | 90% of her average weekly earnings (before tax)
 
-<% if calculator.paid_leave_is_in_tax_year?(2013) %>
+<% if calculator.paid_leave_is_in_year?(2013) %>
 
 Remaining weeks (between <%= calculator.formatted_first_day_in_year(2013) %> and <%= calculator.formatted_last_day_in_year(2013) %>) | £136.78 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2014) %>
+<% if calculator.paid_leave_is_in_year?(2014) %>
 
 Remaining weeks (between <%= calculator.formatted_first_day_in_year(2014) %> and <%= calculator.formatted_last_day_in_year(2014) %>) | £138.18 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2015) %>
+<% if calculator.paid_leave_is_in_year?(2015) %>
 
 Remaining weeks (between <%= calculator.formatted_first_day_in_year(2015) %> and <%= calculator.formatted_last_day_in_year(2015) %>) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2016) %>
+<% if calculator.paid_leave_is_in_year?(2016) %>
 
 Remaining weeks (between <%= calculator.formatted_first_day_in_year(2016) %> and <%= calculator.formatted_last_day_in_year(2016) %>) | £139.58 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2017) %>
+<% if calculator.paid_leave_is_in_year?(2017) %>
 
 Remaining weeks (between <%= calculator.formatted_first_day_in_year(2017) %> and <%= calculator.formatted_last_day_in_year(2017) %>) | £140.98 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2018) %>
+<% if calculator.paid_leave_is_in_year?(2018) %>
 
 Remaining weeks (between <%= calculator.formatted_first_day_in_year(2018) %> and <%= calculator.formatted_last_day_in_year(2018) %>) | £145.18 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2019) %>
+<% if calculator.paid_leave_is_in_year?(2019) %>
 
 Remaining weeks (between <%= calculator.formatted_first_day_in_year(2019) %> and <%= calculator.formatted_last_day_in_year(2019) %>) | £148.68 per week or 90% of her average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2020) %>
+<% if calculator.paid_leave_is_in_year?(2020) %>
 
 Remaining weeks (between <%= calculator.formatted_first_day_in_year(2020) %> and <%= calculator.formatted_last_day_in_year(2020) %>) | £151.20 per week or 90% of her average weekly earnings (before tax), whichever is lower
 

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_shared_pay.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_shared_pay.erb
@@ -4,43 +4,43 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 ###Amount
 
-<% if calculator.paid_leave_is_in_tax_year?(2014) %>
+<% if calculator.paid_leave_is_in_year?(2014) %>
 
 Shared Parental Pay (between <%= calculator.formatted_first_day_in_year(2014) %> and <%= calculator.formatted_last_day_in_year(2014) %>) | £138.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2015) %>
+<% if calculator.paid_leave_is_in_year?(2015) %>
 
 Shared Parental Pay (between <%= calculator.formatted_first_day_in_year(2015) %> and <%= calculator.formatted_last_day_in_year(2015) %>) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2016) %>
+<% if calculator.paid_leave_is_in_year?(2016) %>
 
 Shared Parental Pay (between <%= calculator.formatted_first_day_in_year(2016) %> and <%= calculator.formatted_last_day_in_year(2016) %>) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2017) %>
+<% if calculator.paid_leave_is_in_year?(2017) %>
 
 Shared Parental Pay (between <%= calculator.formatted_first_day_in_year(2017) %> and <%= calculator.formatted_last_day_in_year(2017) %>) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2018) %>
+<% if calculator.paid_leave_is_in_year?(2018) %>
 
 Shared Parental Pay (between <%= calculator.formatted_first_day_in_year(2018) %> and <%= calculator.formatted_last_day_in_year(2018) %>) | £145.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2019) %>
+<% if calculator.paid_leave_is_in_year?(2019) %>
 
 Shared Parental Pay (between <%= calculator.formatted_first_day_in_year(2019) %> and <%= calculator.formatted_last_day_in_year(2019) %>) | £148.68 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2020) %>
+<% if calculator.paid_leave_is_in_year?(2020) %>
 
 Shared Parental Pay (between <%= calculator.formatted_first_day_in_year(2020) %> and <%= calculator.formatted_last_day_in_year(2020) %>) | £151.20 per week or 90% of their average weekly earnings (before tax), whichever is lower
 

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_shared_pay.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_mat_shared_pay.erb
@@ -6,42 +6,42 @@ The mother can get [shared parental pay](/shared-parental-leave-and-pay/overview
 
 <% if calculator.paid_leave_is_in_tax_year?(2014) %>
 
-Shared Parental Pay (between 6 April 2014 and 5 April 2015) | £138.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between <%= calculator.formatted_first_day_in_year(2014) %> and <%= calculator.formatted_last_day_in_year(2014) %>) | £138.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2015) %>
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between <%= calculator.formatted_first_day_in_year(2015) %> and <%= calculator.formatted_last_day_in_year(2015) %>) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2016) %>
 
-Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between <%= calculator.formatted_first_day_in_year(2016) %> and <%= calculator.formatted_last_day_in_year(2016) %>) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2017) %>
 
-Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between <%= calculator.formatted_first_day_in_year(2017) %> and <%= calculator.formatted_last_day_in_year(2017) %>) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2018) %>
 
-Shared Parental Pay (between 6 April 2018 and 5 April 2019) | £145.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between <%= calculator.formatted_first_day_in_year(2018) %> and <%= calculator.formatted_last_day_in_year(2018) %>) | £145.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2019) %>
 
-Shared Parental Pay (between 6 April 2019 and 5 April 2020) | £148.68 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between <%= calculator.formatted_first_day_in_year(2019) %> and <%= calculator.formatted_last_day_in_year(2019) %>) | £148.68 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2020) %>
 
-Shared Parental Pay (between 6 April 2020 and 5 April 2021) | £151.20 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between <%= calculator.formatted_first_day_in_year(2020) %> and <%= calculator.formatted_last_day_in_year(2020) %>) | £151.20 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_pay.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_pay.erb
@@ -4,55 +4,55 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 ###Dates and amounts
 
-<% if calculator.paid_leave_is_in_tax_year?(2013) %>
+<% if calculator.paid_leave_is_in_year?(2013) %>
 
 Weekly rate (between <%= calculator.formatted_first_day_in_year(2013) %> and <%= calculator.formatted_last_day_in_year(2013) %>) | £136.78 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2014) %>
+<% if calculator.paid_leave_is_in_year?(2014) %>
 
 Weekly rate (between <%= calculator.formatted_first_day_in_year(2014) %> and <%= calculator.formatted_last_day_in_year(2014) %>) | £138.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2015) %>
+<% if calculator.paid_leave_is_in_year?(2015) %>
 
 Weekly rate (between <%= calculator.formatted_first_day_in_year(2015) %> and <%= calculator.formatted_last_day_in_year(2015) %>) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2016) %>
+<% if calculator.paid_leave_is_in_year?(2016) %>
 
 Weekly rate (between <%= calculator.formatted_first_day_in_year(2016) %> and <%= calculator.formatted_last_day_in_year(2016) %>) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2017) %>
+<% if calculator.paid_leave_is_in_year?(2017) %>
 
 Weekly rate (between <%= calculator.formatted_first_day_in_year(2017) %> and <%= calculator.formatted_last_day_in_year(2017) %>) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2018) %>
+<% if calculator.paid_leave_is_in_year?(2018) %>
 
 Weekly rate (between <%= calculator.formatted_first_day_in_year(2018) %> and <%= calculator.formatted_last_day_in_year(2018) %>) | £145.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2019) %>
+<% if calculator.paid_leave_is_in_year?(2019) %>
 
 Weekly rate (between <%= calculator.formatted_first_day_in_year(2019) %> and <%= calculator.formatted_last_day_in_year(2019) %>) | £148.68 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2020) %>
+<% if calculator.paid_leave_is_in_year?(2020) %>
 
 Weekly rate (between <%= calculator.formatted_first_day_in_year(2020) %> and <%= calculator.formatted_last_day_in_year(2020) %>) | £151.20 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2013) %>
+<% if calculator.paid_leave_is_in_year?(2013) %>
 
 Tell the partner’s employer | 28 days before they want to start paternity pay
 

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_pay.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_pay.erb
@@ -6,49 +6,49 @@ The mother’s partner can get up to 2 weeks of [paternity pay](/paternity-pay-l
 
 <% if calculator.paid_leave_is_in_tax_year?(2013) %>
 
-Weekly rate (between 6 April 2013 and 5 April 2014) | £136.78 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between <%= calculator.formatted_first_day_in_year(2013) %> and <%= calculator.formatted_last_day_in_year(2013) %>) | £136.78 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2014) %>
 
-Weekly rate (between 6 April 2014 and 5 April 2015) | £138.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between <%= calculator.formatted_first_day_in_year(2014) %> and <%= calculator.formatted_last_day_in_year(2014) %>) | £138.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2015) %>
 
-Weekly rate (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between <%= calculator.formatted_first_day_in_year(2015) %> and <%= calculator.formatted_last_day_in_year(2015) %>) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2016) %>
 
-Weekly rate (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between <%= calculator.formatted_first_day_in_year(2016) %> and <%= calculator.formatted_last_day_in_year(2016) %>) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2017) %>
 
-Weekly rate (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between <%= calculator.formatted_first_day_in_year(2017) %> and <%= calculator.formatted_last_day_in_year(2017) %>) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2018) %>
 
-Weekly rate (between 6 April 2018 and 5 April 2019) | £145.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between <%= calculator.formatted_first_day_in_year(2018) %> and <%= calculator.formatted_last_day_in_year(2018) %>) | £145.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2019) %>
 
-Weekly rate (between 6 April 2019 and 5 April 2020) | £148.68 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between <%= calculator.formatted_first_day_in_year(2019) %> and <%= calculator.formatted_last_day_in_year(2019) %>) | £148.68 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2020) %>
 
-Weekly rate (between 6 April 2020 and 5 April 2021) | £151.20 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Weekly rate (between <%= calculator.formatted_first_day_in_year(2020) %> and <%= calculator.formatted_last_day_in_year(2020) %>) | £151.20 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_shared_pay.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_shared_pay.erb
@@ -6,42 +6,42 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 <% if calculator.paid_leave_is_in_tax_year?(2014) %>
 
-Shared Parental Pay (between 6 April 2014 and 5 April 2015) | £138.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between <%= calculator.formatted_first_day_in_year(2014) %> and <%= calculator.formatted_last_day_in_year(2014) %>) | £138.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2015) %>
 
-Shared Parental Pay (between 6 April 2015 and 5 April 2016) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between <%= calculator.formatted_first_day_in_year(2015) %> and <%= calculator.formatted_last_day_in_year(2015) %>) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2016) %>
 
-Shared Parental Pay (between 6 April 2016 and 5 April 2017) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between <%= calculator.formatted_first_day_in_year(2016) %> and <%= calculator.formatted_last_day_in_year(2016) %>) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2017) %>
 
-Shared Parental Pay (between 6 April 2017 and 5 April 2018) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between <%= calculator.formatted_first_day_in_year(2017) %> and <%= calculator.formatted_last_day_in_year(2017) %>) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2018) %>
 
-Shared Parental Pay (between 6 April 2018 and 5 April 2019) | £145.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between <%= calculator.formatted_first_day_in_year(2018) %> and <%= calculator.formatted_last_day_in_year(2018) %>) | £145.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2019) %>
 
-Shared Parental Pay (between 6 April 2019 and 5 April 2020) | £148.68 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between <%= calculator.formatted_first_day_in_year(2019) %> and <%= calculator.formatted_last_day_in_year(2019) %>) | £148.68 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
 <% if calculator.paid_leave_is_in_tax_year?(2020) %>
 
-Shared Parental Pay (between 6 April 2020 and 5 April 2021) | £151.20 per week or 90% of their average weekly earnings (before tax), whichever is lower
+Shared Parental Pay (between <%= calculator.formatted_first_day_in_year(2020) %> and <%= calculator.formatted_last_day_in_year(2020) %>) | £151.20 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>

--- a/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_shared_pay.erb
+++ b/lib/smart_answer_flows/pay-leave-for-parents/outcomes/_pat_shared_pay.erb
@@ -4,43 +4,43 @@ The mother’s partner can get [shared parental pay](/shared-parental-leave-and-
 
 ###Amount
 
-<% if calculator.paid_leave_is_in_tax_year?(2014) %>
+<% if calculator.paid_leave_is_in_year?(2014) %>
 
 Shared Parental Pay (between <%= calculator.formatted_first_day_in_year(2014) %> and <%= calculator.formatted_last_day_in_year(2014) %>) | £138.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2015) %>
+<% if calculator.paid_leave_is_in_year?(2015) %>
 
 Shared Parental Pay (between <%= calculator.formatted_first_day_in_year(2015) %> and <%= calculator.formatted_last_day_in_year(2015) %>) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2016) %>
+<% if calculator.paid_leave_is_in_year?(2016) %>
 
 Shared Parental Pay (between <%= calculator.formatted_first_day_in_year(2016) %> and <%= calculator.formatted_last_day_in_year(2016) %>) | £139.58 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2017) %>
+<% if calculator.paid_leave_is_in_year?(2017) %>
 
 Shared Parental Pay (between <%= calculator.formatted_first_day_in_year(2017) %> and <%= calculator.formatted_last_day_in_year(2017) %>) | £140.98 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2018) %>
+<% if calculator.paid_leave_is_in_year?(2018) %>
 
 Shared Parental Pay (between <%= calculator.formatted_first_day_in_year(2018) %> and <%= calculator.formatted_last_day_in_year(2018) %>) | £145.18 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2019) %>
+<% if calculator.paid_leave_is_in_year?(2019) %>
 
 Shared Parental Pay (between <%= calculator.formatted_first_day_in_year(2019) %> and <%= calculator.formatted_last_day_in_year(2019) %>) | £148.68 per week or 90% of their average weekly earnings (before tax), whichever is lower
 
 <% end %>
 
-<% if calculator.paid_leave_is_in_tax_year?(2020) %>
+<% if calculator.paid_leave_is_in_year?(2020) %>
 
 Shared Parental Pay (between <%= calculator.formatted_first_day_in_year(2020) %> and <%= calculator.formatted_last_day_in_year(2020) %>) | £151.20 per week or 90% of their average weekly earnings (before tax), whichever is lower
 

--- a/test/unit/calculators/pay_leave_for_parents_calculator_test.rb
+++ b/test/unit/calculators/pay_leave_for_parents_calculator_test.rb
@@ -4,7 +4,7 @@ module SmartAnswer
   module Calculators
     class PayLeaveForParentsCalculatorTest < ActiveSupport::TestCase
       setup do
-        @due_date = Date.parse("2015-1-1")
+        @due_date = Date.parse("2015-01-01")
         @calculator = PayLeaveForParentsCalculator.new
         @calculator.due_date = @due_date
       end
@@ -46,27 +46,27 @@ module SmartAnswer
       end
 
       test "continuity_start_date" do
-        expected = Date.parse("2014-3-29")
+        expected = Date.parse("2014-03-29")
         assert_equal expected, @calculator.continuity_start_date
       end
 
       test "continuity_end_date" do
-        expected = Date.parse("2014-9-14")
+        expected = Date.parse("2014-09-14")
         assert_equal expected, @calculator.continuity_end_date
       end
 
       test "lower_earnings_start_date" do
-        expected = Date.parse("2014-7-26")
+        expected = Date.parse("2014-07-26")
         assert_equal expected, @calculator.lower_earnings_start_date
       end
 
       test "lower_earnings_end_date" do
-        expected = Date.parse("2014-9-20")
+        expected = Date.parse("2014-09-20")
         assert_equal expected, @calculator.lower_earnings_end_date
       end
 
       test "earnings_employment_start_date" do
-        expected = Date.parse("2013-9-22")
+        expected = Date.parse("2013-09-22")
         assert_equal expected, @calculator.earnings_employment_start_date
       end
 
@@ -89,48 +89,48 @@ module SmartAnswer
 
       test "maternity_leave_notice_date" do
         @calculator.due_date = @due_date
-        expected = Date.parse("2014-9-20")
+        expected = Date.parse("2014-09-20")
         assert_equal expected, @calculator.maternity_leave_notice_date
       end
 
       test "paternity_leave_notice_date" do
         @calculator.due_date = @due_date
-        expected = Date.parse("2014-9-20")
+        expected = Date.parse("2014-09-20")
         assert_equal expected, @calculator.paternity_leave_notice_date
       end
 
       context "due date in 2013-2014 range" do
         setup do
-          @date = Date.parse("2014-4-4")
+          @date = Date.parse("2014-04-04")
           @calculator = PayLeaveForParentsCalculator.new
           @calculator.due_date = @date
         end
 
-        should "return £ 109 for lower_earnings_amount" do
+        should "return £109 for lower_earnings_amount" do
           assert_equal 109, @calculator.lower_earnings_amount
         end
       end
 
       context "due date in 2014-2015 range" do
         setup do
-          @date = Date.parse("2015-4-3")
+          @date = Date.parse("2015-04-03")
           @calculator = PayLeaveForParentsCalculator.new
           @calculator.due_date = @date
         end
 
-        should "return £ 111 for lower_earnings_amount" do
+        should "return £111 for lower_earnings_amount" do
           assert_equal 111, @calculator.lower_earnings_amount
         end
       end
 
       context "due date in 2015-2016 range" do
         setup do
-          @date = Date.parse("2016-4-2")
+          @date = Date.parse("2016-04-02")
           @calculator = PayLeaveForParentsCalculator.new
           @calculator.due_date = @date
         end
 
-        should "return £ 112 for lower_earnings_amount" do
+        should "return £112 for lower_earnings_amount" do
           assert_equal 112, @calculator.lower_earnings_amount
         end
       end

--- a/test/unit/calculators/pay_leave_for_parents_calculator_test.rb
+++ b/test/unit/calculators/pay_leave_for_parents_calculator_test.rb
@@ -101,7 +101,7 @@ module SmartAnswer
 
       context "due date in 2013-2014 range" do
         setup do
-          @date = Date.parse("2014-1-1")
+          @date = Date.parse("2014-4-4")
           @calculator = PayLeaveForParentsCalculator.new
           @calculator.due_date = @date
         end
@@ -113,7 +113,7 @@ module SmartAnswer
 
       context "due date in 2014-2015 range" do
         setup do
-          @date = Date.parse("2015-1-1")
+          @date = Date.parse("2015-4-3")
           @calculator = PayLeaveForParentsCalculator.new
           @calculator.due_date = @date
         end
@@ -125,7 +125,7 @@ module SmartAnswer
 
       context "due date in 2015-2016 range" do
         setup do
-          @date = Date.parse("2016-1-1")
+          @date = Date.parse("2016-4-2")
           @calculator = PayLeaveForParentsCalculator.new
           @calculator.due_date = @date
         end
@@ -137,7 +137,7 @@ module SmartAnswer
 
       context "due date in 2016-2017 range" do
         setup do
-          @date = Date.parse("2017-01-01")
+          @date = Date.parse("2017-03-31")
           @calculator = PayLeaveForParentsCalculator.new
           @calculator.due_date = @date
         end
@@ -149,7 +149,7 @@ module SmartAnswer
 
       context "due date in 2017-2018 range" do
         setup do
-          @date = Date.parse("2018-01-01")
+          @date = Date.parse("2018-03-30")
           @calculator = PayLeaveForParentsCalculator.new
           @calculator.due_date = @date
         end
@@ -161,7 +161,7 @@ module SmartAnswer
 
       context "due date in 2018-2019 range" do
         setup do
-          @date = Date.parse("2019-01-01")
+          @date = Date.parse("2019-04-05")
           @calculator = PayLeaveForParentsCalculator.new
           @calculator.due_date = @date
         end
@@ -173,7 +173,7 @@ module SmartAnswer
 
       context "due date in 2019-2020 range" do
         setup do
-          @date = Date.parse("2020-01-01")
+          @date = Date.parse("2020-04-03")
           @calculator = PayLeaveForParentsCalculator.new
           @calculator.due_date = @date
         end
@@ -185,7 +185,7 @@ module SmartAnswer
 
       context "due date in 2020-2021 range" do
         setup do
-          @date = Date.parse("2021-01-01")
+          @date = Date.parse("2021-04-01")
           @calculator = PayLeaveForParentsCalculator.new
           @calculator.due_date = @date
         end

--- a/test/unit/calculators/pay_leave_for_parents_calculator_test.rb
+++ b/test/unit/calculators/pay_leave_for_parents_calculator_test.rb
@@ -9,6 +9,42 @@ module SmartAnswer
         @calculator.due_date = @due_date
       end
 
+      test "calculates start of year to be first Sunday in April" do
+        expectations = {
+          "2013" => Date.parse("2013-04-07"),
+          "2014" => Date.parse("2014-04-06"),
+          "2015" => Date.parse("2015-04-05"),
+          "2016" => Date.parse("2016-04-03"),
+          "2017" => Date.parse("2017-04-02"),
+          "2018" => Date.parse("2018-04-01"),
+          "2019" => Date.parse("2019-04-07"),
+          "2020" => Date.parse("2020-04-05"),
+          "2021" => Date.parse("2021-04-04"),
+        }
+
+        expectations.each do |year, start_date|
+          assert_equal start_date, @calculator.first_day_in_year(year.to_i)
+        end
+      end
+
+      test "calculates end of year to be the day before the first Sunday in next April" do
+        expectations = {
+          "2013" => Date.parse("2014-04-05"),
+          "2014" => Date.parse("2015-04-04"),
+          "2015" => Date.parse("2016-04-02"),
+          "2016" => Date.parse("2017-04-01"),
+          "2017" => Date.parse("2018-03-31"),
+          "2018" => Date.parse("2019-04-06"),
+          "2019" => Date.parse("2020-04-04"),
+          "2020" => Date.parse("2021-04-03"),
+          "2021" => Date.parse("2022-04-02"),
+        }
+
+        expectations.each do |year, start_date|
+          assert_equal start_date, @calculator.last_day_in_year(year.to_i)
+        end
+      end
+
       test "continuity_start_date" do
         expected = Date.parse("2014-3-29")
         assert_equal expected, @calculator.continuity_start_date


### PR DESCRIPTION
The date range used by this calculator is incorrect.  We currently use tax years (6th April to 5th April), but should instead work from the first Sunday in April to the day before the Sunday in the next April.

This updates to use those dates and removes the hardcoded dates from the outcomes.

Trello card: https://trello.com/c/TdxjQXlz

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
