### PR TITLE
Get response for checkboxes

### DIFF
--- a/app/helpers/current_question_helper.rb
+++ b/app/helpers/current_question_helper.rb
@@ -26,14 +26,6 @@ module CurrentQuestionHelper
     end
   end
 
-  def prefill_value_includes?(question, value)
-    if params[:previous_response]
-      question.to_response(params[:previous_response]).include?(value)
-    elsif params[:response]
-      params[:response].include?(value)
-    end
-  end
-
   def prefill_value_for(question, attribute = nil)
     if params[:previous_response]
       response = question.to_response(params[:previous_response])

--- a/app/presenters/checkbox_question_presenter.rb
+++ b/app/presenters/checkbox_question_presenter.rb
@@ -34,4 +34,10 @@ class CheckboxQuestionPresenter < QuestionWithOptionsPresenter
       }
     end
   end
+
+  def checked?(value)
+    return false if response_for_current_question.blank?
+
+    response_for_current_question.include?(value)
+  end
 end

--- a/app/presenters/checkbox_question_presenter.rb
+++ b/app/presenters/checkbox_question_presenter.rb
@@ -1,6 +1,4 @@
 class CheckboxQuestionPresenter < QuestionWithOptionsPresenter
-  include CurrentQuestionHelper
-
   def response_labels(values)
     values.split(",").map do |value|
       if value == SmartAnswer::Question::Checkbox::NONE_OPTION
@@ -29,7 +27,7 @@ class CheckboxQuestionPresenter < QuestionWithOptionsPresenter
         label: option[:label],
         value: option[:value],
         hint: option[:hint_text],
-        checked: prefill_value_includes?(self, option[:value]),
+        checked: checked?(option[:value]),
         exclusive: option[:value] == "none" || nil,
       }
     end

--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -83,7 +83,7 @@ class FlowPresenter
       responses = params[:responses]
       responses[current_state.current_node.to_s]
     elsif params[:previous_response].present?
-      params[:previous_response]
+      current_node.to_response(params[:previous_response])
     else
       question_number = current_state.path.size
       all_responses[question_number]

--- a/test/unit/checkbox_question_presenter_test.rb
+++ b/test/unit/checkbox_question_presenter_test.rb
@@ -15,6 +15,7 @@ module SmartAnswer
       @renderer.stubs(:option).with(:option3).returns({ label: "Option 3" })
 
       @presenter = CheckboxQuestionPresenter.new(@question, nil, nil, renderer: @renderer)
+      @presenter.stubs(:response_for_current_question).returns(nil)
     end
 
     test "#response_labels returns option labels for responses" do

--- a/test/unit/checkbox_question_presenter_test.rb
+++ b/test/unit/checkbox_question_presenter_test.rb
@@ -29,7 +29,7 @@ module SmartAnswer
       assert_equal(%w[option1 option2 option3], @presenter.checkboxes.map { |c| c[:value] })
       assert_equal(["Option 1", "Option 2", "Option 3"], @presenter.checkboxes.map { |c| c[:label] })
       assert_equal([nil, "Hint 2", nil], @presenter.checkboxes.map { |c| c[:hint] })
-      assert_equal([nil, nil, nil], @presenter.checkboxes.map { |c| c[:checked] })
+      assert_equal([false, false, false], @presenter.checkboxes.map { |c| c[:checked] })
     end
 
     test "#checkboxes return array including an or divider for none options" do
@@ -37,11 +37,11 @@ module SmartAnswer
       @renderer.stubs(:option).with(:none).returns({ label: "None" })
 
       expected_value = [
-        { label: "Option 1", value: "option1", hint: nil, checked: nil, exclusive: nil },
-        { label: "Option 2", value: "option2", hint: "Hint 2", checked: nil, exclusive: nil },
-        { label: "Option 3", value: "option3", hint: nil, checked: nil, exclusive: nil },
+        { label: "Option 1", value: "option1", hint: nil, checked: false, exclusive: nil },
+        { label: "Option 2", value: "option2", hint: "Hint 2", checked: false, exclusive: nil },
+        { label: "Option 3", value: "option3", hint: nil, checked: false, exclusive: nil },
         :or,
-        { label: "None", value: "none", hint: nil, checked: nil, exclusive: true },
+        { label: "None", value: "none", hint: nil, checked: false, exclusive: true },
       ]
 
       assert_equal expected_value, @presenter.checkboxes
@@ -52,6 +52,21 @@ module SmartAnswer
       @renderer.stubs(:content_for).with(:caption).returns("caption-text")
 
       assert_equal "caption-text", @presenter.caption
+    end
+
+    context "#checked?" do
+      should "return true if values were previously selected" do
+        @presenter.stubs(:response_for_current_question).returns(%w[option1 option2])
+        assert @presenter.checked?("option2")
+      end
+
+      should "return false if no values have been selected" do
+        @presenter.stubs(:response_for_current_question).returns(nil)
+
+        %w[option1 option2 option3 none].each do |option|
+          assert_not @presenter.checked?(option)
+        end
+      end
     end
   end
 end

--- a/test/unit/flow_presenter_test.rb
+++ b/test/unit/flow_presenter_test.rb
@@ -153,6 +153,22 @@ class FlowPresenterTest < ActiveSupport::TestCase
       flow_presenter = FlowPresenter.new(params, @flow)
       assert_nil(flow_presenter.response_for_current_question)
     end
+
+    should "format the response for checkbox questions" do
+      flow = SmartAnswer::Flow.new do
+        name "flow-name"
+        checkbox_question :first_question_key do
+          next_node { outcome :second_question_key }
+        end
+        value_question :second_question_key do
+          next_node { outcome :outcome_key }
+        end
+      end
+      params = { id: flow.name, responses: "question-1-answer", previous_response: "question-2-answer-a,question-2-answer-b" }
+      flow_presenter = FlowPresenter.new(params, flow)
+
+      assert_equal(["question-2-answer-a", "question-2-answer-b"], flow_presenter.response_for_current_question)
+    end
   end
 
   context "#normalize_responses_param" do


### PR DESCRIPTION
Trello: https://trello.com/c/h5u7N1T9
Follows on from: PR #5315 

# What's changed?

Add a method to `CheckboxQuestionPresenter` to get the current value of the checkbox.

## Changes in this PR
- [x] Checkbox question

## Changes in other PRs
- [x] When a user click back on a URL based Smart Answer then the previous questions show, with the previous answer pre-filled (#5315)
- [x] When a user click back on a session based Smart Answer then the previous questions show, with the previous answer pre-filled (#5315)
- [x] Country-select question (#5315)
- [x] Money question (#5315)
- [x] Postcode question (#5315)
- [x] Value question (#5315)
- [x] Radio button question (#5318)
- [x] Date question (#5319)
- [x] Salary question (#5320)


# Why?

There is currently a bug in session-based smart-answers, where answers to previous checkbox questions are not being populated even though the answers exist in the session. 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
