### PR TITLE
Add GA event to track response submission using question keys

### DIFF
--- a/app/assets/javascripts/modules/track-responses.js
+++ b/app/assets/javascripts/modules/track-responses.js
@@ -9,8 +9,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       track(element[0])
     }
 
-    function getQuestionKey (submittedForm) {
-      return submittedForm.getAttribute('data-question-key')
+    function getQuestionHeading (submittedForm) {
+      return submittedForm.querySelector('h1').innerText
     }
 
     function getResponseLabelsForRadio (submittedForm) {
@@ -80,12 +80,12 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     function track (element) {
       element.addEventListener('submit', function (event) {
         var submittedForm = event.target
-        var questionKey = getQuestionKey(submittedForm)
+        var questionHeading = getQuestionHeading(submittedForm)
         var responseLabels = getResponseLabels(submittedForm)
 
         responseLabels.forEach(function (label) {
           var options = { transport: 'beacon', label: label }
-          GOVUK.analytics.trackEvent('question_answer', questionKey, options)
+          GOVUK.analytics.trackEvent('question_answer', questionHeading, options)
         })
       })
     }

--- a/app/assets/javascripts/modules/track-responses.js
+++ b/app/assets/javascripts/modules/track-responses.js
@@ -13,6 +13,10 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       return submittedForm.querySelector('h1').innerText
     }
 
+    function getQuestionKey (submittedForm) {
+      return submittedForm.getAttribute('data-question-key')
+    }
+
     function getResponseLabelsForRadio (submittedForm) {
       var labels = []
       var checkedOptions = submittedForm.querySelectorAll('input:checked')
@@ -81,11 +85,13 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       element.addEventListener('submit', function (event) {
         var submittedForm = event.target
         var questionHeading = getQuestionHeading(submittedForm)
+        var questionKey = getQuestionKey(submittedForm)
         var responseLabels = getResponseLabels(submittedForm)
 
         responseLabels.forEach(function (label) {
           var options = { transport: 'beacon', label: label }
           GOVUK.analytics.trackEvent('question_answer', questionHeading, options)
+          GOVUK.analytics.trackEvent('response_submission', questionKey, options)
         })
       })
     }

--- a/app/assets/javascripts/modules/track-responses.js
+++ b/app/assets/javascripts/modules/track-responses.js
@@ -10,7 +10,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     }
 
     function getQuestionHeading (submittedForm) {
-      return submittedForm.querySelector('h1').innerText
+      return submittedForm.getAttribute('data-question-text')
     }
 
     function getQuestionKey (submittedForm) {

--- a/app/views/smart_answers/question.html.erb
+++ b/app/views/smart_answers/question.html.erb
@@ -14,7 +14,8 @@
         :data => {
           module: "track-responses",
           type: question.partial_template_name,
-          "question-key": question.node_slug
+          "question-key": question.node_slug,
+          "question-text": question.title
         }) do %>
       <div class="govuk-!-margin-bottom-6 govuk-!-margin-top-8" id="current-question">
         <% show_body = ['salary_question', 'country_select_question'].include? question.partial_template_name %>

--- a/app/views/smart_answers/question.html.erb
+++ b/app/views/smart_answers/question.html.erb
@@ -14,7 +14,7 @@
         :data => {
           module: "track-responses",
           type: question.partial_template_name,
-          "question-key": question.title
+          "question-key": question.node_slug
         }) do %>
       <div class="govuk-!-margin-bottom-6 govuk-!-margin-top-8" id="current-question">
         <% show_body = ['salary_question', 'country_select_question'].include? question.partial_template_name %>

--- a/spec/javascripts/modules/track-responses.spec.js
+++ b/spec/javascripts/modules/track-responses.spec.js
@@ -86,6 +86,12 @@ describe('Track responses', function () {
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
         'question_answer', 'The question title?', { transport: 'beacon', label: 'Accommodation label' }
       )
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'response_submission', 'question-key', { transport: 'beacon', label: 'Construction label' }
+      )
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'response_submission', 'question-key', { transport: 'beacon', label: 'Accommodation label' }
+      )
     })
 
     it('track events sends value of checkbox when no label is set', function () {
@@ -95,6 +101,9 @@ describe('Track responses', function () {
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
         'question_answer', 'The question title?', { transport: 'beacon', label: 'furniture' }
       )
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'response_submission', 'question-key', { transport: 'beacon', label: 'furniture' }
+      )
     })
 
     it('track event triggered when no response is made', function () {
@@ -102,6 +111,9 @@ describe('Track responses', function () {
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
         'question_answer', 'The question title?', { transport: 'beacon', label: 'no response' }
+      )
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'response_submission', 'question-key', { transport: 'beacon', label: 'no response' }
       )
     })
   })
@@ -183,6 +195,9 @@ describe('Track responses', function () {
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
         'question_answer', 'The question title?', { transport: 'beacon', label: 'Accommodation label' }
       )
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'response_submission', 'question-key', { transport: 'beacon', label: 'Accommodation label' }
+      )
     })
 
     it('track event triggered when no response is made', function () {
@@ -190,6 +205,9 @@ describe('Track responses', function () {
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
         'question_answer', 'The question title?', { transport: 'beacon', label: 'no response' }
+      )
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'response_submission', 'question-key', { transport: 'beacon', label: 'no response' }
       )
     })
   })
@@ -257,6 +275,9 @@ describe('Track responses', function () {
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
         'question_answer', 'The question title?', { transport: 'beacon', label: 'Accommodation label' }
       )
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'response_submission', 'question-key', { transport: 'beacon', label: 'Accommodation label' }
+      )
     })
 
     it('track event triggered when no response is made', function () {
@@ -264,6 +285,9 @@ describe('Track responses', function () {
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
         'question_answer', 'The question title?', { transport: 'beacon', label: 'no response' }
+      )
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'response_submission', 'question-key', { transport: 'beacon', label: 'no response' }
       )
     })
   })

--- a/spec/javascripts/modules/track-responses.spec.js
+++ b/spec/javascripts/modules/track-responses.spec.js
@@ -14,16 +14,10 @@ describe('Track responses', function () {
       element.setAttribute('data-module', 'track-responses')
       element.setAttribute('data-type', 'checkbox_question')
       element.setAttribute('data-question-key', 'question-key')
+      element.setAttribute('data-question-text', 'The question title?')
       element.setAttribute('method', 'post')
 
       var fieldset = document.createElement('fieldset')
-
-      var legend = document.createElement('legend')
-      var h1 = document.createElement('h1')
-      h1.innerText = 'The question title?'
-
-      legend.appendChild(h1)
-      fieldset.appendChild(legend)
 
       var checkboxes = [
         { label: 'Construction label', value: 'construction' },
@@ -127,16 +121,10 @@ describe('Track responses', function () {
       element.setAttribute('data-module', 'track-responses')
       element.setAttribute('data-type', 'radio_question')
       element.setAttribute('data-question-key', 'question-key')
+      element.setAttribute('data-question-text', 'The question title?')
       element.setAttribute('method', 'post')
 
       var fieldset = document.createElement('fieldset')
-
-      var legend = document.createElement('legend')
-      var h1 = document.createElement('h1')
-      h1.innerText = 'The question title?'
-
-      legend.appendChild(h1)
-      fieldset.appendChild(legend)
 
       var radios = [
         { label: 'Construction label', value: 'construction' },
@@ -221,6 +209,7 @@ describe('Track responses', function () {
       element.setAttribute('data-module', 'track-responses')
       element.setAttribute('data-type', 'country_select_question')
       element.setAttribute('data-question-key', 'question-key')
+      element.setAttribute('data-question-text', 'The question title?')
       element.setAttribute('method', 'post')
 
       var select = document.createElement('select')
@@ -241,10 +230,6 @@ describe('Track responses', function () {
         select.appendChild(option)
       })
 
-      var h1 = document.createElement('h1')
-      h1.innerText = 'The question title?'
-
-      element.appendChild(h1)
       element.appendChild(select)
 
       var button = document.createElement('button')

--- a/spec/javascripts/modules/track-responses.spec.js
+++ b/spec/javascripts/modules/track-responses.spec.js
@@ -18,6 +18,13 @@ describe('Track responses', function () {
 
       var fieldset = document.createElement('fieldset')
 
+      var legend = document.createElement('legend')
+      var h1 = document.createElement('h1')
+      h1.innerText = 'The question title?'
+
+      legend.appendChild(h1)
+      fieldset.appendChild(legend)
+
       var checkboxes = [
         { label: 'Construction label', value: 'construction' },
         { label: 'Accommodation label', value: 'accommodation' },
@@ -74,10 +81,10 @@ describe('Track responses', function () {
       form.dispatchEvent(new Event('submit'))
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
-        'question_answer', 'question-key', { transport: 'beacon', label: 'Construction label' }
+        'question_answer', 'The question title?', { transport: 'beacon', label: 'Construction label' }
       )
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
-        'question_answer', 'question-key', { transport: 'beacon', label: 'Accommodation label' }
+        'question_answer', 'The question title?', { transport: 'beacon', label: 'Accommodation label' }
       )
     })
 
@@ -86,7 +93,7 @@ describe('Track responses', function () {
       form.dispatchEvent(new Event('submit'))
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
-        'question_answer', 'question-key', { transport: 'beacon', label: 'furniture' }
+        'question_answer', 'The question title?', { transport: 'beacon', label: 'furniture' }
       )
     })
 
@@ -94,7 +101,7 @@ describe('Track responses', function () {
       form.dispatchEvent(new Event('submit'))
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
-        'question_answer', 'question-key', { transport: 'beacon', label: 'no response' }
+        'question_answer', 'The question title?', { transport: 'beacon', label: 'no response' }
       )
     })
   })
@@ -111,6 +118,13 @@ describe('Track responses', function () {
       element.setAttribute('method', 'post')
 
       var fieldset = document.createElement('fieldset')
+
+      var legend = document.createElement('legend')
+      var h1 = document.createElement('h1')
+      h1.innerText = 'The question title?'
+
+      legend.appendChild(h1)
+      fieldset.appendChild(legend)
 
       var radios = [
         { label: 'Construction label', value: 'construction' },
@@ -167,7 +181,7 @@ describe('Track responses', function () {
       form.dispatchEvent(new Event('submit'))
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
-        'question_answer', 'question-key', { transport: 'beacon', label: 'Accommodation label' }
+        'question_answer', 'The question title?', { transport: 'beacon', label: 'Accommodation label' }
       )
     })
 
@@ -175,7 +189,7 @@ describe('Track responses', function () {
       form.dispatchEvent(new Event('submit'))
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
-        'question_answer', 'question-key', { transport: 'beacon', label: 'no response' }
+        'question_answer', 'The question title?', { transport: 'beacon', label: 'no response' }
       )
     })
   })
@@ -209,6 +223,10 @@ describe('Track responses', function () {
         select.appendChild(option)
       })
 
+      var h1 = document.createElement('h1')
+      h1.innerText = 'The question title?'
+
+      element.appendChild(h1)
       element.appendChild(select)
 
       var button = document.createElement('button')
@@ -237,7 +255,7 @@ describe('Track responses', function () {
       form.dispatchEvent(new Event('submit'))
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
-        'question_answer', 'question-key', { transport: 'beacon', label: 'Accommodation label' }
+        'question_answer', 'The question title?', { transport: 'beacon', label: 'Accommodation label' }
       )
     })
 
@@ -245,7 +263,7 @@ describe('Track responses', function () {
       form.dispatchEvent(new Event('submit'))
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
-        'question_answer', 'question-key', { transport: 'beacon', label: 'no response' }
+        'question_answer', 'The question title?', { transport: 'beacon', label: 'no response' }
       )
     })
   })


### PR DESCRIPTION
This PR adds an additional GA event that tracks user responses in reference to the node id of the question, instead of the question text. Tracking using the question text was fragile as minor changes to question text made it difficult to group similar events. Smart Answer's will continue to send the existing GA events for a user response in reference to the question text, to support any existing analytic analysis (e.g. find-coronavirus-support). Ideally in the longer term we will remove that old GA event.

This also fixes confusing code references to the `data-question-key` HTML attribute as the question key. However that was being set as the question text.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
