### PR TITLE
Get response for salary question

### DIFF
--- a/app/presenters/salary_question_presenter.rb
+++ b/app/presenters/salary_question_presenter.rb
@@ -4,4 +4,10 @@ class SalaryQuestionPresenter < QuestionPresenter
   def response_label(value)
     format_salary(SmartAnswer::Salary.new(value))
   end
+
+  def amount
+    return if response_for_current_question.blank?
+
+    response_for_current_question[:amount]
+  end
 end

--- a/app/presenters/salary_question_presenter.rb
+++ b/app/presenters/salary_question_presenter.rb
@@ -10,4 +10,10 @@ class SalaryQuestionPresenter < QuestionPresenter
 
     response_for_current_question[:amount]
   end
+
+  def period
+    return if response_for_current_question.blank?
+
+    response_for_current_question[:period]
+  end
 end

--- a/app/presenters/salary_question_presenter.rb
+++ b/app/presenters/salary_question_presenter.rb
@@ -6,13 +6,13 @@ class SalaryQuestionPresenter < QuestionPresenter
   end
 
   def amount
-    return if response_for_current_question.blank?
+    return response_for_current_question unless response_for_current_question.is_a? Hash
 
     response_for_current_question[:amount]
   end
 
   def period
-    return if response_for_current_question.blank?
+    return unless response_for_current_question.is_a? Hash
 
     response_for_current_question[:period]
   end

--- a/app/views/smart_answers/inputs/_salary_question.html.erb
+++ b/app/views/smart_answers/inputs/_salary_question.html.erb
@@ -10,7 +10,7 @@
   width: 10,
   hint: "in £",
   error_message: question.error,
-  value: prefill_value_for(question, :amount)
+  value: question.amount
 } %>
 <%= render "govuk_publishing_components/components/select", {
   id: "response_month",

--- a/app/views/smart_answers/inputs/_salary_question.html.erb
+++ b/app/views/smart_answers/inputs/_salary_question.html.erb
@@ -21,17 +21,17 @@
     {
       text: "per week",
       value: "week",
-      selected: prefill_value_for(question, :period) == "week"
+      selected: question.period == "week"
     },
     {
       text: "per month",
       value: "month",
-      selected: prefill_value_for(question, :period) == "month"
+      selected: question.period == "month"
     },
     {
       text: "per year",
       value: "year",
-      selected: prefill_value_for(question, :period) == "year"
+      selected: question.period == "year"
     }
   ]
 } %>

--- a/test/functional/smart_answers_controller_salary_question_test.rb
+++ b/test/functional/smart_answers_controller_salary_question_test.rb
@@ -44,6 +44,11 @@ class SmartAnswersControllerSalaryQuestionTest < ActionController::TestCase
           assert_select "h1.govuk-label-wrapper .govuk-label.govuk-label--l", /How much\?/
           assert_select ".govuk-error-message", /Please answer this question/
         end
+
+        should "not error if passed string response" do
+          submit_response "bob"
+          assert_response :success
+        end
       end
 
       should "show a validation error if invalid period" do

--- a/test/unit/salary_question_presenter_test.rb
+++ b/test/unit/salary_question_presenter_test.rb
@@ -21,5 +21,8 @@ module SmartAnswer
       end
     end
 
+    test "#period returns the period the salary is paid" do
+      assert_equal "month", @presenter.period
+    end
   end
 end

--- a/test/unit/salary_question_presenter_test.rb
+++ b/test/unit/salary_question_presenter_test.rb
@@ -1,0 +1,25 @@
+require_relative "../test_helper"
+
+module SmartAnswer
+  class SalaryQuestionPresenterTest < ActiveSupport::TestCase
+    setup do
+      @question = Question::Salary.new(nil, :question_name?)
+      @renderer = stub("renderer")
+
+      @presenter = SalaryQuestionPresenter.new(@question, nil, nil, renderer: @renderer)
+      @presenter.stubs(:response_for_current_question).returns(amount: "4000.0", period: "month")
+    end
+
+    context "#amount" do
+      should "return the amount" do
+        assert_equal "4000.0", @presenter.amount.to_s
+      end
+
+      should "return the user input if the amount is invalid" do
+        @presenter.stubs(:response_for_current_question).returns(amount: "-123", period: "week")
+        assert_equal "-123", @presenter.amount
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/h5u7N1T9
Follows on from: PR #5315 

# What's changed?

Add methods to the `SalaryQuestionPresenter` to get the current value for the amount and period fields.

## Changes in this PR
- [x] Salary question

## Changes in other PRs
- [x] When a user click back on a URL based Smart Answer then the previous questions show, with the previous answer pre-filled (#5315)
- [x] When a user click back on a session based Smart Answer then the previous questions show, with the previous answer pre-filled (#5315)
- [x] Country-select question (#5315)
- [x] Money question (#5315)
- [x] Postcode question (#5315)
- [x] Value question (#5315)
- [x] Checkbox question (#5316)
- [x] Radio button question (#5318)
- [x] Date question (#5319)


# Why?

There is currently a bug in session-based smart-answers, where answers to previous salary questions are not being populated even though the answers exist in the session. 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
