### PR TITLE
Use `heading_level` param instead of `is_page_heading` (radio component)

### DIFF
--- a/app/views/smart_answers/inputs/_radio_question.html.erb
+++ b/app/views/smart_answers/inputs/_radio_question.html.erb
@@ -3,7 +3,7 @@
   heading: question.title,
   heading_size: "l",
   heading_caption: question.caption,
-  is_page_heading: true,
+  heading_level: 1,
   hint: question.hint,
   id_prefix: "response",
   description: question.body,


### PR DESCRIPTION
Replace `is_page_heading: true` with `heading_level: 1` on the radio component.

This is because changes are being made to remove `is_page_heading` and achieve the same outcome using `heading_level` and/or `heading_size` instead. Related issue where this is documented: https://github.com/alphagov/govuk_publishing_components/issues/1953

No visual changes should occur as a result of this update.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
