### PR TITLE
Refactor JavaScript

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,8 +10,3 @@
 //= require components/hide-this-page-banner
 //= require modules/track-responses
 //= require modules/track-results
-
-window.addEventListener('DOMContentLoaded', function () {
-  var error = document.getElementById('current-error')
-  if (error) { error.focus() }
-})

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -7,7 +7,6 @@
 //= require govuk_publishing_components/components/print-link
 //= require govuk_publishing_components/components/radio
 //= require govuk_publishing_components/components/step-by-step-nav
-//= require helpers
 //= require components/hide-this-page-banner
 //= require modules/track-responses
 //= require modules/track-results

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,6 +10,7 @@
 //= require helpers
 //= require components/hide-this-page-banner
 //= require modules/track-responses
+//= require modules/track-results
 
 window.addEventListener('DOMContentLoaded', function () {
   var error = document.getElementById('current-error')

--- a/app/assets/javascripts/components/hide-this-page-banner.js
+++ b/app/assets/javascripts/components/hide-this-page-banner.js
@@ -2,14 +2,13 @@ window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
 (function (Modules) {
-  function HideThisPageBanner () { }
+  function HideThisPageBanner ($module) {
+    this.$module = $module
+    this.$button = this.$module.querySelector('.gem-c-button')
+  }
 
-  HideThisPageBanner.prototype.start = function ($module) {
-    this.$module = $module[0]
-
-    this.$module
-      .querySelector('.gem-c-button')
-      .addEventListener('click', this.handleClick.bind(this))
+  HideThisPageBanner.prototype.init = function () {
+    this.$button.addEventListener('click', this.handleClick.bind(this))
   }
 
   HideThisPageBanner.prototype.handleClick = function (event) {

--- a/app/assets/javascripts/helpers.js
+++ b/app/assets/javascripts/helpers.js
@@ -3,34 +3,3 @@ var SmartAnswer = window.SmartAnswer || {}
 SmartAnswer.isStartPage = function (slug) { // Used mostly during A/B testing
   return window.location.pathname.split('/').join('') === slug
 }
-
-function trackInternalLinks (rootSelector) { // eslint-disable-line no-unused-vars
-  rootSelector = rootSelector || 'body'
-  var currentHost = document.location.protocol + '//' + document.location.hostname
-  var internalLinkSelector = 'a[href^="' + currentHost + '"], a[href^="/"]'
-
-  $(rootSelector).find(internalLinkSelector).on('click', trackClickEvent)
-
-  function trackClickEvent (evt) {
-    var $link = getLinkFromEvent(evt)
-    var options = { transport: 'beacon' }
-    var href = $link.attr('href')
-    var linkText = $.trim($link.text())
-
-    if (linkText) {
-      options.label = linkText
-    }
-
-    GOVUK.analytics.trackEvent('Internal Link Clicked', href, options)
-  };
-
-  function getLinkFromEvent (evt) {
-    var $target = $(evt.target)
-
-    if (!$target.is('a')) {
-      $target = $target.parents('a')
-    }
-
-    return $target
-  };
-};

--- a/app/assets/javascripts/helpers.js
+++ b/app/assets/javascripts/helpers.js
@@ -1,5 +1,0 @@
-var SmartAnswer = window.SmartAnswer || {}
-
-SmartAnswer.isStartPage = function (slug) { // Used mostly during A/B testing
-  return window.location.pathname.split('/').join('') === slug
-}

--- a/app/assets/javascripts/modules/track-responses.js
+++ b/app/assets/javascripts/modules/track-responses.js
@@ -31,7 +31,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     return submittedForm.getAttribute('data-question-key')
   }
 
-  TrackResponses.prototype.getResponseLabelsForRadio = function (submittedForm) {
+  TrackResponses.prototype.getResponseLabelsForInput = function (submittedForm) {
     var labels = []
     var checkedOptions = submittedForm.querySelectorAll('input:checked')
 
@@ -53,7 +53,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     return labels
   }
 
-  TrackResponses.prototype.getResponseLabelsForSelectOption = function (submittedForm) {
+  TrackResponses.prototype.getResponseLabelsForSelect = function (submittedForm) {
     var labels = []
     var selectInputs = submittedForm.querySelectorAll('select')
 
@@ -81,11 +81,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     switch (questionType) {
       case 'checkbox_question':
       case 'radio_question':
-        responseLabels = this.getResponseLabelsForRadio(submittedForm)
+        responseLabels = this.getResponseLabelsForInput(submittedForm)
         break
 
       case 'country_select_question':
-        responseLabels = this.getResponseLabelsForSelectOption(submittedForm)
+        responseLabels = this.getResponseLabelsForSelect(submittedForm)
         break
 
       default:

--- a/app/assets/javascripts/modules/track-responses.js
+++ b/app/assets/javascripts/modules/track-responses.js
@@ -1,99 +1,99 @@
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
-(function (global, GOVUK) {
-  'use strict'
+(function (Modules) {
+  function TrackResponses ($module) {
+    this.$module = $module
+  }
 
-  GOVUK.Modules.TrackResponses = function () {
-    this.start = function (element) {
-      track(element[0])
+  TrackResponses.prototype.init = function () {
+    this.$module.addEventListener('submit', this.handleFormSubmit.bind(this))
+  }
+
+  TrackResponses.prototype.handleFormSubmit = function (event) {
+    var submittedForm = event.target
+    var questionHeading = this.getQuestionHeading(submittedForm)
+    var questionKey = this.getQuestionKey(submittedForm)
+    var responseLabels = this.getResponseLabels(submittedForm)
+
+    responseLabels.forEach(function (label) {
+      var options = { transport: 'beacon', label: label }
+      GOVUK.analytics.trackEvent('question_answer', questionHeading, options)
+      GOVUK.analytics.trackEvent('response_submission', questionKey, options)
+    })
+  }
+
+  TrackResponses.prototype.getQuestionHeading = function (submittedForm) {
+    return submittedForm.getAttribute('data-question-text')
+  }
+
+  TrackResponses.prototype.getQuestionKey = function (submittedForm) {
+    return submittedForm.getAttribute('data-question-key')
+  }
+
+  TrackResponses.prototype.getResponseLabelsForRadio = function (submittedForm) {
+    var labels = []
+    var checkedOptions = submittedForm.querySelectorAll('input:checked')
+
+    if (checkedOptions.length) {
+      checkedOptions.forEach(function (checkedOption) {
+        var checkedOptionId = checkedOption.getAttribute('id')
+        var checkedOptionLabel = submittedForm.querySelectorAll('label[for="' + checkedOptionId + '"]')
+
+        var eventLabel = checkedOptionLabel.length
+          ? checkedOptionLabel[0].innerText.trim()
+          : checkedOption.value
+
+        labels.push(eventLabel)
+      })
+    } else {
+      labels.push('no response')
     }
 
-    function getQuestionHeading (submittedForm) {
-      return submittedForm.getAttribute('data-question-text')
-    }
+    return labels
+  }
 
-    function getQuestionKey (submittedForm) {
-      return submittedForm.getAttribute('data-question-key')
-    }
+  TrackResponses.prototype.getResponseLabelsForSelectOption = function (submittedForm) {
+    var labels = []
+    var selectInputs = submittedForm.querySelectorAll('select')
 
-    function getResponseLabelsForRadio (submittedForm) {
-      var labels = []
-      var checkedOptions = submittedForm.querySelectorAll('input:checked')
+    if (selectInputs.length) {
+      selectInputs.forEach(function (select) {
+        var value = select.value
 
-      if (checkedOptions.length) {
-        checkedOptions.forEach(function (checkedOption) {
-          var checkedOptionId = checkedOption.getAttribute('id')
-          var checkedOptionLabel = submittedForm.querySelectorAll('label[for="' + checkedOptionId + '"]')
-
-          var eventLabel = checkedOptionLabel.length
-            ? checkedOptionLabel[0].innerText.trim()
-            : checkedOption.value
-
+        if (value) {
+          var label = select.options[select.selectedIndex].innerHTML
+          var eventLabel = label.length ? label : value
           labels.push(eventLabel)
-        })
-      } else {
-        labels.push('no response')
-      }
-
-      return labels
-    }
-
-    function getResponseLabelsForSelectOption (submittedForm) {
-      var labels = []
-      var selectInputs = submittedForm.querySelectorAll('select')
-
-      if (selectInputs.length) {
-        selectInputs.forEach(function (select) {
-          var value = select.value
-
-          if (value) {
-            var label = select.options[select.selectedIndex].innerHTML
-            var eventLabel = label.length ? label : value
-            labels.push(eventLabel)
-          } else {
-            labels.push('no response')
-          }
-        })
-      }
-
-      return labels
-    }
-
-    function getResponseLabels (submittedForm) {
-      var responseLabels = []
-      var questionType = submittedForm.getAttribute('data-type')
-
-      switch (questionType) {
-        case 'checkbox_question':
-        case 'radio_question':
-          responseLabels = getResponseLabelsForRadio(submittedForm)
-          break
-
-        case 'country_select_question':
-          responseLabels = getResponseLabelsForSelectOption(submittedForm)
-          break
-
-        default:
-          break
-      }
-
-      return responseLabels
-    }
-
-    function track (element) {
-      element.addEventListener('submit', function (event) {
-        var submittedForm = event.target
-        var questionHeading = getQuestionHeading(submittedForm)
-        var questionKey = getQuestionKey(submittedForm)
-        var responseLabels = getResponseLabels(submittedForm)
-
-        responseLabels.forEach(function (label) {
-          var options = { transport: 'beacon', label: label }
-          GOVUK.analytics.trackEvent('question_answer', questionHeading, options)
-          GOVUK.analytics.trackEvent('response_submission', questionKey, options)
-        })
+        } else {
+          labels.push('no response')
+        }
       })
     }
+
+    return labels
   }
-})(window, window.GOVUK)
+
+  TrackResponses.prototype.getResponseLabels = function (submittedForm) {
+    var responseLabels = []
+    var questionType = submittedForm.getAttribute('data-type')
+
+    switch (questionType) {
+      case 'checkbox_question':
+      case 'radio_question':
+        responseLabels = this.getResponseLabelsForRadio(submittedForm)
+        break
+
+      case 'country_select_question':
+        responseLabels = this.getResponseLabelsForSelectOption(submittedForm)
+        break
+
+      default:
+        break
+    }
+
+    return responseLabels
+  }
+
+  Modules.TrackResponses = TrackResponses
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/modules/track-results.js
+++ b/app/assets/javascripts/modules/track-results.js
@@ -1,0 +1,48 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  function TrackResults ($module) {
+    this.$module = $module
+    this.flowName = this.$module.dataset.flowName
+    this.page = document.location.pathname
+  }
+
+  TrackResults.prototype.init = function () {
+    this.trackCompletedFlow()
+    this.trackResultLinks()
+  }
+
+  TrackResults.prototype.trackCompletedFlow = function () {
+    var options = {
+      label: this.flowName,
+      nonInteraction: true,
+      page: this.page
+    }
+    GOVUK.analytics.trackEvent('Smart Answer', 'Completed', options)
+  }
+
+  TrackResults.prototype.trackResultLinks = function () {
+    var currentHost = document.location.protocol + '//' + document.location.hostname
+    var internalLinkSelector = 'a[href^="' + currentHost + '"], a[href^="/"]'
+    var internalResultLinks = document.querySelectorAll(internalLinkSelector)
+
+    for (var i = 0; i < internalResultLinks.length; i++) {
+      internalResultLinks[i].addEventListener('click', this.trackClickEvent.bind(this))
+    }
+  }
+
+  TrackResults.prototype.trackClickEvent = function (event) {
+    var $link = event.target
+    var options = { transport: 'beacon' }
+    var href = $link.getAttribute('href')
+    var linkText = $link.innerText.trim()
+
+    if (linkText) {
+      options.label = linkText
+    }
+    GOVUK.analytics.trackEvent('Internal Link Clicked', href, options)
+  }
+
+  Modules.TrackResults = TrackResults
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/modules/track-results.js
+++ b/app/assets/javascripts/modules/track-results.js
@@ -10,7 +10,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   TrackResults.prototype.init = function () {
     this.trackCompletedFlow()
-    this.trackResultLinks()
+    this.trackInternalLinks()
   }
 
   TrackResults.prototype.trackCompletedFlow = function () {
@@ -22,7 +22,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     GOVUK.analytics.trackEvent('Smart Answer', 'Completed', options)
   }
 
-  TrackResults.prototype.trackResultLinks = function () {
+  TrackResults.prototype.trackInternalLinks = function () {
     var currentHost = document.location.protocol + '//' + document.location.hostname
     var internalLinkSelector = 'a[href^="' + currentHost + '"], a[href^="/"]'
     var internalResultLinks = document.querySelectorAll(internalLinkSelector)

--- a/app/views/smart_answers/result.html.erb
+++ b/app/views/smart_answers/result.html.erb
@@ -15,7 +15,7 @@
       title: outcome.heading_title
     } %>
 
-    <div class="govuk-!-margin-bottom-6 result-body">
+    <div class="govuk-!-margin-bottom-6" data-module="track-results" data-flow-name="<%= @name %>">
       <% if outcome.title.present? %>
         <%= render "govuk_publishing_components/components/heading", {
           text: outcome.title,
@@ -35,20 +35,6 @@
         <%= outcome.next_steps %>
       </div>
     <% end %>
-
-    <script type="text/javascript">
-      $(function() {
-        var flowName = '<%= @name %>';
-        var page = document.location.pathname;
-        var options = {
-          label: flowName,
-          nonInteraction: true,
-          page: page
-        };
-        GOVUK.analytics.trackEvent('Smart Answer', 'Completed', options);
-        trackInternalLinks('.result-body');
-      });
-    </script>
 
     <%= render 'smart_answers/shared/previous_answers', hide_previous_answers: @presenter.hide_previous_answers_on_results_page? %>
   </div>

--- a/spec/javascripts/components/hide-this-page-banner.spec.js
+++ b/spec/javascripts/components/hide-this-page-banner.spec.js
@@ -3,31 +3,41 @@
 describe('Hide this page banner component', function () {
   'use strict'
 
+  var container
   var hideThisPageBannerElement
+  var hideThisPageBannerButton
   var hideThisPageBannerModule
 
   beforeEach(function () {
-    hideThisPageBannerElement = document.createElement('div')
-    hideThisPageBannerElement.innerHTML = '<div class="app-c-hide-this-page-banner" data-module="app-hide-this-page-banner">' +
-                                            '<div class="app-c-hide-this-page-banner__link-wrapper">' +
-                                              '<a class="gem-c-button govuk-button govuk-button--warning" role="button" rel="nofollow noreferrer noopener" target="_blank" href="https://www.gov.uk/">Hide this page</a>' +
-                                            '</div>' +
-                                          '</div>'
-    hideThisPageBannerModule = new GOVUK.Modules.HideThisPageBanner()
-    hideThisPageBannerModule.start([hideThisPageBannerElement])
+    container = document.createElement('div')
+    container.innerHTML = '<div class="app-c-hide-this-page-banner" data-module="app-hide-this-page-banner">' +
+                            '<div class="app-c-hide-this-page-banner__link-wrapper">' +
+                              '<a class="gem-c-button govuk-button govuk-button--warning" role="button" rel="nofollow noreferrer noopener" target="_blank" href="https://www.gov.uk/">Hide this page</a>' +
+                            '</div>' +
+                          '</div>'
+
+    document.body.appendChild(container)
+    hideThisPageBannerElement = document.querySelector('[data-module="app-hide-this-page-banner"]')
+    hideThisPageBannerButton = hideThisPageBannerElement.querySelector('.gem-c-button')
+    hideThisPageBannerModule = new GOVUK.Modules.HideThisPageBanner(hideThisPageBannerElement)
+    hideThisPageBannerModule.init()
 
     spyOn(window, 'open').and.returnValue({})
     // stub replaceCurrentPage as window.location cannot be stubbed
     spyOn(hideThisPageBannerModule, 'replaceCurrentPage')
   })
 
+  afterEach(function () {
+    document.body.removeChild(container)
+  })
+
   it('opens a new page', function () {
-    hideThisPageBannerElement.querySelector('.gem-c-button').click()
+    hideThisPageBannerButton.dispatchEvent(new window.Event('click'))
     expect(window.open).toHaveBeenCalledWith('https://www.gov.uk/', 'nofollow noreferrer noopener')
   })
 
   it('replaces the original page', function () {
-    hideThisPageBannerElement.querySelector('.gem-c-button').click()
+    hideThisPageBannerButton.dispatchEvent(new window.Event('click'))
     expect(hideThisPageBannerModule.replaceCurrentPage).toHaveBeenCalledWith('https://www.gov.uk/')
   })
 })

--- a/spec/javascripts/modules/track-responses.spec.js
+++ b/spec/javascripts/modules/track-responses.spec.js
@@ -61,8 +61,8 @@ describe('Track responses', function () {
 
       form = createForm()
 
-      tracker = new GOVUK.Modules.TrackResponses()
-      tracker.start([form])
+      tracker = new GOVUK.Modules.TrackResponses(form)
+      tracker.init()
     })
 
     afterEach(function () {
@@ -168,8 +168,8 @@ describe('Track responses', function () {
 
       form = createForm()
 
-      tracker = new GOVUK.Modules.TrackResponses()
-      tracker.start([form])
+      tracker = new GOVUK.Modules.TrackResponses(form)
+      tracker.init()
     })
 
     afterEach(function () {
@@ -245,8 +245,8 @@ describe('Track responses', function () {
 
       form = createForm()
 
-      tracker = new GOVUK.Modules.TrackResponses()
-      tracker.start([form])
+      tracker = new GOVUK.Modules.TrackResponses(form)
+      tracker.init()
     })
 
     afterEach(function () {

--- a/spec/javascripts/modules/track-results.spec.js
+++ b/spec/javascripts/modules/track-results.spec.js
@@ -1,0 +1,63 @@
+/* eslint-env jasmine */
+/* global GOVUK */
+
+describe('Track results', function () {
+  GOVUK.analytics = GOVUK.analytics || {}
+  GOVUK.analytics.trackEvent = function () {}
+
+  describe('checkbox question', function () {
+    var tracker, container, element
+
+    beforeEach(function () {
+      container = document.createElement('div')
+      container.innerHTML = '<div data-module="track-results" data-flow-name="My Flow">' +
+                              '<a class="govuk-link" href="/internal-link">Internal link</a>' +
+                              '<a class="govuk-link" href="https://github.com">External link</a>' +
+                            '</div>'
+      document.body.appendChild(container)
+      element = document.querySelector('[data-module="track-results"]')
+    })
+
+    afterEach(function () {
+      document.body.removeChild(container)
+      GOVUK.analytics.trackEvent.calls.reset()
+    })
+
+    it('tracks completed flow', function () {
+      spyOn(GOVUK.analytics, 'trackEvent')
+
+      tracker = new GOVUK.Modules.TrackResults(element)
+      tracker.init()
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'Smart Answer', 'Completed', { label: 'My Flow', nonInteraction: true, page: document.location.pathname }
+      )
+    })
+
+    it('tracks an internal result link', function () {
+      var internalLink = container.querySelectorAll('a')[0]
+      tracker = new GOVUK.Modules.TrackResults(element)
+      tracker.init()
+
+      spyOn(GOVUK.analytics, 'trackEvent')
+
+      internalLink.dispatchEvent(new window.Event('click'))
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'Internal Link Clicked', '/internal-link', { transport: 'beacon', label: 'Internal link' }
+      )
+    })
+
+    it('does not track an external result link', function () {
+      var externalLink = container.querySelectorAll('a')[1]
+      tracker = new GOVUK.Modules.TrackResults(element)
+      tracker.init()
+
+      spyOn(GOVUK.analytics, 'trackEvent')
+
+      externalLink.dispatchEvent(new window.Event('click'))
+
+      expect(GOVUK.analytics.trackEvent).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/test/integration/engine/country_and_date_questions_test.rb
+++ b/test/integration/engine/country_and_date_questions_test.rb
@@ -143,7 +143,7 @@ class CountryAndDateQuestionsTest < EngineIntegrationTest
       end
 
       within "#result-info" do
-        within(".result-body h2.gem-c-heading") { assert_page_has_content "Great - you've lived in belarus for 37 years, and were born in venezuela!" }
+        within page.find("h2.gem-c-heading", match: :first) { assert_page_has_content "Great - you've lived in belarus for 37 years, and were born in venezuela!" }
       end
     end
   end # with_and_without_javascript

--- a/test/integration/engine/input_validation_test.rb
+++ b/test/integration/engine/input_validation_test.rb
@@ -57,7 +57,7 @@ class InputValidationTest < EngineIntegrationTest
       assert_current_url "/money-and-salary-sample/y/4000.0-month/50000.0"
 
       within "#result-info" do
-        within(".result-body h2.gem-c-heading") { assert_page_has_content "OK, here you go." }
+        within page.find("h2.gem-c-heading", match: :first) { assert_page_has_content "OK, here you go." }
         within(".info-notice") { assert_page_has_content "This is allowed because £50,000 is more than your annual salary of £48,000" }
       end
     end

--- a/test/integration/engine/money_and_salary_questions_test.rb
+++ b/test/integration/engine/money_and_salary_questions_test.rb
@@ -63,7 +63,7 @@ class MoneyAndSalaryQuestionsTest < EngineIntegrationTest
       end
 
       within "#result-info" do
-        within(".result-body h2.gem-c-heading") { assert_page_has_content "OK, here you go." }
+        within page.find("h2.gem-c-heading", match: :first) { assert_page_has_content "OK, here you go." }
         within(".info-notice") { assert_page_has_content "This is allowed because £1,000,000 is more than your annual salary of £60,000" }
       end
     end

--- a/test/integration/engine/radio_and_value_questions_test.rb
+++ b/test/integration/engine/radio_and_value_questions_test.rb
@@ -135,7 +135,7 @@ class RadioAndValueQuestionsTest < EngineIntegrationTest
       end
 
       within "#result-info" do
-        within(".result-body h2.gem-c-heading") { assert_page_has_content "Right, off you go." }
+        within page.find("h2.gem-c-heading", match: :first) { assert_page_has_content "Right, off you go." }
         assert_page_has_content "Oh! Well, thank you. Thank you very much."
       end
     end
@@ -180,7 +180,7 @@ class RadioAndValueQuestionsTest < EngineIntegrationTest
     click_on "Continue"
 
     within "#result-info" do
-      within(".result-body h2.gem-c-heading") { assert_page_has_content "AAAAARRRRRRRRRRRRRRRRGGGGGHHH!!!!!!!" }
+      within page.find("h2.gem-c-heading", match: :first) { assert_page_has_content "AAAAARRRRRRRRRRRRRRRRGGGGGHHH!!!!!!!" }
       within(".info-notice") { assert_page_has_content "Robin is thrown into the Gorge of Eternal Peril" }
     end
   end


### PR DESCRIPTION
### What

Refactor the JavaScript in this repo to use the prototype pattern, remove jQuery calls, use the `init` API (which doesn't require a jQuery object), remove inline scripting and use the `GOVUK.Modules` system consistently.

### Why

To be in line with the GOV.UK-wide established patterns and to allow us to easily update/maintain/remove them.

[Trello card](https://trello.com/c/waLtfVGs/466-refactor-javascript-modules-in-smart-answers)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
