### PR TITLE
Rename collapsed questions to answered questions

### DIFF
--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -35,7 +35,7 @@ class FlowPresenter
                        end
   end
 
-  def collapsed_questions
+  def answered_questions
     @flow.path(all_responses).map do |name|
       presenter_for(@flow.node(name))
     end

--- a/app/views/smart_answers/shared/_previous_answers.html.erb
+++ b/app/views/smart_answers/shared/_previous_answers.html.erb
@@ -19,7 +19,7 @@
   <% end %>
 
   <% unless local_assigns[:hide_previous_answers] %>
-    <% items = @presenter.collapsed_questions.each_with_index.map { |question, question_number|
+    <% items = @presenter.answered_questions.each_with_index.map do |question, question_number|
       accepted_response = @presenter.accepted_responses[question_number]
 
       if question.multiple_responses?
@@ -43,7 +43,7 @@
           }
         }
       }
-    } %>
+    end %>
 
     <%= render "govuk_publishing_components/components/summary_list", {
       wide_title: true,

--- a/test/functional/smart_answers_controller_date_question_test.rb
+++ b/test/functional/smart_answers_controller_date_question_test.rb
@@ -55,7 +55,7 @@ class SmartAnswersControllerDateQuestionTest < ActionController::TestCase
         end
       end
 
-      should "display collapsed question, and format number" do
+      should "display answered question, and format number" do
         get :show, params: { id: "smart-answers-controller-sample-with-date-question", started: "y", responses: "2011-01-01" }
         assert_select ".govuk-summary-list", /When\?\s+1 January 2011/
       end

--- a/test/functional/smart_answers_controller_value_question_test.rb
+++ b/test/functional/smart_answers_controller_value_question_test.rb
@@ -30,7 +30,7 @@ class SmartAnswersControllerValueQuestionTest < ActionController::TestCase
         assert_redirected_to "/smart-answers-controller-sample-with-value-question/y/10"
       end
 
-      should "display collapsed question, and format number" do
+      should "display answered question, and format number" do
         get :show, params: { id: "smart-answers-controller-sample-with-value-question", started: "y", responses: "12345" }
         assert_select ".govuk-summary-list", /How many green bottles\?\s+12,345/
       end

--- a/test/unit/flow_presenter_test.rb
+++ b/test/unit/flow_presenter_test.rb
@@ -108,7 +108,7 @@ class FlowPresenterTest < ActiveSupport::TestCase
       setup do
         params = { responses: "question-1-answer/question-2-answer", id: @flow.name }
         @flow_presenter = FlowPresenter.new(params, @flow)
-        @questions = @flow_presenter.collapsed_questions
+        @questions = @flow_presenter.answered_questions
       end
 
       should "return link to first page with response" do
@@ -133,7 +133,7 @@ class FlowPresenterTest < ActiveSupport::TestCase
         @question = OpenStruct.new(node_slug: "foo")
 
         @flow_presenter = FlowPresenter.new(params, @flow)
-        @questions = @flow_presenter.collapsed_questions
+        @questions = @flow_presenter.answered_questions
       end
 
       should "return link to first page with response" do
@@ -151,7 +151,7 @@ class FlowPresenterTest < ActiveSupport::TestCase
         @question = OpenStruct.new(node_slug: "baz")
 
         @flow_presenter = FlowPresenter.new(params, @flow)
-        @questions = @flow_presenter.collapsed_questions
+        @questions = @flow_presenter.answered_questions
       end
 
       should "return link to first page with response" do


### PR DESCRIPTION
Collapsed is rather confusing terminology as there doesn't seem to be
any scenario where they are visually collapsed. Answered better captures
the use case of these.

This continues the work from:
https://github.com/alphagov/smart-answers/commit/0f2e0e43279bda6e52f55d38dd87b938fc1682e8
and keeps the terminology consistent.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
