### PR TITLE
Update hardcoded "London" string in the benefit cap calculator flow

### DIFF
--- a/lib/smart_answer/calculators/benefit_cap_calculator_configuration.rb
+++ b/lib/smart_answer/calculators/benefit_cap_calculator_configuration.rb
@@ -65,7 +65,7 @@ module SmartAnswer::Calculators
 
     def london?(postcode)
       area(postcode).any? do |result|
-        result["type"] == "EUR" && result["name"] == "London"
+        result["type"] == "EUR" && result["name"].match?(/.*London.*/i)
       end
     end
 

--- a/test/unit/calculators/benefit_cap_calculator_configuration_test.rb
+++ b/test/unit/calculators/benefit_cap_calculator_configuration_test.rb
@@ -104,10 +104,15 @@ module SmartAnswer::Calculators
           end
         end
         context "lives in Greater London" do
-          setup do
+          should "return true when the name is London" do
             stub_imminence_has_areas_for_postcode("IG6%202BA", [{ type: "EUR", name: "London", country_name: "England" }])
+
+            assert_equal true, @config.london?("IG6%202BA")
           end
-          should "return true" do
+
+          should "return true when London is present in the name" do
+            stub_imminence_has_areas_for_postcode("IG6%202BA", [{ type: "EUR", name: "London English Region", country_name: "England" }])
+
             assert_equal true, @config.london?("IG6%202BA")
           end
         end


### PR DESCRIPTION
The benefit cap calculator flow currently tests if the input postcode is within London by testing for a `result["type"]` of `EUR` and a `result["name"]` of `London`.

MySociety have changed the name of the London area in MapIt from `London` to `London English Region`. At least we thought it had been renamed. Actually it had been moved to a different GSS code. This exposed the potential for breaking this code in two ways:

1. Moving a local authority to a different area - changing the GSS code; and
2. Renaming the London area

As a result, the benefit cap calculator's `london?` method no longer worked correctly. For example, it returns false for postcodes within Westminister.

This change updates the `london?` method in the flow's calculator to use a regex that checks the `name` for any presence of the word `London`.

This should buffer us from any change, so long as `London` is somewhere in the name of the London area.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
