### PR TITLE
SPIKE - Implement new testing strategy for smart answer

### DIFF
--- a/lib/smart_answer/calculators/holiday_entitlement.rb
+++ b/lib/smart_answer/calculators/holiday_entitlement.rb
@@ -181,6 +181,40 @@ module SmartAnswer::Calculators
       (shifts_per_shift_pattern / days_per_shift_pattern * DAYS_PER_WEEK).round(10)
     end
 
+    def compressed
+      content_array = []
+      content_array << "your_employer_with_rounding"
+      content_array << "the_user_should_be_aware" if holiday_period == "starting"
+      content_array << "guidance_on_calculations"
+    end
+
+    def days_and_hours_per_week
+      content_array = []
+      content_array << "days_per_week_greater_than_five" if working_days_per_week > 5
+      content_array << "your_employer_with_rounding"
+      content_array << "the_user_should_be_aware" if holiday_period == "starting"
+      content_array << "guidance_on_calculations"
+    end
+
+    def irregular_and_annualised
+      content_array = []
+      content_array << "your_employer_with_rounding"
+      content_array << if holiday_period == "starting"
+                         "irregular_and_annualised_user_awareness"
+                       else
+                         "entitlement_restriction"
+                       end
+      content_array << "guidance_on_calculations"
+    end
+
+    def shift_worker
+      content_array = []
+      content_array << "shifts_per_week_greater_than_five" if shifts_per_week > 5
+      content_array << "shift_worker_your_employer_with_rounding"
+      content_array << "the_user_should_be_aware" if holiday_period == "starting"
+      content_array << "guidance_on_calculations"
+    end
+
   private
 
     def calculate_leave_year_start_date

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/_days_per_week_greater_then_five.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/_days_per_week_greater_then_five.erb
@@ -1,0 +1,1 @@
+Even though more than 5 days a week are worked, the maximum statutory holiday entitlement is 28 days.

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/_shifts_per_week_greater_than_five.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/_shifts_per_week_greater_than_five.erb
@@ -1,0 +1,1 @@
+Even though more than 5 shifts a week are worked the maximum statutory holiday entitlement is 28 shifts.

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/compressed_hours_done.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/compressed_hours_done.erb
@@ -1,11 +1,7 @@
 <% govspeak_for :body do %>
   $!The statutory holiday entitlement is <%= "#{calculator.holiday_entitlement_hours} #{'hour'.pluralize(calculator.holiday_entitlement_hours)}" %> and <%= "#{calculator.holiday_entitlement_minutes} #{'minute'.pluralize(calculator.holiday_entitlement_minutes)}" %> holiday for the year. Rather than taking a day’s holiday it’s <%= "#{calculator.hours_daily} #{'hour'.pluralize(calculator.hours_daily)}" %> and <%= "#{calculator.minutes_daily} #{'minute'.pluralize(calculator.minutes_daily)}" %> holiday for each day otherwise worked.$!
 
-  <%= render partial: 'your_employer_with_rounding' %>
-  
-  <% if calculator.holiday_period == "starting" %>
-    <%= render partial: "the_user_should_be_aware" %>
+  <% calculator.compressed.each do |part| %>
+    <%= render partial: part %>
   <% end %>
-
-  <%= render partial: "guidance_on_calculations" %>
 <% end %>

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/days_per_week_done.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/days_per_week_done.erb
@@ -1,15 +1,7 @@
 <% govspeak_for :body do %>
   $!The statutory holiday entitlement is <%= "#{calculator.formatted_full_time_part_time_days} #{'day'.pluralize(calculator.formatted_full_time_part_time_days)}" %> holiday.$!
 
-  <% if calculator.working_days_per_week > 5 %>
-    Even though more than 5 days a week are worked, the maximum statutory holiday entitlement is 28 days.
+  <% calculator.days_and_hours_per_week.each do |part| %>
+    <%= render partial: part %>
   <% end %>
-
-  <%= render partial: "your_employer_with_rounding" %>
-
-  <% if calculator.holiday_period == "starting" %>
-    <%= render partial: "the_user_should_be_aware" %>
-  <% end %>
-
-  <%= render partial: "guidance_on_calculations" %>
 <% end %>

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/hours_per_week_done.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/hours_per_week_done.erb
@@ -1,15 +1,7 @@
 <% govspeak_for :body do %>
   $!The statutory entitlement is <%= "#{calculator.formatted_full_time_part_time_compressed_hours} #{'hour'.pluralize(calculator.formatted_full_time_part_time_compressed_hours)}" %> holiday.$!
 
-  <% if calculator.working_days_per_week > 5 %>
-    Even though more than 5 days a week are worked the maximum statutory holiday entitlement is 28 days.
+  <% calculator.days_and_hours_per_week.each do |part| %>
+    <%= render partial: part %>
   <% end %>
-
-  <%= render partial: 'your_employer_with_rounding' %>
-
-  <% if calculator.holiday_period == "starting" %>
-    <%= render partial: "the_user_should_be_aware" %>
-  <% end %>
-
-  <%= render partial: "guidance_on_calculations" %>
 <% end %>

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/irregular_and_annualised_done.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/irregular_and_annualised_done.erb
@@ -5,13 +5,7 @@
 
   You may wish to [use the calculator again](/calculate-your-holiday-entitlement/y) and calculate the average days or hours worked each week based on a representative reference period instead.
 
-  <%= render partial: 'your_employer_with_rounding' %>
-
-  <% if calculator.holiday_period == 'starting' %>
-    <%= render partial: 'irregular_and_annualised_user_awareness' %>
-  <% else %>
-    <%= render partial: 'entitlement_restriction' %>
+  <% calculator.irregular_and_annualised.each do |part| %>
+    <%= render partial: part %>
   <% end %>
-
-  <%= render partial: "guidance_on_calculations" %>
 <% end %>

--- a/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/shift_worker_done.erb
+++ b/lib/smart_answer_flows/calculate-your-holiday-entitlement/outcomes/shift_worker_done.erb
@@ -1,15 +1,7 @@
 <% govspeak_for :body do %>
   $!The statutory holiday entitlement is <%= "#{calculator.shift_entitlement} #{'shift'.pluralize(calculator.shift_entitlement)}" %> for the year. Each shift being <%= "#{calculator.hours_per_shift} #{'hour'.pluralize(calculator.hours_per_shift)}" %>.$!
 
-  <% if calculator.shifts_per_week > 5 %>
-    Even though more than 5 shifts a week are worked the maximum statutory holiday entitlement is 28 shifts.
+  <% calculator.shift_worker.each do |part| %>
+    <%= render partial: part %>
   <% end %>
-
-  <%= render partial: 'shift_worker_your_employer_with_rounding' %>
-
-  <% if calculator.holiday_period == "starting" %>
-    <%= render partial: "the_user_should_be_aware" %>
-  <% end %>
-
-  <%= render partial: "guidance_on_calculations" %>
 <% end %>

--- a/test/integration/smart_answer_flows/calculate_your_holiday_entitlement_pseudocode_test.rb
+++ b/test/integration/smart_answer_flows/calculate_your_holiday_entitlement_pseudocode_test.rb
@@ -1,0 +1,387 @@
+require_relative "../../test_helper"
+require_relative "flow_test_helper"
+
+require "smart_answer_flows/calculate-your-holiday-entitlement"
+
+class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
+  include FlowTestHelper
+
+  setup do
+    setup_for_testing_flow SmartAnswer::CalculateYourHolidayEntitlementFlow
+  end
+
+  context "start page" do
+    should see_start_page("calculate-your-holiday-entitlement").with_title("Calculate holiday entitlement")
+  end
+
+  context "question :basis of calculation?" do
+    should see_question(:basis_of_calculation?).with_title("Is the holiday entitlement based on:")
+
+    should "take shift workers to shift_worker_basis? question" do
+      add_response "shift-worker"
+      assert_equal :shift_worker_basis?, next_node_name
+    end
+
+    should "take non-shift workers to calculation_period? question" do
+      add_response "days-worked-per-week"
+      assert_equal :calculation_period?, next_node_name
+    end
+  end
+
+  context "question :calculation period?" do
+    setup do
+      responses = { basis_of_calculation?: "days-worked-per-week" }
+    end
+
+    should see_question(:calculation_period?).with_title("Do you want to work out holiday:")
+
+    should accept_answer("starting").with_next_node(:what_is_your_starting_date?)
+    should accept_answer("starting-and-leaving").with_next_node(:what_is_your_starting_date?)
+    should accept_answer("leaving").with_next_node(:what_is_your_leaving_date?)
+
+    context "when the answer is full-year" do
+      setup do
+        responses[:calculation_period?] = "full-year"
+      end
+
+      should "take irregular-hours to :irregular_and_annualised_done" do
+        responses[:basis_of_calculation?] = "irregular-hours"
+        assert_equal :irregular_and_annualised_done, next_node
+      end
+
+      should "take annualised-hours to :irregular_and_annualised_done" do
+        responses[:basis_of_calculation?] = "annualised-hours"
+        assert_equal :irregular_and_annualised_done, next_node
+      end
+
+      should "take days-worked-per-week to :how_many_days_per_week?" do
+        responses[:basis_of_calculation?] = "days-worked-per-week"
+        assert_equal :how_many_days_per_week?, next_node
+      end
+
+      should "take other answers to :how_many_hours_per_week?" do
+        responses[:basis_of_calculation?] = "compressed-hours"
+        assert_equal :how_many_hours_per_week?, next_node
+      end
+    end
+  end
+
+  context "question :how_many_days_per_week?" do
+    setup do
+      responses = {
+        basis_of_calculation?: "days-worked-per-week",
+        calculation_period?: "full-year",
+      }
+    end
+
+    should see_question(:how_many_days_per_week?).with_title("Number of days worked per week?")
+
+    context "expect a day of the week number to be given" do
+      should accept_answer(5).with_next_node(:days_per_week_done)
+
+      should_not accept_answer(0)
+      should_not accept_answer(8)
+    end
+  end
+
+  context "question :what_is_your_starting_date?" do
+    setup do
+      responses = {
+        basis_of_calculation?: "days-worked-per-week",
+        calculation_period?: "starting-and-leaving",
+      }
+    end
+
+    should see_question(:what_is_your_starting_date?).with_title("What was the employment start date?")
+
+    should accept_answer("2021-01-01")
+
+    should "take starting-and-leaving to :what_is_your_leaving_date?" do
+      responses[:calculation_period?] = "starting-and-leaving"
+      assert_equal :what_is_your_leaving_date?, next_node
+    end
+
+    should "take other answers to :when_does_your_leave_year_start?" do
+      responses[:calculation_period?] = "full-year"
+      assert_equal :when_does_your_leave_year_start?, next_node
+    end
+  end
+
+  context "question :what_is_your_leaving_date?" do
+    setup do
+      responses = {
+        basis_of_calculation?: "days-worked-per-week",
+        calculation_period?: "leaving",
+        what_is_your_starting_date?: "2021-01-01",
+      }
+    end
+
+    should see_question(:what_is_your_leaving_date?).with_title("What was the employment end date?")
+
+    context "invalid end date given" do
+      should_not accept_answer("2020-01-01")
+      should_not accept_answer("2023-01-01")
+    end
+
+    should accept_answer("2020-10-01").with_next_node(:when_does_your_leave_year_start?)
+
+    context "when calculation_period? is starting-and-leaving" do
+      setup do
+        should accept_answer("2021-10-01")
+        responses[:calculation_period?] = "starting-and-leaving"
+      end
+
+      should "take days-worked-per-week to :how_many_days_per_week?" do
+        responses[:basis_of_calculation?] = "days-worked-per-week"
+        assert_equal :how_many_days_per_week?, next_node
+      end
+
+      should "take hours-worked-per-week to :how_many_hours_per_week?" do
+        responses[:basis_of_calculation?] = "hours-worked-per-week"
+        assert_equal :how_many_hours_per_week?, next_node
+      end
+
+      should "take shift-worker to :shift_worker_hours_per_shift?" do
+        responses[:basis_of_calculation?] = "shift-worker"
+        assert_equal :shift_worker_hours_per_shift?, next_node
+      end
+
+      should "take irregular hours to :irregular_and_annualised_done" do
+        responses[:basis_of_calculation?] = "irregular-hours"
+        assert_equal :irregular_and_annualised_done, next_node
+      end
+    end
+  end
+
+  context "question :when_does_your_leave_year_start?" do
+    setup do
+      responses = {
+        basis_of_calculation?: "days-worked-per-week",
+        calculation_period?: "leaving",
+        what_is_your_starting_date?: "2021-01-01",
+        what_is_your_leaving_date?: "2021-10-01",
+      }
+    end
+
+    should see_question(:when_does_your_leave_year_start?).with_title("When does the leave year start?")
+
+    should accept_answer("2021-01-01")
+
+    context "no start date" do
+      responses[:what_is_your_starting_date?] = nil
+      should_not accept_answer("2021-01-01")
+    end
+
+    context "no leave date" do
+      responses[:what_is_your_leaving_date?] = nil
+      should_not accept_answer("2021-01-01")
+    end
+
+    should "take days-worked-per-week to :how_many_days_per_week?" do
+      responses[:basis_of_calculation?] = "days-worked-per-week"
+      assert_equal :how_many_days_per_week?, next_node
+    end
+
+    should "take hours-worked-per-week to :how_many_hours_per_week?" do
+      responses[:basis_of_calculation?] = "hours-worked-per-week"
+      assert_equal :how_many_hours_per_week?, next_node
+    end
+
+    should "take compressed-hours to :how_many_hours_per_week?" do
+      responses[:basis_of_calculation?] = "compressed-hours"
+      assert_equal :how_many_hours_per_week?, next_node
+    end
+
+    should "take irregular-hours to :irregular_and_annualised_done" do
+      responses[:basis_of_calculation?] = "irregular-hours"
+      assert_equal :irregular_and_annualised_done, next_node
+    end
+
+    should "take annualised-hours to :irregular_and_annualised_done" do
+      responses[:basis_of_calculation?] = "annualised-hours"
+      assert_equal :irregular_and_annualised_done, next_node
+    end
+
+    should "take shift-worker to :shift_worker_hours_per_shift?" do
+      responses[:basis_of_calculation?] = "shift-worker"
+      assert_equal :shift_worker_hours_per_shift?, next_node
+    end
+  end
+
+  context "question :how_many_hours_per_week?" do
+    setup do
+      responses = {
+        basis_of_calculation?: "hours-worked-per-week",
+        calculation_period?: "leaving",
+        what_is_your_starting_date?: "2021-01-01",
+        what_is_your_leaving_date?: "2021-10-01",
+      }
+    end
+
+    should see_question(:how_many_hours_per_week?).with_title("Number of hours worked per week?")
+
+    context "invalid no of hours given" do
+      should_not accept_answer(-1)
+      should_not accept_answer(169)
+    end
+
+    should accept_answer(100).with_next_node(:how_many_days_per_week_for_hours?)
+  end
+
+  context "question :how_many_days_per_week_for_hours?" do
+    setup do
+      responses = {
+        basis_of_calculation?: "hours-worked-per-week",
+        calculation_period?: "leaving",
+        what_is_your_starting_date?: "2021-01-01",
+        what_is_your_leaving_date?: "2021-10-01",
+        how_many_hours_per_week?: "40",
+      }
+    end
+
+    should see_question(:how_many_days_per_week_for_hours?).with_title("Number of days worked per week?")
+
+    context "invalid no of hours given" do
+      should_not accept_answer(8)
+      should_not accept_answer(1)
+    end
+
+    should accept_answer(5).with_next_node(:hours_per_week_done)
+
+    should "take compressed-hours to :compressed_hours_done" do
+      responses[:basis_of_calculation?] = "compressed-hours"
+      assert_equal :compressed_hours_done, next_node
+    end
+  end
+
+  context "question :shift_worker_basis?" do
+    setup do
+      responses = { basis_of_calculation?: "shift-worker" }
+    end
+
+    should see_question(:shift_worker_basis?).with_title("Do you want to calculate the holiday:")
+
+    should accept_answer("full-year").with_next_node(:shift_worker_hours_per_shift?)
+    should accept_answer("starting").with_next_node(:what_is_your_starting_date?)
+    should accept_answer("starting-and-leaving").with_next_node(:what_is_your_starting_date?)
+    should accept_answer("leaving").with_next_node(:what_is_your_leaving_date?)
+  end
+
+  context "question :shift_worker_hours_per_shift?" do
+    setup do
+      responses = {
+        basis_of_calculation?: "shift-worker",
+        shift_worker_basis?: "full-year",
+      }
+    end
+
+    should see_question(:shift_worker_hours_per_shift?).with_title("How many hours in each shift?")
+
+    context "invalid no of hours given" do
+      should_not accept_answer(-1)
+      should_not accept_answer(25)
+    end
+
+    should accept_answer(8).with_next_node(:shift_worker_shifts_per_shift_pattern?)
+  end
+
+  context "question :shift_worker_shifts_per_shift_pattern?" do
+    setup do
+      responses = {
+        basis_of_calculation?: "shift-worker",
+        shift_worker_basis?: "full-year",
+        shift_worker_hours_per_shift?: 8,
+      }
+    end
+
+    should see_question(:shift_worker_shifts_per_shift_pattern?).with_title("How many shifts will be worked per shift pattern?")
+
+    context "invalid no of shifts given" do
+      should_not accept_answer(-1)
+    end
+
+    should accept_answer(2).with_next_node(:shift_worker_days_per_shift_pattern?)
+  end
+
+  context "question :shift_worker_days_per_shift_pattern?" do
+    setup do
+      responses = {
+        basis_of_calculation?: "shift-worker",
+        shift_worker_basis?: "full-year",
+        shift_worker_hours_per_shift?: 8,
+        shift_worker_shifts_per_shift_pattern?: 2,
+      }
+    end
+
+    should see_question(:shift_worker_days_per_shift_pattern?).with_title("How many days in the shift pattern?")
+
+    context "invalid no of days given" do
+      should_not accept_answer(1)
+    end
+
+    should accept_answer(2).with_next_node(:shift_worker_done)
+  end
+
+  context "outcome :shift_worker_done" do
+    setup do
+      responses = {
+        basis_of_calculation?: "shift-worker",
+        calculation_period?: "full-year",
+        shift_worker_hours_per_shift?: 8,
+        shift_worker_shifts_per_shift_pattern?: 3,
+        shift_worker_days_per_shift_pattern?: 3,
+      }
+    end
+
+    should see_outcome(:shift_worker_done).with_text("The statutory holiday entitlement is 28 shifts for the year. Each shift being 8.0 hours.")
+  end
+
+  context "outcome :days_per_week_done" do
+    setup do
+      responses = {
+        basis_of_calculation?: "days-worked-per-week",
+        calculation_period?: "full-year",
+        how_many_days_per_week?: 5,
+      }
+    end
+
+    should see_outcome(:days_per_week_done).with_text("The statutory holiday entitlement is 28 days holiday.")
+  end
+
+  context "outcome :hours_per_week_done" do
+    setup do
+      responses = {
+        basis_of_calculation?: "hours-worked-per-week",
+        calculation_period?: "full-year",
+        how_many_hours_per_week?: 40,
+        how_many_days_per_week?: 5,
+      }
+    end
+
+    should see_outcome(:hours_per_week_done).with_text("The statutory entitlement is 224 hours holiday.")
+  end
+
+  context "outcome :compressed_hours_done" do
+    setup do
+      responses = {
+        basis_of_calculation?: "compressed-hours",
+        calculation_period?: "full-year",
+        how_many_hours_per_week?: 40,
+        how_many_days_per_week?: 5,
+      }
+    end
+
+    should see_outcome(:compressed_hours_done).with_text("The statutory holiday entitlement is 224 hours and 0 minutes holiday for the year. Rather than taking a day’s holiday it’s 8 hours and 0 minutes holiday for each day otherwise worked.")
+  end
+
+  context "outcome :irregular_and_annualised_done" do
+    setup do
+      responses = {
+        basis_of_calculation?: "annualised-hours",
+        calculation_period?: "full-year",
+      }
+    end
+
+    should see_outcome(:irregular_and_annualised_done).with_text("The statutory holiday entitlement is 5.6 weeks holiday.")
+  end
+end

--- a/test/integration/smart_answer_flows/calculate_your_holiday_entitlement_test.rb
+++ b/test/integration/smart_answer_flows/calculate_your_holiday_entitlement_test.rb
@@ -1,0 +1,56 @@
+require "test_helper"
+
+class CalculateYourHolidayEntitlementTest < ActionDispatch::IntegrationTest
+  setup do
+    stub_content_store_has_item("/calculate-your-holiday-entitlement")
+  end
+
+  context "compressed hours outcome" do
+    should "render the correct results page" do
+      get "/calculate-your-holiday-entitlement/y/compressed-hours/full-year/40/5"
+      assert_select "p", "The statutory holiday entitlement is 224 hours and 0 minutes holiday for the year. Rather than taking a day’s holiday it’s 8 hours and 0 minutes holiday for each day otherwise worked."
+    end
+  end
+
+  context "days per week outcome" do
+    should "render the correct results page" do
+      get "/calculate-your-holiday-entitlement/y/days-worked-per-week/full-year/5"
+      assert_select "p", "The statutory holiday entitlement is 28 days holiday."
+    end
+  end
+
+  context "hours per week outcome" do
+    should "render the correct results page" do
+      get "/calculate-your-holiday-entitlement/y/hours-worked-per-week/full-year/40/5"
+      assert_select "p", "The statutory entitlement is 224 hours holiday."
+    end
+  end
+
+  context "irregular and annualised outcome" do
+    should "render the correct results page" do
+      get "/calculate-your-holiday-entitlement/y/annualised-hours/full-year"
+      assert_select "p", "The statutory holiday entitlement is 5.6 weeks holiday."
+    end
+  end
+
+  context "shift worker outcome" do
+    should "render the correct results page" do
+      get "/calculate-your-holiday-entitlement/y/shift-worker/full-year/6/8/14"
+      assert_select "p", "The statutory holiday entitlement is 22.4 shifts for the year. Each shift being 6.0 hours."
+    end
+  end
+
+  context "start and end date - non-shift worker" do
+    should "render the correct results page" do
+      get "/calculate-your-holiday-entitlement/y/days-worked-per-week/starting-and-leaving/2021-01-01/2021-10-01/5.0"
+      assert_select "p", "The statutory holiday entitlement is 21.1 days holiday."
+    end
+  end
+
+  context "start and end date - shift worker" do
+    should "render the correct results page" do
+      get "/calculate-your-holiday-entitlement/y/shift-worker/starting/2021-01-01/2020-10-01/8.0/7/7.0"
+      assert_select "p", "The statutory holiday entitlement is 21 shifts for the year. Each shift being 8.0 hours."
+    end
+  end
+end

--- a/test/unit/calculators/holiday_entitlement_test.rb
+++ b/test/unit/calculators/holiday_entitlement_test.rb
@@ -2214,5 +2214,137 @@ module SmartAnswer::Calculators
         end
       end
     end
+
+    context "content for compressed hours" do
+      context "holiday period starting" do
+        should "include \'the user should be aware\'" do
+          @calculator.holiday_period = "starting"
+          expected_results = %w[
+            your_employer_with_rounding
+            the_user_should_be_aware
+            guidance_on_calculations
+          ]
+          assert_equal expected_results, @calculator.compressed
+        end
+      end
+
+      context "holiday not starting" do
+        should "not include \'the user should be aware\'" do
+          @calculator.holiday_period = "leaving"
+          expected_results = %w[
+            your_employer_with_rounding
+            guidance_on_calculations
+          ]
+          assert_equal expected_results, @calculator.compressed
+        end
+      end
+    end
+
+    context "content for days and hours for week" do
+      context "six or more days per week" do
+        should "include \'days per week greater than five\'" do
+          @calculator.working_days_per_week = 6
+          expected_results = %w[
+            days_per_week_greater_than_five
+            your_employer_with_rounding
+            guidance_on_calculations
+          ]
+          assert_equal expected_results, @calculator.days_and_hours_per_week
+        end
+      end
+
+      context "holiday period starting" do
+        should "include \'the user should be aware\'" do
+          @calculator.holiday_period = "starting"
+          @calculator.working_days_per_week = 5
+          expected_results = %w[
+            your_employer_with_rounding
+            the_user_should_be_aware
+            guidance_on_calculations
+          ]
+          assert_equal expected_results, @calculator.days_and_hours_per_week
+        end
+      end
+
+      context "holiday period leaving and working 5 or fewer days per week" do
+        should "not include the extra entries" do
+          @calculator.holiday_period = "leaving"
+          @calculator.working_days_per_week = 5
+          expected_results = %w[
+            your_employer_with_rounding
+            guidance_on_calculations
+          ]
+          assert_equal expected_results, @calculator.days_and_hours_per_week
+        end
+      end
+    end
+
+    context "content for irregular or annualised hours" do
+      context "holiday period starting" do
+        should "include \'irregular and annualised user awareness\'" do
+          @calculator.holiday_period = "starting"
+          expected_results = %w[
+            your_employer_with_rounding
+            irregular_and_annualised_user_awareness
+            guidance_on_calculations
+          ]
+          assert_equal expected_results, @calculator.irregular_and_annualised
+        end
+      end
+
+      context "holiday period not \'starting\'" do
+        should "include \'entitlement restriction\'" do
+          @calculator.holiday_period = "leaving"
+          expected_results = %w[
+            your_employer_with_rounding
+            entitlement_restriction
+            guidance_on_calculations
+          ]
+          assert_equal expected_results, @calculator.irregular_and_annualised
+        end
+      end
+    end
+
+    context "content for shift workers" do
+      context "six or more days per week" do
+        should "include \'shifts_per_week_greater_than_five\'" do
+          @calculator.shifts_per_shift_pattern = 6
+          @calculator.days_per_shift_pattern = 7
+          expected_results = %w[
+            shifts_per_week_greater_than_five
+            shift_worker_your_employer_with_rounding
+            guidance_on_calculations
+          ]
+          assert_equal expected_results, @calculator.shift_worker
+        end
+      end
+
+      context "holiday period starting" do
+        should "include \'the user should be aware\'" do
+          @calculator.holiday_period = "starting"
+          @calculator.shifts_per_shift_pattern = 5
+          @calculator.days_per_shift_pattern = 7
+          expected_results = %w[
+            shift_worker_your_employer_with_rounding
+            the_user_should_be_aware
+            guidance_on_calculations
+          ]
+          assert_equal expected_results, @calculator.shift_worker
+        end
+      end
+
+      context "holiday period leaving and working 5 or fewer days per week" do
+        should "not include the extra entries" do
+          @calculator.holiday_period = "leaving"
+          @calculator.shifts_per_shift_pattern = 5
+          @calculator.days_per_shift_pattern = 7
+          expected_results = %w[
+            shift_worker_your_employer_with_rounding
+            guidance_on_calculations
+          ]
+          assert_equal expected_results, @calculator.shift_worker
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
The intention of this spike is to make sure that all logic is tested and to catch syntax errors on the start/question pages in the steps along the flow of a smart answer.

To do this we have created new integration tests using minitest in the following format;

```ruby
require "test_helper"

class MyFlowTest < ActionDispatch::IntegrationTest
  setup do
    stub_content_store_has_item("/my-flow")
  end

  context "test something" do
    should "render the results page" do
      get "/my-flow/y/all/params/to/results/page"
      assert_select "p", "some text that only exists on the results page"
    end
  end
end
```
This has several advantages over our current tests;
 * We are rendering the result page - without using Capybara.
 * We are concentrating on the flow outcome, not the flow path or route (although, by definition we are exercising the flow path). We're not explicitlly testing the routes, instead relying on the successful rendering of the results page to indicate that we've made it to the end of a route.  
 * We ensure that the tests will fail if there are any syntax errors (i.e. <% if true %>, but no <% end %>) on the start page, any of the interim question pages, or the result page.
 * We are only testing the happy path as this is all we need to test here having moved view logic into the calculator.
 * These tests execute significantly faster than RSpec tests that have similar coverage (see Test speed comparison). They are somewhat slower than existing Minitests but are testing content which was not done previously.


## Reducing logic on result pages

### How?

As a general principle, move as much of the content from the existing result page into a partial or partials.

Add public methods to the flow’s Calculator like so…

```ruby
def outcome_method
  content_array = Array.new
  content_array << "a_partial_name"
  content_array << "another_partial_name" if something == "something_else"
  content_array << "yet_another_partial_name"
end
```

On the result page…

```erb
<% govspeak_for :body do %>
  <%# some text that is always displayed specific to this outcome %>

  <% calculator.outcome_method.each do |part| %>
    <%= render partial: part %>
  <% end %>

  <%# some text that is always displayed specific to this outcome %>
<% end %>
```

### Why is this an improvement?

 * We have removed all of the logic from the result page and into the flow’s Calculator where it belongs.
     - This allows us to do individual unit tests for the methods we’ve created in the calculator. This improves test speed and clarity and also allows us to minimise tests on the frontend as we can be confident in our error handling and alerting before this time.
 * We have moved as much content as possible from the result page into a partial or partials.
     - This change means that we can more easily render the content. It also reduces the amount of logic we need to add to the calculator.
 * We are minimising the potential to break the result page by removing code logic statements.


## Test speed comparison

### RSpec
```shell
Finished in 4 minutes 3.1 seconds (files took 5.56 seconds to load)
24 examples, 0 failures
```

### MiniTest - old version
```shell
Finished in 0.299327s, 434.3076 runs/s, 1530.0992 assertions/s.
130 runs, 458 assertions, 0 failures, 0 errors, 0 skips
```

### MiniTest - new version
```shell
Finished in 4.414292s, 1.1327 runs/s, 1.1327 assertions/s.
5 runs, 5 assertions, 0 failures, 0 errors, 0 skips
```

## Next steps

We’re aware that there’s a good degree of repetition in the outcomes for holiday entitlement smart answer. In the long/medium term this could be moved to a single outcome erb file. This would require the text at the beginning of each outcome to be moved into either its own partial or a new I18N file that could contain content for the whole flow.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
