### PR TITLE
Remove South Africa from countries without registration

### DIFF
--- a/lib/smart_answer/calculators/registrations_data_query.rb
+++ b/lib/smart_answer/calculators/registrations_data_query.rb
@@ -14,7 +14,6 @@ module SmartAnswer::Calculators
       montserrat
       new-zealand
       pitcairn
-      south-africa
       south-georgia-and-the-south-sandwich-islands
       st-helena-ascension-and-tristan-da-cunha
       turks-and-caicos-islands


### PR DESCRIPTION
South Africa will be opening registrations for British nationals born in the country to apply for consular certificates. This change will ensure the relevant outcomes in the 'Register a Death' and 'Register a Birth' Smart Answers are shown for South Africa.

[Trello Card](https://trello.com/c/kL7zUe1d/2468-register-a-birth-and-register-a-death-changes-for-south-africa)