### PR TITLE
Fix changing your answer for query parameter based flows

### DIFF
--- a/app/helpers/flow_helper.rb
+++ b/app/helpers/flow_helper.rb
@@ -1,6 +1,6 @@
 module FlowHelper
   def forwarding_responses
-    flow.response_store == :session ? {} : response_store.all
+    flow.response_store == :query_parameters ? response_store.all : {}
   end
 
   def presenter

--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -91,8 +91,10 @@ class FlowPresenter
     @start_node ||= StartNodePresenter.new(@flow.start_node)
   end
 
-  def change_answer_link(question_number, question)
-    if response_store
+  def change_answer_link(question_number, question, responses)
+    if response_store == :query_parameters
+      flow_path(params[:id], node_slug: question.node_slug, **responses)
+    elsif response_store
       flow_path(params[:id], node_slug: question.node_slug)
     else
       smart_answer_path(

--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -91,15 +91,15 @@ class FlowPresenter
     @start_node ||= StartNodePresenter.new(@flow.start_node)
   end
 
-  def change_collapsed_question_link(question_number, question)
+  def change_answer_link(question_number, question)
     if response_store
       flow_path(params[:id], node_slug: question.node_slug)
     else
       smart_answer_path(
         id: @params[:id],
         started: "y",
-        responses: accepted_responses[0...question_number - 1],
-        previous_response: accepted_responses[question_number - 1],
+        responses: accepted_responses[0...question_number],
+        previous_response: accepted_responses[question_number],
       )
     end
   end

--- a/app/views/smart_answers/shared/_previous_answers.html.erb
+++ b/app/views/smart_answers/shared/_previous_answers.html.erb
@@ -34,7 +34,7 @@
         field: question.title,
         value: value,
         edit: {
-          href: @presenter.change_answer_link(question_number, question),
+          href: @presenter.change_answer_link(question_number, question, forwarding_responses),
           data_attributes: {
             "module": "gem-track-click",
             "track-category": "Smart Answer Change Link",

--- a/app/views/smart_answers/shared/_previous_answers.html.erb
+++ b/app/views/smart_answers/shared/_previous_answers.html.erb
@@ -19,8 +19,8 @@
   <% end %>
 
   <% unless local_assigns[:hide_previous_answers] %>
-    <% items = @presenter.collapsed_questions.each_with_index.map { |question, number_questions_so_far|
-      accepted_response = @presenter.accepted_responses[number_questions_so_far]
+    <% items = @presenter.collapsed_questions.each_with_index.map { |question, question_number|
+      accepted_response = @presenter.accepted_responses[question_number]
 
       if question.multiple_responses?
         value = render "govuk_publishing_components/components/list", {
@@ -34,7 +34,7 @@
         field: question.title,
         value: value,
         edit: {
-          href: @presenter.change_collapsed_question_link(number_questions_so_far + 1, question),
+          href: @presenter.change_answer_link(question_number, question),
           data_attributes: {
             "module": "gem-track-click",
             "track-category": "Smart Answer Change Link",

--- a/spec/helpers/flow_helper_spec.rb
+++ b/spec/helpers/flow_helper_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe FlowHelper do
       expect(helper.forwarding_responses).to eq({})
     end
 
-    it "returns all the previous responses" do
-      flow = SmartAnswer::Flow.new { response_store :other }
+    it "returns all the previous responses for query parameter based flows" do
+      flow = SmartAnswer::Flow.new { response_store :query_parameters }
       allow(helper).to receive(:flow).and_return(flow)
 
       expect(helper.forwarding_responses).to eq({ question1: "response1" })

--- a/test/unit/flow_presenter_test.rb
+++ b/test/unit/flow_presenter_test.rb
@@ -103,34 +103,45 @@ class FlowPresenterTest < ActiveSupport::TestCase
     assert_equal @flow_presenter.name, @flow.name
   end
 
-  context "#change_collapsed_question_link" do
-    should "with smart answer" do
-      params = { responses: "question-1-answer/question-2-answer", id: @flow.name }
-      flow_presenter = FlowPresenter.new(params, @flow)
-      questions = flow_presenter.collapsed_questions
-      assert_equal(
-        "/#{@flow.name}/y?previous_response=question-1-answer",
-        flow_presenter.change_collapsed_question_link(1, questions.first),
-      )
-      assert_equal(
-        "/#{@flow.name}/y/question-1-answer?previous_response=question-2-answer",
-        flow_presenter.change_collapsed_question_link(2, questions.first),
-      )
-      assert_equal(
-        "/#{@flow.name}/y/question-1-answer?previous_response=question-2-answer",
-        flow_presenter.change_collapsed_question_link(2, questions.last),
-      )
+  context "#change_answer_link" do
+    context "with smart answer" do
+      setup do
+        params = { responses: "question-1-answer/question-2-answer", id: @flow.name }
+        @flow_presenter = FlowPresenter.new(params, @flow)
+        @questions = @flow_presenter.collapsed_questions
+      end
+
+      should "return link to first page with response" do
+        assert_equal(
+          "/#{@flow.name}/y?previous_response=question-1-answer",
+          @flow_presenter.change_answer_link(0, @questions.first),
+        )
+      end
+
+      should "return link to second page with response" do
+        assert_equal(
+          "/#{@flow.name}/y/question-1-answer?previous_response=question-2-answer",
+          @flow_presenter.change_answer_link(1, @questions.first),
+        )
+      end
     end
 
-    should "with session answer" do
-      @flow.response_store(:session)
-      params = { id: @flow.name }
-      flow_presenter = FlowPresenter.new(params, @flow)
-      question = OpenStruct.new(node_slug: "foo")
-      assert_equal(
-        flow_presenter.flow_path(@flow.name, question.node_slug),
-        flow_presenter.change_collapsed_question_link(1, question),
-      )
+    context "with session answer" do
+      setup do
+        @flow.response_store(:session)
+        params = { id: @flow.name }
+        @question = OpenStruct.new(node_slug: "foo")
+
+        @flow_presenter = FlowPresenter.new(params, @flow)
+        @questions = @flow_presenter.collapsed_questions
+      end
+
+      should "return link to first page with response" do
+        assert_equal(
+          @flow_presenter.flow_path(@flow.name, @question.node_slug),
+          @flow_presenter.change_answer_link(1, @question),
+        )
+      end
     end
   end
 

--- a/test/unit/flow_presenter_test.rb
+++ b/test/unit/flow_presenter_test.rb
@@ -114,14 +114,14 @@ class FlowPresenterTest < ActiveSupport::TestCase
       should "return link to first page with response" do
         assert_equal(
           "/#{@flow.name}/y?previous_response=question-1-answer",
-          @flow_presenter.change_answer_link(0, @questions.first),
+          @flow_presenter.change_answer_link(0, @questions.first, {}),
         )
       end
 
       should "return link to second page with response" do
         assert_equal(
           "/#{@flow.name}/y/question-1-answer?previous_response=question-2-answer",
-          @flow_presenter.change_answer_link(1, @questions.first),
+          @flow_presenter.change_answer_link(1, @questions.first, {}),
         )
       end
     end
@@ -139,7 +139,25 @@ class FlowPresenterTest < ActiveSupport::TestCase
       should "return link to first page with response" do
         assert_equal(
           @flow_presenter.flow_path(@flow.name, @question.node_slug),
-          @flow_presenter.change_answer_link(1, @question),
+          @flow_presenter.change_answer_link(1, @question, {}),
+        )
+      end
+    end
+
+    context "with query parameters" do
+      setup do
+        @flow.response_store(:query_parameters)
+        params = { id: @flow.name, responses: { "foo" => "bar" } }
+        @question = OpenStruct.new(node_slug: "baz")
+
+        @flow_presenter = FlowPresenter.new(params, @flow)
+        @questions = @flow_presenter.collapsed_questions
+      end
+
+      should "return link to first page with response" do
+        assert_equal(
+          @flow_presenter.flow_path(@flow.name, @question.node_slug, foo: "bar"),
+          @flow_presenter.change_answer_link(2, @question, { "foo" => "bar" }),
         )
       end
     end


### PR DESCRIPTION
The links to change answers for previous question did not work for query parameter based flow. This is because previous responses were not saved in the query string. This mean that changing your answer to a specific question would take you back to the start of the flow. This updates the helper function to generate change answer links to include previous responses in the query string.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
