### PR TITLE
Fix flaky tests for NextStepsForYourBusinessCalculator

### DIFF
--- a/test/unit/calculators/next_steps_for_your_business_calculator_test.rb
+++ b/test/unit/calculators/next_steps_for_your_business_calculator_test.rb
@@ -9,7 +9,8 @@ module SmartAnswer::Calculators
     context "#company_exists?" do
       setup do
         @client = mock
-        CompaniesHouse::Client.stubs(:new).returns(@client)
+        NextStepsForYourBusinessCalculator.stubs(:companies_house_client)
+                                          .returns(@client)
       end
 
       should "return true if company profile is present" do
@@ -34,7 +35,8 @@ module SmartAnswer::Calculators
     context "#company_name" do
       setup do
         @client = mock
-        CompaniesHouse::Client.stubs(:new).returns(@client)
+        NextStepsForYourBusinessCalculator.stubs(:companies_house_client)
+                                          .returns(@client)
       end
 
       should "return the company name" do


### PR DESCRIPTION
These tests were mocking an object that is lazily stored at a class
level on NextStepsForYourBusinessCalculator, which meant that only the
first mock that was configured was used and then used across subsequent
tests.

This lead to warnings in the tests of:

Mocha deprecation warning at /var/lib/jenkins/workspace/smartanswers_seiss-april-2021/lib/smart_answer/calculators/next_steps_for_your_business_calculator.rb:34:in `company_name': #<Mock:0x223d0> was instantiated in one test but it is receiving invocations within another test. This can lead to unintended interactions between tests and hence unexpected test failures. Ensure that every test correctly cleans up any state that it introduces. A Mocha::StubbingError will be raised in this scenario in the future.

And errors depending on the test ordering:

Failure:
SmartAnswer::Calculators::NextStepsForYourBusinessCalculatorTest#test_: #company_name should return the company name.  [/var/lib/jenkins/workspace/smartanswers_seiss-april-2021/test/unit/calculators/next_steps_for_your_business_calculator_test.rb:46]:
Expected: "BUSINESS NAME LTD"
  Actual: nil

The simplest way to fix this is to mock at the
NextStepsForYourBusinessCalculator level rather than at the client.
Although I'm not convinced it should be a class method (presumably it is
to reuse a TCP connection?) as lazily loaded class methods aren't
threadsafe and can produce surprises like this that are hard to debug.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
