### PR TITLE
Remove `/s/` prefix for default routes to FlowController

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,13 +16,14 @@ Rails.application.routes.draw do
         format: false
   end
 
-  get "/:id/s/destroy_session", to: "flow#destroy", as: :destroy_flow
-  get "/:id/s", to: "flow#start", as: :start_flow
-  get "/:id/s/:node_slug", to: "flow#show", as: :flow
-  get "/:id/s/:node_slug/next", to: "flow#update", as: :update_flow
+  get "/:id/s/destroy_session", to: "flow#destroy"
+  get "/:id/s", to: "flow#start"
+  get "/:id/s/:node_slug", to: "flow#show"
+  get "/:id/s/:node_slug/next", to: "flow#update"
 
-  get "/:id/flow/destroy_session", to: "flow#destroy"
-  get "/:id/flow", to: "flow#start"
-  get "/:id/flow/:node_slug", to: "flow#show"
-  get "/:id/flow/:node_slug/next", to: "flow#update"
+  get "/:id/start", to: "flow#start", as: :start_flow
+  get "/:id/destroy_session", to: "flow#destroy", as: :destroy_flow
+
+  get "/:id/:node_slug", to: "flow#show", as: :flow
+  get "/:id/:node_slug/next", to: "flow#update", as: :update_flow
 end

--- a/spec/requests/query_parameters_based_flow_spec.rb
+++ b/spec/requests/query_parameters_based_flow_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Query parameter based flow navigation", flow_dir: :fixture do
   context "urls have /s/ prefix" do
     it "redirects to first node" do
       get "/query-parameters-based/s"
-      expect(response).to redirect_to("/query-parameters-based/s/question1")
+      expect(response).to redirect_to("/query-parameters-based/question1")
       expect(response.headers["Cache-Control"]).to eq(cache_header)
     end
 
@@ -16,19 +16,19 @@ RSpec.describe "Query parameter based flow navigation", flow_dir: :fixture do
 
     it "redirects to preceding unanswered question" do
       get "/query-parameters-based/s/results"
-      expect(response).to redirect_to("/query-parameters-based/s/question1")
+      expect(response).to redirect_to("/query-parameters-based/question1")
       expect(response.headers["Cache-Control"]).to eq(cache_header)
     end
 
     it "redirects to next node when valid response provided" do
       get "/query-parameters-based/s/question1/next", params: { response: "response1", next: "true" }
-      expect(response).to redirect_to("/query-parameters-based/s/question2?question1=response1")
+      expect(response).to redirect_to("/query-parameters-based/question2?question1=response1")
       expect(response.headers["Cache-Control"]).to eq(cache_header)
     end
 
     it "redirects to same node when invalid response provided" do
       get "/query-parameters-based/s/question1/next", params: { response: "invalid", next: "true" }
-      expect(response).to redirect_to("/query-parameters-based/s/question1?question1=invalid")
+      expect(response).to redirect_to("/query-parameters-based/question1?question1=invalid")
       expect(response.headers["Cache-Control"]).to eq(cache_header)
     end
 
@@ -45,45 +45,45 @@ RSpec.describe "Query parameter based flow navigation", flow_dir: :fixture do
     end
   end
 
-  context "urls have /flow/ prefix" do
+  context "urls have no prefix" do
     it "redirects to first node" do
-      get "/query-parameters-based/flow"
-      expect(response).to redirect_to("/query-parameters-based/s/question1")
+      get "/query-parameters-based/start"
+      expect(response).to redirect_to("/query-parameters-based/question1")
       expect(response.headers["Cache-Control"]).to eq(cache_header)
     end
 
     it "renders the first question" do
-      get "/query-parameters-based/flow/question1"
+      get "/query-parameters-based/question1"
       expect(response).to render_template("smart_answers/question")
       expect(response.headers["Cache-Control"]).to eq(cache_header)
     end
 
     it "redirects to preceding unanswered question" do
-      get "/query-parameters-based/flow/results"
-      expect(response).to redirect_to("/query-parameters-based/s/question1")
+      get "/query-parameters-based/results"
+      expect(response).to redirect_to("/query-parameters-based/question1")
       expect(response.headers["Cache-Control"]).to eq(cache_header)
     end
 
     it "redirects to next node when valid response provided" do
-      get "/query-parameters-based/flow/question1/next", params: { response: "response1", next: "true" }
-      expect(response).to redirect_to("/query-parameters-based/s/question2?question1=response1")
+      get "/query-parameters-based/question1/next", params: { response: "response1", next: "true" }
+      expect(response).to redirect_to("/query-parameters-based/question2?question1=response1")
       expect(response.headers["Cache-Control"]).to eq(cache_header)
     end
 
     it "redirects to same node when invalid response provided" do
-      get "/query-parameters-based/flow/question1/next", params: { response: "invalid", next: "true" }
-      expect(response).to redirect_to("/query-parameters-based/s/question1?question1=invalid")
+      get "/query-parameters-based/question1/next", params: { response: "invalid", next: "true" }
+      expect(response).to redirect_to("/query-parameters-based/question1?question1=invalid")
       expect(response.headers["Cache-Control"]).to eq(cache_header)
     end
 
     it "clears the session and redirects to the start page" do
-      get "/query-parameters-based/flow/destroy_session"
+      get "/query-parameters-based/destroy_session"
       expect(response).to redirect_to("/query-parameters-based")
       expect(response.headers["Cache-Control"]).to eq(cache_header)
     end
 
     it "clears the session and redirects to another page" do
-      get "/query-parameters-based/flow/destroy_session", params: { ext_r: "true" }
+      get "/query-parameters-based/destroy_session", params: { ext_r: "true" }
       expect(response).to redirect_to("https://www.bbc.co.uk/weather")
       expect(response.headers["Cache-Control"]).to eq(cache_header)
     end

--- a/spec/requests/session_based_flow_spec.rb
+++ b/spec/requests/session_based_flow_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Session based flow navigation", flow_dir: :fixture do
   context "urls have /s/ prefix" do
     it "redirects to first node" do
       get "/session-based/s"
-      expect(response).to redirect_to("/session-based/s/question1")
+      expect(response).to redirect_to("/session-based/question1")
       expect(response.headers["Cache-Control"]).to eq(no_cache_header)
     end
 
@@ -16,19 +16,19 @@ RSpec.describe "Session based flow navigation", flow_dir: :fixture do
 
     it "redirects to preceding unanswered question" do
       get "/session-based/s/results"
-      expect(response).to redirect_to("/session-based/s/question1")
+      expect(response).to redirect_to("/session-based/question1")
       expect(response.headers["Cache-Control"]).to eq(no_cache_header)
     end
 
     it "redirects to next node when valid response provided" do
       get "/session-based/s/question1/next", params: { response: "response1", next: "true" }
-      expect(response).to redirect_to("/session-based/s/question2")
+      expect(response).to redirect_to("/session-based/question2")
       expect(response.headers["Cache-Control"]).to eq(no_cache_header)
     end
 
     it "redirects to same node when invalid response provided" do
       get "/session-based/s/question1/next", params: { response: "invalid", next: "true" }
-      expect(response).to redirect_to("/session-based/s/question1")
+      expect(response).to redirect_to("/session-based/question1")
       expect(response.headers["Cache-Control"]).to eq(no_cache_header)
     end
 
@@ -44,67 +44,67 @@ RSpec.describe "Session based flow navigation", flow_dir: :fixture do
     end
   end
 
-  context "urls have /flow/ prefix" do
+  context "urls have no prefix" do
     it "redirects to first node" do
-      get "/session-based/flow"
-      expect(response).to redirect_to("/session-based/s/question1")
+      get "/session-based/start"
+      expect(response).to redirect_to("/session-based/question1")
       expect(response.headers["Cache-Control"]).to eq(no_cache_header)
     end
 
     it "renders the first question" do
-      get "/session-based/flow/question1"
+      get "/session-based/question1"
       expect(response).to render_template("smart_answers/question")
       expect(response.headers["Cache-Control"]).to eq(no_cache_header)
     end
 
     it "redirects to preceding unanswered question" do
-      get "/session-based/flow/results"
-      expect(response).to redirect_to("/session-based/s/question1")
+      get "/session-based/results"
+      expect(response).to redirect_to("/session-based/question1")
       expect(response.headers["Cache-Control"]).to eq(no_cache_header)
     end
 
     it "redirects to next node when valid response provided" do
-      get "/session-based/flow/question1/next", params: { response: "response1", next: "true" }
-      expect(response).to redirect_to("/session-based/s/question2")
+      get "/session-based/question1/next", params: { response: "response1", next: "true" }
+      expect(response).to redirect_to("/session-based/question2")
       expect(response.headers["Cache-Control"]).to eq(no_cache_header)
     end
 
     it "redirects to same node when invalid response provided" do
-      get "/session-based/flow/question1/next", params: { response: "invalid", next: "true" }
-      expect(response).to redirect_to("/session-based/s/question1")
+      get "/session-based/question1/next", params: { response: "invalid", next: "true" }
+      expect(response).to redirect_to("/session-based/question1")
       expect(response.headers["Cache-Control"]).to eq(no_cache_header)
     end
 
     it "clears the session and redirects to the start page" do
-      get "/session-based/flow/destroy_session"
+      get "/session-based/destroy_session"
       expect(response).to redirect_to("/session-based")
       expect(response.headers["Cache-Control"]).to eq(no_cache_header)
     end
 
     it "clears the session and redirects to another page" do
-      get "/session-based/flow/destroy_session", params: { ext_r: "true" }
+      get "/session-based/destroy_session", params: { ext_r: "true" }
       expect(response).to redirect_to("https://www.bbc.co.uk/weather")
     end
   end
 
-  context "urls have /flow/ prefix, but are path based flows" do
+  context "urls have no prefix, but are path based flows" do
     it "redirects requests to old route" do
-      get "/path-based/flow"
+      get "/path-based/start"
       expect(response).to redirect_to("/path-based/y")
     end
 
     it "redirects requests for a specific node to old route" do
-      get "/path-based/flow/question1"
+      get "/path-based/question1"
       expect(response).to redirect_to("/path-based/y")
     end
 
     it "redirects requests for a next node to old route" do
-      get "/path-based/flow/question1/next", params: { response: "response1", next: "true" }
+      get "/path-based/question1/next", params: { response: "response1", next: "true" }
       expect(response).to redirect_to("/path-based/y")
     end
 
     it "redirects requests for destroying session to old route" do
-      get "/path-based/flow/destroy_session"
+      get "/path-based/destroy_session"
       expect(response).to redirect_to("/path-based/y")
     end
   end

--- a/test/unit/flow_presenter_test.rb
+++ b/test/unit/flow_presenter_test.rb
@@ -221,7 +221,7 @@ class FlowPresenterTest < ActiveSupport::TestCase
     should "return path to first page in session flow using sessions" do
       @flow.response_store(:session)
       flow_presenter = FlowPresenter.new({}, @flow)
-      assert_equal "/flow-name/s", flow_presenter.start_page_link
+      assert_equal "/flow-name/start", flow_presenter.start_page_link
     end
   end
 end


### PR DESCRIPTION
This sets the defaults routes to the FlowController to not be prefixed with `/s/`. The prefix was introduced to deal with a constraint of publishing the start page and the flow as separate content items in the Publishing API. The two content items needed unique base paths. However, Smart Answers now render the start page and are represented by a single content item and this constraint is removed. Removing the prefix simplifies the url structure and removes confusion around the meaning of the prefix.

The old prefix routes will continue to be supported until existing traffic no longer uses them - then they can be removed entirely. This will automatically update the urls in the pages, so users who continue their user journey will begin to use the non-prefixed routes.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
