### PR TITLE
Fix VAT result logic for Next steps for your business

### DIFF
--- a/lib/smart_answer/calculators/next_steps_for_your_business_calculator.rb
+++ b/lib/smart_answer/calculators/next_steps_for_your_business_calculator.rb
@@ -43,8 +43,8 @@ module SmartAnswer::Calculators
       r13: ->(_) { true },
       r14: ->(_) { true },
       r15: ->(_) { true },
-      r16: ->(calculator) { calculator.annual_turnover_over_85k != "no" },
-      r17: ->(calculator) { calculator.annual_turnover_over_85k != "no" },
+      r16: ->(calculator) { calculator.annual_turnover_over_85k == "yes" },
+      r17: ->(calculator) { calculator.annual_turnover_over_85k == "not_sure" },
       r18: ->(calculator) { calculator.employer != "no" },
       r19: ->(calculator) { calculator.needs_financial_support == "yes" },
       r20: ->(calculator) { calculator.needs_financial_support == "yes" },
@@ -56,7 +56,7 @@ module SmartAnswer::Calculators
       r26: ->(calculator) { calculator.activities.include?("import_goods") },
       r27: ->(calculator) { calculator.activities.include?("export_goods_or_services") },
       r28: ->(_) { true },
-      r29: ->(calculator) { calculator.annual_turnover_over_85k != "yes" },
+      r29: ->(calculator) { calculator.annual_turnover_over_85k == "no" },
       r30: ->(calculator) { calculator.activities.include?("export_goods_or_services") },
     }.with_indifferent_access.freeze
   end


### PR DESCRIPTION
We have three results for VAT registration however we should only show one depending on which option the user selects for the annual turnover question.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
