### PR TITLE
Same-sex Philippines coronavirus update

### DIFF
--- a/lib/smart_answer_flows/marriage-abroad/outcomes/countries/philippines/_same_sex.erb
+++ b/lib/smart_answer_flows/marriage-abroad/outcomes/countries/philippines/_same_sex.erb
@@ -1,64 +1,9 @@
-## Before you start
-You can get married at the British embassy in Manila.
+You cannot currently get married or enter into a civil partnership in the Philippines because of coronavirus (COVID-19).
 
-If you and your partner don’t live in the Philippines, you need to have been there for at least 21 days before you can get married. You need to stay in the country for the 21 days.
+This page will be updated when same-sex marriages and civil partnerships can take place again. Check the [travel advice for the Philippines](/foreign-travel-advice/philippines/coronavirus) for the latest information about COVID-19 restrictions.
 
-## Prove you’re free to get married
+## Legal status of same-sex marriages and civil partnerships
 
-You and your partner need to give notice of your marriage and sign a declaration that you’re legally allowed to marry.
+Usually when there are no COVID-19 restrictions, same-sex marriages or civil partnerships can take place at the British embassy in Manila.
 
-You need to have been in the Philippines for at least 7 full days before you can give notice. This means if you arrived on Monday, you can’t give notice until the following Tuesday.
-
-### Give notice of your marriage
-[Make an appointment at the British embassy in Manila](https://www.book-consular-appointment.service.gov.uk/TimeSelection?location=128&service=10) to give notice of your marriage and set a date for your wedding.
-
-It costs <%= format_money calculator.consular_fee(:receiving_notice_of_marriage) %> to give notice. You can pay:
-
-- in the [local currency](/government/publications/philippines-consular-fees) in cash
-- in pounds sterling (£) by Visa or MasterCard
-
-You need to bring:
-
-- your and your partner’s passports
-- proof that you’ve been in the Philippines for at least 7 full days, for example a utility bill, bank statement, passport stamp or boarding pass
-- proof that your partner is free to get married if they’re not British, for example a certificate of no impediment or a passport showing marital status
-
-If you or your partner have been married or in a civil partnership before, you’ll also need:
-
-- your original [decree absolute or final order](/copy-decree-absolute-final-order) (this could be a printed PDF and covering email from the court) - if you’re divorced
-- your annulment certificate - if your marriage or civil partnership was annulled
-- your civil partnership dissolution - if your civil partnership was dissolved
-- your partner’s [death certificate](/order-copy-birth-death-marriage-certificate/) and marriage certificate - if you’ve been widowed
-
-^If your divorce, civil partnership dissolution or annulment took place outside the UK, you’ll need evidence that you or your ex partner lived in or were a national of that country at the time of the divorce.^
-
-The British embassy will display your notice publicly for 14 days. If nobody registers an objection, you can get married up to 3 months after the end of your notice period.
-
-### Sign a declaration
-You and your partner also need to sign a declaration to say that you’re legally allowed to get married. The British embassy will give you the document to sign.
-
-You both need to bring proof that you live in the Philippines or you’ve been there for at least the last 21 full days. This could be a utility bill, bank statement, passport stamp or boarding pass.
-
-## Get married
-Your wedding ceremony will be at the British embassy in Manila on the date you agreed.
-
-You’ll need to bring 2 witnesses to your ceremony. Your witnesses must:
-
-- bring photo ID
-- be 16 or over
-- know you or your partner
-- understand English well enough to follow the ceremony and read the marriage register
-
-You, your partner and your 2 witnesses will sign the marriage register.
-
-It costs <%= format_money calculator.consular_fee(:registering_marriage) %> to register your marriage. You can also pay <%= format_money calculator.consular_fee(:issuing_marriage_certificate) %> for a marriage certificate if you want one.
-
-You can pay when you give notice or on your wedding day. You need to pay either:
-
-- in the [local currency](/government/publications/philippines-consular-fees) in cash
-- in pounds sterling (£) by Visa or MasterCard
-
-## After you get married
-You’ll be married under UK law, so your marriage will be recognised in the UK but not in the Philippines or other countries where same sex marriage isn’t legal.
-
-If your partner isn’t a British citizen, they can apply for [British citizenship](/becoming-a-british-citizen/if-your-spouse-is-a-british-citizen) once they’ve lived in the UK for 3 years.
+You would be married or in a civil partnership under UK law, so your marriage or civil partnership would be recognised in the UK. It would not be recognised in the Philippines or other countries where same-sex marriages and civil partnerships are not legal.


### PR DESCRIPTION
Removed the current text as same-sex marriages cannot currently take place due to coronavirus restrictions.

Find the old text here, to add back in once marriages can start up again:
https://docs.google.com/document/d/1Ye6ve5kY5Q5y5VBBEUDwAOn7lTRKxH-ciLHP57OhFuU/edit#

https://govuk.zendesk.com/agent/tickets/4505985
https://trello.com/c/W1dqWF3R/3468-covid-19-philippines-getting-married-abroad-appointment-link-removal-same-sex-outcomes

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
