### PR TITLE
Updated link for translators in Italy

### DIFF
--- a/config/smart_answers/translators.yml
+++ b/config/smart_answers/translators.yml
@@ -33,7 +33,7 @@ honduras: /government/publications/list-of-lawyers-and-translators-for-honduras
 hungary: /government/publications/hungary-list-of-translators-and-interpreters
 india: /government/publications/india-list-of-lawyers
 israel: /government/publications/israel-list-of-translators
-italy: /government/publications/italy-list-of-lawyers
+italy: /government/publications/italy-list-of-translators-and-interpreters
 jordan: /government/publications/jordan-list-of-translators
 kazakhstan: /government/publications/kazakhstan-list-of-lawyers-translators
 kuwait: /government/publications/british-embassy-kuwait-translators-list

--- a/test/integration/smart_answer_flows/register_a_death_test.rb
+++ b/test/integration/smart_answer_flows/register_a_death_test.rb
@@ -173,7 +173,7 @@ class RegisterADeathTest < ActiveSupport::TestCase
       end
       should "give the ORU result and be done" do
         assert_current_node :oru_result
-        assert_equal "/government/publications/italy-list-of-lawyers", current_state.calculator.translator_link_url
+        assert_equal "/government/publications/italy-list-of-translators-and-interpreters", current_state.calculator.translator_link_url
       end
     end # Answer Italy
 


### PR DESCRIPTION
https://trello.com/c/Zj9gJCqM/3491-change-of-document-on-registering-a-birth-in-italy

I've updated the link for translators in Italy. Previously it was taking users to a list of lawyers instead. 


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
