### PR TITLE
Remove `/s/` prefixed routes for flow controller

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,11 +16,6 @@ Rails.application.routes.draw do
         format: false
   end
 
-  get "/:id/s/destroy_session", to: "flow#destroy"
-  get "/:id/s", to: "flow#start"
-  get "/:id/s/:node_slug", to: "flow#show"
-  get "/:id/s/:node_slug/next", to: "flow#update"
-
   get "/:id/start", to: "flow#start", as: :start_flow
   get "/:id/destroy_session", to: "flow#destroy", as: :destroy_flow
 

--- a/spec/requests/query_parameters_based_flow_spec.rb
+++ b/spec/requests/query_parameters_based_flow_spec.rb
@@ -5,91 +5,45 @@ RSpec.describe "Query parameter based flow navigation", flow_dir: :fixture do
     allow(Rails.application.config).to receive(:set_http_cache_control_expiry_time).and_return(true)
   end
 
-  context "urls have /s/ prefix" do
-    it "redirects to first node" do
-      get "/query-parameters-based/s"
-      expect(response).to redirect_to("/query-parameters-based/question1")
-      expect(response.headers["Cache-Control"]).to eq(cache_header)
-    end
-
-    it "renders the first question" do
-      get "/query-parameters-based/s/question1"
-      expect(response).to render_template("smart_answers/question")
-      expect(response.headers["Cache-Control"]).to eq(cache_header)
-    end
-
-    it "redirects to preceding unanswered question" do
-      get "/query-parameters-based/s/results"
-      expect(response).to redirect_to("/query-parameters-based/question1")
-      expect(response.headers["Cache-Control"]).to eq(cache_header)
-    end
-
-    it "redirects to next node when valid response provided" do
-      get "/query-parameters-based/s/question1/next", params: { response: "response1", next: "true" }
-      expect(response).to redirect_to("/query-parameters-based/question2?question1=response1")
-      expect(response.headers["Cache-Control"]).to eq(cache_header)
-    end
-
-    it "redirects to same node when invalid response provided" do
-      get "/query-parameters-based/s/question1/next", params: { response: "invalid", next: "true" }
-      expect(response).to redirect_to("/query-parameters-based/question1?question1=invalid")
-      expect(response.headers["Cache-Control"]).to eq(cache_header)
-    end
-
-    it "clears the session and redirects to the start page" do
-      get "/query-parameters-based/s/destroy_session"
-      expect(response).to redirect_to("/query-parameters-based")
-      expect(response.headers["Cache-Control"]).to eq(cache_header)
-    end
-
-    it "clears the session and redirects to another page" do
-      get "/query-parameters-based/s/destroy_session", params: { ext_r: "true" }
-      expect(response).to redirect_to("https://www.bbc.co.uk/weather")
-      expect(response.headers["Cache-Control"]).to eq(cache_header)
-    end
+  it "redirects to first node" do
+    get "/query-parameters-based/start"
+    expect(response).to redirect_to("/query-parameters-based/question1")
+    expect(response.headers["Cache-Control"]).to eq(cache_header)
   end
 
-  context "urls have no prefix" do
-    it "redirects to first node" do
-      get "/query-parameters-based/start"
-      expect(response).to redirect_to("/query-parameters-based/question1")
-      expect(response.headers["Cache-Control"]).to eq(cache_header)
-    end
+  it "renders the first question" do
+    get "/query-parameters-based/question1"
+    expect(response).to render_template("smart_answers/question")
+    expect(response.headers["Cache-Control"]).to eq(cache_header)
+  end
 
-    it "renders the first question" do
-      get "/query-parameters-based/question1"
-      expect(response).to render_template("smart_answers/question")
-      expect(response.headers["Cache-Control"]).to eq(cache_header)
-    end
+  it "redirects to preceding unanswered question" do
+    get "/query-parameters-based/results"
+    expect(response).to redirect_to("/query-parameters-based/question1")
+    expect(response.headers["Cache-Control"]).to eq(cache_header)
+  end
 
-    it "redirects to preceding unanswered question" do
-      get "/query-parameters-based/results"
-      expect(response).to redirect_to("/query-parameters-based/question1")
-      expect(response.headers["Cache-Control"]).to eq(cache_header)
-    end
+  it "redirects to next node when valid response provided" do
+    get "/query-parameters-based/question1/next", params: { response: "response1", next: "true" }
+    expect(response).to redirect_to("/query-parameters-based/question2?question1=response1")
+    expect(response.headers["Cache-Control"]).to eq(cache_header)
+  end
 
-    it "redirects to next node when valid response provided" do
-      get "/query-parameters-based/question1/next", params: { response: "response1", next: "true" }
-      expect(response).to redirect_to("/query-parameters-based/question2?question1=response1")
-      expect(response.headers["Cache-Control"]).to eq(cache_header)
-    end
+  it "redirects to same node when invalid response provided" do
+    get "/query-parameters-based/question1/next", params: { response: "invalid", next: "true" }
+    expect(response).to redirect_to("/query-parameters-based/question1?question1=invalid")
+    expect(response.headers["Cache-Control"]).to eq(cache_header)
+  end
 
-    it "redirects to same node when invalid response provided" do
-      get "/query-parameters-based/question1/next", params: { response: "invalid", next: "true" }
-      expect(response).to redirect_to("/query-parameters-based/question1?question1=invalid")
-      expect(response.headers["Cache-Control"]).to eq(cache_header)
-    end
+  it "clears the session and redirects to the start page" do
+    get "/query-parameters-based/destroy_session"
+    expect(response).to redirect_to("/query-parameters-based")
+    expect(response.headers["Cache-Control"]).to eq(cache_header)
+  end
 
-    it "clears the session and redirects to the start page" do
-      get "/query-parameters-based/destroy_session"
-      expect(response).to redirect_to("/query-parameters-based")
-      expect(response.headers["Cache-Control"]).to eq(cache_header)
-    end
-
-    it "clears the session and redirects to another page" do
-      get "/query-parameters-based/destroy_session", params: { ext_r: "true" }
-      expect(response).to redirect_to("https://www.bbc.co.uk/weather")
-      expect(response.headers["Cache-Control"]).to eq(cache_header)
-    end
+  it "clears the session and redirects to another page" do
+    get "/query-parameters-based/destroy_session", params: { ext_r: "true" }
+    expect(response).to redirect_to("https://www.bbc.co.uk/weather")
+    expect(response.headers["Cache-Control"]).to eq(cache_header)
   end
 end

--- a/spec/requests/session_based_flow_spec.rb
+++ b/spec/requests/session_based_flow_spec.rb
@@ -1,93 +1,48 @@
 RSpec.describe "Session based flow navigation", flow_dir: :fixture do
   let(:no_cache_header) { "max-age=0, private, must-revalidate, no-store" }
 
-  context "urls have /s/ prefix" do
-    it "redirects to first node" do
-      get "/session-based/s"
-      expect(response).to redirect_to("/session-based/question1")
-      expect(response.headers["Cache-Control"]).to eq(no_cache_header)
-    end
-
-    it "renders the first question" do
-      get "/session-based/s/question1"
-      expect(response).to render_template("smart_answers/question")
-      expect(response.headers["Cache-Control"]).to eq(no_cache_header)
-    end
-
-    it "redirects to preceding unanswered question" do
-      get "/session-based/s/results"
-      expect(response).to redirect_to("/session-based/question1")
-      expect(response.headers["Cache-Control"]).to eq(no_cache_header)
-    end
-
-    it "redirects to next node when valid response provided" do
-      get "/session-based/s/question1/next", params: { response: "response1", next: "true" }
-      expect(response).to redirect_to("/session-based/question2")
-      expect(response.headers["Cache-Control"]).to eq(no_cache_header)
-    end
-
-    it "redirects to same node when invalid response provided" do
-      get "/session-based/s/question1/next", params: { response: "invalid", next: "true" }
-      expect(response).to redirect_to("/session-based/question1")
-      expect(response.headers["Cache-Control"]).to eq(no_cache_header)
-    end
-
-    it "clears the session and redirects to the start page" do
-      get "/session-based/s/destroy_session"
-      expect(response).to redirect_to("/session-based")
-      expect(response.headers["Cache-Control"]).to eq(no_cache_header)
-    end
-
-    it "clears the session and redirects to another page" do
-      get "/session-based/s/destroy_session", params: { ext_r: "true" }
-      expect(response).to redirect_to("https://www.bbc.co.uk/weather")
-    end
+  it "redirects to first node" do
+    get "/session-based/start"
+    expect(response).to redirect_to("/session-based/question1")
+    expect(response.headers["Cache-Control"]).to eq(no_cache_header)
   end
 
-  context "urls have no prefix" do
-    it "redirects to first node" do
-      get "/session-based/start"
-      expect(response).to redirect_to("/session-based/question1")
-      expect(response.headers["Cache-Control"]).to eq(no_cache_header)
-    end
-
-    it "renders the first question" do
-      get "/session-based/question1"
-      expect(response).to render_template("smart_answers/question")
-      expect(response.headers["Cache-Control"]).to eq(no_cache_header)
-    end
-
-    it "redirects to preceding unanswered question" do
-      get "/session-based/results"
-      expect(response).to redirect_to("/session-based/question1")
-      expect(response.headers["Cache-Control"]).to eq(no_cache_header)
-    end
-
-    it "redirects to next node when valid response provided" do
-      get "/session-based/question1/next", params: { response: "response1", next: "true" }
-      expect(response).to redirect_to("/session-based/question2")
-      expect(response.headers["Cache-Control"]).to eq(no_cache_header)
-    end
-
-    it "redirects to same node when invalid response provided" do
-      get "/session-based/question1/next", params: { response: "invalid", next: "true" }
-      expect(response).to redirect_to("/session-based/question1")
-      expect(response.headers["Cache-Control"]).to eq(no_cache_header)
-    end
-
-    it "clears the session and redirects to the start page" do
-      get "/session-based/destroy_session"
-      expect(response).to redirect_to("/session-based")
-      expect(response.headers["Cache-Control"]).to eq(no_cache_header)
-    end
-
-    it "clears the session and redirects to another page" do
-      get "/session-based/destroy_session", params: { ext_r: "true" }
-      expect(response).to redirect_to("https://www.bbc.co.uk/weather")
-    end
+  it "renders the first question" do
+    get "/session-based/question1"
+    expect(response).to render_template("smart_answers/question")
+    expect(response.headers["Cache-Control"]).to eq(no_cache_header)
   end
 
-  context "urls have no prefix, but are path based flows" do
+  it "redirects to preceding unanswered question" do
+    get "/session-based/results"
+    expect(response).to redirect_to("/session-based/question1")
+    expect(response.headers["Cache-Control"]).to eq(no_cache_header)
+  end
+
+  it "redirects to next node when valid response provided" do
+    get "/session-based/question1/next", params: { response: "response1", next: "true" }
+    expect(response).to redirect_to("/session-based/question2")
+    expect(response.headers["Cache-Control"]).to eq(no_cache_header)
+  end
+
+  it "redirects to same node when invalid response provided" do
+    get "/session-based/question1/next", params: { response: "invalid", next: "true" }
+    expect(response).to redirect_to("/session-based/question1")
+    expect(response.headers["Cache-Control"]).to eq(no_cache_header)
+  end
+
+  it "clears the session and redirects to the start page" do
+    get "/session-based/destroy_session"
+    expect(response).to redirect_to("/session-based")
+    expect(response.headers["Cache-Control"]).to eq(no_cache_header)
+  end
+
+  it "clears the session and redirects to another page" do
+    get "/session-based/destroy_session", params: { ext_r: "true" }
+    expect(response).to redirect_to("https://www.bbc.co.uk/weather")
+  end
+
+  context "urls are for path based flows" do
     it "redirects requests to old route" do
       get "/path-based/start"
       expect(response).to redirect_to("/path-based/y")


### PR DESCRIPTION
These routes had been deprecated and are now being removed to clean up the codebase. This should only effect the `find-coronavirus-support` flow as it had previous defaulted to the `/s/` prefixed routes and had served traffic from them. Over the past 3 days we've only had 97 requests out of 21052 total request (0.4%). 

Removing these routes will cause 404's served instead. Implementing a more graceful redirect probably isn't worth it as existing usage of the old routes are minimal. Also 60 of the 97 requests were to the first question, so most of those user's probably aren't going to be interrupted mid journey.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
