### PR TITLE
Remove some unused code from the marriage-abroad calculator

### DIFF
--- a/lib/smart_answer/calculators/marriage_abroad_calculator.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_calculator.rb
@@ -230,10 +230,6 @@ module SmartAnswer::Calculators
       MarriageAbroadDataQuery::CEREMONY_COUNTRIES_OFFERING_PACS.include?(ceremony_country)
     end
 
-    def requires_7_day_notice?
-      @data_query.requires_7_day_notice?(ceremony_country)
-    end
-
     def same_sex_alt_fees_table_country?
       @data_query.ss_alt_fees_table_country?(ceremony_country, self)
     end

--- a/lib/smart_answer/calculators/marriage_abroad_data_query.rb
+++ b/lib/smart_answer/calculators/marriage_abroad_data_query.rb
@@ -1,12 +1,5 @@
 module SmartAnswer::Calculators
   class MarriageAbroadDataQuery
-    MARRIAGE_ABROAD_COMMONWEALTH_COUNTRIES = SmartAnswer::Calculators::COMMONWEALTH_COUNTRIES - %w[australia kenya maldives mozambique rwanda south-africa tanzania the-gambia].freeze
-    REQUIRES_7_DAY_NOTICE_CEREMONY_COUNTRIES = (MARRIAGE_ABROAD_COMMONWEALTH_COUNTRIES - %w[brunei].freeze) + %w[
-      ireland
-      rwanda
-      st-lucia
-    ].freeze
-
     BRITISH_OVERSEAS_TERRITORIES = %w[
       anguilla
       bermuda
@@ -474,10 +467,6 @@ module SmartAnswer::Calculators
 
     def os_marriage_via_local_authorities?(country_slug)
       OS_MARRIAGE_VIA_LOCAL_AUTHORITIES.include?(country_slug)
-    end
-
-    def requires_7_day_notice?(ceremony_country_slug)
-      REQUIRES_7_DAY_NOTICE_CEREMONY_COUNTRIES.include?(ceremony_country_slug)
     end
 
     def ss_unknown_no_embassies?(country_slug)

--- a/lib/smart_answer/calculators/register_a_death_calculator.rb
+++ b/lib/smart_answer/calculators/register_a_death_calculator.rb
@@ -26,6 +26,10 @@ module SmartAnswer::Calculators
       @reg_data_query.eea_country_or_switzerland?(country_of_death)
     end
 
+    def died_in_commonwealth?
+      @reg_data_query.commonwealth_country?(country_of_death)
+    end
+
     def died_at_home_or_in_hospital?
       death_location_type == "at_home_hospital"
     end

--- a/lib/smart_answer/calculators/registrations_data_query.rb
+++ b/lib/smart_answer/calculators/registrations_data_query.rb
@@ -197,6 +197,10 @@ module SmartAnswer::Calculators
       COUNTRIES_WITH_BIRTH_REGISTRATION_EXCEPTION.include?(country_slug)
     end
 
+    def commonwealth_country?(country_slug)
+      SmartAnswer::Calculators::COMMONWEALTH_COUNTRIES.include?(country_slug)
+    end
+
     def nonregistrable_country?(country_slug)
       COUNTRIES_WITHOUT_UK_REGISTRATION.include?(country_slug)
     end

--- a/lib/smart_answer_flows/register-a-death/outcomes/oru_result.erb
+++ b/lib/smart_answer_flows/register-a-death/outcomes/oru_result.erb
@@ -3,7 +3,7 @@
 
   This local death certificate will be accepted in the UK. It may need to be a [certified translation](/certifying-a-document) of the document if it’s not in English.
 
-  <% if calculator.died_in_eea_or_switzerland? %>
+  <% if calculator.died_in_eea_or_switzerland? || calculator.died_in_commonwealth? %>
     You can [report the death to most UK government organisations](/after-a-death/death-abroad) in one go using the Tell Us Once service.
   <% end %>
 

--- a/test/integration/smart_answer_flows/register_a_death_test.rb
+++ b/test/integration/smart_answer_flows/register_a_death_test.rb
@@ -7,7 +7,7 @@ class RegisterADeathTest < ActiveSupport::TestCase
   include FlowTestHelper
 
   setup do
-    @location_slugs = %w[afghanistan algeria andorra argentina australia austria barbados belgium brazil cameroon democratic-republic-of-the-congo dominica egypt france germany iran italy kenya libya morocco nigeria north-korea pakistan pitcairn-island poland saint-barthelemy serbia slovakia somalia spain st-kitts-and-nevis st-martin uganda]
+    @location_slugs = %w[afghanistan algeria andorra argentina australia austria barbados belgium brazil cameroon democratic-republic-of-the-congo dominica egypt france germany grenada iran italy kenya libya morocco nigeria north-korea pakistan pitcairn-island poland saint-barthelemy serbia slovakia somalia spain st-kitts-and-nevis st-martin uganda]
     stub_world_locations(@location_slugs)
     setup_for_testing_flow SmartAnswer::RegisterADeathFlow
   end
@@ -417,6 +417,14 @@ class RegisterADeathTest < ActiveSupport::TestCase
     context "death in EEA" do
       should "includes a link to Tell Us Once" do
         add_response "france"
+        add_response "in_the_uk"
+        assert_match("Tell Us Once", outcome_body)
+      end
+    end
+
+    context "death in commonwealth" do
+      should "includes a link to Tell Us Once" do
+        add_response "grenada"
         add_response "in_the_uk"
         assert_match("Tell Us Once", outcome_body)
       end

--- a/test/unit/calculators/marriage_abroad_calculator_test.rb
+++ b/test/unit/calculators/marriage_abroad_calculator_test.rb
@@ -845,17 +845,6 @@ module SmartAnswer
         end
       end
 
-      context "requires_7_day_notice?" do
-        should "delegate to the data query" do
-          data_query = stub.quacks_like(MarriageAbroadDataQuery.new)
-          data_query.stubs(:requires_7_day_notice?).with("ceremony-country").returns("requires-7-day-notice")
-          calculator = MarriageAbroadCalculator.new(data_query: data_query)
-          calculator.ceremony_country = "ceremony-country"
-
-          assert_equal "requires-7-day-notice", calculator.requires_7_day_notice?
-        end
-      end
-
       context "same_sex_alt_fees_table_country?" do
         should "delegate to the data query" do
           data_query = stub.quacks_like(MarriageAbroadDataQuery.new)


### PR DESCRIPTION
It doesn't appear that these methods have been used since 2019: the 'outcome-flattening' in #3952

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
