### PR TITLE
Get response for date question

### DIFF
--- a/app/presenters/date_question_presenter.rb
+++ b/app/presenters/date_question_presenter.rb
@@ -1,6 +1,4 @@
 class DateQuestionPresenter < QuestionPresenter
-  include CurrentQuestionHelper
-
   delegate :default_day,
            :default_month,
            :default_year,
@@ -15,15 +13,21 @@ class DateQuestionPresenter < QuestionPresenter
   end
 
   def selected_day
-    prefill_value_for(self, :day)
+    return if response_for_current_question.blank?
+
+    response_for_current_question[:day]
   end
 
   def selected_month
-    prefill_value_for(self, :month)
+    return if response_for_current_question.blank?
+
+    response_for_current_question[:month]
   end
 
   def selected_year
-    prefill_value_for(self, :year)
+    return if response_for_current_question.blank?
+
+    response_for_current_question[:year]
   end
 
 private

--- a/app/presenters/date_question_presenter.rb
+++ b/app/presenters/date_question_presenter.rb
@@ -13,19 +13,19 @@ class DateQuestionPresenter < QuestionPresenter
   end
 
   def selected_day
-    return if response_for_current_question.blank?
+    return unless response_for_current_question.is_a? Hash
 
     response_for_current_question[:day]
   end
 
   def selected_month
-    return if response_for_current_question.blank?
+    return unless response_for_current_question.is_a? Hash
 
     response_for_current_question[:month]
   end
 
   def selected_year
-    return if response_for_current_question.blank?
+    return unless response_for_current_question.is_a? Hash
 
     response_for_current_question[:year]
   end

--- a/test/unit/date_question_presenter_test.rb
+++ b/test/unit/date_question_presenter_test.rb
@@ -1,0 +1,31 @@
+require_relative "../test_helper"
+
+module SmartAnswer
+  class DateQuestionPresenterTest < ActiveSupport::TestCase
+    setup do
+      @question = Question::Date.new(nil, :question_name?)
+      @renderer = stub("renderer")
+
+      @presenter = DateQuestionPresenter.new(@question, nil, nil, renderer: @renderer)
+      @presenter.stubs(:response_for_current_question).returns(
+        {
+          day: 5,
+          month: 1,
+          year: 2021,
+        },
+      )
+    end
+
+    test "#selected_day returns the day" do
+      assert_equal 5, @presenter.selected_day
+    end
+
+    test "#selected_month returns the month" do
+      assert_equal 1, @presenter.selected_month
+    end
+
+    test "#selected_year returns the year" do
+      assert_equal 2021, @presenter.selected_year
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/h5u7N1T9
Follows on from: PR #5315 

# What's changed?

Add a method to `DateQuestionPresenter` to get the current value of the date fields.

## Changes in this PR
- [x] Date question

## Changes in other PRs
- [x] When a user click back on a URL based Smart Answer then the previous questions show, with the previous answer pre-filled (#5315)
- [x] When a user click back on a session based Smart Answer then the previous questions show, with the previous answer pre-filled (#5315)
- [x] Country-select question (#5315)
- [x] Money question (#5315)
- [x] Postcode question (#5315)
- [x] Value question (#5315)
- [x] Checkbox question (#5316)
- [x] Radio button question
- [x] Salary question (#5320)


# Why?

There is currently a bug in session-based smart-answers, where answers to previous date questions are not being populated even though the answers exist in the session. 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
