### PR TITLE
Fix business premises logic for "Next steps for your business"

### DIFF
--- a/config/smart_answers/next_steps_for_your_business.yml
+++ b/config/smart_answers/next_steps_for_your_business.yml
@@ -138,7 +138,7 @@
   group: "Rules to follow"
 - id: r24
   title: "Find out about rules for business premises"
-  description: "Rules that affect your business premises. "
+  description: "Rules that affect your business premises."
   url: "/browse/business/premises-rates"
   topic: "Business location"
   group: "Rules to follow"

--- a/lib/smart_answer/calculators/next_steps_for_your_business_calculator.rb
+++ b/lib/smart_answer/calculators/next_steps_for_your_business_calculator.rb
@@ -51,7 +51,7 @@ module SmartAnswer::Calculators
       r21: ->(calculator) { calculator.employer != "no" },
       r22: ->(calculator) { calculator.business_premises.include?("home") },
       r23: ->(calculator) { calculator.business_premises.include?("rented") },
-      r24: ->(calculator) { calculator.business_premises.exclude?("none") },
+      r24: ->(calculator) { (calculator.business_premises & %w[rented owned none]).present? },
       r25: ->(calculator) { (calculator.business_premises & %w[rented owned none]).present? },
       r26: ->(calculator) { calculator.activities.include?("import_goods") },
       r27: ->(calculator) { calculator.activities.include?("export_goods_or_services") },


### PR DESCRIPTION
The business premise rules only need to be shown to those who own, rent or "other" a business premise. People running their business from home should be covered by a separate result.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
