### PR TITLE
Don't set cache expiry time in tests

### DIFF
--- a/config/initializers/http_cache_control.rb
+++ b/config/initializers/http_cache_control.rb
@@ -1,5 +1,5 @@
 SmartAnswers::Application.configure do
-  config.set_http_cache_control_expiry_time = if Rails.env.development?
+  config.set_http_cache_control_expiry_time = if Rails.env.development? || Rails.env.test?
                                                 false
                                               else
                                                 true

--- a/spec/requests/query_parameters_based_flow_spec.rb
+++ b/spec/requests/query_parameters_based_flow_spec.rb
@@ -1,6 +1,10 @@
 RSpec.describe "Query parameter based flow navigation", flow_dir: :fixture do
   let(:cache_header) { "max-age=1800, public" }
 
+  before do
+    allow(Rails.application.config).to receive(:set_http_cache_control_expiry_time).and_return(true)
+  end
+
   context "urls have /s/ prefix" do
     it "redirects to first node" do
       get "/query-parameters-based/s"


### PR DESCRIPTION
Trello: https://trello.com/c/XeC0vZkl

# What's changed?

Reinstates the original config to not set cache expiry in the test environment. Instead stubs the cache expiry headers in the only place they're being tested, the "Query parameter based flow navigation" [4].

# Why?

There is an integration test that fails intermittently:

```
Failure:
CountryAndDateQuestionsTest#test_: with javascript should handle country and date questions 42.  [/govuk/smart-answers/test/integration/engine/country_and_date_questions_test.rb:111]:
--- expected
+++ actual
@@ -1 +1 @@
-["angola", "aruba", "bangladesh", "belarus", "brazil", "brunei", "cambodia", "chad", "croatia", "denmark", "eritrea", "france", "ghana", "iceland", "japan", "laos", "luxembourg", "malta", "micronesia", "mozambique", "nicaragua", "panama", "portugal", "sao-tome-and-principe", "singapore", "south-korea", "sri-lanka", "venezuela", "vietnam"]
+["argentina", "belarus"]

rails test test/integration/engine/country_and_date_questions_test.rb:43
```

A loop was added [1] to replicate the problem locally.

`CountryAndDateQuestionsTest` and `ChangingAnswerTest` both visit "/country-and-date-sample/y" but only `CountryAndDateQuestionsTest` tests the contents of the WorldLocation drop-down, so it's the only test that fails.

I originally thought this was a caching issue, caused by the tests running in parallel [2].

After a bit of investigation [3], it turns out it's failing because the Chrome instance of Capybara is caching a HTTP response for "/country-and-date-sample/y" (due to expiry headers set).

There were a few ways we could fix this. One of them is was to remove the cache expiry setting for the Javascript Capybara tests. However, there are only one set of tests that explicitly test the cache header [4], so rather turn off the cache expiry for the integration tests, I have decided to put back the original config that was removed when these tests were added [4], and stub the cache expiry in the only place that the cache headers are being tested.

[1]:https://github.com/alphagov/smart-answers/pull/5384/commits/220a6955fef83bfc8b975f6f7933647c0eff682f
[2]: https://github.com/alphagov/smart-answers/blob/main/test/test_helper.rb#L40
[3]: https://github.com/alphagov/smart-answers/commit/83478e0b4f9ec255f753679d7c2a752903fcd542
[4]: https://github.com/alphagov/smart-answers/commit/047df59818126fce8bdb86525a42bf7f4cd1bbe5#diff-3180c288738612297a7a24d405fbade1c6766b27d7050eeee2ecdbef2e14cef0L2

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
