### PR TITLE
Change penalty dates for late Self Assessment payment

### DIFF
--- a/lib/smart_answer/calculators/self_assessment_penalties.rb
+++ b/lib/smart_answer/calculators/self_assessment_penalties.rb
@@ -169,9 +169,9 @@ module SmartAnswer::Calculators
     def late_payment_penalty
       if overdue_payment_days <= first_late_payment_days
         0
-      elsif overdue_payment_days <= 181
+      elsif overdue_payment_days <= 183
         SmartAnswer::Money.new(late_payment_penalty_part.round(2))
-      elsif overdue_payment_days <= 365
+      elsif overdue_payment_days <= 367
         SmartAnswer::Money.new((late_payment_penalty_part * 2).round(2))
       else
         SmartAnswer::Money.new((late_payment_penalty_part * 3).round(2))

--- a/test/integration/smart_answer_flows/estimate_self_assessment_penalties_test.rb
+++ b/test/integration/smart_answer_flows/estimate_self_assessment_penalties_test.rb
@@ -185,16 +185,16 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
     # #5% fine + 1000pounds(previous fine)(band 3), taxdue > 6002pounds
     context "5% fine + 1000pounds(previous fine)(band 3), taxdue > 6002pounds" do
       setup do
-        add_response "2015-08-01"
-        add_response "2015-08-01"
+        add_response "2015-08-03"
+        add_response "2015-08-03"
         add_response "10000.00"
       end
       should "show results" do
         assert_equal 1500, current_state.calculator.late_filing_penalty
         assert_equal 10_000, current_state.calculator.estimated_bill
-        assert_equal 161.16, current_state.calculator.interest
+        assert_equal 162.95, current_state.calculator.interest
         assert_equal 1000, current_state.calculator.late_payment_penalty
-        assert_equal 12_661, current_state.calculator.total_owed_plus_filing_penalty
+        assert_equal 12_662, current_state.calculator.total_owed_plus_filing_penalty
       end
     end
     # #band 4 case 1
@@ -214,16 +214,16 @@ class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
     # #10% fine + 1000pounds(previous fine)(band 4), taxdue > 6002pounds
     context "10% fine + 1000pounds(previous fine)(band 4), taxdue > 6002pounds" do
       setup do
-        add_response "2016-02-01"
-        add_response "2016-02-01"
+        add_response "2016-02-03"
+        add_response "2016-02-03"
         add_response "10000.00"
       end
       should "show results" do
         assert_equal 2000, current_state.calculator.late_filing_penalty
         assert_equal 10_000, current_state.calculator.estimated_bill
-        assert_equal 325, current_state.calculator.interest
+        assert_equal 326.78, current_state.calculator.interest
         assert_equal 1500, current_state.calculator.late_payment_penalty
-        assert_equal 13_825, current_state.calculator.total_owed_plus_filing_penalty
+        assert_equal 13_826, current_state.calculator.total_owed_plus_filing_penalty
       end
     end
   end

--- a/test/unit/calculators/self_assessment_penalties_test.rb
+++ b/test/unit/calculators/self_assessment_penalties_test.rb
@@ -245,21 +245,21 @@ module SmartAnswer::Calculators
             @calculator.payment_date = Date.parse("2015-04-02")
             assert_equal 53.42, @calculator.interest # 50.14 + 0.04 penalty interest
             # one day before late payment penalty 2
-            @calculator.payment_date = Date.parse("2015-08-01")
+            @calculator.payment_date = Date.parse("2015-08-03")
             assert_equal 1000, @calculator.late_payment_penalty
-            assert_equal 161.16, @calculator.interest
+            assert_equal 162.95, @calculator.interest
             # should calculate PenaltyInterest2
             @calculator.payment_date = Date.parse("2015-09-02")
             assert_equal 1000, @calculator.late_payment_penalty
             assert_equal 189.66, @calculator.interest
             # one day before late payment penalty 3
-            @calculator.payment_date = Date.parse("2016-02-01")
+            @calculator.payment_date = Date.parse("2016-02-03")
             assert_equal 1500, @calculator.late_payment_penalty
-            assert_equal 325, @calculator.interest
+            assert_equal 326.78, @calculator.interest
             # should apply late payment penalty 3
-            @calculator.payment_date = Date.parse("2016-02-02")
+            @calculator.payment_date = Date.parse("2016-02-04")
             assert_equal 1500, @calculator.late_payment_penalty
-            assert_equal 325.89, @calculator.interest
+            assert_equal 327.67, @calculator.interest
             # should calculate PenaltyInterest3
             @calculator.payment_date = Date.parse("2016-03-05")
             assert_equal 1500, @calculator.late_payment_penalty
@@ -271,11 +271,11 @@ module SmartAnswer::Calculators
             assert_equal 5000, @calculator.total_owed
             @calculator.payment_date = Date.parse("2015-02-04")
             assert_equal 5001, @calculator.total_owed
-            @calculator.payment_date = Date.parse("2015-08-01")
-            assert_equal 5580, @calculator.total_owed
-            @calculator.payment_date = Date.parse("2016-02-02")
+            @calculator.payment_date = Date.parse("2015-08-03")
+            assert_equal 5581, @calculator.total_owed
+            @calculator.payment_date = Date.parse("2016-02-03")
             assert_equal 750, @calculator.late_payment_penalty
-            assert_equal 5912, @calculator.total_owed
+            assert_equal 5913, @calculator.total_owed
           end
         end
 


### PR DESCRIPTION
The dates being used to calculate the penalty were two days early.  Therefore we need to add another 2 days to each payment penalty step start date.

Also added a new set of tests that cover all tax years and all penalty steps to ensure there are no glitches in how the calculator works (e.g. in leap years).  These are based on the table provided by HMRC in https://govuk.zendesk.com/agent/tickets/4571228.

Note that changing the payment date in the tests also changes the interest due, as the payment is being made 2 days later in both cases, therefore a number of tests have needed to be updated.

[Trello card](https://trello.com/c/91XYwlNb)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️