### PR TITLE
Rename State#current_node to State#current_node_name

### DIFF
--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -57,7 +57,7 @@ class FlowPresenter
   end
 
   def current_node
-    presenter_for(@flow.node(state.current_node))
+    presenter_for(@flow.node(state.current_node_name))
   end
 
   def start_node

--- a/lib/smart_answer/question/base.rb
+++ b/lib/smart_answer/question/base.rb
@@ -38,7 +38,7 @@ module SmartAnswer
         next_node = state.instance_exec(input, &next_node_block)
         if next_node.blank?
           responses_and_input = current_state.accepted_responses.values + [input]
-          message = "Next node undefined. Node: #{current_state.current_node}."
+          message = "Next node undefined. Node: #{current_state.current_node_name}."
           message << " Responses: #{responses_and_input}."
           raise NextNodeUndefined, message
         end

--- a/lib/smart_answer/state.rb
+++ b/lib/smart_answer/state.rb
@@ -2,8 +2,8 @@ require "ostruct"
 
 module SmartAnswer
   class State < OpenStruct
-    def initialize(start_node, forwarding_responses: {})
-      super(current_node: start_node,
+    def initialize(start_node_name, forwarding_responses: {})
+      super(current_node_name: start_node_name,
             accepted_responses: {},
             forwarding_responses: forwarding_responses,
             current_response: nil,
@@ -22,10 +22,10 @@ module SmartAnswer
       method_name =~ /=$/ || super
     end
 
-    def transition_to(new_node, input)
+    def transition_to(new_node_name, input)
       dup.tap do |new_state|
-        new_state.current_node = new_node
-        new_state.accepted_responses[current_node] = input
+        new_state.current_node_name = new_node_name
+        new_state.accepted_responses[current_node_name] = input
         new_state.freeze
       end
     end

--- a/lib/smart_answer/state_resolver.rb
+++ b/lib/smart_answer/state_resolver.rb
@@ -32,7 +32,7 @@ module SmartAnswer
   private
 
     def resolve_state(state, response_store, requested_node)
-      node_name = state.current_node.to_s
+      node_name = state.current_node_name.to_s
       response = response_store.get(node_name)
       reached_an_outcome = @flow.node(node_name.to_sym).outcome?
 
@@ -61,7 +61,7 @@ module SmartAnswer
     end
 
     def transition_state_to_next_node(state, response)
-      @flow.node(state.current_node).transition(state, response)
+      @flow.node(state.current_node_name).transition(state, response)
     rescue BaseStateTransitionError => e
       error_state(state, response, e)
     end

--- a/test/integration/smart_answer_flows/flow_test_helper.rb
+++ b/test/integration/smart_answer_flows/flow_test_helper.rb
@@ -26,20 +26,20 @@ module FlowTestHelper
 
   def current_question
     @current_question ||= begin
-      presenter = QuestionPresenter.new(@flow.node(current_state.current_node), nil, current_state)
+      presenter = QuestionPresenter.new(@flow.node(current_state.current_node_name), nil, current_state)
       presenter.title
     end
   end
 
   def outcome_body
     @outcome_body ||= begin
-      presenter = OutcomePresenter.new(@flow.node(current_state.current_node), nil, current_state)
+      presenter = OutcomePresenter.new(@flow.node(current_state.current_node_name), nil, current_state)
       Nokogiri::HTML::DocumentFragment.parse(presenter.body)
     end
   end
 
   def assert_current_node(node_name, opts = {})
-    assert_equal node_name, current_state.current_node
+    assert_equal node_name, current_state.current_node_name
     assert @flow.node_exists?(node_name), "Node #{node_name} does not exist."
     if opts[:error]
       assert_current_node_is_error(opts[:error].is_a?(Class) ? (opts[:error]).to_s : nil)
@@ -59,7 +59,7 @@ module FlowTestHelper
   end
 
   def assert_current_node_is_error(message = nil)
-    assert current_state.error, "Expected #{current_state.current_node} to be in error state"
+    assert current_state.error, "Expected #{current_state.current_node_name} to be in error state"
     assert_equal message, current_state.error if message
   end
 

--- a/test/unit/question_base_test.rb
+++ b/test/unit/question_base_test.rb
@@ -61,19 +61,19 @@ class QuestionBaseTest < ActiveSupport::TestCase
       assert_equal "Carried over", new_state.something_else
     end
 
-    should "set current_node to value returned from next_node_for" do
+    should "set current_node_name to value returned from next_node_for" do
       @question.next_node { outcome :done }
       initial_state = SmartAnswer::State.new(@question.name)
       @question.stubs(:next_node_for).returns(:done)
       new_state = @question.transition(initial_state, :anything)
-      assert_equal :done, new_state.current_node
+      assert_equal :done, new_state.current_node_name
     end
 
-    should "set current_node to result of calling next_node block" do
+    should "set current_node_name to result of calling next_node block" do
       @question.next_node { outcome :done_done }
       initial_state = SmartAnswer::State.new(@question.name)
       new_state = @question.transition(initial_state, :anything)
-      assert_equal :done_done, new_state.current_node
+      assert_equal :done_done, new_state.current_node_name
     end
 
     should "make state available to code in next_node block" do
@@ -83,7 +83,7 @@ class QuestionBaseTest < ActiveSupport::TestCase
       initial_state = SmartAnswer::State.new(@question.name)
       initial_state.colour = "red"
       new_state = @question.transition(initial_state, "anything")
-      assert_equal :was_red, new_state.current_node
+      assert_equal :was_red, new_state.current_node_name
     end
 
     should "pass input to next_node block" do

--- a/test/unit/radio_question_test.rb
+++ b/test/unit/radio_question_test.rb
@@ -29,7 +29,7 @@ module SmartAnswer
 
       current_state = State.new(:example)
       new_state = q.transition(current_state, :yes)
-      assert_equal :fred, new_state.current_node
+      assert_equal :fred, new_state.current_node_name
       assert new_state.frozen?
     end
 
@@ -41,7 +41,7 @@ module SmartAnswer
       end
 
       new_state = q.transition(State.new(:example), :no)
-      assert_equal :baz, new_state.current_node
+      assert_equal :baz, new_state.current_node_name
     end
 
     test "Error raised on illegal input" do

--- a/test/unit/smart_answer_flows/calculate_agricultural_holiday_entitlement_flow_test.rb
+++ b/test/unit/smart_answer_flows/calculate_agricultural_holiday_entitlement_flow_test.rb
@@ -27,7 +27,7 @@ module SmartAnswer
       end
 
       should "go to worked_for_same_employer? question" do
-        assert_equal :worked_for_same_employer?, @new_state.current_node
+        assert_equal :worked_for_same_employer?, @new_state.current_node_name
         assert_node_exists :worked_for_same_employer?
       end
 
@@ -63,7 +63,7 @@ module SmartAnswer
       end
 
       should "go to done_with_number_formatting outcomeuestion" do
-        assert_equal :done_with_number_formatting, @new_state.current_node
+        assert_equal :done_with_number_formatting, @new_state.current_node_name
         assert_node_exists :done_with_number_formatting
       end
 

--- a/test/unit/smart_answer_flows/calculate_statutory_sick_pay_flow_test.rb
+++ b/test/unit/smart_answer_flows/calculate_statutory_sick_pay_flow_test.rb
@@ -28,7 +28,7 @@ module SmartAnswer
         end
 
         should "go to has_linked_sickness? question" do
-          assert_equal :has_linked_sickness?, @new_state.current_node
+          assert_equal :has_linked_sickness?, @new_state.current_node_name
           assert_node_exists :has_linked_sickness?
         end
       end
@@ -44,7 +44,7 @@ module SmartAnswer
         end
 
         should "go to must_be_sick_for_4_days outcome" do
-          assert_equal :must_be_sick_for_4_days, @new_state.current_node
+          assert_equal :must_be_sick_for_4_days, @new_state.current_node_name
           assert_node_exists :must_be_sick_for_4_days
         end
       end

--- a/test/unit/smart_answer_flows/child_benefit_tax_calculator_flow_test.rb
+++ b/test/unit/smart_answer_flows/child_benefit_tax_calculator_flow_test.rb
@@ -36,7 +36,7 @@ module SmartAnswer
         end
 
         should "go to which_tax_year? question" do
-          assert_equal :which_tax_year?, @new_state.current_node
+          assert_equal :which_tax_year?, @new_state.current_node_name
           assert_node_exists :which_tax_year?
         end
       end
@@ -60,7 +60,7 @@ module SmartAnswer
         end
 
         should "go to is_part_year_claim? question" do
-          assert_equal :is_part_year_claim?, @new_state.current_node
+          assert_equal :is_part_year_claim?, @new_state.current_node_name
           assert_node_exists :is_part_year_claim?
         end
       end
@@ -81,7 +81,7 @@ module SmartAnswer
           end
 
           should "go to how_many_children_part_year? question" do
-            assert_equal :how_many_children_part_year?, @new_state.current_node
+            assert_equal :how_many_children_part_year?, @new_state.current_node_name
             assert_node_exists :how_many_children_part_year?
           end
         end
@@ -107,7 +107,7 @@ module SmartAnswer
                 initial_state: { calculator: @calculator },
               )
             end
-            assert_equal :income_details?, @new_state.current_node
+            assert_equal :income_details?, @new_state.current_node_name
             assert_node_exists :income_details?
           end
         end
@@ -130,7 +130,7 @@ module SmartAnswer
           end
 
           should "go to child_benefit_start? question" do
-            assert_equal :child_benefit_start?, @new_state.current_node
+            assert_equal :child_benefit_start?, @new_state.current_node_name
             assert_node_exists :child_benefit_start?
           end
         end
@@ -153,7 +153,7 @@ module SmartAnswer
           end
 
           should "go to add_child_benefit_stop? question" do
-            assert_equal :add_child_benefit_stop?, @new_state.current_node
+            assert_equal :add_child_benefit_stop?, @new_state.current_node_name
             assert_node_exists :add_child_benefit_stop?
           end
         end
@@ -175,7 +175,7 @@ module SmartAnswer
           end
 
           should "go to child_benefit_stop? question" do
-            assert_equal :child_benefit_stop?, @new_state.current_node
+            assert_equal :child_benefit_stop?, @new_state.current_node_name
             assert_node_exists :child_benefit_stop?
           end
         end
@@ -194,7 +194,7 @@ module SmartAnswer
           end
 
           should "go to income_details? question" do
-            assert_equal :income_details?, @new_state.current_node
+            assert_equal :income_details?, @new_state.current_node_name
             assert_node_exists :income_details?
           end
         end
@@ -223,7 +223,7 @@ module SmartAnswer
           end
 
           should "go to child_benefit_start? question" do
-            assert_equal :child_benefit_start?, @new_state.current_node
+            assert_equal :child_benefit_start?, @new_state.current_node_name
             assert_node_exists :child_benefit_start?
           end
         end
@@ -242,7 +242,7 @@ module SmartAnswer
           end
 
           should "go to income_details? question" do
-            assert_equal :income_details?, @new_state.current_node
+            assert_equal :income_details?, @new_state.current_node_name
             assert_node_exists :income_details?
           end
         end
@@ -267,7 +267,7 @@ module SmartAnswer
         end
 
         should "go to add_allowable_deductions? question" do
-          assert_equal :add_allowable_deductions?, @new_state.current_node
+          assert_equal :add_allowable_deductions?, @new_state.current_node_name
           assert_node_exists :add_allowable_deductions?
         end
       end
@@ -288,7 +288,7 @@ module SmartAnswer
           end
 
           should "go to allowable_deductions? question" do
-            assert_equal :allowable_deductions?, @new_state.current_node
+            assert_equal :allowable_deductions?, @new_state.current_node_name
             assert_node_exists :allowable_deductions?
           end
         end
@@ -307,7 +307,7 @@ module SmartAnswer
           end
 
           should "go to outcome" do
-            assert_equal :results, @new_state.current_node
+            assert_equal :results, @new_state.current_node_name
             assert_node_exists :results
           end
         end
@@ -332,7 +332,7 @@ module SmartAnswer
         end
 
         should "go to add_other_allowable_deductions? question" do
-          assert_equal :add_other_allowable_deductions?, @new_state.current_node
+          assert_equal :add_other_allowable_deductions?, @new_state.current_node_name
           assert_node_exists :add_other_allowable_deductions?
         end
       end
@@ -353,7 +353,7 @@ module SmartAnswer
           end
 
           should "go to other_allowable_deductions? question" do
-            assert_equal :other_allowable_deductions?, @new_state.current_node
+            assert_equal :other_allowable_deductions?, @new_state.current_node_name
             assert_node_exists :other_allowable_deductions?
           end
         end
@@ -372,7 +372,7 @@ module SmartAnswer
           end
 
           should "go to outcome" do
-            assert_equal :results, @new_state.current_node
+            assert_equal :results, @new_state.current_node_name
             assert_node_exists :results
           end
         end
@@ -397,7 +397,7 @@ module SmartAnswer
         end
 
         should "go to results page" do
-          assert_equal :results, @new_state.current_node
+          assert_equal :results, @new_state.current_node_name
           assert_node_exists :results
         end
       end

--- a/test/unit/smart_answer_flows/estimate_self_assessment_penalties_flow_test.rb
+++ b/test/unit/smart_answer_flows/estimate_self_assessment_penalties_flow_test.rb
@@ -27,7 +27,7 @@ module SmartAnswer
       end
 
       should "go to when_paid? question" do
-        assert_equal :when_paid?, @new_state.current_node
+        assert_equal :when_paid?, @new_state.current_node_name
         assert_node_exists :when_paid?
       end
 
@@ -64,7 +64,7 @@ module SmartAnswer
       end
 
       should "go to filed_and_paid_on_time outcome" do
-        assert_equal :filed_and_paid_on_time, @new_state.current_node
+        assert_equal :filed_and_paid_on_time, @new_state.current_node_name
         assert_node_exists :filed_and_paid_on_time
       end
 

--- a/test/unit/smart_answer_flows/flow_unit_test_helper.rb
+++ b/test/unit/smart_answer_flows/flow_unit_test_helper.rb
@@ -14,7 +14,7 @@ module SmartAnswer
     end
 
     def assert_node_has_name(name, node, belongs_to_another_flow: false)
-      assert_equal(name, node.current_node)
+      assert_equal(name, node.current_node_name)
       assert_node_exists(name) unless belongs_to_another_flow
     end
   end

--- a/test/unit/smart_answer_flows/part_year_profit_tax_credits_flow_test.rb
+++ b/test/unit/smart_answer_flows/part_year_profit_tax_credits_flow_test.rb
@@ -44,7 +44,7 @@ module SmartAnswer
       end
 
       should "go to what_date_do_your_accounts_go_up_to? question" do
-        assert_equal :what_date_do_your_accounts_go_up_to?, @new_state.current_node
+        assert_equal :what_date_do_your_accounts_go_up_to?, @new_state.current_node_name
         assert_node_exists :what_date_do_your_accounts_go_up_to?
       end
     end
@@ -63,7 +63,7 @@ module SmartAnswer
       end
 
       should "go to have_you_stopped_trading? question" do
-        assert_equal :have_you_stopped_trading?, @new_state.current_node
+        assert_equal :have_you_stopped_trading?, @new_state.current_node_name
         assert_node_exists :have_you_stopped_trading?
       end
     end
@@ -83,7 +83,7 @@ module SmartAnswer
         end
 
         should "go to did_you_start_trading_before_the_relevant_accounting_year? question" do
-          assert_equal :did_you_start_trading_before_the_relevant_accounting_year?, @new_state.current_node
+          assert_equal :did_you_start_trading_before_the_relevant_accounting_year?, @new_state.current_node_name
           assert_node_exists :did_you_start_trading_before_the_relevant_accounting_year?
         end
       end
@@ -102,7 +102,7 @@ module SmartAnswer
         end
 
         should "go to do_your_accounts_cover_a_12_month_period? question" do
-          assert_equal :do_your_accounts_cover_a_12_month_period?, @new_state.current_node
+          assert_equal :do_your_accounts_cover_a_12_month_period?, @new_state.current_node_name
           assert_node_exists :do_your_accounts_cover_a_12_month_period?
         end
       end
@@ -131,7 +131,7 @@ module SmartAnswer
         end
 
         should "go to when_did_you_stop_trading? question" do
-          assert_equal :when_did_you_stop_trading?, @new_state.current_node
+          assert_equal :when_did_you_stop_trading?, @new_state.current_node_name
           assert_node_exists :when_did_you_stop_trading?
         end
       end
@@ -147,7 +147,7 @@ module SmartAnswer
         end
 
         should "go to when_did_you_start_trading question" do
-          assert_equal :when_did_you_start_trading?, @new_state.current_node
+          assert_equal :when_did_you_start_trading?, @new_state.current_node_name
           assert_node_exists :when_did_you_start_trading?
         end
       end
@@ -209,7 +209,7 @@ module SmartAnswer
         end
 
         should "go to when_did_you_stop_trading? question" do
-          assert_equal :when_did_you_stop_trading?, @new_state.current_node
+          assert_equal :when_did_you_stop_trading?, @new_state.current_node_name
           assert_node_exists :when_did_you_stop_trading?
         end
       end
@@ -225,7 +225,7 @@ module SmartAnswer
         end
 
         should "go to when_did_you_stop_trading? question" do
-          assert_equal :what_is_your_taxable_profit?, @new_state.current_node
+          assert_equal :what_is_your_taxable_profit?, @new_state.current_node_name
           assert_node_exists :what_is_your_taxable_profit?
         end
       end
@@ -257,7 +257,7 @@ module SmartAnswer
       end
 
       should "go to what_is_your_taxable_profit? question" do
-        assert_equal :what_is_your_taxable_profit?, @new_state.current_node
+        assert_equal :what_is_your_taxable_profit?, @new_state.current_node_name
         assert_node_exists :what_is_your_taxable_profit?
       end
 
@@ -292,7 +292,7 @@ module SmartAnswer
         end
 
         should "go to what_is_your_taxable_profit? question" do
-          assert_equal :what_is_your_taxable_profit?, @new_state.current_node
+          assert_equal :what_is_your_taxable_profit?, @new_state.current_node_name
           assert_node_exists :what_is_your_taxable_profit?
         end
       end
@@ -309,7 +309,7 @@ module SmartAnswer
         end
 
         should "go to when_did_you_start_trading question" do
-          assert_equal :when_did_you_start_trading?, @new_state.current_node
+          assert_equal :when_did_you_start_trading?, @new_state.current_node_name
           assert_node_exists :when_did_you_start_trading?
         end
       end
@@ -331,7 +331,7 @@ module SmartAnswer
       end
 
       should "go to result outcome" do
-        assert_equal :result, @new_state.current_node
+        assert_equal :result, @new_state.current_node_name
         assert_node_exists :result
       end
     end

--- a/test/unit/state_resolver_test.rb
+++ b/test/unit/state_resolver_test.rb
@@ -37,7 +37,7 @@ module SmartAnswer
         response_store = ResponseStore.new(responses: {})
         state = @state_resolver.state_from_response_store(response_store)
 
-        assert_equal :x, state.current_node
+        assert_equal :x, state.current_node_name
         assert_empty state.accepted_responses
         assert_nil state.current_response
       end
@@ -46,7 +46,7 @@ module SmartAnswer
         response_store = ResponseStore.new(responses: { "x" => "yes" })
         state = @state_resolver.state_from_response_store(response_store)
 
-        assert_equal :y, state.current_node
+        assert_equal :y, state.current_node_name
         assert_equal ({ x: "yes" }), state.accepted_responses
         assert_nil state.current_response
       end
@@ -55,7 +55,7 @@ module SmartAnswer
         response_store = ResponseStore.new(responses: { "x" => "yes", "y" => "no" })
         state = @state_resolver.state_from_response_store(response_store)
 
-        assert_equal :b, state.current_node
+        assert_equal :b, state.current_node_name
         assert_equal ({ x: "yes", y: "no" }), state.accepted_responses
         assert_nil state.current_response
       end
@@ -64,7 +64,7 @@ module SmartAnswer
         response_store = ResponseStore.new(responses: { "x" => "yes", "y" => "invalid" })
         state = @state_resolver.state_from_response_store(response_store)
 
-        assert_equal :y, state.current_node
+        assert_equal :y, state.current_node_name
         assert_equal ({ x: "yes" }), state.accepted_responses
         assert_equal "invalid", state.current_response
         assert state.error.present?
@@ -74,7 +74,7 @@ module SmartAnswer
         response_store = ResponseStore.new(responses: { "x" => "invalid", "y" => "no" })
         state = @state_resolver.state_from_response_store(response_store, "y")
 
-        assert_equal :x, state.current_node
+        assert_equal :x, state.current_node_name
         assert_equal ({}), state.accepted_responses
         assert_equal "invalid", state.current_response
         assert state.error.present?
@@ -84,7 +84,7 @@ module SmartAnswer
         response_store = ResponseStore.new(responses: { "x" => "invalid", "y" => "no" })
         state = @state_resolver.state_from_response_store(response_store, "x")
 
-        assert_equal :x, state.current_node
+        assert_equal :x, state.current_node_name
         assert_equal ({}), state.accepted_responses
         assert_equal "invalid", state.current_response
         assert state.error.present?
@@ -94,7 +94,7 @@ module SmartAnswer
         response_store = ResponseStore.new(responses: { "x" => "yes", "y" => "no" })
         state = @state_resolver.state_from_response_store(response_store, "y")
 
-        assert_equal :y, state.current_node
+        assert_equal :y, state.current_node_name
         assert_equal ({ x: "yes" }), state.accepted_responses
         assert_equal "no", state.current_response
       end
@@ -103,7 +103,7 @@ module SmartAnswer
         response_store = ResponseStore.new(responses: { "y" => "no" })
         state = @state_resolver.state_from_response_store(response_store, "y")
 
-        assert_equal :x, state.current_node
+        assert_equal :x, state.current_node_name
         assert_equal ({}), state.accepted_responses
         assert_nil state.current_response
       end
@@ -133,7 +133,7 @@ module SmartAnswer
       should "return the state for the first question when there are no responses" do
         state = @state_resolver.state_from_params({ responses: "" })
 
-        assert_equal :x, state.current_node
+        assert_equal :x, state.current_node_name
         assert_empty state.accepted_responses
         assert_nil state.current_response
       end
@@ -141,7 +141,7 @@ module SmartAnswer
       should "return the state for the next question when a valid answer is given" do
         state = @state_resolver.state_from_params({ responses: "", next: "1", response: "yes" })
 
-        assert_equal :y, state.current_node
+        assert_equal :y, state.current_node_name
         assert_equal ({ x: "yes" }), state.accepted_responses
         assert_nil state.current_response
       end
@@ -149,7 +149,7 @@ module SmartAnswer
       should "return the state for the next question when an answer is in the path" do
         state = @state_resolver.state_from_params({ responses: "yes" })
 
-        assert_equal :y, state.current_node
+        assert_equal :y, state.current_node_name
         assert_equal ({ x: "yes" }), state.accepted_responses
         assert_nil state.current_response
       end
@@ -157,7 +157,7 @@ module SmartAnswer
       should "return an error state for the current question when an answer is invalid" do
         state = @state_resolver.state_from_params({ responses: "yes/invalid" })
 
-        assert_equal :y, state.current_node
+        assert_equal :y, state.current_node_name
         assert_equal ({ x: "yes" }), state.accepted_responses
         assert_equal "invalid", state.current_response
         assert state.error.present?
@@ -166,7 +166,7 @@ module SmartAnswer
       should "return an outcome state when all questions are answered" do
         state = @state_resolver.state_from_params({ responses: "yes/no" })
 
-        assert_equal :b, state.current_node
+        assert_equal :b, state.current_node_name
         assert_equal ({ x: "yes", y: "no" }), state.accepted_responses
         assert_nil state.current_response
       end
@@ -174,7 +174,7 @@ module SmartAnswer
       should "determine the current response from a previous_response parameter" do
         state = @state_resolver.state_from_params({ responses: "yes", previous_response: "no" })
 
-        assert_equal :y, state.current_node
+        assert_equal :y, state.current_node_name
         assert_equal ({ x: "yes" }), state.accepted_responses
         assert_equal "no", state.current_response
       end
@@ -182,7 +182,7 @@ module SmartAnswer
       should "return an error state if a previous_response contains an invalid response" do
         state = @state_resolver.state_from_params({ responses: "yes", previous_response: "invalid" })
 
-        assert_equal :y, state.current_node
+        assert_equal :y, state.current_node_name
         assert_equal ({ x: "yes" }), state.accepted_responses
         assert_equal "invalid", state.current_response
       end

--- a/test/unit/state_test.rb
+++ b/test/unit/state_test.rb
@@ -17,7 +17,7 @@ module SmartAnswer
 
     should "return the default values of attributes set in the constructor" do
       state = State.new(:start_node)
-      assert_equal :start_node, state.current_node
+      assert_equal :start_node, state.current_node_name
       assert_equal ({}), state.accepted_responses
       assert_equal ({}), state.forwarding_responses
       assert_nil state.current_response
@@ -39,7 +39,7 @@ module SmartAnswer
 
     should "respond_to reader method for attribute set in constructor" do
       state = State.new(:start_node)
-      assert state.respond_to?(:current_node)
+      assert state.respond_to?(:current_node_name)
     end
 
     should "respond_to reader method for attribute that has previously been set" do
@@ -55,7 +55,7 @@ module SmartAnswer
 
     should "respond_to writer method for attribute set in constructor" do
       state = State.new(:start_node)
-      assert state.respond_to?(:current_node=)
+      assert state.respond_to?(:current_node_name=)
     end
 
     should "respond_to writer method for attribute that has previously been set" do


### PR DESCRIPTION
This builds on the work in https://github.com/alphagov/smart-answers/pull/5337 and is in reference to: https://github.com/alphagov/smart-answers/pull/5337#discussion_r626660627. I decided to do this as a separate PR as it has quite a lot of code churn and I didn't want to block the other one.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This renames the somewhat confusingly named, `State#current_name`, method to `State#current_node_name`. This has been changed because the current method name provides the impression that this method would return a `Node` instance but instead a symbol is returned. There is further information in the commit messages.