### PR TITLE
Move outcome link to govspeak body block

### DIFF
--- a/lib/smart_answer_flows/childcare-costs-for-tax-credits/outcomes/call_helpline_plain.erb
+++ b/lib/smart_answer_flows/childcare-costs-for-tax-credits/outcomes/call_helpline_plain.erb
@@ -1,3 +1,7 @@
 <% text_for :title do %>
-  Contact [HM Revenue and Customs (HMRC)](/government/organisations/hm-revenue-customs/contact/tax-credits-enquiries) for help in working out your costs.
+  Contact HM Revenue and Customs (HMRC) for help in working out your costs.
+<% end %>
+
+<% govspeak_for :body do %>
+  [Contact HMRC](/government/organisations/hm-revenue-customs/contact/tax-credits-enquiries).
 <% end %>


### PR DESCRIPTION
This outcome had a govspeak-style link in the title, which was rendering as plain text. This change moves it to the govspeak-enabled body.