### PR TITLE
Bump mimemagic 0.3.5 => 0.3.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,7 +181,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0225)
-    mimemagic (0.3.5)
+    mimemagic (0.3.6)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.4)


### PR DESCRIPTION
Bump mimemagic as 0.3.5 is no longer available
https://rubygems.org/gems/mimemagic/versions/0.3.5