### PR TITLE
Get response for radio buttons

### DIFF
--- a/app/helpers/current_question_helper.rb
+++ b/app/helpers/current_question_helper.rb
@@ -18,14 +18,6 @@ module CurrentQuestionHelper
     end
   end
 
-  def prefill_value_is?(value)
-    if params[:previous_response]
-      params[:previous_response] == value
-    elsif params[:response]
-      params[:response] == value
-    end
-  end
-
   def prefill_value_for(question, attribute = nil)
     if params[:previous_response]
       response = question.to_response(params[:previous_response])

--- a/app/presenters/multiple_choice_question_presenter.rb
+++ b/app/presenters/multiple_choice_question_presenter.rb
@@ -1,6 +1,4 @@
 class MultipleChoiceQuestionPresenter < QuestionWithOptionsPresenter
-  include CurrentQuestionHelper
-
   def response_label(value)
     options.find { |option| option[:value] == value }[:label]
   end
@@ -11,8 +9,14 @@ class MultipleChoiceQuestionPresenter < QuestionWithOptionsPresenter
         text: option[:label],
         value: option[:value],
         hint_text: option[:hint_text],
-        checked: prefill_value_is?(option[:value]),
+        checked: selected?(option[:value]),
       }
     end
+  end
+
+  def selected?(value)
+    return false if response_for_current_question.blank?
+
+    value == response_for_current_question
   end
 end

--- a/test/unit/multiple_choice_question_presenter_test.rb
+++ b/test/unit/multiple_choice_question_presenter_test.rb
@@ -15,6 +15,7 @@ module SmartAnswer
       @renderer.stubs(:option).with(:option3).returns("Option 3")
 
       @presenter = MultipleChoiceQuestionPresenter.new(@question, nil, nil, renderer: @renderer)
+      @presenter.stubs(:response_for_current_question).returns(nil)
     end
 
     test "#response_label returns option label" do
@@ -24,7 +25,13 @@ module SmartAnswer
     test "#radio_buttons return hashes of radio attributes" do
       assert_equal(%w[option1 option2 option3], @presenter.radio_buttons.map { |c| c[:value] })
       assert_equal(["Option 1", "Option 2", "Option 3"], @presenter.radio_buttons.map { |c| c[:text] })
-      assert_equal([nil, nil, nil], @presenter.radio_buttons.map { |c| c[:checked] })
+      assert_equal([false, false, false], @presenter.radio_buttons.map { |c| c[:checked] })
+    end
+
+    test "#radio_buttons sets an existing selection to true" do
+      @presenter.stubs(:response_for_current_question).returns("option2")
+
+      assert_equal([false, true, false], @presenter.radio_buttons.map { |c| c[:checked] })
     end
 
     test "#caption returns the given caption when a caption is given" do


### PR DESCRIPTION
Trello: https://trello.com/c/h5u7N1T9
Follows on from: PR #5315 

# What's changed?

Add a method to `MultipleChoiceQuestionPresenter` to get the current value of the radio buttons.

## Changes in this PR
- [x] Radio button question

## Changes in other PRs
- [x] When a user click back on a URL based Smart Answer then the previous questions show, with the previous answer pre-filled (#5315)
- [x] When a user click back on a session based Smart Answer then the previous questions show, with the previous answer pre-filled (#5315)
- [x] Country-select question (#5315)
- [x] Money question (#5315)
- [x] Postcode question (#5315)
- [x] Value question (#5315)
- [x] Checkbox question (#5316)
- [x] Date question (#5319)
- [x] Salary question (#5320)

# Why?

There is currently a bug in session-based smart-answers, where answers to previous radio button questions are not being populated even though the answers exist in the session. 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
