### PR TITLE
Add feedback link for the 'next-steps-for-your-business' flow

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,7 +35,7 @@
     <div id="wrapper">
       <%= yield :hide_this_page_banner %>
       <div class="govuk-width-container smart_answer">
-        <%= yield :phase_banner %>
+        <%= render "smart_answers/shared/phase_banner" %>
         <%= yield :breadcrumbs %>
         <main id="content" role="main">
           <%= yield %>

--- a/app/views/smart_answers/custom_result.html.erb
+++ b/app/views/smart_answers/custom_result.html.erb
@@ -7,28 +7,6 @@
   <meta name="robots" content="noindex">
 <% end %>
 
-<% content_for :phase_banner do %>
-  <% feedback_message = capture do %>
-    We’re still building this part of GOV.UK –
-    <%= link_to "give us your feedback (opens in a new tab)",
-      "/done/next-steps-for-your-business",
-      class: "govuk-link",
-      data: {
-        module: "gem-track-click",
-        "track-action": "/done/next-steps-for-your-business",
-        "track-category": "Internal Links Clicked",
-        "track-label": "give us your feedback"
-      }
-    %>
-    to help us improve it.
-  <% end %>
-
-  <%= render "govuk_publishing_components/components/phase_banner", {
-    phase: "beta",
-    message: feedback_message
-  } %>
-<% end %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/title", {

--- a/app/views/smart_answers/shared/_phase_banner.html.erb
+++ b/app/views/smart_answers/shared/_phase_banner.html.erb
@@ -1,0 +1,22 @@
+<% if @presenter.present? && @presenter.flow.name === 'next-steps-for-your-business' %>
+  <% feedback_message = capture do %>
+    We’re still building this part of GOV.UK –
+    <%= link_to "give us your feedback (opens in a new tab)",
+      "/done/next-steps-for-your-business",
+      class: "govuk-link",
+      target: "_blank",
+      rel: "noopener noreferrer",
+      data: {
+        module: "gem-track-click",
+        "track-action": "/done/next-steps-for-your-business",
+        "track-category": "Internal Links Clicked",
+        "track-label": "give us your feedback"
+      }
+    %>
+    to help us improve it.
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/phase_banner", {
+    message: feedback_message
+  } %>
+<% end %>


### PR DESCRIPTION
Add a phase banner component linking to a feedback page for the 'next-steps-for-your-business' flow.

Raising this early as a draft to review how this component can be applied to the entire flow, not only the results page.
To match design, the phase banner component requires [an update to be able to render without the phase tag](https://github.com/alphagov/govuk_publishing_components/pull/2057).

[Trello](https://trello.com/c/vhA3uZ6U)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
