### PR TITLE
Fix SharedAdoptionMaternityPaternityFlow namespacing

### DIFF
--- a/lib/smart_answer_flows/maternity-paternity-calculator/shared_adoption_maternity_paternity_flow.rb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/shared_adoption_maternity_paternity_flow.rb
@@ -1,104 +1,106 @@
 module SmartAnswer
-  class SharedAdoptionMaternityPaternityFlow < Flow
-    def define
-      payment_options = Calculators::MaternityPayCalculator.payment_options
+  class MaternityPaternityCalculatorFlow < SmartAnswer::Flow
+    class SharedAdoptionMaternityPaternityFlow < SmartAnswer::Flow
+      def define
+        payment_options = SmartAnswer::Calculators::MaternityPayCalculator.payment_options
 
-      # This question is being used in:
-      # QM8 in MaternityCalculatorFlow
-      # QP13 in PaternityCalculatorFlow
-      # QA10 in AdoptionCalculatorFlow
-      radio :how_many_payments_weekly? do
-        payment_options[:weekly].each_key do |payment_option|
-          option payment_option
-        end
+        # This question is being used in:
+        # QM8 in MaternityCalculatorFlow
+        # QP13 in PaternityCalculatorFlow
+        # QA10 in AdoptionCalculatorFlow
+        radio :how_many_payments_weekly? do
+          payment_options[:weekly].each_key do |payment_option|
+            option payment_option
+          end
 
-        on_response do |response|
-          calculator.payment_option = response
-        end
+          on_response do |response|
+            calculator.payment_option = response
+          end
 
-        next_node do
-          case calculator.leave_type
-          when "adoption"
-            question :how_do_you_want_the_sap_calculated?
-          when "maternity"
-            question :how_do_you_want_the_smp_calculated?
-          else
-            question :how_do_you_want_the_spp_calculated?
+          next_node do
+            case calculator.leave_type
+            when "adoption"
+              question :how_do_you_want_the_sap_calculated?
+            when "maternity"
+              question :how_do_you_want_the_smp_calculated?
+            else
+              question :how_do_you_want_the_spp_calculated?
+            end
           end
         end
-      end
 
-      # This question is being used in:
-      # QM8 in MaternityCalculatorFlow
-      # QP13 in PaternityCalculatorFlow
-      # QA10 in AdoptionCalculatorFlow
-      radio :how_many_payments_every_2_weeks? do
-        payment_options[:every_2_weeks].each_key do |payment_option|
-          option payment_option
-        end
+        # This question is being used in:
+        # QM8 in MaternityCalculatorFlow
+        # QP13 in PaternityCalculatorFlow
+        # QA10 in AdoptionCalculatorFlow
+        radio :how_many_payments_every_2_weeks? do
+          payment_options[:every_2_weeks].each_key do |payment_option|
+            option payment_option
+          end
 
-        on_response do |response|
-          calculator.payment_option = response
-        end
+          on_response do |response|
+            calculator.payment_option = response
+          end
 
-        next_node do
-          case calculator.leave_type
-          when "adoption"
-            question :how_do_you_want_the_sap_calculated?
-          when "maternity"
-            question :how_do_you_want_the_smp_calculated?
-          else
-            question :how_do_you_want_the_spp_calculated?
+          next_node do
+            case calculator.leave_type
+            when "adoption"
+              question :how_do_you_want_the_sap_calculated?
+            when "maternity"
+              question :how_do_you_want_the_smp_calculated?
+            else
+              question :how_do_you_want_the_spp_calculated?
+            end
           end
         end
-      end
 
-      # This question is being used in:
-      # QM8 in MaternityCalculatorFlow
-      # QP13 in PaternityCalculatorFlow
-      # QA10 in AdoptionCalculatorFlow
-      radio :how_many_payments_every_4_weeks? do
-        payment_options[:every_4_weeks].each_key do |payment_option|
-          option payment_option
-        end
+        # This question is being used in:
+        # QM8 in MaternityCalculatorFlow
+        # QP13 in PaternityCalculatorFlow
+        # QA10 in AdoptionCalculatorFlow
+        radio :how_many_payments_every_4_weeks? do
+          payment_options[:every_4_weeks].each_key do |payment_option|
+            option payment_option
+          end
 
-        on_response do |response|
-          calculator.payment_option = response
-        end
+          on_response do |response|
+            calculator.payment_option = response
+          end
 
-        next_node do
-          case calculator.leave_type
-          when "adoption"
-            question :how_do_you_want_the_sap_calculated?
-          when "maternity"
-            question :how_do_you_want_the_smp_calculated?
-          else
-            question :how_do_you_want_the_spp_calculated?
+          next_node do
+            case calculator.leave_type
+            when "adoption"
+              question :how_do_you_want_the_sap_calculated?
+            when "maternity"
+              question :how_do_you_want_the_smp_calculated?
+            else
+              question :how_do_you_want_the_spp_calculated?
+            end
           end
         end
-      end
 
-      # This question is being used in:
-      # QM8 in MaternityCalculatorFlow
-      # QP13 in PaternityCalculatorFlow
-      # QA10 in AdoptionCalculatorFlow
-      radio :how_many_payments_monthly? do
-        payment_options[:monthly].each_key do |payment_option|
-          option payment_option
-        end
+        # This question is being used in:
+        # QM8 in MaternityCalculatorFlow
+        # QP13 in PaternityCalculatorFlow
+        # QA10 in AdoptionCalculatorFlow
+        radio :how_many_payments_monthly? do
+          payment_options[:monthly].each_key do |payment_option|
+            option payment_option
+          end
 
-        on_response do |response|
-          calculator.payment_option = response
-        end
+          on_response do |response|
+            calculator.payment_option = response
+          end
 
-        next_node do
-          case calculator.leave_type
-          when "adoption"
-            question :how_do_you_want_the_sap_calculated?
-          when "maternity"
-            question :how_do_you_want_the_smp_calculated?
-          else
-            question :how_do_you_want_the_spp_calculated?
+          next_node do
+            case calculator.leave_type
+            when "adoption"
+              question :how_do_you_want_the_sap_calculated?
+            when "maternity"
+              question :how_do_you_want_the_smp_calculated?
+            else
+              question :how_do_you_want_the_spp_calculated?
+            end
           end
         end
       end


### PR DESCRIPTION
Trello: https://trello.com/c/fU4RQYvF/494-foundational-work-to-implement-smart-answer-flow-test-adr

Unlike the other Flows defined in the maternity-paternity-calculator this class has not been defined within the MaternityPaternityCalculatorFlow namespace.

This inconsistency has caused problems on related work I'm doing to move the flows to test/flow and interface nicer with the Zeitwerk autoloader.

This is a much smaller change than this diff may suggest. [View without whitespace being included](https://github.com/alphagov/smart-answers/pull/5487/files?diff=split&w=1) for an easier review.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
