### PR TITLE
Remove prefill method

### DIFF
--- a/app/helpers/current_question_helper.rb
+++ b/app/helpers/current_question_helper.rb
@@ -17,21 +17,4 @@ module CurrentQuestionHelper
       smart_answer_path(presenter.name)
     end
   end
-
-  def prefill_value_for(question, attribute = nil)
-    if params[:previous_response]
-      response = question.to_response(params[:previous_response])
-    elsif params[:response]
-      response = params[:response]
-    end
-    if response.present? && attribute
-      begin
-        response[attribute]
-      rescue TypeError
-        response
-      end
-    else
-      response
-    end
-  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/h5u7N1T9
Follows on from: PR #5315

# What's changed?

Removes `prefill_value_for` helper method.

# Why?

All uses of this method were removed in PRs:
- #5315
- #5319
- #5320 
 


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
