### PR TITLE
Add FlowHelper to abstract logic from FlowController

### DIFF
--- a/app/controllers/flow_controller.rb
+++ b/app/controllers/flow_controller.rb
@@ -11,7 +11,6 @@ class FlowController < ApplicationController
 
   def show
     @title = presenter.title
-    @content_item = ContentItemRetriever.fetch(flow.name) if presenter.finished?
 
     if params[:node_slug] == presenter.node_slug
       render presenter.current_node.view_template_path, formats: [:html]

--- a/app/controllers/flow_controller.rb
+++ b/app/controllers/flow_controller.rb
@@ -1,4 +1,6 @@
 class FlowController < ApplicationController
+  include FlowHelper
+
   before_action :set_cache_headers
   before_action :redirect_path_based_flows
 
@@ -45,41 +47,5 @@ private
     elsif Rails.configuration.set_http_cache_control_expiry_time
       expires_in(30.minutes, public: true)
     end
-  end
-
-  def forwarding_responses
-    flow.response_store == :session ? {} : response_store.all
-  end
-  helper_method :forwarding_responses
-
-  def presenter
-    @presenter ||= begin
-      params.merge!(responses: response_store.all, node_name: node_name)
-      FlowPresenter.new(params, flow)
-    end
-  end
-
-  def flow
-    @flow ||= SmartAnswer::FlowRegistry.instance.find(params[:id])
-  end
-
-  def response_store
-    @response_store ||= begin
-      if flow.response_store == :session
-        SessionResponseStore.new(flow_name: params[:id], session: session)
-      else
-        allowable_keys = flow.nodes.map(&:name)
-        query_parameters = request.query_parameters.slice(*allowable_keys)
-        ResponseStore.new(responses: query_parameters)
-      end
-    end
-  end
-
-  def node_name
-    @node_name ||= params[:node_slug].underscore if params[:node_slug].present?
-  end
-
-  def next_node_slug
-    presenter.current_state.current_node.to_s.dasherize
   end
 end

--- a/app/controllers/flow_controller.rb
+++ b/app/controllers/flow_controller.rb
@@ -9,7 +9,7 @@ class FlowController < ApplicationController
 
   def show
     @title = presenter.title
-    @content_item = ContentItemRetriever.fetch(name) if presenter.finished?
+    @content_item = ContentItemRetriever.fetch(flow.name) if presenter.finished?
 
     if params[:node_slug] == presenter.node_slug
       render presenter.current_node.view_template_path, formats: [:html]
@@ -59,18 +59,14 @@ private
     end
   end
 
-  def name
-    @name ||= params[:id].gsub(/_/, "-").to_sym
-  end
-
   def flow
-    @flow ||= SmartAnswer::FlowRegistry.instance.find(name.to_s)
+    @flow ||= SmartAnswer::FlowRegistry.instance.find(params[:id])
   end
 
   def response_store
     @response_store ||= begin
       if flow.response_store == :session
-        SessionResponseStore.new(flow_name: name, session: session)
+        SessionResponseStore.new(flow_name: params[:id], session: session)
       else
         allowable_keys = flow.nodes.map(&:name)
         query_parameters = request.query_parameters.slice(*allowable_keys)

--- a/app/helpers/flow_helper.rb
+++ b/app/helpers/flow_helper.rb
@@ -1,0 +1,38 @@
+module FlowHelper
+  def forwarding_responses
+    flow.response_store == :session ? {} : response_store.all
+  end
+
+  def presenter
+    @presenter ||= begin
+      params.merge!(responses: response_store.all, node_name: node_name)
+      FlowPresenter.new(params, flow)
+    end
+  end
+
+  def flow
+    @flow ||= SmartAnswer::FlowRegistry.instance.find(params[:id])
+  end
+
+  def response_store
+    @response_store ||= begin
+      if flow.response_store == :session
+        SessionResponseStore.new(flow_name: params[:id], session: session)
+      else
+        allowable_keys = flow.nodes.map(&:name)
+        query_parameters = request.query_parameters.slice(*allowable_keys)
+        ResponseStore.new(responses: query_parameters)
+      end
+    end
+  end
+
+private
+
+  def node_name
+    @node_name ||= params[:node_slug].underscore if params[:node_slug].present?
+  end
+
+  def next_node_slug
+    presenter.current_state.current_node.to_s.dasherize
+  end
+end

--- a/app/helpers/flow_helper.rb
+++ b/app/helpers/flow_helper.rb
@@ -26,6 +26,10 @@ module FlowHelper
     end
   end
 
+  def content_item
+    @content_item ||= ContentItemRetriever.fetch(flow.name)
+  end
+
 private
 
   def node_name

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,9 +21,9 @@
     <%= javascript_include_tag "test-dependencies" if Rails.env.test? %>
     <%= javascript_include_tag "application", defer: true %>
     <%= yield :head %>
-    <% if @content_item %>
+    <% if content_item %>
       <%= render "govuk_publishing_components/components/meta_tags",
-        content_item: @content_item,
+        content_item: content_item,
         strip_dates_pii: true,
         strip_postcode_pii: true %>
     <% end %>

--- a/app/views/smart_answers/landing.html.erb
+++ b/app/views/smart_answers/landing.html.erb
@@ -4,19 +4,23 @@
   <% if start_node.meta_description.present? %>
     <meta name="description" content="<%= start_node.meta_description %>">
   <% end %>
-  <% if @content_item.present? %>
+  <% if content_item.present? %>
+    <%= render "govuk_publishing_components/components/meta_tags",
+      content_item: content_item,
+      strip_dates_pii: true,
+      strip_postcode_pii: true %>
     <%= render 'govuk_publishing_components/components/machine_readable_metadata',
       schema: :article,
-      content_item: @content_item %>
+      content_item: content_item %>
     <%= render 'govuk_publishing_components/components/machine_readable_metadata',
       schema: :government_service,
-      content_item: @content_item %>
+      content_item: content_item %>
   <% end %>
   <link title="Search" rel="search" type="application/opensearchdescription+xml" href="/search/opensearch.xml"/>
 <% end %>
 
 <% content_for :breadcrumbs do %>
-  <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: @content_item %>
+  <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item %>
 <% end %>
 
 <div class="govuk-grid-row">
@@ -63,9 +67,9 @@
       <% end %>
     </article>
 
-    <%= render 'govuk_publishing_components/components/contextual_footer', content_item: @content_item %>
+    <%= render 'govuk_publishing_components/components/contextual_footer', content_item: content_item %>
   </div>
   <div class="govuk-grid-column-one-third">
-    <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: @content_item %>
+    <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: content_item %>
   </div>
 </div>

--- a/app/views/smart_answers/result.html.erb
+++ b/app/views/smart_answers/result.html.erb
@@ -61,7 +61,7 @@
 
   <% if defined?(@presenter.finished?) and @presenter.finished? %>
     <div class="govuk-grid-column-one-third govuk-!-margin-top-9">
-      <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: @content_item %>
+      <%= render 'govuk_publishing_components/components/contextual_sidebar', content_item: content_item %>
     </div>
   <% end %>
 </div>

--- a/spec/helpers/flow_helper_spec.rb
+++ b/spec/helpers/flow_helper_spec.rb
@@ -1,0 +1,90 @@
+RSpec.describe FlowHelper do
+  describe "#forwarding_responses" do
+    before do
+      response_store = ResponseStore.new(responses: { question1: "response1" })
+      allow(helper).to receive(:response_store).and_return(response_store)
+    end
+
+    it "returns an empty hash for session based flows" do
+      flow = SmartAnswer::Flow.new { response_store :session }
+      allow(helper).to receive(:flow).and_return(flow)
+
+      expect(helper.forwarding_responses).to eq({})
+    end
+
+    it "returns all the previous responses" do
+      flow = SmartAnswer::Flow.new { response_store :other }
+      allow(helper).to receive(:flow).and_return(flow)
+
+      expect(helper.forwarding_responses).to eq({ question1: "response1" })
+    end
+  end
+
+  describe "#presenter" do
+    it "returns the flow presenter" do
+      params[:node_slug] = "question-2"
+
+      flow = SmartAnswer::Flow.new { response_store :other }
+      allow(helper).to receive(:flow).and_return(flow)
+
+      response_store = ResponseStore.new(responses: { question1: "response1" })
+      allow(helper).to receive(:response_store).and_return(response_store)
+
+      expect(helper.presenter).to be_a(FlowPresenter)
+      expect(helper.presenter.flow).to be(flow)
+    end
+  end
+
+  describe "#flow" do
+    it "returns the flow for the current request" do
+      params[:id] = "flow-name"
+
+      flow = SmartAnswer::Flow.new { name "flow-name" }
+      flow_registry = instance_double("SmartAnswer::FlowRegistry")
+      allow(SmartAnswer::FlowRegistry).to receive(:instance).and_return(flow_registry)
+      allow(flow_registry).to receive(:find).with("flow-name").and_return(flow)
+
+      expect(helper.flow).to be(flow)
+    end
+  end
+
+  describe "#response_store" do
+    context "for session based flow" do
+      it "returns a session response store with flow name and session" do
+        params[:id] = "flow-name"
+
+        store = double("response-store")
+
+        flow = SmartAnswer::Flow.new { response_store :session }
+        allow(helper).to receive(:flow).and_return(flow)
+
+        expect(SessionResponseStore).to receive(:new).with(
+          flow_name: params[:id], session: session,
+        ).and_return(store)
+
+        expect(helper.response_store).to be(store)
+      end
+    end
+
+    context "for non-session based flow" do
+      it "returns a response store" do
+        store = double("response-store")
+        controller.request.query_parameters["question1"] = "response1"
+        controller.request.query_parameters["key"] = "value"
+
+        flow = SmartAnswer::Flow.new do
+          response_store :other
+          radio :question1
+        end
+
+        allow(helper).to receive(:flow).and_return(flow)
+
+        expect(ResponseStore).to receive(:new).with(
+          responses: { "question1" => "response1" },
+        ).and_return(store)
+
+        expect(helper.response_store).to be(store)
+      end
+    end
+  end
+end

--- a/spec/helpers/flow_helper_spec.rb
+++ b/spec/helpers/flow_helper_spec.rb
@@ -87,4 +87,17 @@ RSpec.describe FlowHelper do
       end
     end
   end
+
+  describe "#content_item" do
+    it "returns a content item for the flow" do
+      flow = SmartAnswer::Flow.new { name "flow-name" }
+      allow(helper).to receive(:flow).and_return(flow)
+
+      content_item = { "content_item": "value" }
+      allow(ContentItemRetriever).to receive(:fetch).with("flow-name")
+        .and_return(content_item)
+
+      expect(helper.content_item).to be(content_item)
+    end
+  end
 end


### PR DESCRIPTION
This PR is aimed at improving code organisation. The FlowController class had a lot of private helper methods and was getting long. Moving the the methods into a help modules makes it easier to access these methods from views and allows them to be unit tested.

With this code refactor it was noticed that the `name` method was redundant and that there was a issue of not fetching the content item for question views on session based flows.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
