### PR TITLE
Replace stubbing of WorldLocation `find` and `all`

### DIFF
--- a/test/unit/country_select_question_test.rb
+++ b/test/unit/country_select_question_test.rb
@@ -4,16 +4,9 @@ module SmartAnswer
   class CountrySelectQuestionTest < ActiveSupport::TestCase
     context "using the worldwide API data" do
       setup do
-        location1 = stub(slug: "afghanistan", name: "Afghanistan")
-        location2 = stub(slug: "british-antarctic-territory", name: "British Antartic Territory")
-        location3 = stub(slug: "denmark", name: "Denmark")
-        location4 = stub(slug: "the-gambia", name: "The Gambia")
-        location5 = stub(slug: "holy-see", name: "Holy See")
-        location6 = stub(slug: "united-kingdom", name: "United Kingdom")
-        location7 = stub(slug: "vietnam", name: "Vietnam")
-        location8 = stub(slug: "greenland", name: "Greenland")
-        WorldLocation.stubs(:all).returns([location1, location2, location3, location4, location5, location6, location7])
-        UkbaCountry.stubs(:all).returns([location8])
+        stub_worldwide_api_has_locations(%w[afghanistan british-antarctic-territory denmark the-gambia holy-see united-kingdom vietnam])
+        location = stub(slug: "greenland", name: "Greenland")
+        UkbaCountry.stubs(:all).returns([location])
       end
 
       should "be able to list options" do

--- a/test/unit/smart_answer_flows/marriage_abroad_flow_test.rb
+++ b/test/unit/smart_answer_flows/marriage_abroad_flow_test.rb
@@ -10,15 +10,7 @@ module SmartAnswer
     setup do
       @calculator = Calculators::MarriageAbroadCalculator.new
       @flow = MarriageAbroadFlow.build
-
-      world_location = stub(
-        "WorldLocation",
-        slug: "afghanistan",
-        name: "Afghanistan",
-        fco_organisation: nil,
-      )
-      WorldLocation.stubs(:all).returns([world_location])
-      WorldLocation.stubs(:find).with("afghanistan").returns(world_location)
+      stub_worldwide_api_has_locations(%w[afghanistan])
     end
 
     should "start with the country_of_ceremony? question" do


### PR DESCRIPTION
Trello: https://trello.com/c/xTCxOAD6

# What's changed?

Uses the helper methods in gds-api-adaptors to stub the WorldLocation data rather than stubbing the `find` and `all` method.

# Why?

WorldLocation is used to populate country lists in multiple smart-answers, I believe that stubbing the `all` method has led to some strange behaviour in the tests. 

The tests in `uk_benefits_abroad_test.rb` fail intermittently in CI [1].
I've tested this locally by adding a loop to the tests and running the "when going abroad" tests 50 times

e.g.
```
50.times do |i|
  context "when going abroad #{i}" do
```

I found that two of assertions in tests would always fail. They weren't the same test each time. The only thing the failures have in common is that the node would always drop back to the `:which_country?` node, implying that there was something wrong with the country data. Either a country hadn't been selected, or the more likely reason that the country selected in the test wasn't available in the list of countries returned by `WorldLocation.all`.

If a stub of the `all` method was indeed lingering about, then it would explain why the tests sometimes fail.

Removing the remaining stubs for the `find` and `all` method has made all of the tests in `uk_benefits_abroad_test` stable.

There are a few lingering concerns...

Firstly, why were the stubs leaking between tests?

Also, I'm not sure about the changes to the `MarriageAbroadCalculatorTest`. The stubbing feels a bit low-level. It feels like the test needs to know too much about what is returned from Worldwide API. Also, should the tests for `fco_organisation` even be in `MarriageAbroadCalculatorTest`? This method delegates to `WorldLocation` so it feels like the tests should be there.

[1]: https://ci.integration.publishing.service.gov.uk/job/smartanswers/job/main/5525/console

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
