### PR TITLE
Remove external related links from Smart Answers

### DIFF
--- a/app/presenters/flow_content_item.rb
+++ b/app/presenters/flow_content_item.rb
@@ -10,10 +10,8 @@ class FlowContentItem
       base_path: flow_presenter.start_page_link,
       title: flow_presenter.title,
       update_type: "minor",
-      details: {
-        external_related_links: flow_presenter.external_related_links,
-      },
-      schema_name: "generic_with_external_related_links",
+      details: {},
+      schema_name: "generic",
       document_type: "smart_answer",
       publishing_app: "smartanswers",
       rendering_app: "smartanswers",

--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -128,10 +128,6 @@ class FlowPresenter
     end
   end
 
-  def external_related_links
-    @flow.external_related_links || []
-  end
-
   def flows_content
     extract_flow_content(@flow)
   end

--- a/app/presenters/start_page_content_item.rb
+++ b/app/presenters/start_page_content_item.rb
@@ -12,7 +12,6 @@ class StartPageContentItem
       description: flow_presenter.meta_description,
       update_type: "minor",
       details: {
-        external_related_links: flow_presenter.external_related_links,
         introductory_paragraph: [
           {
             content: flow_presenter.start_node.body,

--- a/docs/smart-answers/flow-definition.md
+++ b/docs/smart-answers/flow-definition.md
@@ -51,16 +51,12 @@ module SmartAnswer
       name 'example-smart-answer' # this is the path where the Smart Answer will be registered on gov.uk (via the publishing-api)
       content_id "bfda3b4f-166b-48e7-9aaf-21bfbd606207" # a UUID used by v2 of the Publishing API (?)
       status :published # this indicates whether or not the flow is available to be published to live gov.uk , those with `:draft` status will be available on draft gov.uk
-      external_related_links { title: "Child Maintenance Options - How much should be paid",
-                               url: "http://www.cmoptions.org/en/maintenance/how-much.asp" } # External links associated to the Smart-Answer
 
       # question & outcome definitions specified here
     end
   end
 end
 ```
-
-* `external_related_links` will be stored in [content-tagger](https://github.com/alphagov/content-tagger) with the objective of retrieving them from there. This is a temporary fix, we want to be able to set external related links via a publishing tool like `content-tagger` rather than hardcoding them.
 
 ### Arbitrary Ruby code
 

--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -68,11 +68,6 @@ module SmartAnswer
       ActiveModel::Type::Boolean.new.cast(@hide_previous_answers_on_results_page)
     end
 
-    def external_related_links(external_related_links = nil)
-      @external_related_links = external_related_links unless external_related_links.nil?
-      @external_related_links
-    end
-
     def status(potential_status = nil)
       if potential_status
         raise Flow::InvalidStatus unless %i[published draft].include? potential_status

--- a/test/unit/flow_content_item_test.rb
+++ b/test/unit/flow_content_item_test.rb
@@ -14,7 +14,6 @@ module SmartAnswer
         "flow-registration-presenter",
         name: "flow-name",
         title: "flow-title",
-        external_related_links: [],
         start_page_link: "/flow-name/y",
       )
     end
@@ -31,17 +30,7 @@ module SmartAnswer
       presenter = stub_flow_registration_presenter
       content_item = FlowContentItem.new(presenter)
 
-      assert_valid_against_schema(content_item.payload, "generic_with_external_related_links")
-    end
-
-    test "#payload returns a valid content-item with external related links" do
-      presenter = stub_flow_registration_presenter
-      presenter.stubs(:external_related_links).returns(
-        [{ title: "hmrc", url: "https://hmrc.gov.uk" }],
-      )
-      content_item = FlowContentItem.new(presenter)
-
-      assert_valid_against_schema(content_item.payload, "generic_with_external_related_links")
+      assert_valid_against_schema(content_item.payload, "generic")
     end
 
     test "#base_path is the path to the first question" do
@@ -56,21 +45,6 @@ module SmartAnswer
       content_item = FlowContentItem.new(presenter)
 
       assert_equal "flow-title", content_item.payload[:title]
-    end
-
-    test "#payload details hash includes external_related_links" do
-      presenter = stub_flow_registration_presenter
-      presenter.stubs(:external_related_links).returns(%w[link-1])
-      content_item = FlowContentItem.new(presenter)
-
-      assert_equal "link-1", content_item.payload[:details][:external_related_links][0]
-    end
-
-    test "#payload schema_name is generic_with_external_related_links" do
-      presenter = stub_flow_registration_presenter
-      content_item = FlowContentItem.new(presenter)
-
-      assert_equal "generic_with_external_related_links", content_item.payload[:schema_name]
     end
 
     test "#payload document_type is smart_answer" do

--- a/test/unit/flow_presenter_test.rb
+++ b/test/unit/flow_presenter_test.rb
@@ -159,19 +159,6 @@ class FlowPresenterTest < ActiveSupport::TestCase
     end
   end
 
-  context "#external_related_links" do
-    should "return the external_related_links" do
-      @flow.external_related_links([title: "a-title", url: "a-description"])
-
-      flow_presenter = FlowPresenter.new({}, @flow)
-      assert_equal [title: "a-title", url: "a-description"], flow_presenter.external_related_links
-    end
-
-    should "return empty list if no external links" do
-      assert_equal [], @flow_presenter.external_related_links
-    end
-  end
-
   context "publish?" do
     should "return true for a published flow" do
       @flow.status(:published)

--- a/test/unit/flow_test.rb
+++ b/test/unit/flow_test.rb
@@ -114,24 +114,6 @@ class FlowTest < ActiveSupport::TestCase
     assert_equal "587920ff-b854-4adb-9334-451b45652467", s.flow_content_id
   end
 
-  test "Defaults the external_related_links to nil" do
-    s = SmartAnswer::Flow.new
-
-    assert_nil s.external_related_links
-  end
-
-  test "Can set the external_related_links" do
-    links = [
-      { title: "Book appointment", url: "https://www.booking-an-appointment.gov.uk" },
-      { title: "Buy stamps", url: "https://www.stamps.uk" },
-    ]
-    s = SmartAnswer::Flow.new do
-      external_related_links links
-    end
-
-    assert_equal links, s.external_related_links
-  end
-
   test "Can build outcome nodes" do
     s = SmartAnswer::Flow.new do
       outcome :you_dont_have_a_sweet_tooth

--- a/test/unit/services/content_item_syncer_test.rb
+++ b/test/unit/services/content_item_syncer_test.rb
@@ -19,7 +19,6 @@ class ContentItemSyncerTest < ActiveSupport::TestCase
         name: "bridge-of-death",
         start_page_content_id: start_page_content_id,
         flow_content_id: flow_content_id,
-        external_related_links: nil,
         response_store: nil,
         nodes: [],
       )

--- a/test/unit/start_page_content_item_test.rb
+++ b/test/unit/start_page_content_item_test.rb
@@ -22,7 +22,6 @@ module SmartAnswer
           post_body: "start-page-post-body",
           start_button_text: "start-button-text",
         ),
-        external_related_links: [],
         start_page_link: "/flow-name/y",
       )
     end
@@ -36,16 +35,6 @@ module SmartAnswer
 
     test "#payload returns a valid content-item" do
       presenter = stub_flow_registration_presenter
-      content_item = StartPageContentItem.new(presenter)
-
-      assert_valid_against_schema(content_item.payload, "transaction")
-    end
-
-    test "#payload returns a valid content-item with external related links" do
-      presenter = stub_flow_registration_presenter
-      presenter.stubs(:external_related_links).returns(
-        [{ title: "hmrc", url: "https://hmrc.gov.uk" }],
-      )
       content_item = StartPageContentItem.new(presenter)
 
       assert_valid_against_schema(content_item.payload, "transaction")
@@ -70,14 +59,6 @@ module SmartAnswer
       content_item = StartPageContentItem.new(presenter)
 
       assert_equal "flow-description", content_item.payload[:description]
-    end
-
-    test "#payload details hash includes external_related_links" do
-      presenter = stub_flow_registration_presenter
-      presenter.stubs(:external_related_links).returns(%w[link-1])
-      content_item = StartPageContentItem.new(presenter)
-
-      assert_equal "link-1", content_item.payload[:details][:external_related_links][0]
     end
 
     test "#payload details hash includes includes the introductory paragraph as govspeak" do


### PR DESCRIPTION
This removes the ability to set external related links for Smart Answers. There are no flows that currently use this functionality and should built into content tagger instead.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
