### PR TITLE
Avoid empty elements

### DIFF
--- a/app/presenters/question_presenter.rb
+++ b/app/presenters/question_presenter.rb
@@ -32,7 +32,7 @@ class QuestionPresenter < NodePresenter
   end
 
   def hint
-    @renderer.content_for(:hint)
+    @renderer.content_for(:hint).presence
   end
 
   def caption
@@ -56,7 +56,7 @@ class QuestionPresenter < NodePresenter
   end
 
   def body
-    @renderer.content_for(:body)
+    @renderer.content_for(:body).presence
   end
 
   def post_body


### PR DESCRIPTION
Questions' hint and description/body elements end up being rendered without content because of the way we use renderers. We check for the content to exists before passing it to the component to avoid such empty elements.

### Empty hint element
<img width="1439" alt="empty-hint" src="https://user-images.githubusercontent.com/788096/116979782-52083c80-acbd-11eb-9a08-962dc127b785.png">


### Empty description/body element
<img width="1437" alt="empty-description" src="https://user-images.githubusercontent.com/788096/116979791-546a9680-acbd-11eb-8a18-18e1f83cb1e5.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
