### PR TITLE
Move input validation to transition method

### DIFF
--- a/lib/smart_answer/question/base.rb
+++ b/lib/smart_answer/question/base.rb
@@ -33,7 +33,6 @@ module SmartAnswer
       end
 
       def next_node_for(current_state, input)
-        validate!(current_state, input)
         state = current_state.dup.extend(NextNodeBlock::InstanceMethods).freeze
         next_node = state.instance_exec(input, &next_node_block)
         if next_node.blank?
@@ -54,6 +53,7 @@ module SmartAnswer
         new_state = @on_response_blocks.inject(current_state.dup) do |state, block|
           block.evaluate(state, input)
         end
+        validate!(new_state, input)
         next_node = next_node_for(new_state, input)
         new_state.transition_to(next_node, input)
       end


### PR DESCRIPTION
This moves the input validation from the next node resolution method to more general transition method. This makes the concerns of the next_node_for method clearer and less confusing. Having input validation decoupled from next_node resolution will in future allow other node types (including those that don't have user input) to specify a next node.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
