### PR TITLE
Open result links in new tab for "Next steps for your business"

### DIFF
--- a/app/views/components/_result-item.html.erb
+++ b/app/views/components/_result-item.html.erb
@@ -11,6 +11,8 @@
   <h4 class="govuk-heading-s">
     <%= link_to title, url,
     class: "govuk-link",
+    target: "_blank",
+    rel: "noopener noreferrer",
     data: {
       module: "gem-track-click",
       "track-action": "#{section_index}.#{result_index}",


### PR DESCRIPTION
We changed the behaviour so links on the results page open in a new tab or window. This is to help user return to the results page.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
