### PR TITLE
Fix tracking on start again link

### DIFF
--- a/app/views/smart_answers/custom_result.html.erb
+++ b/app/views/smart_answers/custom_result.html.erb
@@ -26,7 +26,15 @@
     } %>
 
     <%= tag.p class: "govuk-body govuk-!-margin-bottom-8" do %>
-      <%= link_to "Start again", restart_flow_path(@presenter), class: "govuk-link" %>
+      <%= link_to "Start again",
+        restart_flow_path(@presenter),
+        class: "govuk-link",
+        data: {
+          module: "gem-track-click",
+          "track-action": "Start again",
+          "track-category": "StartAgain",
+          "track-label": @presenter.current_node.title
+        } %>
     <% end %>
 
     <%= render "govuk_publishing_components/components/print_link" %>


### PR DESCRIPTION
For the "Next steps of your business" flow, the data attributes to enable link tracking were missing for the "Start again" link.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
