### PR TITLE
Add StartNode class

### DIFF
--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -31,7 +31,7 @@ class ContentItemPresenter
 private
 
   def start_node_presenter
-    @start_node_presenter ||= StartNodePresenter.new(flow.start_node)
+    @start_node_presenter ||= flow.start_node.presenter(nil, nil)
   end
 
   def base_path

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -31,7 +31,7 @@ class ContentItemPresenter
 private
 
   def start_node_presenter
-    @start_node_presenter ||= flow.start_node.presenter(nil, nil)
+    @start_node_presenter ||= flow.start_node.presenter
   end
 
   def base_path

--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -31,29 +31,7 @@ class FlowPresenter
   end
 
   def presenter_for(node)
-    presenter_class = case node
-                      when SmartAnswer::Question::Date
-                        DateQuestionPresenter
-                      when SmartAnswer::Question::CountrySelect
-                        CountrySelectQuestionPresenter
-                      when SmartAnswer::Question::Radio
-                        RadioQuestionPresenter
-                      when SmartAnswer::Question::Checkbox
-                        CheckboxQuestionPresenter
-                      when SmartAnswer::Question::Value
-                        ValueQuestionPresenter
-                      when SmartAnswer::Question::Money
-                        MoneyQuestionPresenter
-                      when SmartAnswer::Question::Salary
-                        SalaryQuestionPresenter
-                      when SmartAnswer::Question::Base
-                        QuestionPresenter
-                      when SmartAnswer::Outcome
-                        OutcomePresenter
-                      else
-                        NodePresenter
-                      end
-    @node_presenters[node.name] ||= presenter_class.new(node, self, state, {})
+    @node_presenters[node.name] ||= node.presenter(self, state)
   end
 
   def current_node

--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -39,7 +39,7 @@ class FlowPresenter
   end
 
   def start_node
-    @start_node ||= StartNodePresenter.new(@flow.start_node)
+    @start_node ||= @flow.start_node.presenter(self, nil)
   end
 
   def change_answer_link(question)

--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -31,7 +31,7 @@ class FlowPresenter
   end
 
   def presenter_for(node)
-    @node_presenters[node.name] ||= node.presenter(self, state)
+    @node_presenters[node.name] ||= node.presenter(flow_presenter: self, state: state)
   end
 
   def current_node
@@ -39,7 +39,7 @@ class FlowPresenter
   end
 
   def start_node
-    @start_node ||= @flow.start_node.presenter(self, nil)
+    @start_node ||= @flow.start_node.presenter(flow_presenter: self)
   end
 
   def change_answer_link(question)

--- a/app/presenters/graph_presenter.rb
+++ b/app/presenters/graph_presenter.rb
@@ -85,6 +85,6 @@ private
   end
 
   def start_node_presenter
-    @start_node_presenter ||= StartNodePresenter.new(@flow.start_node)
+    @start_node_presenter ||= @flow.start_node.presenter(nil, nil)
   end
 end

--- a/app/presenters/graph_presenter.rb
+++ b/app/presenters/graph_presenter.rb
@@ -85,6 +85,6 @@ private
   end
 
   def start_node_presenter
-    @start_node_presenter ||= @flow.start_node.presenter(nil, nil)
+    @start_node_presenter ||= @flow.start_node.presenter
   end
 end

--- a/app/presenters/start_node_presenter.rb
+++ b/app/presenters/start_node_presenter.rb
@@ -1,6 +1,6 @@
 class StartNodePresenter < NodePresenter
-  def initialize(node, state = nil, options = {})
-    super(node, state)
+  def initialize(node, flow_presenter, state = nil, options = {})
+    super(node, flow_presenter, state)
     @renderer = options[:renderer] || SmartAnswer::ErbRenderer.new(
       template_directory: @node.template_directory,
       template_name: @node.name.to_s,

--- a/app/views/smart_answers/index.html.erb
+++ b/app/views/smart_answers/index.html.erb
@@ -15,7 +15,7 @@
           { text: "" },
         ],
         rows: @flows.map do |flow|
-          presenter = StartNodePresenter.new(flow.start_node)
+          presenter = flow.start_node.presenter(nil, nil)
           [
             { text: title_and_url(flow.name, presenter.title) },
             { text: link_to(flow.status.capitalize, live_link(flow.name, flow.status)) },

--- a/app/views/smart_answers/index.html.erb
+++ b/app/views/smart_answers/index.html.erb
@@ -15,7 +15,7 @@
           { text: "" },
         ],
         rows: @flows.map do |flow|
-          presenter = flow.start_node.presenter(nil, nil)
+          presenter = flow.start_node.presenter
           [
             { text: title_and_url(flow.name, presenter.title) },
             { text: link_to(flow.status.capitalize, live_link(flow.name, flow.status)) },

--- a/lib/smart_answer/flow.rb
+++ b/lib/smart_answer/flow.rb
@@ -120,7 +120,7 @@ module SmartAnswer
     end
 
     def start_node
-      Node.new(self, name.underscore.to_sym)
+      StartNode.new(self, name.underscore.to_sym)
     end
 
     class InvalidStatus < StandardError; end

--- a/lib/smart_answer/node.rb
+++ b/lib/smart_answer/node.rb
@@ -24,7 +24,7 @@ module SmartAnswer
       @template_name
     end
 
-    def presenter(flow_presenter, state)
+    def presenter(flow_presenter: nil, state: nil)
       self.class::PRESENTER_CLASS.new(self, flow_presenter, state)
     end
 

--- a/lib/smart_answer/node.rb
+++ b/lib/smart_answer/node.rb
@@ -2,6 +2,8 @@ require "active_support/inflector"
 
 module SmartAnswer
   class Node
+    PRESENTER_CLASS = NodePresenter
+
     attr_accessor :flow
     attr_reader :name, :view_template_path
 
@@ -20,6 +22,10 @@ module SmartAnswer
     def template_name(template_name = nil)
       @template_name = template_name unless template_name.nil?
       @template_name
+    end
+
+    def presenter(flow_presenter, state)
+      self.class::PRESENTER_CLASS.new(self, flow_presenter, state)
     end
 
     def filesystem_friendly_name

--- a/lib/smart_answer/outcome.rb
+++ b/lib/smart_answer/outcome.rb
@@ -1,5 +1,7 @@
 module SmartAnswer
   class Outcome < Node
+    PRESENTER_CLASS = OutcomePresenter
+
     def outcome?
       true
     end

--- a/lib/smart_answer/question/base.rb
+++ b/lib/smart_answer/question/base.rb
@@ -1,6 +1,8 @@
 module SmartAnswer
   module Question
     class Base < Node
+      PRESENTER_CLASS = QuestionPresenter
+
       class NextNodeUndefined < StandardError; end
 
       def initialize(flow, name, &block)

--- a/lib/smart_answer/question/checkbox.rb
+++ b/lib/smart_answer/question/checkbox.rb
@@ -1,6 +1,7 @@
 module SmartAnswer
   module Question
     class Checkbox < Base
+      PRESENTER_CLASS = CheckboxQuestionPresenter
       NONE_OPTION = "none".freeze
 
       attr_reader :options

--- a/lib/smart_answer/question/country_select.rb
+++ b/lib/smart_answer/question/country_select.rb
@@ -1,6 +1,8 @@
 module SmartAnswer
   module Question
     class CountrySelect < Base
+      PRESENTER_CLASS = CountrySelectQuestionPresenter
+
       def initialize(flow, name, options = {}, &block)
         @exclude_countries = options.delete(:exclude_countries)
         @include_uk = options.delete(:include_uk)

--- a/lib/smart_answer/question/date.rb
+++ b/lib/smart_answer/question/date.rb
@@ -3,6 +3,8 @@ require "date"
 module SmartAnswer
   module Question
     class Date < Base
+      PRESENTER_CLASS = DateQuestionPresenter
+
       def validate_in_range
         @validate_in_range = true
       end

--- a/lib/smart_answer/question/money.rb
+++ b/lib/smart_answer/question/money.rb
@@ -1,6 +1,8 @@
 module SmartAnswer
   module Question
     class Money < Base
+      PRESENTER_CLASS = MoneyQuestionPresenter
+
       def parse_input(raw_input)
         SmartAnswer::Money.new(raw_input)
       end

--- a/lib/smart_answer/question/radio.rb
+++ b/lib/smart_answer/question/radio.rb
@@ -1,6 +1,8 @@
 module SmartAnswer
   module Question
     class Radio < Base
+      PRESENTER_CLASS = RadioQuestionPresenter
+
       attr_reader :permitted_options
 
       def initialize(flow, name, &block)

--- a/lib/smart_answer/question/salary.rb
+++ b/lib/smart_answer/question/salary.rb
@@ -1,6 +1,8 @@
 module SmartAnswer
   module Question
     class Salary < Base
+      PRESENTER_CLASS = SalaryQuestionPresenter
+
       def parse_input(raw_input)
         SmartAnswer::Salary.new(raw_input)
       end

--- a/lib/smart_answer/question/value.rb
+++ b/lib/smart_answer/question/value.rb
@@ -1,6 +1,8 @@
 module SmartAnswer
   module Question
     class Value < Base
+      PRESENTER_CLASS = ValueQuestionPresenter
+
       def initialize(flow, name, options = {}, &block)
         @parse = options[:parse]
         super(flow, name, &block)

--- a/lib/smart_answer/start_node.rb
+++ b/lib/smart_answer/start_node.rb
@@ -1,0 +1,5 @@
+module SmartAnswer
+  class StartNode < Node
+    PRESENTER_CLASS = StartNodePresenter
+  end
+end

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -19,21 +19,13 @@ class SmartAnswersControllerTest < ActionController::TestCase
                      status: :published,
                      questions: stub(count: 2),
                      outcomes: stub(count: 3),
-                     start_node: stub)
-
-      StartNodePresenter.stubs(:new)
-                        .with(@flow_a.start_node)
-                        .returns(stub(title: "Flow A"))
+                     start_node: stub(presenter: stub(title: "Flow A")))
 
       @flow_b = stub(name: "flow-b",
                      status: :draft,
                      questions: stub(count: 3),
                      outcomes: stub(count: 0),
-                     start_node: stub)
-
-      StartNodePresenter.stubs(:new)
-                        .with(@flow_b.start_node)
-                        .returns(stub(title: "Flow B"))
+                     start_node: stub(presenter: stub(title: "Flow B")))
 
       registry = stub("Flow registry")
       registry.stubs(:flows).returns([@flow_b, @flow_a])

--- a/test/helpers/content_item_helper_test.rb
+++ b/test/helpers/content_item_helper_test.rb
@@ -7,8 +7,8 @@ class ContentItemHelperTest < ActionView::TestCase
     setup_fixture_flows
     @flow = SmartAnswer::FlowSampleFlow.build
 
-    node = SmartAnswer::Node.new(@flow, @flow.name.underscore.to_sym)
-    @start_node = StartNodePresenter.new(node)
+    node = SmartAnswer::StartNode.new(@flow, @flow.name.underscore.to_sym)
+    @start_node = node.presenter(nil, nil)
   end
 
   def teardown

--- a/test/helpers/content_item_helper_test.rb
+++ b/test/helpers/content_item_helper_test.rb
@@ -8,7 +8,7 @@ class ContentItemHelperTest < ActionView::TestCase
     @flow = SmartAnswer::FlowSampleFlow.build
 
     node = SmartAnswer::StartNode.new(@flow, @flow.name.underscore.to_sym)
-    @start_node = node.presenter(nil, nil)
+    @start_node = node.presenter
   end
 
   def teardown

--- a/test/unit/flow_test.rb
+++ b/test/unit/flow_test.rb
@@ -245,7 +245,7 @@ class FlowTest < ActiveSupport::TestCase
   test "Can build a start node" do
     start_node = SmartAnswer::Flow.new { name "my-flow" }.start_node
 
-    assert_instance_of SmartAnswer::Node, start_node
+    assert_instance_of SmartAnswer::StartNode, start_node
     assert start_node.name, "my_flow"
   end
 

--- a/test/unit/node_test.rb
+++ b/test/unit/node_test.rb
@@ -52,7 +52,7 @@ module SmartAnswer
 
     test "#presenter returns a presenter object" do
       node = Node.new(@flow, "node-name")
-      assert_instance_of Node::PRESENTER_CLASS, node.presenter(nil, nil)
+      assert_instance_of Node::PRESENTER_CLASS, node.presenter
     end
   end
 end

--- a/test/unit/node_test.rb
+++ b/test/unit/node_test.rb
@@ -49,5 +49,10 @@ module SmartAnswer
       node = Node.new(@flow, "node-name")
       assert_nil node.view_template_path
     end
+
+    test "#presenter returns a presenter object" do
+      node = Node.new(@flow, "node-name")
+      assert_instance_of Node::PRESENTER_CLASS, node.presenter(nil, nil)
+    end
   end
 end

--- a/test/unit/start_node_presenter_test.rb
+++ b/test/unit/start_node_presenter_test.rb
@@ -5,7 +5,7 @@ module SmartAnswer
     setup do
       start_node = Node.new(nil, :start_node_name)
       @renderer = stub("renderer")
-      @presenter = StartNodePresenter.new(start_node, nil, renderer: @renderer)
+      @presenter = StartNodePresenter.new(start_node, nil, nil, renderer: @renderer)
     end
 
     test "renderer is constructed using template name and directory obtained from start node" do
@@ -18,7 +18,7 @@ module SmartAnswer
         ),
       )
 
-      StartNodePresenter.new(start_node)
+      StartNodePresenter.new(start_node, nil)
     end
 
     test "#title returns single line of content rendered for title block" do


### PR DESCRIPTION
This PR helps position the codebase to make start pages as first class nodes. Changes in this PR include:
- Adds a StartNode class for the StartNodePresenter class, so it's consistent with other node types.
- Refactors the node presenter initialisation code, to help ensure we maintain this 1 to 1 relationship between node and node presenter classes.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
