### PR TITLE
Remove nightclub exemption from business support finder

### DIFF
--- a/lib/smart_answer_flows/business-coronavirus-support-finder.rb
+++ b/lib/smart_answer_flows/business-coronavirus-support-finder.rb
@@ -85,11 +85,7 @@ module SmartAnswer
         end
 
         next_node do
-          if calculator.sectors == %w[nightclubs_or_adult_entertainment]
-            outcome :results
-          else
-            question :closed_by_restrictions?
-          end
+          question :closed_by_restrictions?
         end
       end
 

--- a/spec/features/flows/business_coronavirus_support_finder_spec.rb
+++ b/spec/features/flows/business_coronavirus_support_finder_spec.rb
@@ -44,15 +44,4 @@ RSpec.feature "SmartAnswer::BusinessCoronavirusSupportFinderFlow" do
 
     ensure_page_has(header: headings[:results])
   end
-
-  scenario "Skip last question if business type nightclubs" do
-    answer(question: headings[:business_based], of_type: :radio, with: answers[:england])
-    answer(question: headings[:business_size], of_type: :radio, with: answers[:employees])
-    answer(question: headings[:paye_scheme], of_type: :radio, with: answers[:yes])
-    answer(question: headings[:self_employed], of_type: :radio, with: answers[:yes])
-    answer(question: headings[:non_domestic_property], of_type: :radio, with: answers[:property])
-    answer(question: headings[:sectors], of_type: :checkbox, with: answers[:adult])
-
-    ensure_page_has(header: headings[:results])
-  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/wjis8nfh/313-business-support-smart-answer-further-updates

The closed_by_restrictions outcomes are no longer exclusive to
businesses that are not nightclubs. Nightclubs were previously not shown
the LRSG Closed Addendum which we believe they could be eligible for.

We discussed whether to remove the nightclubs_or_adult_entertainment
option as no results depend on it, however content wanted to keep this
as it provided a distinction with leisure which nightclubs are typically
not eligible for.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
