### PR TITLE
Fix publishing flows

### DIFF
--- a/lib/method_missing_object.rb
+++ b/lib/method_missing_object.rb
@@ -20,7 +20,7 @@ class MethodMissingObject
     @parent_method ? "#{@parent_method.description}.#{@method}" : @method.to_s
   end
 
-  def to_s
+  def to_s(_format = nil)
     @blank_to_s ? "" : "<%= #{description} %>".html_safe
   end
 

--- a/lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_affected_greater_than_cap_london.erb
+++ b/lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_affected_greater_than_cap_london.erb
@@ -4,8 +4,8 @@
 <% end %>
 
 <%
-  new_housing_benefit_amount = config.new_housing_benefit_amount(housing_benefit_amount, total_over_cap)
-  new_housing_benefit = config.new_housing_benefit(new_housing_benefit_amount)
+  new_housing_benefit_amount = calculator.new_housing_benefit_amount(housing_benefit_amount, total_over_cap)
+  new_housing_benefit = calculator.new_housing_benefit(new_housing_benefit_amount)
 %>
 
 <% govspeak_for :body do %>

--- a/lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_affected_greater_than_cap_national.erb
+++ b/lib/smart_answer_flows/benefit-cap-calculator/outcomes/outcome_affected_greater_than_cap_national.erb
@@ -4,8 +4,8 @@
 <% end %>
 
 <%
-  new_housing_benefit_amount = config.new_housing_benefit_amount(housing_benefit_amount, total_over_cap)
-  new_housing_benefit = config.new_housing_benefit(new_housing_benefit_amount)
+  new_housing_benefit_amount = calculator.new_housing_benefit_amount(housing_benefit_amount, total_over_cap)
+  new_housing_benefit = calculator.new_housing_benefit(new_housing_benefit_amount)
 %>
 
 <% govspeak_for :body do %>

--- a/lib/smart_answer_flows/benefit-cap-calculator/questions/single_couple_lone_parent.erb
+++ b/lib/smart_answer_flows/benefit-cap-calculator/questions/single_couple_lone_parent.erb
@@ -2,4 +2,4 @@
   Are you:
 <% end %>
 
-<% options(config.weekly_benefit_cap_descriptions) %>
+<% options(calculator.weekly_benefit_cap_descriptions) %>

--- a/lib/smart_answer_flows/check-uk-visa.rb
+++ b/lib/smart_answer_flows/check-uk-visa.rb
@@ -299,7 +299,6 @@ module SmartAnswer
       outcome :outcome_transit_taiwan
       outcome :outcome_transit_taiwan_through_border_control
       outcome :outcome_transit_to_the_republic_of_ireland
-      outcome :outcome_transit_venezuela
       outcome :outcome_tourism_n
       outcome :outcome_tourism_visa_partner
       outcome :outcome_visit_waiver


### PR DESCRIPTION
This PR includes fixes for publishing flows using the `publishing_api:sync` and `publishing_api:sync_all` rake task. When the publishing a flow, the content from the flow is extracted by force rendering each of the node templates. However, some flows have over time introduced issues with extraction process causing it fail and preventing the flow from being re-published.

The flows this primarily effects are:
- check-uk-visa (Unused reference to an outcome template)
- benefit-cap-calculator  (Re-using already set variables that prevent placeholder values being added)
- vat-payment-deadlines  (Calls to `to_s` with an argument not stubbed)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
