### PR TITLE
Adds country notice to the business support smart answer

### DIFF
--- a/app/assets/stylesheets/_country-notice.scss
+++ b/app/assets/stylesheets/_country-notice.scss
@@ -1,0 +1,12 @@
+.country-notice {
+  background-color: govuk-colour('blue');
+  padding: govuk-spacing(4) govuk-spacing(4) govuk-spacing(1);
+
+  @include govuk-media-query($from: tablet) {
+    padding: govuk-spacing(5) govuk-spacing(5) govuk-spacing(1);
+  }
+}
+
+.country-notice__text {
+  color: govuk-colour('white');
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -27,3 +27,4 @@ $govuk-use-legacy-palette: false;
 @import "components/email-link";
 @import "components/escape-link";
 @import "smart_answers";
+@import "country-notice";

--- a/app/views/smart_answers/shared/_country-notice.html.erb
+++ b/app/views/smart_answers/shared/_country-notice.html.erb
@@ -1,0 +1,5 @@
+<div class="country-notice">
+  <p class="country-notice__text">
+    Applies to: <strong>England, Scotland, Wales and Northern Ireland</strong>
+  </p>
+</div>

--- a/lib/smart_answer_flows/business-coronavirus-support-finder/business_coronavirus_support_finder.erb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder/business_coronavirus_support_finder.erb
@@ -7,6 +7,8 @@
 <% end %>
 
 <% govspeak_for :body do %>
+  <%= render 'smart_answers/shared/country-notice' %>
+
   Coronavirus (COVID‑19) support is available to employers and the
   self-employed, including sole traders and limited company directors.
   You may be eligible for loans, tax relief and cash grants, whether your


### PR DESCRIPTION
## WHAT
We get the blue banner up (and down) on the business support smart answer for two weeks for the purpose of the test.

## WHY
We are doing a before and after test and the banner is the key bit!

https://trello.com/c/Py8XjzRQ/275-implement-blue-banner-for-before-and-after-test

<img width="1029" alt="Screenshot 2021-03-26 at 01 12 15" src="https://user-images.githubusercontent.com/4599889/112562974-66107280-8dd0-11eb-92ac-0a9a0f5db449.png">
<img width="368" alt="Screenshot 2021-03-26 at 01 12 23" src="https://user-images.githubusercontent.com/4599889/112562983-6872cc80-8dd0-11eb-822a-8b4f2abb224b.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
