### PR TITLE
Revert "Add flow prefix route to the content item"

### DIFF
--- a/app/presenters/flow_content_item.rb
+++ b/app/presenters/flow_content_item.rb
@@ -19,10 +19,7 @@ class FlowContentItem
       rendering_app: "smartanswers",
       locale: "en",
       public_updated_at: Time.zone.now.iso8601,
-      routes: [
-        { type: "prefix", path: flow_presenter.start_page_link },
-        { type: "prefix", path: "/#{flow_presenter.name}/flow" },
-      ],
+      routes: [{ type: "prefix", path: flow_presenter.start_page_link }],
     }
   end
 

--- a/test/unit/flow_content_item_test.rb
+++ b/test/unit/flow_content_item_test.rb
@@ -115,10 +115,8 @@ module SmartAnswer
       presenter = stub_flow_registration_presenter
       content_item = FlowContentItem.new(presenter)
 
-      old_route = { type: "prefix", path: "/flow-name/y" }
-      new_route = { type: "prefix", path: "/flow-name/flow" }
-      assert content_item.payload[:routes].include?(old_route)
-      assert content_item.payload[:routes].include?(new_route)
+      expected_route = { type: "prefix", path: "/flow-name/y" }
+      assert content_item.payload[:routes].include?(expected_route)
     end
   end
 end


### PR DESCRIPTION
The content item was previously invalid as the new route doesn't fall under the base path. This is an interim fix to allow publishing of Smart Answers. This reverts commit b30443c2ccee3981db80175f37c51dc12f719ec8.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
