### PR TITLE
Fix tests broken by daylight savings

### DIFF
--- a/test/unit/calculators/state_pension_age_calculator_test.rb
+++ b/test/unit/calculators/state_pension_age_calculator_test.rb
@@ -187,7 +187,7 @@ module SmartAnswer::Calculators
 
       should "return true for someone yet to reach their state pension date" do
         Timecop.freeze do
-          @calculator.stubs(:state_pension_date).returns(Time.zone.today + 1.minute)
+          @calculator.stubs(:state_pension_date).returns(Time.zone.today + 1.day)
           assert @calculator.before_state_pension_date?
         end
       end
@@ -201,7 +201,7 @@ module SmartAnswer::Calculators
 
       should "return false for someone who has just passed their state pension date" do
         Timecop.freeze do
-          @calculator.stubs(:state_pension_date).returns(Time.zone.today - 1.minute)
+          @calculator.stubs(:state_pension_date).returns(Time.zone.today - 1.day)
           assert_not @calculator.before_state_pension_date?
         end
       end
@@ -241,7 +241,7 @@ module SmartAnswer::Calculators
 
       should "return true for someone yet to reach their pension credit date" do
         Timecop.freeze do
-          @calculator.stubs(:pension_credit_date).returns(Time.zone.today + 1.minute)
+          @calculator.stubs(:pension_credit_date).returns(Time.zone.today + 1.day)
           assert @calculator.before_pension_credit_date?
         end
       end
@@ -255,7 +255,7 @@ module SmartAnswer::Calculators
 
       should "return false for someone who has just passed their pension credit date" do
         Timecop.freeze do
-          @calculator.stubs(:pension_credit_date).returns(Time.zone.today - 1.minute)
+          @calculator.stubs(:pension_credit_date).returns(Time.zone.today - 1.day)
           assert_not @calculator.before_pension_credit_date?
         end
       end


### PR DESCRIPTION
These had started to fail because '1 minute in the future' was actually 59 minutes in the past, due to timezone weirdness — adding 61 minutes worked as expected, but I've changed it to ±1 _day_ because this code really appears to deal with dates not times.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
