### PR TITLE
Prefill "none" option in checkboxes

### DIFF
--- a/lib/smart_answer/question/checkbox.rb
+++ b/lib/smart_answer/question/checkbox.rb
@@ -38,7 +38,7 @@ module SmartAnswer
       end
 
       def to_response(input)
-        input.split(",").reject { |v| v == NONE_OPTION }
+        input.split(",")
       end
 
       def none_option?

--- a/lib/smart_answer/question/checkbox.rb
+++ b/lib/smart_answer/question/checkbox.rb
@@ -38,6 +38,8 @@ module SmartAnswer
       end
 
       def to_response(input)
+        return unless input.respond_to?(:split)
+
         input.split(",")
       end
 

--- a/test/unit/checkbox_question_test.rb
+++ b/test/unit/checkbox_question_test.rb
@@ -104,8 +104,8 @@ module SmartAnswer
         assert_equal %w[red green], @question.to_response("red,green")
       end
 
-      should "remove the none option from the results" do
-        assert_equal [], @question.to_response("none")
+      should "not remove the none option from the results" do
+        assert_equal %w[none], @question.to_response("none")
       end
     end
   end

--- a/test/unit/checkbox_question_test.rb
+++ b/test/unit/checkbox_question_test.rb
@@ -107,6 +107,10 @@ module SmartAnswer
       should "not remove the none option from the results" do
         assert_equal %w[none], @question.to_response("none")
       end
+
+      should "return nil for invalid input" do
+        assert_nil @question.to_response({ anything: "anything" })
+      end
     end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/h5u7N1T9
Follows on from: #5316 

# What's changed?

Stop removing "none" options when results to checkbox questions are processed.

# Why?

In url-based flows, if a user selected "none" in a checkbox question, and then went back to change their answer, nothing would be populated, and it would appear as though the user had never answered at all.
This issue doesn't seem to affect session-based smart-answers.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
