### PR TITLE
Increase group spacing

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -33,5 +33,5 @@ $govuk-use-legacy-palette: false;
 @import "components/email-link";
 @import "components/hide-this-page-banner";
 @import "components/result-item";
-@import "components/result-section";
+@import "components/result-sections";
 @import "smart_answers";

--- a/app/assets/stylesheets/components/_result-sections.scss
+++ b/app/assets/stylesheets/components/_result-sections.scss
@@ -1,4 +1,8 @@
-.app-c-result-section {
+.app-c-result-sections {
+  margin-bottom: govuk-spacing(7) * 2;
+}
+
+.app-c-result-sections__section {
   @include govuk-font($size: 19);
   @include govuk-responsive-padding(4, 'top');
   border-top: 1px solid $govuk-border-colour;

--- a/app/views/components/_result-sections.html.erb
+++ b/app/views/components/_result-sections.html.erb
@@ -3,16 +3,18 @@
   group_index ||= 1
   result_index ||= 1
 %>
-<% topics.each do |topic, results| %>
-  <section class="app-c-result-section">
-    <h3 class="govuk-heading-m"><%= topic %></h3>
-    <% results.each do |result| %>
-      <%= render "components/result-item", {
-        highlighted: highlighted,
-        group_index: group_index,
-        result_index: result_index
-      }.merge(result.symbolize_keys) %>
-      <% result_index += 1 %>
-    <% end %>
-  </section>
-<% end %>
+<div class="app-c-result-sections">
+  <% topics.each do |topic, results| %>
+    <section class="app-c-result-sections__section">
+      <h3 class="govuk-heading-m"><%= topic %></h3>
+      <% results.each do |result| %>
+        <%= render "components/result-item", {
+          highlighted: highlighted,
+          group_index: group_index,
+          result_index: result_index
+        }.merge(result.symbolize_keys) %>
+        <% result_index += 1 %>
+      <% end %>
+    </section>
+  <% end %>
+</div>


### PR DESCRIPTION
Increase the group spacing to 80px on desktop (50px on mobile). As [the spacing scale currently supports up to 8 units](https://design-system.service.gov.uk/styles/spacing/) we're going to compose this value. We previously renamed `result-section` component to `result-sections` to accommodate analytics and design needs – so we refactor the SCSS to be consistent with the component name

[Trello card](https://trello.com/c/P5onu5lj)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
