### PR TITLE
Fix WorldLocation cache affecting future tests

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,15 +14,6 @@ Mocha.configure { |c| c.stubbing_non_existent_method = :prevent }
 require "webmock/minitest"
 WebMock.disable_net_connect!(allow_localhost: true)
 
-module MinitestWithTeardownCustomisations
-  def teardown
-    super
-    Timecop.return
-    WorldLocation.reset_cache
-  end
-end
-Minitest::Test.prepend MinitestWithTeardownCustomisations
-
 require "gds_api/test_helpers/json_client_helper"
 require "gds_api/test_helpers/content_store"
 require "gds_api/test_helpers/imminence"
@@ -38,6 +29,11 @@ class ActiveSupport::TestCase
   include GdsApi::TestHelpers::Worldwide
   include ActionDispatch::Assertions
   parallelize workers: 6
+
+  teardown do
+    Timecop.return
+    WorldLocation.reset_cache
+  end
 end
 
 require "slimmer/test"


### PR DESCRIPTION
This is to resolve a problem where we see flaky tests related to tests
that read from WorldLocation cache.

The problem is that the code to run WorldLocation.reset_cache doesn't
run on integration tests (tests that inherit from
ActionDispatch::IntegrationTest) which meant that any integration tests
that populated the cache didn't clear it - meaning the next test to run
after them would have a surprise value for WorldLocation.all.

I've resolved this by moving the teardown code to
ActiveSupport::TestCase so that it runs in all scenarios. This seems to
be a more conventional way to set-up a teardown. I haven't been able to
work out quite why the prepend approach failed for integration tests but
I was able to reliably replicate it.

Prior to this change, failure scenario:

```
➜  smart-answers git:(fix-flaky-world-location-tests) PARALLEL_WORKERS=1 rails test -f --seed 1 test/functional/smart_answers_controller_country_question_test.rb test/integration/smart_answer_flows/register_a_birth_test.rb
Run options: -f --seed 1

..F

Failure:
RegisterABirthTest#test_: Registration duration should display custom duration if child born in a lower risk (non phase-5) country and currently in North Korea.  [/Users/kevindew/govuk/smart-answers/test/integration/smart_answer_flows/register_a_birth_test.rb:566]:
Expected: :north_korea_result
  Actual: :country_of_birth?

rails test test/integration/smart_answer_flows/register_a_birth_test.rb:559

Interrupted. Exiting...

Finished in 3.924460s, 0.7644 runs/s, 1.5289 assertions/s.
3 runs, 6 assertions, 1 failures, 0 errors, 0 skips
```

After this change:

```
➜  smart-answers git:(fix-flaky-world-location-tests) ✗ PARALLEL_WORKERS=1 rails test -f --seed 1 test/functional/smart_answers_controller_country_question_test.rb test/integration/smart_answer_flows/register_a_birth_test.rb
Run options: -f --seed 1

................................................................

Finished in 7.107710s, 9.0043 runs/s, 27.9978 assertions/s.
64 runs, 199 assertions, 0 failures, 0 errors, 0 skips
```

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
