### PR TITLE
Refactor `use_session` flow option to `response_store`

### DIFF
--- a/app/controllers/flow_controller.rb
+++ b/app/controllers/flow_controller.rb
@@ -36,7 +36,7 @@ class FlowController < ApplicationController
 private
 
   def redirect_path_based_flows
-    redirect_to smart_answer_path(params[:id], started: "y") unless flow.use_session?
+    redirect_to smart_answer_path(params[:id], started: "y") if flow.response_store.nil?
   end
 
   def set_cache_headers

--- a/app/helpers/current_question_helper.rb
+++ b/app/helpers/current_question_helper.rb
@@ -1,6 +1,6 @@
 module CurrentQuestionHelper
   def current_question_path(presenter)
-    if presenter.use_session?
+    if presenter.response_store == :session
       flow_question_path(presenter)
     else
       smart_answers_question_path(presenter)
@@ -19,7 +19,7 @@ module CurrentQuestionHelper
   end
 
   def restart_flow_path(presenter)
-    if presenter.use_session?
+    if presenter.response_store == :session
       destroy_flow_path(presenter.name)
     else
       smart_answer_path(presenter.name)

--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -11,7 +11,7 @@ class FlowPresenter
            :start_page_content_id,
            :flow_content_id,
            :need_it,
-           :use_session?,
+           :response_store,
            :questions,
            :use_escape_button?,
            :show_escape_link?,
@@ -41,7 +41,7 @@ class FlowPresenter
   end
 
   def current_state
-    @current_state ||= if use_session?
+    @current_state ||= if response_store == :session
                          requested_node = params[:node_name] unless params[:next]
                          @flow.resolve_state(params[:responses], requested_node)
                        else
@@ -95,7 +95,7 @@ class FlowPresenter
   end
 
   def change_collapsed_question_link(question_number, question)
-    if use_session?
+    if response_store == :session
       flow_path(params[:id], node_slug: question.node_slug)
     else
       smart_answer_path(
@@ -139,7 +139,7 @@ class FlowPresenter
   end
 
   def start_page_link
-    if use_session?
+    if response_store == :session
       start_flow_path(name)
     else
       smart_answer_path(name, started: "y")

--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -42,12 +42,9 @@ module SmartAnswer
       @name
     end
 
-    def use_session(use_session) # rubocop:disable Style/TrivialAccessors
-      @use_session = use_session
-    end
-
-    def use_session?
-      ActiveModel::Type::Boolean.new.cast(@use_session)
+    def response_store(response_store = nil)
+      @response_store = response_store unless response_store.nil?
+      @response_store
     end
 
     def use_escape_button(use_escape_button) # rubocop:disable Style/TrivialAccessors
@@ -55,13 +52,13 @@ module SmartAnswer
     end
 
     def use_escape_button?
-      raise NonSessionBasedFlow, "This flow is not session-based" unless use_session?
+      raise NonSessionBasedFlow, "This flow is not session-based" unless response_store == :session
 
       ActiveModel::Type::Boolean.new.cast(@use_escape_button)
     end
 
     def show_escape_link?
-      use_session? && use_escape_button?
+      response_store == :session && use_escape_button?
     end
 
     def hide_previous_answers_on_results_page(hide_previous_answers_on_results_page) # rubocop:disable Style/TrivialAccessors

--- a/lib/smart_answer_flows/find-coronavirus-support.rb
+++ b/lib/smart_answer_flows/find-coronavirus-support.rb
@@ -5,7 +5,7 @@ module SmartAnswer
       start_page_content_id "d67f2c92-d0f0-438b-9c81-c0059dd71baf"
       flow_content_id "31d81949-aa15-48cf-a7f1-f0d0a670e8db"
       status :published
-      use_session true
+      response_store :session
       use_escape_button true
       hide_previous_answers_on_results_page true
 

--- a/lib/smart_answer_flows/next-steps-for-your-business.rb
+++ b/lib/smart_answer_flows/next-steps-for-your-business.rb
@@ -5,7 +5,7 @@ module SmartAnswer
       start_page_content_id "4d7751b5-d860-4812-aa36-5b8c57253ff2"
       flow_content_id "981e0708-9fa5-42fb-baf5-ee5630a9b722"
       status :draft
-      use_session true
+      response_store :session
 
       # ======================================================================
       # What is your company registration number?

--- a/spec/fixtures/flows/test.rb
+++ b/spec/fixtures/flows/test.rb
@@ -4,7 +4,7 @@ module SmartAnswer
       name "test"
       satisfies_need "dccab509-bd3b-4f92-9af6-30f88485ac41"
       start_page_content_id "f26e566e-2557-4921-b944-9373c32255f1"
-      use_session true
+      response_store :session
 
       radio :question1 do
         option :response1

--- a/test/helpers/current_question_helper_test.rb
+++ b/test/helpers/current_question_helper_test.rb
@@ -44,7 +44,7 @@ class CurrentQuestionHelperTest < ActionView::TestCase
 
   def session_presenter
     @session_presenter ||= OpenStruct.new(
-      "use_session?" => true,
+      response_store: :session,
       current_state: current_state,
       questions: [first_question],
       name: flow_name,

--- a/test/unit/flow_presenter_test.rb
+++ b/test/unit/flow_presenter_test.rb
@@ -192,7 +192,7 @@ class FlowPresenterTest < ActiveSupport::TestCase
     end
 
     should "return path to first page in session flow using sessions" do
-      @flow.use_session(true)
+      @flow.response_store(:session)
       flow_presenter = FlowPresenter.new({}, @flow)
       assert_equal "/flow-name/s", flow_presenter.start_page_link
     end

--- a/test/unit/flow_test.rb
+++ b/test/unit/flow_test.rb
@@ -9,39 +9,22 @@ class FlowTest < ActiveSupport::TestCase
     assert_equal "sweet-or-savoury", s.name
   end
 
-  test "can set to use session" do
+  test "can set response store type" do
     smart_answer = SmartAnswer::Flow.new do
-      use_session true
+      response_store(:session)
     end
 
-    assert smart_answer.use_session?
+    assert_equal smart_answer.response_store, :session
   end
 
-  test "can set to use session with string" do
-    smart_answer = SmartAnswer::Flow.new do
-      use_session "yes"
-    end
-
-    assert smart_answer.use_session?
-  end
-
-  test "can set not to use session" do
-    smart_answer = SmartAnswer::Flow.new do
-      use_session "false"
-    end
-
-    assert_not smart_answer.use_session?
-  end
-
-  test "defaults to not use session" do
+  test "defaults to no response store" do
     smart_answer = SmartAnswer::Flow.new
 
-    assert_not smart_answer.use_session?
+    assert_equal smart_answer.response_store, nil
   end
 
-  test "cannot set a flag to use the escape button if the use session flag is not also set" do
+  test "cannot use the escape button if the response store isn't session" do
     smart_answer = SmartAnswer::Flow.new do
-      use_session false
       use_escape_button true
     end
 
@@ -50,9 +33,9 @@ class FlowTest < ActiveSupport::TestCase
     end
   end
 
-  test "can set a flag to use the escape button when the use session flag is also set" do
+  test "can use the escape button when response store is session" do
     smart_answer = SmartAnswer::Flow.new do
-      use_session true
+      response_store :session
       use_escape_button true
     end
 
@@ -61,7 +44,7 @@ class FlowTest < ActiveSupport::TestCase
 
   test "can set a flag to use the escape button with a string" do
     smart_answer = SmartAnswer::Flow.new do
-      use_session true
+      response_store :session
       use_escape_button "yes"
     end
 
@@ -70,7 +53,7 @@ class FlowTest < ActiveSupport::TestCase
 
   test "can set a flag not to use the escape button with a string" do
     smart_answer = SmartAnswer::Flow.new do
-      use_session true
+      response_store :session
       use_escape_button "false"
     end
 
@@ -79,7 +62,7 @@ class FlowTest < ActiveSupport::TestCase
 
   test "defaults to not use the escape button" do
     smart_answer = SmartAnswer::Flow.new do
-      use_session true
+      response_store :session
     end
 
     assert_not smart_answer.use_escape_button?

--- a/test/unit/services/content_item_syncer_test.rb
+++ b/test/unit/services/content_item_syncer_test.rb
@@ -20,7 +20,7 @@ class ContentItemSyncerTest < ActiveSupport::TestCase
         start_page_content_id: start_page_content_id,
         flow_content_id: flow_content_id,
         external_related_links: nil,
-        use_session?: false,
+        response_store: nil,
         nodes: [],
       )
     end


### PR DESCRIPTION
This changes the boolean `use_session` parameter in flow definitions to `response_store`. The new parameter now accepts a symbol to indicate which response store to use. This will allow the flag to be used to specify more than one response storage type. 

The change for session based flows is the following:
`use_session true` => `responses_store :session`

This is prerequisite work for enable flows to store user responses in query parameters.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
