### PR TITLE
Fix error messages when user gives no answer for a question

### DIFF
--- a/app/controllers/flow_controller.rb
+++ b/app/controllers/flow_controller.rb
@@ -20,7 +20,7 @@ class FlowController < ApplicationController
   end
 
   def update
-    response_store.add(node_name, params[:response])
+    response_store.add(node_name, params.fetch(:response, ""))
     redirect_to flow_path(id: params[:id], node_slug: next_node_slug, params: forwarding_responses)
   end
 

--- a/spec/features/smart_answers/query_parameters_based_flow_navigation_spec.rb
+++ b/spec/features/smart_answers/query_parameters_based_flow_navigation_spec.rb
@@ -11,6 +11,15 @@ RSpec.feature "Query parameters based flow navigation", flow_dir: :fixture do
     expect(page).to have_text("Results title")
   end
 
+  scenario "User tries to submit a question without an answer" do
+    visit "/query-parameters-based/s"
+
+    click_button "Continue"
+
+    expect(page).to have_text("Question 1 title")
+    expect(page).to have_text("Please answer this question")
+  end
+
   scenario "User changes their answer to previous question" do
     visit "/query-parameters-based/s"
 

--- a/spec/features/smart_answers/session_based_flow_navigation_spec.rb
+++ b/spec/features/smart_answers/session_based_flow_navigation_spec.rb
@@ -11,6 +11,15 @@ RSpec.feature "Session based flow navigation", flow_dir: :fixture do
     expect(page).to have_text("Results title")
   end
 
+  scenario "User tries to submit a question without an answer" do
+    visit "/session-based/s"
+
+    click_button "Continue"
+
+    expect(page).to have_text("Question 1 title")
+    expect(page).to have_text("Please answer this question")
+  end
+
   scenario "User changes their answer to previous question" do
     visit "/session-based/s"
 


### PR DESCRIPTION
There was a bug with query parameter based flows where no error message was displayed when a user tried to progress without selecting an option on a question.

This was because the default response was nil, therefore unable to detect if the user was seeing the question for the first time or hadn't previously responded. Now the the default response is an empty string.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
