### PR TITLE
Remove legacy /healthcheck route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,6 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root to: "smart_answers#index"
 
-  get "healthcheck", to: proc { [200, {}, [""]] }
-
   get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
   get "/healthcheck/ready", to: GovukHealthcheck.rack_response
 

--- a/test/integration/healthcheck_test.rb
+++ b/test/integration/healthcheck_test.rb
@@ -1,8 +1,0 @@
-require_relative "../integration_test_helper"
-
-class HealthcheckTest < ActionDispatch::IntegrationTest
-  should "returns health check status" do
-    get "/healthcheck"
-    assert_response :success
-  end
-end


### PR DESCRIPTION
govuk-puppet and govuk-aws have now been updated to only use the new
routes, so the old one is no longer needed.

See RFC 141 for more information.

---

[Trello card](https://trello.com/c/tl6RV1el/723-improve-govuk-healthchecks)
