### PR TITLE
Remove with_cache_control_expiry test helper

### DIFF
--- a/test/functional/smart_answers_controller_salary_question_test.rb
+++ b/test/functional/smart_answers_controller_salary_question_test.rb
@@ -63,17 +63,15 @@ class SmartAnswersControllerSalaryQuestionTest < ActionController::TestCase
       end
 
       context "a response has been accepted" do
-        setup do
-          with_cache_control_expiry do
-            get :show, params: { id: "smart-answers-controller-sample-with-salary-question", started: "y", responses: "1.0-month" }
-          end
-        end
-
         should "show response summary" do
+          get :show, params: { id: "smart-answers-controller-sample-with-salary-question", started: "y", responses: "1.0-month" }
           assert_select ".govuk-summary-list", /How much\?\s+£1 per month/
         end
 
         should "have cache headers set to 30 mins for inner pages" do
+          Rails.application.config.stubs(:set_http_cache_control_expiry_time).returns(true)
+
+          get :show, params: { id: "smart-answers-controller-sample-with-salary-question", started: "y", responses: "1.0-month" }
           assert_equal "max-age=1800, public", @response.header["Cache-Control"]
         end
       end

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -130,10 +130,10 @@ class SmartAnswersControllerTest < ActionController::TestCase
     end
 
     should "have cache headers set to 30 mins" do
-      with_cache_control_expiry do
-        get :show, params: { id: "smart-answers-controller-sample" }
-        assert_equal "max-age=1800, public", @response.header["Cache-Control"]
-      end
+      Rails.application.config.stubs(:set_http_cache_control_expiry_time).returns(true)
+
+      get :show, params: { id: "smart-answers-controller-sample" }
+      assert_equal "max-age=1800, public", @response.header["Cache-Control"]
     end
 
     context "meta description in erb template" do

--- a/test/functional/smart_answers_controller_test_helper.rb
+++ b/test/functional/smart_answers_controller_test_helper.rb
@@ -19,11 +19,4 @@ module SmartAnswersControllerTestHelper
     params[:response] = response if response
     get :show, params: params.merge(other_params)
   end
-
-  def with_cache_control_expiry(&block)
-    original_value = Rails.configuration.set_http_cache_control_expiry_time
-    Rails.configuration.set_http_cache_control_expiry_time = true
-    block.call
-    Rails.configuration.set_http_cache_control_expiry_time = original_value
-  end
 end


### PR DESCRIPTION
The `with_cache_control_expiry` method is only used in two tests, and is
doing the same job as a stub, so it's not really needed.

Also, it felt odd to be calling a `get` from within the setup, so that
has been moved to be called explicitly within in each test as well.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
