### PR TITLE
Add company name to the "Next steps for your business" flow

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby File.read(".ruby-version").chomp
 gem "rails", "6.0.3.2"
 
 gem "ast"
+gem "companies-house-rest"
 gem "gds-api-adapters"
 gem "gds_zendesk"
 gem "govspeak"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,8 @@ GEM
       xpath (~> 3.2)
     childprocess (3.0.0)
     coderay (1.1.3)
+    companies-house-rest (0.6.0)
+      dry-struct (~> 1)
     concurrent-ruby (1.1.8)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -87,6 +89,28 @@ GEM
     docile (1.3.2)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
+    dry-configurable (0.12.1)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 0.5, >= 0.5.0)
+    dry-container (0.7.2)
+      concurrent-ruby (~> 1.0)
+      dry-configurable (~> 0.1, >= 0.1.3)
+    dry-core (0.5.0)
+      concurrent-ruby (~> 1.0)
+    dry-inflector (0.2.0)
+    dry-logic (1.1.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 0.5, >= 0.5)
+    dry-struct (1.4.0)
+      dry-core (~> 0.5, >= 0.5)
+      dry-types (~> 1.5)
+      ice_nine (~> 0.11)
+    dry-types (1.5.1)
+      concurrent-ruby (~> 1.0)
+      dry-container (~> 0.3)
+      dry-core (~> 0.5, >= 0.5)
+      dry-inflector (~> 0.1, >= 0.1.2)
+      dry-logic (~> 1.0, >= 1.0.2)
     erubi (1.10.0)
     execjs (2.7.0)
     faraday (1.3.0)
@@ -145,6 +169,7 @@ GEM
       domain_name (~> 0.5)
     i18n (1.8.9)
       concurrent-ruby (~> 1.0)
+    ice_nine (0.11.2)
     inflection (1.0.0)
     jasmine (3.6.0)
       jasmine-core (~> 3.6.0)
@@ -402,6 +427,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   byebug
+  companies-house-rest
   gds-api-adapters
   gds_zendesk
   govspeak

--- a/app.json
+++ b/app.json
@@ -14,6 +14,9 @@
     },
     "BASIC_AUTH_PASSWORD": {
       "required": true
+    },
+    "COMPANIES_HOUSE_API_KEY": {
+      "required": true
     }
   },
   "image": "heroku/ruby",

--- a/lib/smart_answer/calculators/next_steps_for_your_business_calculator.rb
+++ b/lib/smart_answer/calculators/next_steps_for_your_business_calculator.rb
@@ -1,3 +1,5 @@
+require "companies_house/client"
+
 # ======================================================================
 # Allows access to the quesion answers provides custom validations
 # and calculations, and other supporting methods.
@@ -6,6 +8,10 @@
 module SmartAnswer::Calculators
   class NextStepsForYourBusinessCalculator
     RESULT_DATA = YAML.load_file(Rails.root.join("config/smart_answers/next_steps_for_your_business.yml")).freeze
+
+    def self.companies_house_client
+      @companies_house_client ||= CompaniesHouse::Client.new(api_key: ENV["COMPANIES_HOUSE_API_KEY"])
+    end
 
     attr_accessor :crn,
                   :annual_turnover,
@@ -16,6 +22,13 @@ module SmartAnswer::Calculators
 
     def grouped_results
       RESULT_DATA.group_by { |result| result["section_name"] }
+    end
+
+    def company_name
+      profile = self.class.companies_house_client.company(crn)
+      profile["company_name"]
+    rescue CompaniesHouse::APIError
+      # Will try best attempt at getting company name, but not necessary for flow
     end
   end
 end

--- a/lib/smart_answer/calculators/next_steps_for_your_business_calculator.rb
+++ b/lib/smart_answer/calculators/next_steps_for_your_business_calculator.rb
@@ -24,6 +24,12 @@ module SmartAnswer::Calculators
       RESULT_DATA.group_by { |result| result["section_name"] }
     end
 
+    def company_exists?
+      self.class.companies_house_client.company(crn).present?
+    rescue CompaniesHouse::NotFoundError
+      false
+    end
+
     def company_name
       profile = self.class.companies_house_client.company(crn)
       profile["company_name"]

--- a/lib/smart_answer_flows/next-steps-for-your-business.rb
+++ b/lib/smart_answer_flows/next-steps-for-your-business.rb
@@ -16,6 +16,10 @@ module SmartAnswer
           calculator.crn = response
         end
 
+        validate :error_company_not_found do
+          calculator.company_exists?
+        end
+
         next_node do
           question :annual_turnover
         end

--- a/lib/smart_answer_flows/next-steps-for-your-business/outcomes/results.erb
+++ b/lib/smart_answer_flows/next-steps-for-your-business/outcomes/results.erb
@@ -6,7 +6,7 @@
 %>
 
 <% text_for :title do %>
-  Next steps for your business
+  Next steps for <%= calculator.company_name || "your business" %>
 <% end %>
 
 <% text_for :description do %>

--- a/lib/smart_answer_flows/next-steps-for-your-business/questions/crn.erb
+++ b/lib/smart_answer_flows/next-steps-for-your-business/questions/crn.erb
@@ -7,3 +7,7 @@
 <% text_for :title do %>
   What is your company registration number?
 <% end %>
+
+<% text_for :error_company_not_found do %>
+  Company not found. Enter a valid company registration number.
+<% end %>

--- a/spec/features/flows/next_steps_for_your_business_flow_spec.rb
+++ b/spec/features/flows/next_steps_for_your_business_flow_spec.rb
@@ -9,13 +9,13 @@ RSpec.feature "SmartAnswer::NextStepsForYourBusinessFlow" do
       business_intent: "Does your business do any of the following?",
       business_support: "Are you looking for financial support for:",
       business_premises: "Where are you running your business?",
-      results: "Next steps for your business",
+      results: "Next steps for BUSINESS NAME LTD",
     }
   end
 
   let(:answers) do
     {
-      crn: "08161564",
+      crn: "123456789",
       annual_turnover: "Maybe in the future",
       employ_someone: "Maybe in the future",
       business_intent: "Sell goods online",
@@ -27,6 +27,14 @@ RSpec.feature "SmartAnswer::NextStepsForYourBusinessFlow" do
   before do
     stub_content_store_has_item("/next-steps-for-your-business")
     start(the_flow: headings[:flow_title], at: "next-steps-for-your-business")
+    stub_request(:get, "https://api.companieshouse.gov.uk/company/123456789")
+      .to_return(status: 200, body: { "company_name" => "BUSINESS NAME LTD" }.to_json)
+  end
+
+  around do |example|
+    ENV["COMPANIES_HOUSE_API_KEY"] = "api-key"
+    example.run
+    ENV["COMPANIES_HOUSE_API_KEY"] = nil
   end
 
   scenario "Answers all questions" do

--- a/spec/features/flows/next_steps_for_your_business_flow_spec.rb
+++ b/spec/features/flows/next_steps_for_your_business_flow_spec.rb
@@ -29,6 +29,11 @@ RSpec.feature "SmartAnswer::NextStepsForYourBusinessFlow" do
     start(the_flow: headings[:flow_title], at: "next-steps-for-your-business")
     stub_request(:get, "https://api.companieshouse.gov.uk/company/123456789")
       .to_return(status: 200, body: { "company_name" => "BUSINESS NAME LTD" }.to_json)
+
+    stub_request(:get, "https://api.companieshouse.gov.uk/company/987654321")
+      .to_return(status: 404, body: { "errors" => [
+        { "type" => "ch:service", "error" => "company-profile-not-found" },
+      ] }.to_json)
   end
 
   around do |example|
@@ -46,5 +51,14 @@ RSpec.feature "SmartAnswer::NextStepsForYourBusinessFlow" do
     answer(question: headings[:business_premises], of_type: :radio, with: answers[:business_premises])
 
     ensure_page_has(header: headings[:results])
+  end
+
+  scenario "Enters a invalid company registration number" do
+    answer(question: headings[:crn], of_type: :value, with: "987654321")
+
+    ensure_page_has(
+      header: headings[:crn],
+      text: "Company not found. Enter a valid company registration number.",
+    )
   end
 end

--- a/test/unit/calculators/next_steps_for_your_business_calculator_test.rb
+++ b/test/unit/calculators/next_steps_for_your_business_calculator_test.rb
@@ -1,0 +1,34 @@
+require_relative "../../test_helper"
+
+module SmartAnswer::Calculators
+  class NextStepsForYourBusinessCalculatorTest < ActiveSupport::TestCase
+    setup do
+      @calculator = NextStepsForYourBusinessCalculator.new
+    end
+
+    context "#company_name" do
+      setup do
+        @client = mock
+        CompaniesHouse::Client.stubs(:new).returns(@client)
+      end
+
+      should "return the company name" do
+        @client.stubs(:company)
+          .with("123456789")
+          .returns({ "company_name" => "BUSINESS NAME LTD" })
+
+        @calculator.crn = "123456789"
+        assert_equal "BUSINESS NAME LTD", @calculator.company_name
+      end
+
+      should "return the nil if request not successful" do
+        @client.stubs(:company)
+          .with("123456789")
+          .raises(CompaniesHouse::APIError, "Request error")
+
+        @calculator.crn = "123456789"
+        assert_nil @calculator.company_name
+      end
+    end
+  end
+end

--- a/test/unit/calculators/next_steps_for_your_business_calculator_test.rb
+++ b/test/unit/calculators/next_steps_for_your_business_calculator_test.rb
@@ -6,6 +6,31 @@ module SmartAnswer::Calculators
       @calculator = NextStepsForYourBusinessCalculator.new
     end
 
+    context "#company_exists?" do
+      setup do
+        @client = mock
+        CompaniesHouse::Client.stubs(:new).returns(@client)
+      end
+
+      should "return true if company profile is present" do
+        @client.stubs(:company)
+          .with("123456789")
+          .returns({ "company_name" => "BUSINESS NAME LTD" })
+
+        @calculator.crn = "123456789"
+        assert @calculator.company_exists?
+      end
+
+      should "return false if company profile not found" do
+        @client.stubs(:company)
+          .with("123456789")
+          .raises(CompaniesHouse::NotFoundError, "Not found")
+
+        @calculator.crn = "123456789"
+        assert_not @calculator.company_exists?
+      end
+    end
+
     context "#company_name" do
       setup do
         @client = mock


### PR DESCRIPTION
For the "Next steps for your business" flow we use the company name in the title of the results page. This derived from the supplied company registration number to query the Companies House Public Data API. Displaying the company name isn't critical, so there is a fallback heading so user's continue to see results if the request fails.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
