### PR TITLE
Update custom result page grouping

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -3,6 +3,7 @@
 //= require govuk_publishing_components/components/checkboxes
 //= require govuk_publishing_components/components/feedback
 //= require govuk_publishing_components/components/govspeak
+//= require govuk_publishing_components/components/print-link
 //= require govuk_publishing_components/components/radio
 //= require govuk_publishing_components/components/step-by-step-nav
 //= require helpers

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,6 +16,7 @@ $govuk-use-legacy-palette: false;
 @import "govuk_publishing_components/components/hint";
 @import "govuk_publishing_components/components/input";
 @import "govuk_publishing_components/components/label";
+@import "govuk_publishing_components/components/print-link";
 @import "govuk_publishing_components/components/radio";
 @import "govuk_publishing_components/components/related-navigation";
 @import "govuk_publishing_components/components/select";

--- a/app/views/smart_answers/custom_result.html.erb
+++ b/app/views/smart_answers/custom_result.html.erb
@@ -16,6 +16,7 @@
     <%= tag.p outcome.description, class: "govuk-body govuk-!-margin-bottom-9" %>
 
     <%= outcome.body %>
+    <%= render "govuk_publishing_components/components/print_link" %>
     <%= render 'smart_answers/shared/debug' %>
   </div>
 </div>

--- a/lib/smart_answer/calculators/next_steps_for_your_business_calculator.rb
+++ b/lib/smart_answer/calculators/next_steps_for_your_business_calculator.rb
@@ -14,7 +14,11 @@ module SmartAnswer::Calculators
                   :business_premises
 
     def grouped_results
-      filtered_results.group_by { |result| result["topic"] }
+      grouped_results = filtered_results.group_by { |result| result["group"] }
+
+      grouped_results.transform_values do |results|
+        results.group_by { |result| result["topic"] }
+      end
     end
 
     def filtered_results

--- a/lib/smart_answer_flows/next-steps-for-your-business/outcomes/results.erb
+++ b/lib/smart_answer_flows/next-steps-for-your-business/outcomes/results.erb
@@ -14,17 +14,19 @@
 <% end %>
 
 <% text_for :body do %>
-  <%= render "govuk_publishing_components/components/heading", {
-    text: "Things you need to do next",
-    font_size: "l",
-    border_top: 2,
-    margin_bottom: 4
-  } %>
-  <% calculator.grouped_results.each do |section_name, results| %>
-    <%= render "components/result-section", {
-      title: section_name,
-      results: results,
-      highlighted: true
+  <% calculator.grouped_results.each do |group, topics| %>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: group,
+      font_size: "l",
+      border_top: 2,
+      padding: true
     } %>
+    <% topics.each do |topic, results| %>
+      <%= render "components/result-section", {
+        title: topic,
+        results: results,
+        highlighted: true
+      } %>
+    <% end %>
   <% end %>
 <% end %>


### PR DESCRIPTION
Note: There might be a less verbose way of grouping these results in Ruby. Open to suggestions.

### Visual changes

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

![localhost_3010_next-steps-for-your-business_s_results_activities%5B%5D=import_goods annual_turnover_over_85k=yes business_premises%5B%5D=home employ_someone=in_future financial_support=yes (1)](https://user-images.githubusercontent.com/788096/116250813-fe01d300-a765-11eb-982d-3b353f9062b3.png)


</td><td valign="top">

![localhost_3010_next-steps-for-your-business_s_results_activities%5B%5D=import_goods annual_turnover_over_85k=yes business_premises%5B%5D=home employ_someone=in_future financial_support=yes](https://user-images.githubusercontent.com/788096/116250825-01955a00-a766-11eb-8da9-c5f55e4b1dd1.png)


</td></tr>
</table>

[Trello card](https://trello.com/c/aJHoYSqm)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
