### PR TITLE
Temporarily update breadcrumbs

### DIFF
--- a/app/assets/stylesheets/smart_answers.scss
+++ b/app/assets/stylesheets/smart_answers.scss
@@ -1,4 +1,10 @@
 .smart_answer {
+
+  // TODO Remove after gem layout swaps complete.
+  .gem-c-step-nav-header {
+    line-height: 1;
+  }
+
   a:not(.govuk-button):focus {
     @include govuk-focused-text;
   }


### PR DESCRIPTION
## What 

Hotfix to resolve line-height spacing issuer on breadcrumbs on:
https://www.gov.uk/business-coronavirus-support-finder

## Why

There is a spacing issue that was highlighted. This has been on Production since 13/4 this PR is a hot-fix, [an issue has been raised here](https://github.com/alphagov/smart-answers/issues/5434)

## Visuals 

![image](https://user-images.githubusercontent.com/71266765/121713987-5520f480-cad5-11eb-9722-7f1d51a861bf.png)


## Anything else.

Similar page
https://www.gov.uk/government/collections/financial-support-for-businesses-during-coronavirus-covid-19

I'm not entirely sure of our policy on hotfixes like this

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
