### PR TITLE
Add `/flow/` prefix routes for FlowController

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,7 @@ Naming/FileName:
   Exclude:
     - lib/smart_answer_flows/*.rb
     - test/fixtures/smart_answer_flows/*.rb
+    - spec/fixtures/flows/*.rb
 
 # Long conditionals are inherent in smart answers, due
 # to the complexity of the problem they represent. It is

--- a/app/controllers/flow_controller.rb
+++ b/app/controllers/flow_controller.rb
@@ -1,5 +1,6 @@
 class FlowController < ApplicationController
   before_action :set_cache_headers
+  before_action :redirect_path_based_flows
 
   def start
     session_store.clear
@@ -33,6 +34,10 @@ class FlowController < ApplicationController
   end
 
 private
+
+  def redirect_path_based_flows
+    redirect_to smart_answer_path(params[:id], started: "y") unless flow.use_session?
+  end
 
   def set_cache_headers
     response.headers["Cache-Control"] = "private, no-store, max-age=0, must-revalidate"

--- a/app/presenters/flow_content_item.rb
+++ b/app/presenters/flow_content_item.rb
@@ -19,7 +19,10 @@ class FlowContentItem
       rendering_app: "smartanswers",
       locale: "en",
       public_updated_at: Time.zone.now.iso8601,
-      routes: [{ type: "prefix", path: flow_presenter.start_page_link }],
+      routes: [
+        { type: "prefix", path: flow_presenter.start_page_link },
+        { type: "prefix", path: "/#{flow_presenter.name}/flow" },
+      ],
     }
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,4 +19,9 @@ Rails.application.routes.draw do
   get "/:id/s", to: "flow#start", as: :start_flow
   get "/:id/s/:node_slug", to: "flow#show", as: :flow
   get "/:id/s/:node_slug/next", to: "flow#update", as: :update_flow
+
+  get "/:id/flow/destroy_session", to: "flow#destroy"
+  get "/:id/flow", to: "flow#start"
+  get "/:id/flow/:node_slug", to: "flow#show"
+  get "/:id/flow/:node_slug/next", to: "flow#update"
 end

--- a/spec/fixtures/flows/path-based.rb
+++ b/spec/fixtures/flows/path-based.rb
@@ -1,0 +1,17 @@
+module SmartAnswer
+  class PathBasedFlow < Flow
+    def define
+      name "path-based"
+      satisfies_need "cccab629-bd2b-3f02-9af7-30f58555ac41"
+      start_page_content_id "d26e566e-1550-4913-b945-9372c32256f1"
+
+      value_question :question1 do
+        next_node do
+          outcome :results
+        end
+      end
+
+      outcome :results
+    end
+  end
+end

--- a/spec/fixtures/flows/path-based/outcomes/results.erb
+++ b/spec/fixtures/flows/path-based/outcomes/results.erb
@@ -1,0 +1,7 @@
+<% text_for :title do %>
+  Results title
+<% end %>
+
+<% govspeak_for :body do %>
+  Results body
+<% end %>

--- a/spec/fixtures/flows/path-based/path-based.erb
+++ b/spec/fixtures/flows/path-based/path-based.erb
@@ -1,0 +1,11 @@
+<% text_for :title do %>
+  This is a path based flow
+<% end %>
+
+<% text_for :meta_description do %>
+  This flow uses the URL path to store user responses
+<% end %>
+
+<% govspeak_for :body do %>
+  This flow uses the URL path to store user responses
+<% end %>

--- a/spec/fixtures/flows/path-based/questions/question1.erb
+++ b/spec/fixtures/flows/path-based/questions/question1.erb
@@ -1,0 +1,7 @@
+<% text_for :title do %>
+  Question 1 title
+<% end %>
+
+<% text_for :hint do %>
+  Question 1 hint
+<% end %>

--- a/spec/requests/flow_spec.rb
+++ b/spec/requests/flow_spec.rb
@@ -87,8 +87,25 @@ RSpec.describe "Flow navigation", flow_dir: :fixture do
     end
   end
 
-  it "clears the session and redirects to another page" do
-    get "/test/s/destroy_session", params: { ext_r: "true" }
-    expect(response).to redirect_to("https://www.bbc.co.uk/weather")
+  context "urls have /flow/ prefix, but are path based flows" do
+    it "redirects requests to old route" do
+      get "/path-based/flow"
+      expect(response).to redirect_to("/path-based/y")
+    end
+
+    it "redirects requests for a specific node to old route" do
+      get "/path-based/flow/question1"
+      expect(response).to redirect_to("/path-based/y")
+    end
+
+    it "redirects requests for a next node to old route" do
+      get "/path-based/flow/question1/next", params: { response: "response1", next: "true" }
+      expect(response).to redirect_to("/path-based/y")
+    end
+
+    it "redirects requests for destroying session to old route" do
+      get "/path-based/flow/destroy_session"
+      expect(response).to redirect_to("/path-based/y")
+    end
   end
 end

--- a/spec/requests/flow_spec.rb
+++ b/spec/requests/flow_spec.rb
@@ -1,40 +1,90 @@
 RSpec.describe "Flow navigation", flow_dir: :fixture do
   let(:no_cache_header) { "max-age=0, private, must-revalidate, no-store" }
 
-  it "redirects to first node" do
-    get "/test/s"
-    expect(response).to redirect_to("/test/s/question1")
-    expect(response.headers["Cache-Control"]).to eq(no_cache_header)
+  context "urls have /s/ prefix" do
+    it "redirects to first node" do
+      get "/test/s"
+      expect(response).to redirect_to("/test/s/question1")
+      expect(response.headers["Cache-Control"]).to eq(no_cache_header)
+    end
+
+    it "renders the first question" do
+      get "/test/s/question1"
+      expect(response).to render_template("smart_answers/question")
+      expect(response.headers["Cache-Control"]).to eq(no_cache_header)
+    end
+
+    it "redirects to preceding unanswered question" do
+      get "/test/s/results"
+      expect(response).to redirect_to("/test/s/question1")
+      expect(response.headers["Cache-Control"]).to eq(no_cache_header)
+    end
+
+    it "redirects to next node when valid response provided" do
+      get "/test/s/question1/next", params: { response: "response1", next: "true" }
+      expect(response).to redirect_to("/test/s/question2")
+      expect(response.headers["Cache-Control"]).to eq(no_cache_header)
+    end
+
+    it "redirects to same node when invalid response provided" do
+      get "/test/s/question1/next", params: { response: "invalid", next: "true" }
+      expect(response).to redirect_to("/test/s/question1")
+      expect(response.headers["Cache-Control"]).to eq(no_cache_header)
+    end
+
+    it "clears the session and redirects to the start page" do
+      get "/test/s/destroy_session"
+      expect(response).to redirect_to("/test")
+      expect(response.headers["Cache-Control"]).to eq(no_cache_header)
+    end
+
+    it "clears the session and redirects to another page" do
+      get "/test/s/destroy_session", params: { ext_r: "true" }
+      expect(response).to redirect_to("https://www.bbc.co.uk/weather")
+    end
   end
 
-  it "renders the first question" do
-    get "/test/s/question1"
-    expect(response).to render_template("smart_answers/question")
-    expect(response.headers["Cache-Control"]).to eq(no_cache_header)
-  end
+  context "urls have /flow/ prefix" do
+    it "redirects to first node" do
+      get "/test/flow"
+      expect(response).to redirect_to("/test/s/question1")
+      expect(response.headers["Cache-Control"]).to eq(no_cache_header)
+    end
 
-  it "redirects to preceding unanswered question" do
-    get "/test/s/results"
-    expect(response).to redirect_to("/test/s/question1")
-    expect(response.headers["Cache-Control"]).to eq(no_cache_header)
-  end
+    it "renders the first question" do
+      get "/test/flow/question1"
+      expect(response).to render_template("smart_answers/question")
+      expect(response.headers["Cache-Control"]).to eq(no_cache_header)
+    end
 
-  it "redirects to next node when valid response provided" do
-    get "/test/s/question1/next", params: { response: "response1", next: "true" }
-    expect(response).to redirect_to("/test/s/question2")
-    expect(response.headers["Cache-Control"]).to eq(no_cache_header)
-  end
+    it "redirects to preceding unanswered question" do
+      get "/test/flow/results"
+      expect(response).to redirect_to("/test/s/question1")
+      expect(response.headers["Cache-Control"]).to eq(no_cache_header)
+    end
 
-  it "redirects to same node when invalid response provided" do
-    get "/test/s/question1/next", params: { response: "invalid", next: "true" }
-    expect(response).to redirect_to("/test/s/question1")
-    expect(response.headers["Cache-Control"]).to eq(no_cache_header)
-  end
+    it "redirects to next node when valid response provided" do
+      get "/test/flow/question1/next", params: { response: "response1", next: "true" }
+      expect(response).to redirect_to("/test/s/question2")
+      expect(response.headers["Cache-Control"]).to eq(no_cache_header)
+    end
 
-  it "clears the session and redirects to the start page" do
-    get "/test/s/destroy_session"
-    expect(response).to redirect_to("/test")
-    expect(response.headers["Cache-Control"]).to eq(no_cache_header)
+    it "redirects to same node when invalid response provided" do
+      get "/test/flow/question1/next", params: { response: "invalid", next: "true" }
+      expect(response).to redirect_to("/test/s/question1")
+      expect(response.headers["Cache-Control"]).to eq(no_cache_header)
+    end
+
+    it "clears the session and redirects to the start page" do
+      get "/test/flow/destroy_session"
+      expect(response).to redirect_to("/test")
+      expect(response.headers["Cache-Control"]).to eq(no_cache_header)
+    end
+
+    it "clears the session and redirects to another page" do
+      get "/test/flow/destroy_session", params: { ext_r: "true" }
+      expect(response).to redirect_to("https://www.bbc.co.uk/weather")
+    end
   end
 
   it "clears the session and redirects to another page" do

--- a/test/unit/flow_content_item_test.rb
+++ b/test/unit/flow_content_item_test.rb
@@ -115,8 +115,10 @@ module SmartAnswer
       presenter = stub_flow_registration_presenter
       content_item = FlowContentItem.new(presenter)
 
-      expected_route = { type: "prefix", path: "/flow-name/y" }
-      assert content_item.payload[:routes].include?(expected_route)
+      old_route = { type: "prefix", path: "/flow-name/y" }
+      new_route = { type: "prefix", path: "/flow-name/flow" }
+      assert content_item.payload[:routes].include?(old_route)
+      assert content_item.payload[:routes].include?(new_route)
     end
   end
 end


### PR DESCRIPTION
This adds new routes using the `/flow/` segment prefix instead of `/s/` for the FlowController. The existing `/s/` prefix routes are still supported and continue to be the default for flow navigation.

It was agreed that "flow" is more descriptive than "s" as the segment name. "s" was originally thought to mean "session" when session based flows were introduced, however we'd like to generalise the FlowController to also support storing user responses in the query string.

This registers the new routes in the content item, so GOV.UK's router handles both sets of URLs whilst we transition to use `/flow/` prefix exclusively.

These changes are prerequisite work needed by the [agreed implementation plan](https://github.com/alphagov/smart-answers/blob/master/docs/arch/002-store-responses-in-query-string.md#suggested-steps-for-implementation) to migrate flows to use query parameters to store user responses. 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
