### PR TITLE
Remove `saved_input` attr from question nodes

### DIFF
--- a/lib/smart_answer/question/base.rb
+++ b/lib/smart_answer/question/base.rb
@@ -6,7 +6,6 @@ module SmartAnswer
       def initialize(flow, name, &block)
         @validations = []
         @default_next_node_block = ->(_) { nil }
-        @saved_input = nil
         @next_node_block = nil
         super
       end


### PR DESCRIPTION
This attribute isn't used anywhere in the codebase and seems to be left over since removing the the save_input_as method in flow definition in commit bc9102cda142959726c4440307d298c49c5cb43c.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
