### PR TITLE
Use new hover link styles

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,6 @@
 $govuk-compatibility-govuktemplate: true;
 $govuk-use-legacy-palette: false;
+$govuk-new-link-styles: true;
 
 @import "govuk_publishing_components/govuk_frontend_support";
 @import "govuk_publishing_components/component_support";


### PR DESCRIPTION
We turn on the `$govuk-new-link-styles` flag to make the new hover styles available to smart-answers. An extensive visual check was performed to make sure the style applies as intended across flows.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
