### PR TITLE
Update redundancy_pay_northern_ireland.yml

### DIFF
--- a/config/smart_answers/rates/redundancy_pay_northern_ireland.yml
+++ b/config/smart_answers/rates/redundancy_pay_northern_ireland.yml
@@ -35,3 +35,7 @@
   end_date: 2021-04-05
   max: "16,800"
   rate: 560
+- start_date: 2021-04-06
+  end_date: 2022-04-05
+  max: "16,980"
+  rate: 566

--- a/test/unit/calculators/redundancy_calculator_test.rb
+++ b/test/unit/calculators/redundancy_calculator_test.rb
@@ -63,7 +63,8 @@ module SmartAnswer::Calculators
 
       should "vary the max amount per year" do
         assert_equal "16,410", RedundancyCalculator.northern_ireland_redundancy_rates(Date.new(2019, 4, 6)).max
-        assert_equal "16,800", RedundancyCalculator.northern_ireland_redundancy_rates(Date.new(Time.zone.today.year, 12, 31)).max
+        assert_equal "16,800", RedundancyCalculator.northern_ireland_redundancy_rates(Date.new(2020, 4, 6)).max
+        assert_equal "16,980", RedundancyCalculator.northern_ireland_redundancy_rates(Date.new(Time.zone.today.year, 12, 31)).max
       end
     end
 


### PR DESCRIPTION
Add new weekly and yearly cap for 2021-22 - part of uprating. Deploy 00.01 6 April.