### PR TITLE
Parallelize tests based on number of processors

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -28,7 +28,7 @@ class ActiveSupport::TestCase
   include GdsApi::TestHelpers::PublishingApi
   include GdsApi::TestHelpers::Worldwide
   include ActionDispatch::Assertions
-  parallelize workers: 6
+  parallelize workers: :number_of_processors
 
   teardown do
     Timecop.return


### PR DESCRIPTION
Rather than hard coding the number of workers that this should run on
this option uses the number of cores on the executing machine to decide
the distribution. At the time of me setting the original option I didn't
know that this option was available.

For most GOV.UK users this shouldn't make much difference as GDS issued
Macbook Pro's have 6 physical coress. But this should be more friendly to
any configurations that have a differing number of cores.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
