### PR TITLE
Remove legacy response tracking events

### DIFF
--- a/app/assets/javascripts/modules/track-responses.js
+++ b/app/assets/javascripts/modules/track-responses.js
@@ -12,20 +12,14 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   TrackResponses.prototype.handleFormSubmit = function (event) {
     var submittedForm = event.target
-    var questionHeading = this.getQuestionHeading(submittedForm)
     var questionKey = this.getQuestionKey(submittedForm)
     var responseLabels = this.getResponseLabels(submittedForm)
 
     for (var i = 0; i < responseLabels.length; i++) {
       var label = responseLabels[i]
       var options = { transport: 'beacon', label: label }
-      GOVUK.analytics.trackEvent('question_answer', questionHeading, options)
       GOVUK.analytics.trackEvent('response_submission', questionKey, options)
     }
-  }
-
-  TrackResponses.prototype.getQuestionHeading = function (submittedForm) {
-    return submittedForm.getAttribute('data-question-text')
   }
 
   TrackResponses.prototype.getQuestionKey = function (submittedForm) {

--- a/app/views/smart_answers/question.html.erb
+++ b/app/views/smart_answers/question.html.erb
@@ -15,7 +15,6 @@
           module: "track-responses",
           type: question.partial_template_name,
           "question-key": question.node_slug,
-          "question-text": question.title
         }) do %>
       <div class="govuk-!-margin-bottom-6 govuk-!-margin-top-8" id="current-question">
 

--- a/spec/javascripts/modules/track-responses.spec.js
+++ b/spec/javascripts/modules/track-responses.spec.js
@@ -14,7 +14,6 @@ describe('Track responses', function () {
       element.setAttribute('data-module', 'track-responses')
       element.setAttribute('data-type', 'checkbox_question')
       element.setAttribute('data-question-key', 'question-key')
-      element.setAttribute('data-question-text', 'The question title?')
       element.setAttribute('method', 'post')
 
       var fieldset = document.createElement('fieldset')
@@ -76,12 +75,6 @@ describe('Track responses', function () {
       form.dispatchEvent(new Event('submit'))
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
-        'question_answer', 'The question title?', { transport: 'beacon', label: 'Construction label' }
-      )
-      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
-        'question_answer', 'The question title?', { transport: 'beacon', label: 'Accommodation label' }
-      )
-      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
         'response_submission', 'question-key', { transport: 'beacon', label: 'Construction label' }
       )
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
@@ -94,9 +87,6 @@ describe('Track responses', function () {
       form.dispatchEvent(new Event('submit'))
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
-        'question_answer', 'The question title?', { transport: 'beacon', label: 'furniture' }
-      )
-      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
         'response_submission', 'question-key', { transport: 'beacon', label: 'furniture' }
       )
     })
@@ -104,9 +94,6 @@ describe('Track responses', function () {
     it('track event triggered when no response is made', function () {
       form.dispatchEvent(new Event('submit'))
 
-      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
-        'question_answer', 'The question title?', { transport: 'beacon', label: 'no response' }
-      )
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
         'response_submission', 'question-key', { transport: 'beacon', label: 'no response' }
       )
@@ -122,7 +109,6 @@ describe('Track responses', function () {
       element.setAttribute('data-module', 'track-responses')
       element.setAttribute('data-type', 'radio_question')
       element.setAttribute('data-question-key', 'question-key')
-      element.setAttribute('data-question-text', 'The question title?')
       element.setAttribute('method', 'post')
 
       var fieldset = document.createElement('fieldset')
@@ -183,9 +169,6 @@ describe('Track responses', function () {
       form.dispatchEvent(new Event('submit'))
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
-        'question_answer', 'The question title?', { transport: 'beacon', label: 'Accommodation label' }
-      )
-      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
         'response_submission', 'question-key', { transport: 'beacon', label: 'Accommodation label' }
       )
     })
@@ -193,9 +176,6 @@ describe('Track responses', function () {
     it('track event triggered when no response is made', function () {
       form.dispatchEvent(new Event('submit'))
 
-      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
-        'question_answer', 'The question title?', { transport: 'beacon', label: 'no response' }
-      )
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
         'response_submission', 'question-key', { transport: 'beacon', label: 'no response' }
       )
@@ -211,7 +191,6 @@ describe('Track responses', function () {
       element.setAttribute('data-module', 'track-responses')
       element.setAttribute('data-type', 'country_select_question')
       element.setAttribute('data-question-key', 'question-key')
-      element.setAttribute('data-question-text', 'The question title?')
       element.setAttribute('method', 'post')
 
       var select = document.createElement('select')
@@ -261,9 +240,6 @@ describe('Track responses', function () {
       form.dispatchEvent(new Event('submit'))
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
-        'question_answer', 'The question title?', { transport: 'beacon', label: 'Accommodation label' }
-      )
-      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
         'response_submission', 'question-key', { transport: 'beacon', label: 'Accommodation label' }
       )
     })
@@ -271,9 +247,6 @@ describe('Track responses', function () {
     it('track event triggered when no response is made', function () {
       form.dispatchEvent(new Event('submit'))
 
-      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
-        'question_answer', 'The question title?', { transport: 'beacon', label: 'no response' }
-      )
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
         'response_submission', 'question-key', { transport: 'beacon', label: 'no response' }
       )


### PR DESCRIPTION
In #5348 we introduced a new event for tracking responses in `smart-answers`. As performance analysts have updated their dashboards to use the new event we can remove the old way of tracking responses.

[Trello card](https://trello.com/c/9u9E1sEX)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
