### PR TITLE
Move landing page to FlowController

### DIFF
--- a/app/controllers/flow_controller.rb
+++ b/app/controllers/flow_controller.rb
@@ -52,7 +52,7 @@ class FlowController < ApplicationController
 private
 
   def redirect_path_based_flows
-    redirect_to smart_answer_path(params[:id], started: "y") if flow.response_store.nil?
+    redirect_to smart_answer_path(params[:id]) if flow.response_store.nil?
   end
 
   def set_cache_headers

--- a/app/controllers/flow_controller.rb
+++ b/app/controllers/flow_controller.rb
@@ -2,7 +2,14 @@ class FlowController < ApplicationController
   include FlowHelper
 
   before_action :set_cache_headers
-  before_action :redirect_path_based_flows
+  before_action :redirect_path_based_flows, except: :landing
+
+  def landing
+    @presenter = FlowPresenter.new(flow, nil)
+    @title = @presenter.title
+
+    render @presenter.start_node.view_template_path, formats: [:html]
+  end
 
   def start
     response_store.clear

--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -60,7 +60,6 @@ private
   end
 
   def page_type
-    return :landing unless params[:started]
     return :result if @presenter.finished?
 
     :question

--- a/app/controllers/smart_answers_controller.rb
+++ b/app/controllers/smart_answers_controller.rb
@@ -70,7 +70,7 @@ private
   def redirect_response_to_canonical_path
     if params[:next] && !@presenter.state.error
       set_expiry
-      redirect_to smart_answer_path(@name, started: "y", responses: @presenter.accepted_responses.values)
+      redirect_to smart_answer_path(@name, responses: @presenter.accepted_responses.values)
     end
   end
 

--- a/app/helpers/current_question_helper.rb
+++ b/app/helpers/current_question_helper.rb
@@ -13,7 +13,7 @@ module CurrentQuestionHelper
     if presenter.response_store
       destroy_flow_path(presenter.name)
     else
-      smart_answer_path(presenter.name)
+      flow_landing_path(presenter.name)
     end
   end
 end

--- a/app/helpers/current_question_helper.rb
+++ b/app/helpers/current_question_helper.rb
@@ -3,7 +3,7 @@ module CurrentQuestionHelper
     if presenter.response_store
       update_flow_path(id: presenter.name, node_slug: presenter.node_slug)
     else
-      attrs = params.permit(:id, :started).to_h.symbolize_keys
+      attrs = params.permit(:id).to_h.symbolize_keys
       attrs[:responses] = presenter.accepted_responses.values if presenter.accepted_responses.any?
       smart_answer_path(attrs)
     end

--- a/app/helpers/index_helper.rb
+++ b/app/helpers/index_helper.rb
@@ -1,6 +1,6 @@
 module IndexHelper
   def title_and_url(flow_name, title)
-    sanitize(title) + tag.br + link_to("/#{flow_name}", smart_answer_path(flow_name))
+    sanitize(title) + tag.br + link_to("/#{flow_name}", flow_landing_path(flow_name))
   end
 
   def live_link(flow_name, status)

--- a/app/presenters/flow_presenter.rb
+++ b/app/presenters/flow_presenter.rb
@@ -50,7 +50,6 @@ class FlowPresenter
 
       smart_answer_path(
         id: @flow.name,
-        started: "y",
         responses: accepted_responses.values[0...question_number],
         previous_response: accepted_responses[question.node_name],
       )
@@ -61,7 +60,7 @@ class FlowPresenter
     if response_store
       start_flow_path(name)
     else
-      smart_answer_path(name, started: "y")
+      smart_answer_path(name)
     end
   end
 end

--- a/app/presenters/start_node_presenter.rb
+++ b/app/presenters/start_node_presenter.rb
@@ -27,4 +27,8 @@ class StartNodePresenter < NodePresenter
     custom_button_text = @renderer.content_for(:start_button_text)
     custom_button_text.presence || "Start now"
   end
+
+  def view_template_path
+    "smart_answers/landing"
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,10 +7,12 @@ Rails.application.routes.draw do
 
   mount GovukPublishingComponents::Engine, at: "/component-guide"
 
-  constraints id: /[a-z0-9-]+/i, started: /y/ do
+  get "/:id", to: "flow#landing", as: :flow_landing
+
+  constraints id: /[a-z0-9-]+/i do
     get "/:id/y/visualise(.:format)", to: "smart_answers#visualise", as: :visualise
 
-    get "/:id(/:started(/*responses))",
+    get "/:id(/y(/*responses))",
         to: "smart_answers#show",
         as: :smart_answer,
         format: false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,14 +9,8 @@ Rails.application.routes.draw do
 
   get "/:id", to: "flow#landing", as: :flow_landing
 
-  constraints id: /[a-z0-9-]+/i do
-    get "/:id/y/visualise(.:format)", to: "smart_answers#visualise", as: :visualise
-
-    get "/:id(/y(/*responses))",
-        to: "smart_answers#show",
-        as: :smart_answer,
-        format: false
-  end
+  get "/:id/y/visualise(.:format)", to: "smart_answers#visualise", as: :visualise
+  get "/:id(/y(/*responses))", to: "smart_answers#show", as: :smart_answer, format: false
 
   get "/:id/start", to: "flow#start", as: :start_flow
   get "/:id/destroy_session", to: "flow#destroy", as: :destroy_flow

--- a/test/functional/flow_controller_test.rb
+++ b/test/functional/flow_controller_test.rb
@@ -1,0 +1,47 @@
+require_relative "../test_helper"
+require_relative "../fixtures/smart_answer_flows/smart-answers-controller-sample"
+require_relative "smart_answers_controller_test_helper"
+
+class FlowControllerTest < ActionController::TestCase
+  include SmartAnswersControllerTestHelper
+
+  def setup
+    setup_fixture_flows
+  end
+
+  def teardown
+    teardown_fixture_flows
+  end
+
+  context "GET /<slug>" do
+    setup do
+      stub_content_store_has_item("/smart-answers-controller-sample")
+    end
+
+    should "display landing page in html if no questions answered yet" do
+      get :landing, params: { id: "smart-answers-controller-sample" }
+      assert_select "h1", /Smart answers controller sample/
+    end
+
+    should "not have noindex tag on landing page" do
+      get :landing, params: { id: "smart-answers-controller-sample" }
+      assert_select "meta[name=robots][content=noindex]", count: 0
+    end
+
+    should "have cache headers set to 30 mins" do
+      Rails.application.config.stubs(:set_http_cache_control_expiry_time).returns(true)
+
+      get :landing, params: { id: "smart-answers-controller-sample" }
+      assert_equal "max-age=1800, public", @response.header["Cache-Control"]
+    end
+
+    context "meta description in erb template" do
+      should "be shown" do
+        get :landing, params: { id: "smart-answers-controller-sample" }
+        assert_select "head meta[name=description]" do |meta_tags|
+          assert_equal "This is a test description", meta_tags.first["content"]
+        end
+      end
+    end
+  end
+end

--- a/test/functional/routing_test.rb
+++ b/test/functional/routing_test.rb
@@ -3,12 +3,6 @@ require_relative "../test_helper"
 class RoutingTest < ActionDispatch::IntegrationTest
   include Rack::Test::Methods
 
-  should "not 404 without blowing up when given a slug with invalid UTF-8" do
-    assert_raises ActionController::RoutingError do
-      get "/non-gb-driving-licence%E2%EF%BF%BD%EF%BF%BD"
-    end
-  end
-
   should "route root path to smart answers controller index action" do
     assert_routing "/", controller: "smart_answers", action: "index"
   end

--- a/test/functional/smart_answers_controller_test.rb
+++ b/test/functional/smart_answers_controller_test.rb
@@ -83,11 +83,6 @@ class SmartAnswersControllerTest < ActionController::TestCase
       assert_response :missing
     end
 
-    should "display landing page in html if no questions answered yet" do
-      get :show, params: { id: "smart-answers-controller-sample" }
-      assert_select "h1", /Smart answers controller sample/
-    end
-
     context "when a smart answer exist on the content store" do
       setup do
         @content_item = {
@@ -113,27 +108,6 @@ class SmartAnswersControllerTest < ActionController::TestCase
 
       should "assign empty hash to content_item" do
         assert_equal({}, assigns(:content_item))
-      end
-    end
-
-    should "not have noindex tag on landing page" do
-      get :show, params: { id: "smart-answers-controller-sample" }
-      assert_select "meta[name=robots][content=noindex]", count: 0
-    end
-
-    should "have cache headers set to 30 mins" do
-      Rails.application.config.stubs(:set_http_cache_control_expiry_time).returns(true)
-
-      get :show, params: { id: "smart-answers-controller-sample" }
-      assert_equal "max-age=1800, public", @response.header["Cache-Control"]
-    end
-
-    context "meta description in erb template" do
-      should "be shown" do
-        get :show, params: { id: "smart-answers-controller-sample" }
-        assert_select "head meta[name=description]" do |meta_tags|
-          assert_equal "This is a test description", meta_tags.first["content"]
-        end
       end
     end
 

--- a/test/helpers/current_question_helper_test.rb
+++ b/test/helpers/current_question_helper_test.rb
@@ -13,7 +13,7 @@ class CurrentQuestionHelperTest < ActionView::TestCase
 
   context "#restart_flow_path" do
     should "return root smart answer path" do
-      assert_equal smart_answer_path(flow_name), restart_flow_path(presenter)
+      assert_equal flow_landing_path(flow_name), restart_flow_path(presenter)
     end
 
     should "return root smart answer path for session answer" do

--- a/test/integration/smart_answers_controller_error_handling_test.rb
+++ b/test/integration/smart_answers_controller_error_handling_test.rb
@@ -14,7 +14,7 @@ class SmartAnswersControllerErrorHandlingTest < ActionDispatch::IntegrationTest
     end
 
     should "set response status code to 404" do
-      get "/flow-name"
+      get "/flow-name/y"
       assert_response 404
     end
   end
@@ -25,7 +25,7 @@ class SmartAnswersControllerErrorHandlingTest < ActionDispatch::IntegrationTest
     end
 
     should "set response status code to 404" do
-      get "/flow-name"
+      get "/flow-name/y"
       assert_response 404
     end
   end


### PR DESCRIPTION
This is a new controller method to handle request for the landing/start page. This will replace the logic already within the SmartAnswerController. This will make it easier to pass query parameters from the start page to the flow (needed by the Next steps for you business flow), as logic will be within a the single FlowController. 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
