### PR TITLE
Add change answer link to custom result page

### DIFF
--- a/app/views/smart_answers/custom_result.html.erb
+++ b/app/views/smart_answers/custom_result.html.erb
@@ -17,6 +17,18 @@
     <%= outcome.description %>
 
     <%= outcome.body %>
+
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Change your answers",
+      font_size: "l",
+      border_top: 2,
+      padding: true
+    } %>
+
+    <%= tag.p class: "govuk-body govuk-!-margin-bottom-8" do %>
+      <%= link_to "Start again", restart_flow_path(@presenter), class: "govuk-link" %>
+    <% end %>
+
     <%= render "govuk_publishing_components/components/print_link" %>
     <%= render 'smart_answers/shared/debug' %>
   </div>


### PR DESCRIPTION
### Visual changes

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

<img width="1000" alt="before" src="https://user-images.githubusercontent.com/788096/116555525-6979ab00-a8f4-11eb-8955-d0bd6669e87e.png">


</td><td valign="top">

<img width="1000" alt="after" src="https://user-images.githubusercontent.com/788096/116555535-6bdc0500-a8f4-11eb-9daa-bfa9c9cca15b.png">


</td></tr>
</table>


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
