### PR TITLE
Get current response for question

### DIFF
--- a/app/presenters/country_select_question_presenter.rb
+++ b/app/presenters/country_select_question_presenter.rb
@@ -1,12 +1,10 @@
 class CountrySelectQuestionPresenter < QuestionPresenter
-  include CurrentQuestionHelper
-
   def select_options
     @node.options.map do |option|
       {
         text: option.name,
         value: option.slug,
-        selected: option.slug == prefill_value_for(self),
+        selected: option.slug == response_for_current_question,
       }
     end
   end

--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -79,8 +79,15 @@ class FlowPresenter
   end
 
   def response_for_current_question
-    responses = params[:responses]
-    responses[current_state.current_node.to_s]
+    if response_store
+      responses = params[:responses]
+      responses[current_state.current_node.to_s]
+    elsif params[:previous_response].present?
+      params[:previous_response]
+    else
+      question_number = current_state.path.size
+      all_responses[question_number]
+    end
   end
 
   def current_question_number

--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -78,6 +78,11 @@ class FlowPresenter
     @node_presenters[node.name] ||= presenter_class.new(node, self, current_state, {}, params)
   end
 
+  def response_for_current_question
+    responses = params[:responses]
+    responses[current_state.current_node.to_s]
+  end
+
   def current_question_number
     current_state.path.size + 1
   end

--- a/app/presenters/question_presenter.rb
+++ b/app/presenters/question_presenter.rb
@@ -1,4 +1,6 @@
 class QuestionPresenter < NodePresenter
+  delegate :response_for_current_question, to: :@flow_presenter
+
   attr_reader :params
 
   def initialize(node, flow_presenter, state = nil, options = {}, params = {})

--- a/app/views/smart_answers/inputs/_money_question.html.erb
+++ b/app/views/smart_answers/inputs/_money_question.html.erb
@@ -10,6 +10,6 @@
   width: 10,
   hint: question.hint,
   suffix: question.suffix_label,
-  value: prefill_value_for(question),
+  value: question.response_for_current_question,
   error_message: question.error
 } %>

--- a/app/views/smart_answers/inputs/_postcode_question.html.erb
+++ b/app/views/smart_answers/inputs/_postcode_question.html.erb
@@ -10,5 +10,5 @@
   width: 10,
   error_message: question.error,
   hint: question.body,
-  value: prefill_value_for(question)
+  value: question.response_for_current_question
 } %>

--- a/app/views/smart_answers/inputs/_value_question.html.erb
+++ b/app/views/smart_answers/inputs/_value_question.html.erb
@@ -10,6 +10,6 @@
   width: 10,
   hint: question.hint_text,
   suffix: question.suffix_label,
-  value: prefill_value_for(question),
+  value: question.response_for_current_question,
   error_message: question.error
 } %>

--- a/test/unit/flow_presenter_test.rb
+++ b/test/unit/flow_presenter_test.rb
@@ -141,6 +141,18 @@ class FlowPresenterTest < ActiveSupport::TestCase
       flow_presenter = FlowPresenter.new(params, @flow)
       assert_equal("question-1-answer", flow_presenter.response_for_current_question)
     end
+
+    should "get the response for the current page for url-based smart-answers when previous_response" do
+      params = { id: @flow.name, responses: "question-1-answer", previous_response: "question-2-answer" }
+      flow_presenter = FlowPresenter.new(params, @flow)
+      assert_equal("question-2-answer", flow_presenter.response_for_current_question)
+    end
+
+    should "leave response for the current page blank for url-based smart-answers when no previous_response" do
+      params = { id: @flow.name, responses: "question-1-answer/question-2-answer" }
+      flow_presenter = FlowPresenter.new(params, @flow)
+      assert_nil(flow_presenter.response_for_current_question)
+    end
   end
 
   context "#normalize_responses_param" do

--- a/test/unit/flow_presenter_test.rb
+++ b/test/unit/flow_presenter_test.rb
@@ -134,6 +134,15 @@ class FlowPresenterTest < ActiveSupport::TestCase
     end
   end
 
+  context "#response_for_current_question" do
+    should "get the response for the current page for session-based smart-answers" do
+      @flow.response_store(:session)
+      params = { id: @flow.name, node_name: "first_question_key", responses: { "first_question_key" => "question-1-answer", "second_question_key" => "question-2-answer" } }
+      flow_presenter = FlowPresenter.new(params, @flow)
+      assert_equal("question-1-answer", flow_presenter.response_for_current_question)
+    end
+  end
+
   context "#normalize_responses_param" do
     should "return empty array when no responses in params" do
       params = {}


### PR DESCRIPTION
Trello: https://trello.com/c/h5u7N1T9

# What's changed?

Add a method to `FlowPresenter` to get the existing answer (if it exists) to the current question that the user is on on the flow.

The simplest questions have been updated to pre-populate their answers using this new method.

To make the changes easier to review, the other, more complex questions will be updated in separate PRs.

## Changes in this PR
- [x] When a user click back on a URL based Smart Answer then the previous questions show, with the previous answer pre-filled
- [x] When a user click back on a session based Smart Answer then the previous questions show, with the previous answer pre-filled
- [x] Country-select question
- [x] Money question
- [x] Postcode question
- [x] Value question

## Changes in other PRs
- [x] Checkbox question (#5316)
- [x] Radio button question (#5318)
- [x] Date question (#5319)
- [x] Salary question (#5320)

# Why?

There is currently a bug in session-based smart-answers, where answers to previous questions are not being populated even though the answers exist in the session.

Getting the responses in one place (`FlowPresenter`) means that in future PRs we can remove the `prefill_value_*` methods in the helper and instead have each `QuestionPresenter` get the value of the current question from `FlowPresenter` and have the presenter itself decide how it needs to work with the data in custom cases, e.g. checkboxes.

The benefit of this approach is that each presenter doesn't need to know what type of flow (url, session) the smart-answer is.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
