### PR TITLE
Make question hints interface more consistent

### DIFF
--- a/app/presenters/checkbox_question_presenter.rb
+++ b/app/presenters/checkbox_question_presenter.rb
@@ -13,10 +13,6 @@ class CheckboxQuestionPresenter < QuestionWithOptionsPresenter
     true
   end
 
-  def hint_text
-    hint
-  end
-
   def checkboxes
     options.each_with_object([]) do |option, items|
       if option[:value] == "none"

--- a/app/presenters/question_presenter.rb
+++ b/app/presenters/question_presenter.rb
@@ -51,10 +51,6 @@ class QuestionPresenter < NodePresenter
     content.presence
   end
 
-  def pretext
-    @renderer.content_for(:pretext)
-  end
-
   def body
     @renderer.content_for(:body).presence
   end

--- a/app/presenters/value_question_presenter.rb
+++ b/app/presenters/value_question_presenter.rb
@@ -4,9 +4,4 @@ class ValueQuestionPresenter < QuestionPresenter
   def response_label(value)
     number_with_delimiter(value)
   end
-
-  def hint_text
-    text = [body, hint].reject(&:blank?).compact.join(", ")
-    ActionView::Base.full_sanitizer.sanitize(text)
-  end
 end

--- a/app/views/smart_answers/inputs/_checkbox_question.html.erb
+++ b/app/views/smart_answers/inputs/_checkbox_question.html.erb
@@ -7,6 +7,6 @@
   description: question.body,
   id: "response",
   error: question.error,
-  hint_text: question.hint_text,
+  hint_text: question.hint,
   items: question.checkboxes
 } %>

--- a/app/views/smart_answers/inputs/_date_question.html.erb
+++ b/app/views/smart_answers/inputs/_date_question.html.erb
@@ -3,12 +3,9 @@
     <%= question.body %>
   <% end %>
 
-  <% if question.hint.present? %>
-    <p class="govuk-hint"><%= question.hint %></p>
-  <% end %>
-
   <%= render "govuk_publishing_components/components/date_input", {
     error_message: question.error,
+    hint: question.hint,
     items: [
       question.default_day ? nil : {
         label: "Day",

--- a/app/views/smart_answers/inputs/_postcode_question.html.erb
+++ b/app/views/smart_answers/inputs/_postcode_question.html.erb
@@ -9,6 +9,6 @@
   heading_size: "l",
   width: 10,
   error_message: question.error,
-  hint: question.body,
+  hint: question.hint,
   value: question.response_for_current_question
 } %>

--- a/app/views/smart_answers/inputs/_salary_question.html.erb
+++ b/app/views/smart_answers/inputs/_salary_question.html.erb
@@ -8,7 +8,8 @@
   id: "response_amount",
   heading_size: "l",
   width: 10,
-  hint: "in £",
+  hint: question.hint,
+  suffix: "£",
   error_message: question.error,
   value: question.amount
 } %>

--- a/app/views/smart_answers/inputs/_value_question.html.erb
+++ b/app/views/smart_answers/inputs/_value_question.html.erb
@@ -8,7 +8,7 @@
   id: "response",
   heading_size: "l",
   width: 10,
-  hint: question.hint_text,
+  hint: question.hint,
   suffix: question.suffix_label,
   value: question.response_for_current_question,
   error_message: question.error

--- a/app/views/smart_answers/question.html.erb
+++ b/app/views/smart_answers/question.html.erb
@@ -17,11 +17,6 @@
           "question-key": question.title
         }) do %>
       <div class="govuk-!-margin-bottom-6 govuk-!-margin-top-8" id="current-question">
-        <% if question.pretext.present? %>
-          <div class="govuk-!-margin-bottom-8">
-            <%= question.pretext %>
-          </div>
-        <% end %>
 
         <%= render partial: "smart_answers/inputs/#{question.partial_template_name}", locals: { question: question } %>
 

--- a/app/views/smart_answers/question.html.erb
+++ b/app/views/smart_answers/question.html.erb
@@ -17,14 +17,6 @@
           "question-key": question.title
         }) do %>
       <div class="govuk-!-margin-bottom-6 govuk-!-margin-top-8" id="current-question">
-        <% show_body = ['salary_question', 'country_select_question'].include? question.partial_template_name %>
-
-        <% if question.body.present? && show_body %>
-          <article role="article">
-            <%= question.body %>
-          </article>
-        <% end %>
-
         <% if question.pretext.present? %>
           <div class="govuk-!-margin-bottom-8">
             <%= question.pretext %>

--- a/lib/smart_answer_flows/calculate-statutory-sick-pay/questions/total_employee_earnings.erb
+++ b/lib/smart_answer_flows/calculate-statutory-sick-pay/questions/total_employee_earnings.erb
@@ -2,9 +2,8 @@
   Enter the total amount (before deductions like Income Tax and National Insurance) of your employee’s earnings on paydays between <%= format_date(calculator.relevant_period_from) %> and <%= format_date(calculator.relevant_period_to) %>.
 <% end %>
 
-<% govspeak_for :body do %>
+<% govspeak_for :hint do %>
   Different rules apply for [directors of limited companies incorporated before 1 October 2009](/statutory-sick-pay-how-different-employment-types-affect-what-you-pay)
-
 <% end %>
 
 <% text_for :error_message do %>

--- a/test/unit/value_question_presenter_test.rb
+++ b/test/unit/value_question_presenter_test.rb
@@ -10,21 +10,6 @@ module SmartAnswer
       @presenter = ValueQuestionPresenter.new(@question, nil, nil, renderer: @renderer)
     end
 
-    test "#hint_text returns single line of content rendered for hint block" do
-      @renderer.stubs(:content_for).with(:body).returns("")
-      @renderer.stubs(:content_for).with(:hint).returns("hint-text")
-      @renderer.stubs(:content_for).with(:suffix_label).returns("")
-
-      assert_equal "hint-text", @presenter.hint_text
-    end
-
-    test "#hint_text also returns body if present" do
-      @renderer.stubs(:content_for).with(:body).returns("body")
-      @renderer.stubs(:content_for).with(:hint).returns("hint-text")
-
-      assert_equal "body, hint-text", @presenter.hint_text
-    end
-
     test "#caption returns the given caption when a caption is given" do
       @renderer.stubs(:hide_caption).returns(false)
       @renderer.stubs(:content_for).with(:caption).returns("caption-text")


### PR DESCRIPTION
This makes the interface and behaviour more consistent across different question types. Now all question access hint text via the `hint` attribute and pass it to relevant property on the component. This also unused fields `pretext` and `body` for some question types where they aren't used - in preference to use hint or post body text in future.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
