### PR TITLE
Rename FlowTestHelper to FlowIntegrationTestHelper

### DIFF
--- a/test/integration/smart_answer_flows/additional_commodity_code_test.rb
+++ b/test/integration/smart_answer_flows/additional_commodity_code_test.rb
@@ -1,10 +1,10 @@
 require_relative "../../test_helper"
-require_relative "flow_test_helper"
+require_relative "flow_integration_test_helper"
 
 require "smart_answer_flows/additional-commodity-code"
 
 class AdditionalCommodityCodeTest < ActiveSupport::TestCase
-  include FlowTestHelper
+  include FlowIntegrationTestHelper
 
   setup do
     setup_for_testing_flow SmartAnswer::AdditionalCommodityCodeFlow

--- a/test/integration/smart_answer_flows/adoption_calculator_test.rb
+++ b/test/integration/smart_answer_flows/adoption_calculator_test.rb
@@ -1,12 +1,12 @@
 require_relative "../../test_helper"
-require_relative "flow_test_helper"
+require_relative "flow_integration_test_helper"
 require_relative "../../../lib/smart_answer/date_helper"
 
 require "smart_answer_flows/maternity-paternity-calculator"
 
 class AdoptionCalculatorTest < ActiveSupport::TestCase
   include SmartAnswer::DateHelper
-  include FlowTestHelper
+  include FlowIntegrationTestHelper
 
   setup do
     setup_for_testing_flow SmartAnswer::MaternityPaternityCalculatorFlow

--- a/test/integration/smart_answer_flows/am_i_getting_minimum_wage_test.rb
+++ b/test/integration/smart_answer_flows/am_i_getting_minimum_wage_test.rb
@@ -1,10 +1,10 @@
 require_relative "../../test_helper"
-require_relative "flow_test_helper"
+require_relative "flow_integration_test_helper"
 
 require "smart_answer_flows/am-i-getting-minimum-wage"
 
 class AmIGettingMinimumWageTest < ActiveSupport::TestCase
-  include FlowTestHelper
+  include FlowIntegrationTestHelper
 
   setup do
     Timecop.freeze(Date.parse("2015-01-01"))

--- a/test/integration/smart_answer_flows/benefit_cap_calculator_test.rb
+++ b/test/integration/smart_answer_flows/benefit_cap_calculator_test.rb
@@ -1,10 +1,10 @@
 require_relative "../../test_helper"
-require_relative "flow_test_helper"
+require_relative "flow_integration_test_helper"
 
 require "smart_answer_flows/benefit-cap-calculator"
 
 class BenefitCapCalculatorTest < ActiveSupport::TestCase
-  include FlowTestHelper
+  include FlowIntegrationTestHelper
 
   setup do
     setup_for_testing_flow SmartAnswer::BenefitCapCalculatorFlow

--- a/test/integration/smart_answer_flows/calculate_agricultural_holiday_entitlement_test.rb
+++ b/test/integration/smart_answer_flows/calculate_agricultural_holiday_entitlement_test.rb
@@ -1,10 +1,10 @@
 require_relative "../../test_helper"
-require_relative "flow_test_helper"
+require_relative "flow_integration_test_helper"
 
 require "smart_answer_flows/calculate-agricultural-holiday-entitlement"
 
 class CalculateAgriculturalHolidayEntitlementTest < ActiveSupport::TestCase
-  include FlowTestHelper
+  include FlowIntegrationTestHelper
 
   setup do
     setup_for_testing_flow SmartAnswer::CalculateAgriculturalHolidayEntitlementFlow

--- a/test/integration/smart_answer_flows/calculate_employee_redundancy_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_employee_redundancy_pay_test.rb
@@ -1,10 +1,10 @@
 require_relative "../../test_helper"
-require_relative "flow_test_helper"
+require_relative "flow_integration_test_helper"
 
 require "smart_answer_flows/calculate-employee-redundancy-pay"
 
 class CalculateEmployeeRedundancyPayTest < ActiveSupport::TestCase
-  include FlowTestHelper
+  include FlowIntegrationTestHelper
 
   setup do
     Timecop.freeze("2019-08-31")

--- a/test/integration/smart_answer_flows/calculate_married_couples_allowance_test.rb
+++ b/test/integration/smart_answer_flows/calculate_married_couples_allowance_test.rb
@@ -1,10 +1,10 @@
 require_relative "../../test_helper"
-require_relative "flow_test_helper"
+require_relative "flow_integration_test_helper"
 
 require "smart_answer_flows/calculate-married-couples-allowance"
 
 class CalculateMarriedCouplesAllowanceTest < ActiveSupport::TestCase
-  include FlowTestHelper
+  include FlowIntegrationTestHelper
 
   setup do
     setup_for_testing_flow SmartAnswer::CalculateMarriedCouplesAllowanceFlow

--- a/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_statutory_sick_pay_test.rb
@@ -1,10 +1,10 @@
 require_relative "../../test_helper"
-require_relative "flow_test_helper"
+require_relative "flow_integration_test_helper"
 
 require "smart_answer_flows/calculate-statutory-sick-pay"
 
 class CalculateStatutorySickPayTest < ActiveSupport::TestCase
-  include FlowTestHelper
+  include FlowIntegrationTestHelper
 
   setup do
     setup_for_testing_flow SmartAnswer::CalculateStatutorySickPayFlow

--- a/test/integration/smart_answer_flows/calculate_your_redundancy_pay_test.rb
+++ b/test/integration/smart_answer_flows/calculate_your_redundancy_pay_test.rb
@@ -1,10 +1,10 @@
 require_relative "../../test_helper"
-require_relative "flow_test_helper"
+require_relative "flow_integration_test_helper"
 
 require "smart_answer_flows/calculate-your-redundancy-pay"
 
 class CalculateYourRedundancyPayTest < ActiveSupport::TestCase
-  include FlowTestHelper
+  include FlowIntegrationTestHelper
 
   setup do
     Timecop.freeze("2019-08-31")

--- a/test/integration/smart_answer_flows/check_uk_visa_test.rb
+++ b/test/integration/smart_answer_flows/check_uk_visa_test.rb
@@ -1,10 +1,10 @@
 require_relative "../../test_helper"
-require_relative "flow_test_helper"
+require_relative "flow_integration_test_helper"
 
 require "smart_answer_flows/check-uk-visa"
 
 class CheckUkVisaTest < ActiveSupport::TestCase
-  include FlowTestHelper
+  include FlowIntegrationTestHelper
 
   setup do
     @location_slugs = %w[andorra anguilla armenia austria bolivia canada china colombia croatia estonia hong-kong ireland latvia macao mexico south-africa stateless-or-refugee syria turkey democratic-republic-of-the-congo oman united-arab-emirates qatar taiwan venezuela afghanistan yemen]

--- a/test/integration/smart_answer_flows/child_benefit_tax_calculator_test.rb
+++ b/test/integration/smart_answer_flows/child_benefit_tax_calculator_test.rb
@@ -1,10 +1,10 @@
 require_relative "../../test_helper"
-require_relative "flow_test_helper"
+require_relative "flow_integration_test_helper"
 
 require "smart_answer_flows/child-benefit-tax-calculator"
 
 class ChildBenefitTaxCalculatorTest < ActiveSupport::TestCase
-  include FlowTestHelper
+  include FlowIntegrationTestHelper
 
   setup do
     setup_for_testing_flow SmartAnswer::ChildBenefitTaxCalculatorFlow

--- a/test/integration/smart_answer_flows/childcare_costs_for_tax_credits_test.rb
+++ b/test/integration/smart_answer_flows/childcare_costs_for_tax_credits_test.rb
@@ -1,10 +1,10 @@
 require_relative "../../test_helper"
-require_relative "flow_test_helper"
+require_relative "flow_integration_test_helper"
 
 require "smart_answer_flows/childcare-costs-for-tax-credits"
 
 class ChildcareCostsForTaxCreditsTest < ActiveSupport::TestCase
-  include FlowTestHelper
+  include FlowIntegrationTestHelper
 
   setup do
     setup_for_testing_flow SmartAnswer::ChildcareCostsForTaxCreditsFlow

--- a/test/integration/smart_answer_flows/estimate_self_assessment_penalties_test.rb
+++ b/test/integration/smart_answer_flows/estimate_self_assessment_penalties_test.rb
@@ -1,5 +1,5 @@
 require_relative "../../test_helper"
-require_relative "flow_test_helper"
+require_relative "flow_integration_test_helper"
 
 require "smart_answer_flows/estimate-self-assessment-penalties"
 
@@ -18,7 +18,7 @@ TEST_CALCULATOR_DATES = {
   },
 }.freeze
 class EstimateSelfAssessmentPenaltiesTest < ActiveSupport::TestCase
-  include FlowTestHelper
+  include FlowIntegrationTestHelper
 
   setup do
     setup_for_testing_flow SmartAnswer::EstimateSelfAssessmentPenaltiesFlow

--- a/test/integration/smart_answer_flows/find_coronavirus_support_test.rb
+++ b/test/integration/smart_answer_flows/find_coronavirus_support_test.rb
@@ -1,10 +1,10 @@
 require_relative "../../test_helper"
-require_relative "flow_test_helper"
+require_relative "flow_integration_test_helper"
 
 require "smart_answer_flows/find-coronavirus-support"
 
 class FindCoronavirusSupportFlowTest < ActiveSupport::TestCase
-  include FlowTestHelper
+  include FlowIntegrationTestHelper
 
   setup do
     setup_for_testing_flow SmartAnswer::FindCoronavirusSupportFlow

--- a/test/integration/smart_answer_flows/flow_integration_test_helper.rb
+++ b/test/integration/smart_answer_flows/flow_integration_test_helper.rb
@@ -1,4 +1,4 @@
-module FlowTestHelper
+module FlowIntegrationTestHelper
   def setup_for_testing_flow(klass)
     @flow = klass.build
     reset_responses

--- a/test/integration/smart_answer_flows/help_if_you_are_arrested_abroad_test.rb
+++ b/test/integration/smart_answer_flows/help_if_you_are_arrested_abroad_test.rb
@@ -1,10 +1,10 @@
 require_relative "../../test_helper"
-require_relative "flow_test_helper"
+require_relative "flow_integration_test_helper"
 
 require "smart_answer_flows/help-if-you-are-arrested-abroad"
 
 class HelpIfYouAreArrestedAbroadTest < ActiveSupport::TestCase
-  include FlowTestHelper
+  include FlowIntegrationTestHelper
 
   setup do
     @location_slugs = %w[aruba belgium bermuda greece iran syria democratic-republic-of-the-congo]

--- a/test/integration/smart_answer_flows/inherits_someone_dies_without_will_test.rb
+++ b/test/integration/smart_answer_flows/inherits_someone_dies_without_will_test.rb
@@ -1,10 +1,10 @@
 require_relative "../../test_helper"
-require_relative "flow_test_helper"
+require_relative "flow_integration_test_helper"
 
 require "smart_answer_flows/inherits-someone-dies-without-will"
 
 class InheritsSomeoneDiesWithoutWillTest < ActiveSupport::TestCase
-  include FlowTestHelper
+  include FlowIntegrationTestHelper
 
   setup do
     setup_for_testing_flow SmartAnswer::InheritsSomeoneDiesWithoutWillFlow

--- a/test/integration/smart_answer_flows/marriage_abroad_test.rb
+++ b/test/integration/smart_answer_flows/marriage_abroad_test.rb
@@ -1,10 +1,10 @@
 require_relative "../../test_helper"
-require_relative "flow_test_helper"
+require_relative "flow_integration_test_helper"
 
 require "smart_answer_flows/marriage-abroad"
 
 class MarriageAbroadTest < ActiveSupport::TestCase
-  include FlowTestHelper
+  include FlowIntegrationTestHelper
 
   FLATTEN_COUNTRIES_CEREMONY_LOCATION_OUTCOMES = %w[finland iceland].freeze
   FLATTEN_COUNTRIES_1_OUTCOME = %w[french-guiana french-polynesia guadeloupe martinique mayotte reunion st-pierre-and-miquelon].freeze

--- a/test/integration/smart_answer_flows/maternity_calculator_test.rb
+++ b/test/integration/smart_answer_flows/maternity_calculator_test.rb
@@ -1,5 +1,5 @@
 require_relative "../../test_helper"
-require_relative "flow_test_helper"
+require_relative "flow_integration_test_helper"
 require_relative "maternity_calculator_helper"
 require_relative "../../../lib/smart_answer/date_helper"
 
@@ -7,7 +7,7 @@ require "smart_answer_flows/maternity-paternity-calculator"
 
 class MaternityCalculatorTest < ActiveSupport::TestCase
   include SmartAnswer::DateHelper
-  include FlowTestHelper
+  include FlowIntegrationTestHelper
   include MaternityCalculatorHelper
 
   setup do

--- a/test/integration/smart_answer_flows/maternity_paternity_pay_leave_test.rb
+++ b/test/integration/smart_answer_flows/maternity_paternity_pay_leave_test.rb
@@ -1,10 +1,10 @@
 require_relative "../../test_helper"
-require_relative "flow_test_helper"
+require_relative "flow_integration_test_helper"
 
 require "smart_answer_flows/maternity-paternity-pay-leave"
 
 class MaternityPaternityPayLeaveTest < ActiveSupport::TestCase
-  include FlowTestHelper
+  include FlowIntegrationTestHelper
 
   setup do
     setup_for_testing_flow SmartAnswer::MaternityPaternityPayLeaveFlow

--- a/test/integration/smart_answer_flows/minimum_wage_calculator_employers_test.rb
+++ b/test/integration/smart_answer_flows/minimum_wage_calculator_employers_test.rb
@@ -1,5 +1,5 @@
 require_relative "../../test_helper"
-require_relative "flow_test_helper"
+require_relative "flow_integration_test_helper"
 
 require "smart_answer_flows/minimum-wage-calculator-employers"
 
@@ -7,7 +7,7 @@ class MinimumWageCalculatorEmployersTest < ActionDispatch::IntegrationTest
   # This tests the parts of the flow defined within MinimumWageCalculatorEmployersFlow
   # Much of the user journey is through a shared flow Shared::MinimumWageFlow
   # Which is tested via AmIGettingMinimumWageTest
-  include FlowTestHelper
+  include FlowIntegrationTestHelper
 
   setup do
     setup_for_testing_flow SmartAnswer::MinimumWageCalculatorEmployersFlow

--- a/test/integration/smart_answer_flows/part_year_profit_tax_credits_test.rb
+++ b/test/integration/smart_answer_flows/part_year_profit_tax_credits_test.rb
@@ -1,10 +1,10 @@
 require_relative "../../test_helper"
-require_relative "flow_test_helper"
+require_relative "flow_integration_test_helper"
 
 require "smart_answer_flows/part-year-profit-tax-credits"
 
 class PartYearProfitTaxCreditsTest < ActiveSupport::TestCase
-  include FlowTestHelper
+  include FlowIntegrationTestHelper
 
   setup do
     setup_for_testing_flow SmartAnswer::PartYearProfitTaxCreditsFlow

--- a/test/integration/smart_answer_flows/paternity_calculator_test.rb
+++ b/test/integration/smart_answer_flows/paternity_calculator_test.rb
@@ -1,12 +1,12 @@
 require_relative "../../test_helper"
-require_relative "flow_test_helper"
+require_relative "flow_integration_test_helper"
 require_relative "../../../lib/smart_answer/date_helper"
 
 require "smart_answer_flows/maternity-paternity-calculator"
 
 class PaternityCalculatorTest < ActiveSupport::TestCase
   include SmartAnswer::DateHelper
-  include FlowTestHelper
+  include FlowIntegrationTestHelper
 
   setup do
     setup_for_testing_flow SmartAnswer::MaternityPaternityCalculatorFlow

--- a/test/integration/smart_answer_flows/plan_adoption_leave_test.rb
+++ b/test/integration/smart_answer_flows/plan_adoption_leave_test.rb
@@ -1,10 +1,10 @@
 require_relative "../../test_helper"
-require_relative "flow_test_helper"
+require_relative "flow_integration_test_helper"
 
 require "smart_answer_flows/plan-adoption-leave"
 
 class PlanAdoptionLeaveTest < ActiveSupport::TestCase
-  include FlowTestHelper
+  include FlowIntegrationTestHelper
 
   context "test basic flow" do
     setup do

--- a/test/integration/smart_answer_flows/register_a_birth_test.rb
+++ b/test/integration/smart_answer_flows/register_a_birth_test.rb
@@ -1,10 +1,10 @@
 require_relative "../../test_helper"
-require_relative "flow_test_helper"
+require_relative "flow_integration_test_helper"
 
 require "smart_answer_flows/register-a-birth"
 
 class RegisterABirthTest < ActiveSupport::TestCase
-  include FlowTestHelper
+  include FlowIntegrationTestHelper
 
   setup do
     @location_slugs = %w[afghanistan algeria andorra australia bangladesh barbados belize cambodia cameroon democratic-republic-of-the-congo el-salvador estonia germany guatemala grenada india iran iraq israel laos libya maldives morocco netherlands north-korea pakistan philippines pitcairn-island saint-barthelemy serbia sierra-leone somalia spain sri-lanka st-kitts-and-nevis st-martin thailand turkey uganda united-arab-emirates venezuela]

--- a/test/integration/smart_answer_flows/register_a_death_test.rb
+++ b/test/integration/smart_answer_flows/register_a_death_test.rb
@@ -1,10 +1,10 @@
 require_relative "../../test_helper"
-require_relative "flow_test_helper"
+require_relative "flow_integration_test_helper"
 
 require "smart_answer_flows/register-a-death"
 
 class RegisterADeathTest < ActiveSupport::TestCase
-  include FlowTestHelper
+  include FlowIntegrationTestHelper
 
   setup do
     @location_slugs = %w[afghanistan algeria andorra argentina australia austria barbados belgium brazil cameroon democratic-republic-of-the-congo dominica egypt france germany grenada iran italy kenya libya morocco nigeria north-korea pakistan pitcairn-island poland saint-barthelemy serbia slovakia somalia spain st-kitts-and-nevis st-martin uganda]

--- a/test/integration/smart_answer_flows/report_a_lost_or_stolen_passport_test.rb
+++ b/test/integration/smart_answer_flows/report_a_lost_or_stolen_passport_test.rb
@@ -1,10 +1,10 @@
 require_relative "../../test_helper"
-require_relative "flow_test_helper"
+require_relative "flow_integration_test_helper"
 
 require "smart_answer_flows/report-a-lost-or-stolen-passport"
 
 class ReportALostOrStolenPassportTest < ActiveSupport::TestCase
-  include FlowTestHelper
+  include FlowIntegrationTestHelper
 
   setup do
     @location_slugs = %w[azerbaijan canada]

--- a/test/integration/smart_answer_flows/simplified_expenses_checker_test.rb
+++ b/test/integration/smart_answer_flows/simplified_expenses_checker_test.rb
@@ -1,10 +1,10 @@
 require_relative "../../test_helper"
-require_relative "flow_test_helper"
+require_relative "flow_integration_test_helper"
 
 require "smart_answer_flows/simplified-expenses-checker"
 
 class SimplifiedExpensesCheckerTest < ActiveSupport::TestCase
-  include FlowTestHelper
+  include FlowIntegrationTestHelper
 
   setup do
     setup_for_testing_flow SmartAnswer::SimplifiedExpensesCheckerFlow

--- a/test/integration/smart_answer_flows/state_pension_age_test.rb
+++ b/test/integration/smart_answer_flows/state_pension_age_test.rb
@@ -1,10 +1,10 @@
 require_relative "../../test_helper"
-require_relative "flow_test_helper"
+require_relative "flow_integration_test_helper"
 
 require "smart_answer_flows/state-pension-age"
 
 class StatePensionAgeTest < ActiveSupport::TestCase
-  include FlowTestHelper
+  include FlowIntegrationTestHelper
 
   setup do
     setup_for_testing_flow SmartAnswer::StatePensionAgeFlow

--- a/test/integration/smart_answer_flows/state_pension_through_partner_test.rb
+++ b/test/integration/smart_answer_flows/state_pension_through_partner_test.rb
@@ -1,11 +1,11 @@
 require_relative "../../test_helper"
-require_relative "flow_test_helper"
+require_relative "flow_integration_test_helper"
 require "gds_api/test_helpers/worldwide"
 
 require "smart_answer_flows/state-pension-through-partner"
 
 class StatePensionThroughPartnerTest < ActiveSupport::TestCase
-  include FlowTestHelper
+  include FlowIntegrationTestHelper
 
   setup do
     setup_for_testing_flow SmartAnswer::StatePensionThroughPartnerFlow

--- a/test/integration/smart_answer_flows/student_finance_calculator_test.rb
+++ b/test/integration/smart_answer_flows/student_finance_calculator_test.rb
@@ -1,10 +1,10 @@
 require_relative "../../test_helper"
-require_relative "flow_test_helper"
+require_relative "flow_integration_test_helper"
 
 require "smart_answer_flows/student-finance-calculator"
 
 class StudentFinanceCalculatorTest < ActiveSupport::TestCase
-  include FlowTestHelper
+  include FlowIntegrationTestHelper
 
   setup do
     setup_for_testing_flow SmartAnswer::StudentFinanceCalculatorFlow

--- a/test/integration/smart_answer_flows/towing_rules_test.rb
+++ b/test/integration/smart_answer_flows/towing_rules_test.rb
@@ -1,10 +1,10 @@
 require_relative "../../test_helper"
-require_relative "flow_test_helper"
+require_relative "flow_integration_test_helper"
 
 require "smart_answer_flows/towing-rules"
 
 class TowingRulesTest < ActiveSupport::TestCase
-  include FlowTestHelper
+  include FlowIntegrationTestHelper
 
   setup do
     setup_for_testing_flow SmartAnswer::TowingRulesFlow

--- a/test/integration/smart_answer_flows/uk_benefits_abroad_test.rb
+++ b/test/integration/smart_answer_flows/uk_benefits_abroad_test.rb
@@ -1,10 +1,10 @@
 require_relative "../../test_helper"
-require_relative "flow_test_helper"
+require_relative "flow_integration_test_helper"
 
 require "smart_answer_flows/uk-benefits-abroad"
 
 class UKBenefitsAbroadTest < ActiveSupport::TestCase
-  include FlowTestHelper
+  include FlowIntegrationTestHelper
 
   setup do
     setup_for_testing_flow SmartAnswer::UkBenefitsAbroadFlow

--- a/test/integration/smart_answer_flows/vat_payment_deadlines_test.rb
+++ b/test/integration/smart_answer_flows/vat_payment_deadlines_test.rb
@@ -1,10 +1,10 @@
 require_relative "../../test_helper"
-require_relative "flow_test_helper"
+require_relative "flow_integration_test_helper"
 
 require "smart_answer_flows/vat-payment-deadlines"
 
 class VatPaymentDeadlinesTest < ActiveSupport::TestCase
-  include FlowTestHelper
+  include FlowIntegrationTestHelper
 
   setup do
     WebMock.stub_request(:get, WorkingDays::BANK_HOLIDAYS_URL)


### PR DESCRIPTION
Trello: https://trello.com/c/fU4RQYvF/494-foundational-work-to-implement-smart-answer-flow-test-adr

This has been done in preparation for the implementation of ADR-3 [1].
This changes the name of FlowTestHelper so that namespace can be free
for the new flow testing approach.

The choice of FlowIntegrationTestHelp was made due to an existing
precedence for this naming convention with the FlowUnitTestHelper [2].

[1]: https://github.com/alphagov/smart-answers/blob/main/docs/arch/003-testing-flows.md
[2]: https://github.com/alphagov/smart-answers/blob/18bcb469558e4d61146031db0050d6c1e05d9636/test/unit/smart_answer_flows/flow_unit_test_helper.rb

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
