### PR TITLE
Remove the annual turnover question

### DIFF
--- a/lib/smart_answer/calculators/business_coronavirus_support_finder_calculator.rb
+++ b/lib/smart_answer/calculators/business_coronavirus_support_finder_calculator.rb
@@ -2,7 +2,6 @@ module SmartAnswer::Calculators
   class BusinessCoronavirusSupportFinderCalculator
     attr_accessor :business_based,
                   :business_size,
-                  :annual_turnover,
                   :paye_scheme,
                   :non_domestic_property,
                   :sectors,

--- a/lib/smart_answer_flows/business-coronavirus-support-finder.rb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder.rb
@@ -30,21 +30,6 @@ module SmartAnswer
         end
 
         next_node do
-          question :annual_turnover?
-        end
-      end
-
-      radio :annual_turnover? do
-        option :under_85k
-        option :"85k_to_45m"
-        option :"45m_to_500m"
-        option :"500m_and_over"
-
-        on_response do |response|
-          calculator.annual_turnover = response
-        end
-
-        next_node do
           question :paye_scheme?
         end
       end

--- a/spec/features/flows/business_coronavirus_support_finder_spec.rb
+++ b/spec/features/flows/business_coronavirus_support_finder_spec.rb
@@ -3,7 +3,6 @@ RSpec.feature "SmartAnswer::BusinessCoronavirusSupportFinderFlow" do
     # <question name>: <text_for :title from erb>
     {
       flow_title: "Find coronavirus financial support for your business",
-      annual_turnover: "What is your annual turnover?",
       business_based: "Where is your business based?",
       business_size: "How many employees does your business have?",
       non_domestic_property: "Does your business have any rateable non-domestic property?",
@@ -22,7 +21,6 @@ RSpec.feature "SmartAnswer::BusinessCoronavirusSupportFinderFlow" do
       yes: "Yes",
       no: "No",
       employees: "0 to 249 employees",
-      turnover: "Under £85,000",
       property: "Yes",
       non_adult: "Nurseries",
       adult: "Nightclub, dancehall, or adult entertainment venue",
@@ -37,7 +35,6 @@ RSpec.feature "SmartAnswer::BusinessCoronavirusSupportFinderFlow" do
   scenario "Answers all questions" do
     answer(question: headings[:business_based], of_type: :radio, with: answers[:england])
     answer(question: headings[:business_size], of_type: :radio, with: answers[:employees])
-    answer(question: headings[:annual_turnover], of_type: :radio, with: answers[:turnover])
     answer(question: headings[:paye_scheme], of_type: :radio, with: answers[:yes])
     answer(question: headings[:non_domestic_property], of_type: :radio, with: answers[:property])
     answer(question: headings[:sectors], of_type: :checkbox, with: answers[:non_adult])
@@ -49,7 +46,6 @@ RSpec.feature "SmartAnswer::BusinessCoronavirusSupportFinderFlow" do
   scenario "Skip last question if business type nightclubs" do
     answer(question: headings[:business_based], of_type: :radio, with: answers[:england])
     answer(question: headings[:business_size], of_type: :radio, with: answers[:employees])
-    answer(question: headings[:annual_turnover], of_type: :radio, with: answers[:turnover])
     answer(question: headings[:paye_scheme], of_type: :radio, with: answers[:yes])
     answer(question: headings[:non_domestic_property], of_type: :radio, with: answers[:property])
     answer(question: headings[:sectors], of_type: :checkbox, with: answers[:adult])


### PR DESCRIPTION
This removes the "What is your annual turnover?" question from the business coronavirus support finder flow. The response to this question is no longer needed to determine the eligibility of any of the existing schemes.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
