### PR TITLE
Update criteria for "How and when to charge VAT" result

### DIFF
--- a/lib/smart_answer/calculators/next_steps_for_your_business_calculator.rb
+++ b/lib/smart_answer/calculators/next_steps_for_your_business_calculator.rb
@@ -55,7 +55,7 @@ module SmartAnswer::Calculators
       r25: ->(calculator) { (calculator.business_premises & %w[rented owned none]).present? },
       r26: ->(calculator) { calculator.activities.include?("import_goods") },
       r27: ->(calculator) { calculator.activities.include?("export_goods_or_services") },
-      r28: ->(_) { true },
+      r28: ->(calculator) { calculator.annual_turnover_over_85k == "yes" },
       r29: ->(calculator) { calculator.annual_turnover_over_85k == "no" },
       r30: ->(calculator) { calculator.activities.include?("export_goods_or_services") },
     }.with_indifferent_access.freeze


### PR DESCRIPTION
In the "Next steps for you business" flow, we have a result for "How and when to charge VAT". This updates the logic so the result is only shown to business who earn more than £85K, as this result is shown in the "rules to follow" section and isn't a "must" for business who earn less.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
