### PR TITLE
SPIKE - Show proposed test approach

### DIFF
--- a/test/integration/smart_answer_flows/another_towing_rules_test.rb
+++ b/test/integration/smart_answer_flows/another_towing_rules_test.rb
@@ -1,0 +1,362 @@
+require_relative "../../test_helper"
+require_relative "flow_test_helper"
+
+require "smart_answer_flows/towing-rules"
+
+class TowingRulesTest < ActiveSupport::TestCase
+  include FlowTestHelper
+
+  setup do
+    setup_for_testing_flow SmartAnswer::TowingRulesFlow
+  end
+
+  context "start page" do
+    should see_start_page.with_title("  Work out if you’re old enough or have the right kind of licence to tow a trailer from different kinds of vehicle")
+  end
+
+  context "question :towing_vehicle_type" do
+    should see_question(:towing_vehicle_type).with_title("What kind of vehicle do you want to tow with?")
+    should accept_answer("car-or-light-vehicle").with_next_node(:existing_towing_entitlements?)
+    should accept_answer("medium-sized-vehicle").with_next_node(:medium_sized_vehicle_licenceholder?)
+    should accept_answer("large-vehicle").with_next_node(:existing_large_vehicle_licence?)
+    should accept_answer("minibus").with_next_node(:car_licence_before_jan_1997?)
+    should accept_answer("bus").with_next_node(:bus_licenceholder?)
+  end
+
+  context "question :existing_towing_entitlements?" do
+    setup do
+      responses = { towing_vehicle_type: "car-or-light-vehicle" }
+    end
+
+    should see_question(:existing_towing_entitlements).with_title("Do you already have a driving licence with any of the following entitlements on it:")
+    should accept_answer("yes").with_next_node(:how_long_entitlements?)
+    should accept_answer("no").with_next_node(:date_licence_was_issued?)
+  end
+
+  context "question :how_long_entitlements?" do
+    setup do
+      responses = { towing_vehicle_type: "car-or-light-vehicle", existing_towing_entitlements?: "yes" }
+    end
+
+    should see_question(:how_long_entitlements).with_title("When did you get this entitlement on your licence?")
+    should accept_answer("before-19-Jan-2013").with_next_node(:car_light_vehicle_entitlement)
+    should accept_answer("after-19-Jan-2013").with_next_node(:full_entitlement?)
+  end
+
+  context "question :date_licence_was_issued?" do
+    setup do
+      responses = { towing_vehicle_type: "car-or-light-vehicle", existing_towing_entitlements?: "no" }
+    end
+
+    should see_question(:date_licence_was_issued).with_title("When was your driving licence issued?")
+    should accept_answer("licence-issued-before-19-Jan").with_next_node(:limited_trailer_entitlement)
+    should accept_answer("licence-issued-after-19-Jan").with_next_node(:limited_trailer_entitlement_2013)
+  end
+
+  context "question :medium_sized_vehicle_licenceholder?" do
+    setup do
+      responses = { :towing_vehicle_type?: "medium-sized-vehicle" }
+    end
+
+    should see_question(:medium_sized_vehicle_licenceholder).with_title("Do you already have a C1 medium-sized vehicle licence?")
+    should accept_answer("yes").with_next_node(:how_old_are_you_msv)
+    should accept_answer("no").with_next_node(:existing_large_vehicle_towing_entitlements)
+  end
+
+  context "question :how_old_are_you_msv?" do
+    setup do
+      responses = { :towing_vehicle_type?: "medium-sized-vehicle", :medium_sized_vehicle_licenceholder?: "yes" }
+    end
+
+    should see_question(:how_old_are_you_msv).with_title("How old are you?")
+    should accept_answer("under-21").with_next_node(:limited_conditional_trailer_entitlement_msv)
+    should accept_answer("21-or-over").with_next_node(:limited_trailer_entitlement_msv)
+  end
+
+  context "question :existing_large_vehicle_towing_entitlements?" do
+    setup do
+      responses = { :towing_vehicle_type?: "medium-sized-vehicle", :medium_sized_vehicle_licenceholder?: "no" }
+    end
+
+    should see_question(:existing_large_vehicle_towing_entitlements).with_title("Do you already have a driving licence with the C+E towing with a large vehicle entitlement on it?")
+    should accept_answer("yes").with_next_node(:included_entitlement_msv)
+    should accept_answer("no").with_next_node(:date_licence_was_issued_msv)
+  end
+
+  context "question :date_licence_was_issued_msv?" do
+    setup do
+      responses = { :towing_vehicle_type?: "medium-sized-vehicle", :medium_sized_vehicle_licenceholder?: "no", :existing_large_vehicle_towing_entitlements: "no" }
+    end
+
+    should see_question(:date_licence_was_issued_msv).with_title("When was your driving licence issued?")
+    should accept_answer("before-jan-1997").with_next_node(:full_entitlement_msv)
+    should accept_answer("after-jan-1997").with_next_node(:how_old_are_you_msv_2)
+  end
+
+  context "question :how_old_are_you_msv_2?" do
+    setup do
+      responses = { :towing_vehicle_type?: "medium-sized-vehicle", :medium_sized_vehicle_licenceholder?: "no", :existing_large_vehicle_towing_entitlements: "no", :date_licence_was_issued_msv: "after-jan-1997" }
+    end
+
+    should see_question(:how_old_are_you_msv_2).with_title("How old are you?")
+    should accept_answer("under-18").with_next_node(:too_young_msv)
+    should accept_answer("under-21").with_next_node(:apply_for_provisional_with_exceptions_msv)
+    should accept_answer("21-or-over").with_next_node(:apply_for_provisional_msv)
+  end
+
+  context "question :existing_large_vehicle_licence?" do
+    setup do
+      responses = { :towing_vehicle_type?: "large-vehicle"  }
+    end
+
+    should see_question(:existing_large_vehicle_licence).with_title("Do you already have a category C large vehicle licence?")
+    should accept_answer("yes").with_next_node(:full_cat_c_entitlement)
+    should accept_answer("no").with_next_node(:how_old_are_you_lv)
+  end
+
+  context "question :how_old_are_you_lv?" do
+    setup do
+      responses = { :towing_vehicle_type?: "large-vehicle", :existing_large_vehicle_licence: "no" }
+    end
+
+    should see_question(:how_old_are_you_lv).with_title("How old are you?")
+    should accept_answer("under-21").with_next_node(:not_old_enough_lv)
+    should accept_answer("21-or-over").with_next_node(:apply_for_provisional_lv)
+  end
+
+  context "question :car_licence_before_jan_1997?" do
+    setup do
+      responses = { :towing_vehicle_type?: "minibus" }
+    end
+
+    should see_question(:car_licence_before_jan_1997).with_title("Did you pass your test before 1 January 1997?")
+    should accept_answer("yes").with_next_node(:full_entitlement_minibus)
+    should accept_answer("no").with_next_node(:do_you_have_lv_or_bus_towing_entitlement)
+  end
+
+  context "question :do_you_have_lv_or_bus_towing_entitlement?" do
+    setup do
+      responses = { :towing_vehicle_type?: "minibus", :car_licence_before_jan_1997: "no" }
+    end
+
+    should see_question(:do_you_have_lv_or_bus_towing_entitlement?).with_title("Do you have a full category D+E towing with a bus licence?")
+    should accept_answer("yes").with_next_node(:included_entitlement_minibus)
+    should accept_answer("no").with_next_node(:full_minibus_licence?)
+  end
+
+  context "question :full_minibus_licence?" do
+    setup do
+      responses = { :towing_vehicle_type?: "minibus", :car_licence_before_jan_1997: "no", :do_you_have_lv_or_bus_towing_entitlement?: "no" }
+    end
+
+    should see_question(:full_minibus_licence?).with_title("Do you have a full category D1 minibus licence?")
+    should accept_answer("yes").with_next_node(:limited_towing_entitlement_minibus?)
+    should accept_answer("no").with_next_node(:how_old_are_you_minibus?)
+  end
+
+  context "question :how_old_are_you_minibus?" do
+    setup do
+      responses = { :towing_vehicle_type?: "minibus", :car_licence_before_jan_1997: "no", :do_you_have_lv_or_bus_towing_entitlement?: "no", :full_minibus_licence?: "no" }
+    end
+
+    should see_question(:how_old_are_you_minibus).with_title("How old are you?")
+    should accept_answer("under-21").with_next_node(:not_old_enough_minibus)
+    should accept_answer("21-or-over").with_next_node(:limited_overall_entitlement_minibus)
+  end
+
+  context "question :bus_licenceholder?" do
+    setup do
+      responses = { :towing_vehicle_type?: "bus" }
+    end
+
+    should see_question(:bus_licenceholder?).with_title("Do you already have a full category D bus licence?")
+    should accept_answer("yes").with_next_node(:full_entitlement_bus)
+    should accept_answer("no").with_next_node(:how_old_are_you_bus?)
+  end
+
+  context "question :how_old_are_you_bus?" do
+    setup do
+      responses = { :towing_vehicle_type?: "bus", :bus_licenceholder?: "no" }
+    end
+
+    should see_question(:how_old_are_you_bus).with_title("How old are you?")
+    should accept_answer("under-21").with_next_node(:not_old_enough_bus)
+    should accept_answer("21-or-over").with_next_node(:apply_for_provisional_bus)
+  end
+
+  context "outcome :car_light_vehicle_entitlement" do
+    setup do
+      responses = { towing_vehicle_type: "car-or-light-vehicle", existing_towing_entitlements?: "yes", how_long_entitlements?: "before-19-Jan-2013" }
+    end
+
+    should see_outcome(:car_light_vehicle_entitlement).with_text("You can already tow trailers up to 3,500kg MAM (maximum authorised mass) with a car.")
+  end
+
+  context "outcome :full_entitlement" do
+    setup do
+      responses = { towing_vehicle_type: "car-or-light-vehicle", existing_towing_entitlements?: "yes", how_long_entitlements?: "after-19-Jan-2013" }
+    end
+
+    should see_outcome(:full_entitlement).with_text("You can already tow trailers of any weight with a car.")
+  end
+
+  context "outcome :limited_trailer_entitlement" do
+    setup do
+      responses = { towing_vehicle_type: "car-or-light-vehicle", existing_towing_entitlements?: "no", date_licence_was_issued?: "licence-issued-before-19-Jan-2013" }
+    end
+
+    should see_outcome(:limited_trailer_entitlement).with_text("Check if you have category B or B+E on your licence.")
+  end
+
+  context "outcome :limited_trailer_entitlement_2013" do
+    setup do
+      responses = { towing_vehicle_type: "car-or-light-vehicle", existing_towing_entitlements?: "no", date_licence_was_issued?: "licence-issued-after-19-Jan-2013" }
+    end
+
+    should see_outcome(:limited_trailer_entitlement_2013).with_text("You can already tow trailers up to 750kg.")
+  end
+
+  context "outcome :limited_conditional_trailer_entitlement_msv" do
+    setup do
+      responses = { :towing_vehicle_type?: "medium-sized-vehicle", :medium_sized_vehicle_licenceholder?: "yes", :how_old_are_you_msv?: "under-21" }
+    end
+
+    should see_outcome(:limited_conditional_trailer_entitlement_msv).with_text("You can tow trailers up to 750kg with a standard C1 medium-sized vehicle licence as long as the vehicle weight is not more than 7,500kg.")
+  end
+
+  context "outcome :limited_trailer_entitlement_msv" do
+    setup do
+      responses = { :towing_vehicle_type?: "medium-sized-vehicle", :medium_sized_vehicle_licenceholder?: "yes", :how_old_are_you_msv?: "21-or-over" }
+    end
+
+    should see_outcome(:limited_trailer_entitlement_msv).with_text("You can tow trailers up to 750kg with a standard C1 medium-sized vehicle licence as long as the vehicle weight is not more than 7,500kg.")
+  end
+
+  context "outcome :included_entitlement_msv" do
+    setup do
+      responses = { :towing_vehicle_type?: "medium-sized-vehicle", :medium_sized_vehicle_licenceholder?: "no", :existing_large_vehicle_towing_entitlements?: "yes" }
+    end
+
+    should see_outcome(:included_entitlement_msv).with_text("You already have the C1+E towing with a medium-sized vehicle entitlement on your licence.")
+  end
+
+  context "outcome :full_entitlement_msv" do
+    setup do
+      responses = { :towing_vehicle_type?: "medium-sized-vehicle", :medium_sized_vehicle_licenceholder?: "no", :existing_large_vehicle_towing_entitlements?: "no", :date_licence_was_issued_msv?: "before-jan-1997" }
+    end
+
+    should see_outcome(:full_entitlement_msv).with_text("You already have a restricted C1+E towing with a medium-sized vehicle entitlement on your licence.")
+  end
+
+  context "outcome :too_young_msv" do
+    setup do
+      responses = { :towing_vehicle_type?: "medium-sized-vehicle", :medium_sized_vehicle_licenceholder?: "no", :existing_large_vehicle_towing_entitlements?: "no", :date_licence_was_issued_msv?: "from-jan-1997", :how_old_are_you_msv_2?: "under-18" }
+    end
+
+    should see_outcome(:too_young_msv).with_text("You’re too young to tow with a category C1 medium-sized vehicle.")
+  end
+
+  context "outcome :apply_for_provisional_with_exceptions_msv" do
+    setup do
+      responses = { :towing_vehicle_type?: "medium-sized-vehicle", :medium_sized_vehicle_licenceholder?: "no", :existing_large_vehicle_towing_entitlements?: "no", :date_licence_was_issued_msv?: "from-jan-1997", :how_old_are_you_msv_2?: "under-21" }
+    end
+
+    should see_outcome(:apply_for_provisional_with_exceptions_msv).with_text("You can tow trailers up to 750kg with a standard C1 medium-sized vehicle licence as long as the vehicle weight is not more than 7,500kg.")
+  end
+
+  context "outcome :apply_for_provisional_msv" do
+    setup do
+      responses = { :towing_vehicle_type?: "medium-sized-vehicle", :medium_sized_vehicle_licenceholder?: "no", :existing_large_vehicle_towing_entitlements?: "no", :date_licence_was_issued_msv?: "from-jan-1997", :how_old_are_you_msv_2?: "21-or-over" }
+    end
+
+    should see_outcome(:apply_for_provisional_msv).with_text("If you apply for a provisional C1 medium-sized vehicle licence then pass the C1 test you can tow trailers up to 750kg, as long as the combined vehicle and trailer weight is not more than 7,500kg.")
+  end
+
+  context "outcome :full_cat_c_entitlement" do
+    setup do
+      responses = { :towing_vehicle_type?: "large-vehicle", :existing_large_vehicle_licence?: "yes" }
+    end
+
+    should see_outcome(:full_cat_c_entitlement).with_text("You can tow trailers up to 750kg with a standard category C large vehicle licence.")
+  end
+
+  context "outcome :not_old_enough_lv" do
+    setup do
+      responses = { :towing_vehicle_type?: "large-vehicle", :existing_large_vehicle_licence?: "no", :how_old_are_you_lv?: "under-21" }
+    end
+
+    should see_outcome(:not_old_enough_lv).with_text("In most cases you have to wait until you’re 21 to drive, or tow, with a category C large vehicle.")
+  end
+
+  context "outcome :apply_for_provisional_lv" do
+    setup do
+      responses = { :towing_vehicle_type?: "large-vehicle", :existing_large_vehicle_licence?: "no", :how_old_are_you_lv?: "21-or-over" }
+    end
+
+    should see_outcome(:apply_for_provisional_lv).with_text("If you get provisional category C large vehicle entitlement then pass the category C test you can tow trailers up to 750kg.")
+  end
+
+  context "outcome :full_entitlement_minibus" do
+    setup do
+      responses = { :towing_vehicle_type?: "minibus", :car_licence_before_jan_1997?: "yes" }
+    end
+
+    should see_outcome(:full_entitlement_minibus).with_text("You can already tow with minibuses, but ‘not for hire or reward’.")
+  end
+
+  context "outcome :included_entitlement_minibus" do
+    setup do
+      responses = { :towing_vehicle_type?: "minibus", :car_licence_before_jan_1997?: "no", :do_you_have_lv_or_bus_towing_entitlement?: "yes" }
+    end
+
+    should see_outcome(:included_entitlement_minibus).with_text("You can already tow with minibuses.")
+  end
+
+  context "outcome :limited_towing_entitlement_minibus" do
+    setup do
+      responses = { :towing_vehicle_type?: "minibus", :car_licence_before_jan_1997?: "no", :do_you_have_lv_or_bus_towing_entitlement?: "no", :full_minibus_licence?: "yes" }
+    end
+
+    should see_outcome(:limited_towing_entitlement_minibus).with_text("You can already tow trailers up to 750kg with your D1 minibus licence.")
+  end
+
+  context "outcome :not_old_enough_minibus" do
+    setup do
+      responses = { :towing_vehicle_type?: "minibus", :car_licence_before_jan_1997?: "no", :do_you_have_lv_or_bus_towing_entitlement?: "no", :full_minibus_licence?: "no", :how_old_are_you_minibus?: "under-21" }
+    end
+
+    should see_outcome(:not_old_enough_minibus).with_text("You cannot normally drive or tow with a minibus until you’re 21. You then need to first take the D1 minibus test to tow trailers up to 750kg. To tow heavier trailers you’ll then need to take the D1+E towing test.")
+  end
+
+  context "outcome :limited_overall_entitlement_minibus" do
+    setup do
+      responses = { :towing_vehicle_type?: "minibus", :car_licence_before_jan_1997?: "no", :do_you_have_lv_or_bus_towing_entitlement?: "no", :full_minibus_licence?: "no", :how_old_are_you_minibus?: "21-or-over" }
+    end
+
+    should see_outcome(:limited_overall_entitlement_minibus).with_text("You need to apply for a provisional D1 minibus licence then pass a D1 minibus test to tow trailers up to 750kg.")
+  end
+
+  context "outcome :full_entitlement_bus" do
+    setup do
+      responses = { :towing_vehicle_type?: "bus", :bus_licenceholder?: "yes" }
+    end
+
+    should see_outcome(:full_entitlement_bus).with_text("You can already tow trailers up to 750kg. To tow heavier trailers you need to apply for provisional D+E towing with a bus entitlement then pass the D+E test.")
+  end
+
+  context "outcome :not_old_enough_bus" do
+    setup do
+      responses = { :towing_vehicle_type?: "bus", :bus_licenceholder?: "no", :how_old_are_you_bus?: "under-21" }
+    end
+
+    should see_outcome(:not_old_enough_bus).with_text("You cannot normally tow with a bus until you’re 21. You’ll then need to pass the category D test to tow trailers up to 750kg, and then pass the D+E test to tow heavier trailers.")
+  end
+
+  context "outcome :apply_for_provisional_bus" do
+    setup do
+      responses = { :towing_vehicle_type?: "bus", :bus_licenceholder?: "no", :how_old_are_you_bus?: "21-or-over" }
+    end
+
+    should see_outcome(:apply_for_provisional_bus).with_text("You need to apply for provisional category D bus entitlement then pass a category D test. You can then tow trailers up to 750kg.")
+  end
+end

--- a/test/integration/smart_answer_flows/calculate_your_holiday_entitlement_test.rb
+++ b/test/integration/smart_answer_flows/calculate_your_holiday_entitlement_test.rb
@@ -1,0 +1,389 @@
+require_relative "../../test_helper"
+require_relative "flow_test_helper"
+
+require "smart_answer_flows/calculate-your-holiday-entitlement"
+
+class CalculateYourHolidayEntitlementTest < ActiveSupport::TestCase
+  include FlowTestHelper
+
+  setup do
+    setup_for_testing_flow SmartAnswer::CalculateYourHolidayEntitlementFlow
+  end
+
+  context "start page" do
+    should see_start_page.with_title("Calculate holiday entitlement")
+  end
+
+  context "question :basis of calculation?" do
+    should see_question(:basis_of_calculation?).with_title("Is the holiday entitlement based on:")
+
+    should "take people who work shifts to the shift_worker_basis? question" do
+      add_response "shift-worker"
+      assert_equal :shift_worker_basis?, next_node_name
+    end
+
+    should "take people who don't work shifts to the calculation_period? question" do
+      add_response "days-worked-per-week"
+      assert_equal :calculation_period?, next_node_name
+    end
+  end
+
+  context "question :calculation period?" do
+    setup do
+      responses = { basis_of_calculation?: "days-worked-per-week" }
+    end
+
+    should see_question(:calculation_period?).with_title("Do you want to work out holiday:")
+
+    should accept_answer("starting").with_next_node(:what_is_your_starting_date?)
+    should accept_answer("starting-and-leaving").with_next_node(:what_is_your_starting_date?)
+    should accept_answer("leaving").with_next_node(:what_is_your_leaving_date?)
+
+    context "when the answer is full-year" do
+      setup do
+        responses[:calculation_period?] = "full-year"
+      end
+
+      should "take people with irregular hours to the :irregular_and_annualised_done outcome" do
+        responses[:basis_of_calculation?] = "irregular-hours"
+        assert_equal :irregular_and_annualised_done, next_node
+      end
+
+      should "take people with annualised hours to the :irregular_and_annualised_done outcome" do
+        responses[:basis_of_calculation?] = "annualised-hours"
+        assert_equal :irregular_and_annualised_done, next_node
+      end
+
+      should "take people who want a days worked per week calculation to the :how_many_days_per_week? question" do
+        responses[:basis_of_calculation?] = "days-worked-per-week"
+        assert_equal :how_many_days_per_week?, next_node
+      end
+
+      should "take people who want other types of calculation to the :how_many_hours_per_week? question" do
+        responses[:basis_of_calculation?] = "compressed-hours"
+        assert_equal :how_many_hours_per_week?, next_node
+      end
+    end
+  end
+
+  context "question :how_many_days_per_week?" do
+    setup do
+      responses = {
+        basis_of_calculation?: "days-worked-per-week",
+        calculation_period?: "full-year",
+      }
+    end
+
+    should see_question(:how_many_days_per_week?).with_title("Number of days worked per week?")
+
+    context "when given an invalid day of the week" do
+      should_not accept_answer(0)
+      should_not accept_answer(8)
+    end
+
+    should accept_answer(5).with_next_node(:days_per_week_done)
+  end
+
+  context "question :what_is_your_starting_date?" do
+    setup do
+      responses = {
+        basis_of_calculation?: "days-worked-per-week",
+        calculation_period?: "starting-and-leaving",
+      }
+    end
+
+    should see_question(:what_is_your_starting_date?).with_title("What was the employment start date?")
+
+    add_response "2021-01-01"
+
+    should "take people who want a starting and leaving calculation to the :what_is_your_leaving_date? question" do
+      responses[:calculation_period?] = "starting-and-leaving"
+      assert_equal :what_is_your_leaving_date?, next_node
+    end
+
+    should "take people who want other types of calculation to the :when_does_your_leave_year_start? question" do
+      responses[:calculation_period?] = "full-year"
+      assert_equal :when_does_your_leave_year_start?, next_node
+    end
+  end
+
+  context "question :what_is_your_leaving_date?" do
+    setup do
+      responses = {
+        basis_of_calculation?: "days-worked-per-week",
+        calculation_period?: "leaving",
+        what_is_your_starting_date?: "2021-01-01",
+      }
+    end
+
+    should see_question(:what_is_your_leaving_date?).with_title("What was the employment end date?")
+
+    should_not_accept_a_response_before(responses[:what_is_your_starting_date?])
+    should_not_accept_a_response_more_than_a_year_from(responses[:what_is_your_starting_date?])
+
+    should accept_answer("2020-10-01").with_next_node(:when_does_your_leave_year_start?)
+
+    context "when calculation_period? is starting-and-leaving" do
+      setup do
+        responses[:calculation_period?] = "starting-and-leaving"
+        add_response "2021-01-01"
+      end
+
+      should "take people who want a days worked per week calculation to the :how_many_days_per_week? question" do
+        responses[:basis_of_calculation?] = "days-worked-per-week"
+        assert_equal :how_many_days_per_week?, next_node
+      end
+
+      should "take people who want an hours worked per week calculation to the :how_many_hours_per_week? question" do
+        responses[:basis_of_calculation?] = "hours-worked-per-week"
+        assert_equal :how_many_hours_per_week?, next_node
+      end
+
+      should "take people who work shifts to the :shift_worker_hours_per_shift? question" do
+        responses[:basis_of_calculation?] = "shift-worker"
+        assert_equal :shift_worker_hours_per_shift?, next_node
+      end
+
+      should "take people with irregular hours to the :irregular_and_annualised_done outcome" do
+        responses[:basis_of_calculation?] = "irregular-hours"
+        assert_equal :irregular_and_annualised_done, next_node
+      end
+    end
+  end
+
+  context "question :when_does_your_leave_year_start?" do
+    setup do
+      responses = {
+        basis_of_calculation?: "days-worked-per-week",
+        calculation_period?: "leaving",
+        what_is_your_starting_date?: "2021-01-01",
+        what_is_your_leaving_date?: "2021-10-01",
+      }
+    end
+
+    should see_question(:when_does_your_leave_year_start?).with_title("When does the leave year start?")
+
+    add_response "2021-01-01"
+
+    should_not_accept_a_response_before(responses[:what_is_your_starting_date?])
+    should_not_accept_a_response_before(responses[:what_is_your_leaving_date?])
+
+    should_not_accept_a_response_more_than_a_year_from(responses[:what_is_your_starting_date?])
+    should_not_accept_a_response_more_than_a_year_from(responses[:what_is_your_leaving_date?])
+
+    should "take people who want a days worked per week calculation to the :how_many_days_per_week? question" do
+      responses[:basis_of_calculation?] = "days-worked-per-week"
+      assert_equal :how_many_days_per_week?, next_node
+    end
+
+    should "take people who want an hours worked per week calculation to the :how_many_hours_per_week? question" do
+      responses[:basis_of_calculation?] = "hours-worked-per-week"
+      assert_equal :how_many_hours_per_week?, next_node
+    end
+
+    should "take people with compressed hours to the :how_many_hours_per_week? question" do
+      responses[:basis_of_calculation?] = "compressed-hours"
+      assert_equal :how_many_hours_per_week?, next_node
+    end
+
+    should "take people with irregular hours to the :irregular_and_annualised_done outcome" do
+      responses[:basis_of_calculation?] = "irregular-hours"
+      assert_equal :irregular_and_annualised_done, next_node
+    end
+
+    should "take people with annualised hours to the :irregular_and_annualised_done outcome" do
+      responses[:basis_of_calculation?] = "annualised-hours"
+      assert_equal :irregular_and_annualised_done, next_node
+    end
+
+    should "take people who work shifts to the :shift_worker_hours_per_shift? question" do
+      responses[:basis_of_calculation?] = "shift-worker"
+      assert_equal :shift_worker_hours_per_shift?, next_node
+    end
+  end
+
+  context "question :how_many_hours_per_week?" do
+    setup do
+      responses = {
+        basis_of_calculation?: "hours-worked-per-week",
+        calculation_period?: "leaving",
+        what_is_your_starting_date?: "2021-01-01",
+        what_is_your_leaving_date?: "2021-10-01",
+      }
+    end
+
+    should see_question(:how_many_hours_per_week?).with_title("Number of hours worked per week?")
+
+    context "when given an invalid number of hours per week" do
+      should_not accept_answer(-1)
+      should_not accept_answer(169)
+    end
+
+    should accept_answer(100).with_next_node(:how_many_days_per_week_for_hours?)
+  end
+
+  context "question :how_many_days_per_week_for_hours?" do
+    setup do
+      responses = {
+        basis_of_calculation?: "hours-worked-per-week",
+        calculation_period?: "leaving",
+        what_is_your_starting_date?: "2021-01-01",
+        what_is_your_leaving_date?: "2021-10-01",
+        how_many_hours_per_week?: "40",
+      }
+    end
+
+    should see_question(:how_many_days_per_week_for_hours?).with_title("Number of days worked per week?")
+
+    context "when given an invalid day of the week" do
+      should_not accept_answer(0)
+      should_not accept_answer(8)
+    end
+
+    context "validate the hours worked per day is less than 24" do
+      should "reject a period of greater than 24 hours" do
+        responses[:how_many_hours_per_week?] = 25
+        should_not accept_answer(1)
+      end
+
+      should "accept less than 24 hours in a day" do
+        responses[:how_many_hours_per_week?] = 23
+        should accept_answer(1).with_next_node(:hours_per_week_done)
+      end
+    end
+
+    should "take people with compressed hours to the :compressed_hours_done outcome" do
+      responses[:basis_of_calculation?] = "compressed-hours"
+      assert_equal :compressed_hours_done, next_node
+    end
+  end
+
+  context "question :shift_worker_basis?" do
+    setup do
+      responses = { basis_of_calculation?: "shift-worker" }
+    end
+
+    should see_question(:shift_worker_basis?).with_title("Do you want to calculate the holiday:")
+
+    should accept_answer("full-year").with_next_node(:shift_worker_hours_per_shift?)
+    should accept_answer("starting").with_next_node(:what_is_your_starting_date?)
+    should accept_answer("starting-and-leaving").with_next_node(:what_is_your_starting_date?)
+    should accept_answer("leaving").with_next_node(:what_is_your_leaving_date?)
+  end
+
+  context "question :shift_worker_hours_per_shift?" do
+    setup do
+      responses = {
+        basis_of_calculation?: "shift-worker",
+        shift_worker_basis?: "full-year",
+      }
+    end
+
+    should see_question(:shift_worker_hours_per_shift?).with_title("How many hours in each shift?")
+
+    context "when given an invalid number of hours per day" do
+      should_not accept_answer(-1)
+      should_not accept_answer(25)
+    end
+
+    should accept_answer(8).with_next_node(:shift_worker_shifts_per_shift_pattern?)
+  end
+
+  context "question :shift_worker_shifts_per_shift_pattern?" do
+    setup do
+      responses = {
+        basis_of_calculation?: "shift-worker",
+        shift_worker_basis?: "full-year",
+        shift_worker_hours_per_shift?: 8,
+      }
+    end
+
+    should see_question(:shift_worker_shifts_per_shift_pattern?).with_title("How many shifts will be worked per shift pattern?")
+
+    context "when given an invalid number of shifts per shift pattern" do
+      should_not accept_answer(-1)
+    end
+
+    should accept_answer(2).with_next_node(:shift_worker_days_per_shift_pattern?)
+  end
+
+  context "question :shift_worker_days_per_shift_pattern?" do
+    setup do
+      responses = {
+        basis_of_calculation?: "shift-worker",
+        shift_worker_basis?: "full-year",
+        shift_worker_hours_per_shift?: 8,
+        shift_worker_shifts_per_shift_pattern?: 2,
+      }
+    end
+
+    should see_question(:shift_worker_days_per_shift_pattern?).with_title("How many days in the shift pattern?")
+
+    should_not_accept_a_response_before(response[:shift_worker_shifts_per_shift_pattern?])
+
+    should accept_answer(2).with_next_node(:shift_worker_done)
+  end
+
+  context "outcome :shift_worker_done" do
+    setup do
+      responses = {
+        basis_of_calculation?: "shift-worker",
+        calculation_period?: "full-year",
+        shift_worker_hours_per_shift?: 8,
+        shift_worker_shifts_per_shift_pattern?: 3,
+        shift_worker_days_per_shift_pattern?: 3,
+      }
+    end
+
+    should see_outcome(:shift_worker_done).with_text("The statutory holiday entitlement is 28 shifts for the year. Each shift being 8.0 hours.")
+  end
+
+  context "outcome :days_per_week_done" do
+    setup do
+      responses = {
+        basis_of_calculation?: "days-worked-per-week",
+        calculation_period?: "full-year",
+        how_many_days_per_week?: 5,
+      }
+    end
+
+    should see_outcome(:days_per_week_done).with_text("The statutory holiday entitlement is 28 days holiday.")
+  end
+
+  context "outcome :hours_per_week_done" do
+    setup do
+      responses = {
+        basis_of_calculation?: "hours-worked-per-week",
+        calculation_period?: "full-year",
+        how_many_hours_per_week?: 40,
+        how_many_days_per_week?: 5,
+      }
+    end
+
+    should see_outcome(:hours_per_week_done).with_text("The statutory entitlement is 224 hours holiday.")
+  end
+
+  context "outcome :compressed_hours_done" do
+    setup do
+      responses = {
+        basis_of_calculation?: "compressed-hours",
+        calculation_period?: "full-year",
+        how_many_hours_per_week?: 40,
+        how_many_days_per_week?: 5,
+      }
+    end
+
+    should see_outcome(:compressed_hours_done).with_text("The statutory holiday entitlement is 224 hours and 0 minutes holiday for the year.")
+  end
+
+  context "outcome :irregular_and_annualised_done" do
+    setup do
+      responses = {
+        basis_of_calculation?: "annualised-hours",
+        calculation_period?: "full-year",
+      }
+    end
+
+    should see_outcome(:irregular_and_annualised_done).with_text("The statutory holiday entitlement is 5.6 weeks holiday.")
+  end
+end

--- a/test/integration/smart_answer_flows/find_coronavirus_support_reworked_test.rb
+++ b/test/integration/smart_answer_flows/find_coronavirus_support_reworked_test.rb
@@ -1,0 +1,235 @@
+require_relative "../../test_helper"
+require_relative "flow_test_helper"
+
+require "smart_answer_flows/find-coronavirus-support"
+
+class FindCoronavirusSupportReworkedFlowTest < ActiveSupport::TestCase
+  include FlowTestHelper
+
+  setup { setup_for_testing_flow SmartAnswer::FindCoronavirusSupportFlow }
+
+  should render_start_page
+
+  context "question: need_help_with" do
+    should render_question(:need_help_with)
+    should reach_question(:nation).on_response(["nation"])
+  end
+
+  context "question: feel_unsafe" do
+    setup { responses = { need_help_with: %w[feeling_unsafe] } }
+    should render_question(:feel_unsafe)
+    should reach_question(:nation).on_response("yes")
+  end
+
+  context "question: afford_rent_mortgage_bills" do
+    setup { responses = { need_help_with: %w[paying_bills] } }
+    should render_question(:afford_rent_mortgage_bills)
+    should reach_question(:nation).on_response("yes")
+  end
+
+  context "question: afford_food" do
+    setup { responses = { need_help_with: %w[getting_food] } }
+    should render_question(:afford_food)
+    should reach_question(:get_food).on_response("yes")
+  end
+
+  context "question: get_food" do
+    setup { responses = { need_help_with: %w[getting_food], afford_food: "yes" } }
+    should render_question(:get_food)
+    should reach_question(:nation).on_response("yes")
+  end
+
+  context "question: self_employed" do
+    setup { responses = { need_help_with: %w[being_unemployed] } }
+    should render_question(:self_employed)
+    should reach_question(:have_you_been_made_unemployed).on_response("no")
+    should reach_question(:nation).on_response("yes")
+  end
+
+  context "question: have_you_been_made_unemployed" do
+    setup { responses = { need_help_with: %w[being_unemployed], self_employed: "no" } }
+    should render_question(:have_you_been_made_unemployed)
+    should reach_question(:nation).on_response("yes_i_have_been_made_unemployed")
+  end
+
+  context "question: worried_about_work" do
+    setup { responses = { need_help_with: %w[going_to_work] } }
+    should render_question(:worried_about_work)
+    should reach_question(:nation).on_response("yes")
+  end
+
+  context "question: worried_about_self_isolating" do
+    setup { responses = { need_help_with: %w[self_isolating] } }
+    should render_question(:worried_about_self_isolating)
+    should reach_question(:nation).on_response("yes")
+  end
+
+  context "question: have_somewhere_to_live" do
+    setup { responses = { need_help_with: %w[somewhere_to_live] } }
+    should render_question(:have_somewhere_to_live)
+    should reach_question(:have_you_been_evicted).on_response("yes")
+  end
+
+  context "question: have_you_been_evicted" do
+    setup do
+      responses = { need_help_with: %w[somewhere_to_live],
+                    have_somewhere_to_live: "yes" }
+    end
+    should render_question(:have_you_been_evicted)
+    should reach_question(:nation).on_response("yes")
+  end
+
+  context "question: mental_health_worries" do
+    setup { responses = { need_help_with: %w[mental_health] } }
+    should render_question(:mental_health_worries)
+    should reach_question(:nation).on_response("yes")
+  end
+
+  context "question: nation" do
+    setup { responses = { need_help_with: %w[none] } }
+    should render_question(:nation)
+    should reach_outcome(:nation).on_response("england")
+  end
+
+  context "outcome: results" do
+    context "when a user is feeling unsafe" do
+      setup do
+        responses = { need_help_with: %w[feeling_unsafe],
+                      feeling_unsafe: "yes",
+                      nation: "england" }
+      end
+
+      should reach_outcome(:results).with_text(
+        "If you feel unsafe where you live or you’re worried about someone else",
+      )
+    end
+
+    context "when a user is finding it hard to pay bills" do
+      setup do
+        responses = { need_help_with: %w[paying_bills],
+                      afford_rent_mortgage_bills: "yes",
+                      nation: "england" }
+      end
+
+      should reach_outcome(:results).with_text(
+        "If you’re finding it hard to pay your rent, mortgage or bills",
+      )
+    end
+
+    context "when a user is finding it hard to afford food" do
+      setup do
+        responses = { need_help_with: %w[getting_food],
+                      afford_food: "yes",
+                      nation: "england" }
+      end
+
+      should reach_outcome(:results).with_text("If you're finding it hard to afford food")
+    end
+
+    context "when a user is finding it hard to get food" do
+      setup do
+        responses = { need_help_with: %w[getting_food],
+                      afford_food: "yes",
+                      get_food: "no",
+                      nation: "england" }
+      end
+
+      should reach_outcome(:results).with_text("If you're unable to get food or medicine")
+    end
+
+    context "when a user is struggling with employment" do
+      setup do
+        responses = { need_help_with: %w[being_unemployed],
+                      self_employed: "no",
+                      have_you_been_made_unemployed: "yes",
+                      nation: "england" }
+      end
+
+      should reach_outcome(:results).with_text(
+        "If you’ve been made redundant or unemployed, or put on temporary leave (on furlough)",
+      )
+    end
+
+    context "when a user is self-employed" do
+      setup do
+        responses = { need_help_with: %w[being_unemployed],
+                      self_employed: "yes",
+                      have_you_been_made_unemployed: "no",
+                      nation: "england" }
+      end
+
+      should reach_outcome(:results).with_text("If you’re self employed, a freelancer, or a sole trader")
+    end
+
+    context "when a user is worried about going to work" do
+      setup do
+        responses = { need_help_with: %w[going_to_work],
+                      worried_about_work: "yes",
+                      nation: "england" }
+      end
+
+      should reach_outcome(:results).with_text("If you’re worried about going in to work")
+    end
+
+    context "when a user is worried about self-isolating" do
+      setup do
+        responses = { need_help_with: %w[self_isolating],
+                      worried_about_self_isolating: "yes",
+                      nation: "england" }
+      end
+
+      should reach_outcome(:results).with_text("If you're self-isolating")
+    end
+
+    context "when a user is worried about where to live" do
+      setup do
+        responses = { need_help_with: %w[somewhere_to_live],
+                      have_somewhere_to_live: "no",
+                      nation: "england" }
+      end
+
+      should reach_outcome(:results).with_text(
+        "If you do not have somewhere to live or might become homeless"
+      )
+    end
+
+    context "when a user is or might be evicted" do
+      setup do
+        responses = { need_help_with: %w[somewhere_to_live],
+                      have_somewhere_to_live: "yes",
+                      have_you_been_eviceted: "yes",
+                      nation: "england" }
+      end
+
+      should reach_outcome(:results).with_text("If you’ve been evicted or might be soon")
+    end
+
+    context "when a user has worries about mental health" do
+      setup do
+        responses = { need_help_with: %w[mental_health],
+                      mental_health_worries: "yes",
+                      nation: "england" }
+      end
+
+      should reach_outcome(:results).with_text(
+        "If you’re worried about your mental health or someone else’s mental health",
+      )
+    end
+
+    context "when a user is in Northern Ireland" do
+      setup { responses = { need_help_with: %w[none], nation: "northern_ireland" } }
+      should reach_outcome(:results).with_text("Additional information for Northern Ireland")
+      end
+    end
+
+    context "when a user is in Scotland" do
+      setup { responses = { need_help_with: %w[none], nation: "scotland" } }
+      should reach_outcome(:results).with_text("Additional information for Scotland")
+    end
+
+    context "when a user is in Wales" do
+      setup { responses = { need_help_with: %w[none], nation: "wales" } }
+      should reach_outcome(:results).with_text("Additional information for Wales")
+    end
+  end
+end


### PR DESCRIPTION
This adds the proposed test layout for two flows. Towing rules is currently a minitest whilst the holiday entitlement was moved over to Rspec. Existing minitest tests are concerned with testing the flow of a question, an approach that was copied when some test suites were moved over to RSpec. Our proposed approach instead focuses on nodal testing. We test each start page, question page and outcome page separately and the assertions focus on which nodes follow which when given a specific history. The major benefit of this is that we greatly reduce the amount of nesting required to test an entire flow. Within the tests we will load up each nodes erb file without rendering the page in a browser. This ensures that syntax errors on the frontend are caught without needing something like capybara and the time that takes to run.

Slight caveat for this particular piece of work is that some of the methods used (such as `see_question`) don't actually exist yet. They will obviously need to be written before these tests could work. This is more about getting feedback on the overall approach of node testing over flow testing.

Many thanks and such!

Co-authored-by: Jon Hallam <jonathan.hallam@digital.cabinet-office.gov.uk>
Co-authored-by: Graham Lewis <graham.lewis@digital.cabinet-office.gov.uk>

[Trello](https://trello.com/c/n0yuPABN/393-spike-into-how-smart-answer-flow-tests-can-test-erb-rendering)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
