### PR TITLE
Fix result title in Next steps for you business

### DIFF
--- a/config/smart_answers/next_steps_for_your_business.yml
+++ b/config/smart_answers/next_steps_for_your_business.yml
@@ -89,7 +89,7 @@
   topic: "Help and support"
   group: "Good to know"
 - id: r16
-  title: "Learn how to deal with personal information"
+  title: "Register for VAT"
   description: "You need to register your business for VAT if your business takes more than £85,000 (the 'turnover'), if you have not already."
   url: "/vat-registration"
   topic: Tax


### PR DESCRIPTION
Incorrect link text for 'register for VAT' showing.
From: https://trello.com/c/DjO7Hy9D/442-content-edit-dealing-with-personal-information-link

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
